### PR TITLE
Ensure `<` characters are displayed correctly

### DIFF
--- a/docs/surrealql/functions/math.mdx
+++ b/docs/surrealql/functions/math.mdx
@@ -133,7 +133,7 @@ RETURN math::abs(13.746189);
 The `math::bottom` function returns the bottom X set of numbers in a set of numbers.
 
 ```surql title="API DEFINITION"
-math::bottom(array{{ "<" }}number>, number) -> number
+math::bottom(array<number>, number) -> number
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
@@ -201,7 +201,7 @@ RETURN math::floor(13.746189);
 The `math::interquartile` function returns the interquartile of an array of numbers.
 
 ```surql title="API DEFINITION"
-math::interquartile(array{{ "<" }}number>) -> number
+math::interquartile(array<number>) -> number
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
@@ -269,7 +269,7 @@ RETURN math::median([ 26.164, 13.746189, 23, 16.4, 41.42 ]);
 The `math::midhinge` function returns the midhinge of an array of numbers.
 
 ```surql title="API DEFINITION"
-math::midhinge(array{{ "<" }}number>) -> number
+math::midhinge(array<number>) -> number
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
@@ -303,7 +303,7 @@ RETURN math::min([ 26.164, 13.746189, 23, 16.4, 41.42 ]);
 The `math::mode` function returns the value that occurs most often in a set of numbers.
 
 ```surql title="API DEFINITION"
-math::mode(array{{ "<" }}number>) -> number
+math::mode(array<number>) -> number
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
@@ -320,7 +320,7 @@ RETURN math::mode([ 1, 40, 60, 10, 2, 901 ]);
 The `math::nearestrank` function returns the nearestrank of an array of numbers.
 
 ```surql title="API DEFINITION"
-math::nearestrank(array{{ "<" }}number>, number) -> number
+math::nearestrank(array<number>, number) -> number
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
@@ -337,7 +337,7 @@ RETURN math::nearestrank([1, 40, 60, 10, 2, 901], 50);
 The `math::percentile` function returns the value below which a percentage of data falls.
 
 ```surql title="API DEFINITION"
-math::percentile(array{{ "<" }}number>, number) -> number
+math::percentile(array<number>, number) -> number
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
@@ -388,7 +388,7 @@ RETURN math::round(13.53124);
 The `math::spread` function returns the spread of an array of numbers.
 
 ```surql title="API DEFINITION"
-math::spread(array{{ "<" }}number>) -> number
+math::spread(array<number>) -> number
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
@@ -422,7 +422,7 @@ RETURN math::sqrt(15);
 The `math::stddev` function calculates how far a set of numbers are away from the mean.
 
 ```surql title="API DEFINITION"
-math::stddev(array{{ "<" }}number>) -> number
+math::stddev(array<number>) -> number
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
@@ -456,7 +456,7 @@ RETURN math::sum([ 26.164, 13.746189, 23, 16.4, 41.42 ]);
 The `math::top` function returns the top of an array of numbers.
 
 ```surql title="API DEFINITION"
-math::top(array{{ "<" }}number>, number) -> number
+math::top(array<number>, number) -> number
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
@@ -473,7 +473,7 @@ RETURN math::top([1, 40, 60, 10, 2, 901], 3);
 The `math::trimean` function returns the trimean of an array of numbers.
 
 ```surql title="API DEFINITION"
-math::trimean(array{{ "<" }}number>) -> number
+math::trimean(array<number>) -> number
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
@@ -490,7 +490,7 @@ RETURN math::trimean([ 1, 40, 60, 10, 2, 901 ]);
 The `math::variance` function returns the variance of an array of numbers.
 
 ```surql title="API DEFINITION"
-math::variance(array{{ "<" }}number>) -> number
+math::variance(array<number>) -> number
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 

--- a/docs/surrealql/functions/type.mdx
+++ b/docs/surrealql/functions/type.mdx
@@ -568,7 +568,7 @@ type::is::decimal(any) -> bool
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
 ```surql
-RETURN type::is::decimal({{ "<" }}decimal> 13.5719384719384719385639856394139476937756394756);
+RETURN type::is::decimal(<decimal> 13.5719384719384719385639856394139476937756394756);
 
 true
 ```
@@ -585,7 +585,7 @@ type::is::duration(any) -> bool
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
 ```surql
-RETURN type::is::duration({{ "<" }}datetime> '1970-01-01T00:00:00');
+RETURN type::is::duration(<datetime> '1970-01-01T00:00:00');
 
 true
 ```
@@ -602,7 +602,7 @@ type::is::float(any) -> bool
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
 ```surql
-RETURN type::is::float({{ "<" }}float> 41.5);
+RETURN type::is::float(<float> 41.5);
 
 true
 ```
@@ -636,7 +636,7 @@ type::is::int(any) -> bool
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
 ```surql
-RETURN type::is::int({{ "<" }}int> 123);
+RETURN type::is::int(<int> 123);
 
 true
 ```

--- a/versioned_docs/version-nightly/surrealql/functions/math.mdx
+++ b/versioned_docs/version-nightly/surrealql/functions/math.mdx
@@ -133,7 +133,7 @@ RETURN math::abs(13.746189);
 The `math::bottom` function returns the bottom X set of numbers in a set of numbers.
 
 ```surql title="API DEFINITION"
