### PR TITLE
Fix content container padding

### DIFF
--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -1583,3 +1583,9 @@ g {
   stroke: 900;
   stroke-width: 2.2;
 }
+
+@media (min-width: 1662px) {
+  .container > .row > .col {
+    padding-left: 40px;
+  }
+}


### PR DESCRIPTION
The content container's padding on the left would jump from 40px to 0px from a page width of `1662px` and onwards, resulting in the content being glued to the sidebar until the `max-width` and `margin: 0 auto` came into effect.

You can validate this by opening the current docs and resizing the window to be `1662px` wide.