### PR TITLE
Separate Navbar & Footer from content

### DIFF
--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -195,7 +195,18 @@ a:link {
   text-decoration: none;
 }
 
+.theme-doc-sidebar-container nav {
+  padding: 20px 10px;
+}
+
+.navbar {
+  border-bottom: 1px solid var(--ifm-toc-border-color);
+}
+
 .footer {
+  border-top: 1px solid var(--ifm-toc-border-color);
+  padding-top: 50px;
+
   p {
     font-size: 12px;
     margin-top: 30px;


### PR DESCRIPTION
It's sometimes not easy to separate the sidebar from the navbar/footer, adding a border to both of those solves that problem