-math::bottom(array{{ "<" }}number>, number) -> number
+math::bottom(array<number>, number) -> number
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
@@ -201,7 +201,7 @@ RETURN math::floor(13.746189);
 The `math::interquartile` function returns the interquartile of an array of numbers.
 
 ```surql title="API DEFINITION"
-math::interquartile(array{{ "<" }}number>) -> number
+math::interquartile(array<number>) -> number
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
@@ -269,7 +269,7 @@ RETURN math::median([ 26.164, 13.746189, 23, 16.4, 41.42 ]);
 The `math::midhinge` function returns the midhinge of an array of numbers.
 
 ```surql title="API DEFINITION"
-math::midhinge(array{{ "<" }}number>) -> number
+math::midhinge(array<number>) -> number
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
@@ -303,7 +303,7 @@ RETURN math::min([ 26.164, 13.746189, 23, 16.4, 41.42 ]);
 The `math::mode` function returns the value that occurs most often in a set of numbers.
 
 ```surql title="API DEFINITION"
-math::mode(array{{ "<" }}number>) -> number
+math::mode(array<number>) -> number
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
@@ -320,7 +320,7 @@ RETURN math::mode([ 1, 40, 60, 10, 2, 901 ]);
 The `math::nearestrank` function returns the nearestrank of an array of numbers.
 
 ```surql title="API DEFINITION"
-math::nearestrank(array{{ "<" }}number>, number) -> number
+math::nearestrank(array<number>, number) -> number
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
@@ -337,7 +337,7 @@ RETURN math::nearestrank([1, 40, 60, 10, 2, 901], 50);
 The `math::percentile` function returns the value below which a percentage of data falls.
 
 ```surql title="API DEFINITION"
-math::percentile(array{{ "<" }}number>, number) -> number
+math::percentile(array<number>, number) -> number
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
@@ -388,7 +388,7 @@ RETURN math::round(13.53124);
 The `math::spread` function returns the spread of an array of numbers.
 
 ```surql title="API DEFINITION"
-math::spread(array{{ "<" }}number>) -> number
+math::spread(array<number>) -> number
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
@@ -422,7 +422,7 @@ RETURN math::sqrt(15);
 The `math::stddev` function calculates how far a set of numbers are away from the mean.
 
 ```surql title="API DEFINITION"
-math::stddev(array{{ "<" }}number>) -> number
+math::stddev(array<number>) -> number
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
@@ -456,7 +456,7 @@ RETURN math::sum([ 26.164, 13.746189, 23, 16.4, 41.42 ]);
 The `math::top` function returns the top of an array of numbers.
 
 ```surql title="API DEFINITION"
-math::top(array{{ "<" }}number>, number) -> number
+math::top(array<number>, number) -> number
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
@@ -473,7 +473,7 @@ RETURN math::top([1, 40, 60, 10, 2, 901], 3);
 The `math::trimean` function returns the trimean of an array of numbers.
 
 ```surql title="API DEFINITION"
-math::trimean(array{{ "<" }}number>) -> number
+math::trimean(array<number>) -> number
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
@@ -490,7 +490,7 @@ RETURN math::trimean([ 1, 40, 60, 10, 2, 901 ]);
 The `math::variance` function returns the variance of an array of numbers.
 
 ```surql title="API DEFINITION"
-math::variance(array{{ "<" }}number>) -> number
+math::variance(array<number>) -> number
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 

--- a/versioned_docs/version-nightly/surrealql/functions/type.mdx
+++ b/versioned_docs/version-nightly/surrealql/functions/type.mdx
@@ -572,7 +572,7 @@ type::is::decimal(any) -> bool
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
 ```surql
-RETURN type::is::decimal({{ "<" }}decimal> 13.5719384719384719385639856394139476937756394756);
+RETURN type::is::decimal(<decimal> 13.5719384719384719385639856394139476937756394756);
 
 true
 ```
@@ -589,7 +589,7 @@ type::is::duration(any) -> bool
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
 ```surql
-RETURN type::is::duration({{ "<" }}datetime> '1970-01-01T00:00:00');
+RETURN type::is::duration(<datetime> '1970-01-01T00:00:00');
 
 true
 ```
@@ -606,7 +606,7 @@ type::is::float(any) -> bool
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
 ```surql
-RETURN type::is::float({{ "<" }}float> 41.5);
+RETURN type::is::float(<float> 41.5);
 
 true
 ```
@@ -640,7 +640,7 @@ type::is::int(any) -> bool
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
 ```surql
-RETURN type::is::int({{ "<" }}int> 123);
+RETURN type::is::int(<int> 123);
 
 true
 ```


### PR DESCRIPTION
In certain places around the docs, `<` characters were displayed incorrectly (due to the conversion from Ember.js to Docusaurus). This fix ensures all `array{{ "<" }}` code is replaced with `<`.

Closes #118.