### PR TITLE
Remove unused header from HTTP integration page

### DIFF
--- a/docs/integration/http.mdx
+++ b/docs/integration/http.mdx
@@ -69,23 +69,23 @@ The HTTP endpoints enable simple selection and modifications of all records or a
             <td>Deletes all records in a table from the database</td>
         </tr>
         <tr>
-            <td><a href="#get-table-id"><code>GET /key/:table/:id</code></a></td>
+            <td><a href="#get-record"><code>GET /key/:table/:id</code></a></td>
             <td>Selects the specific record from the database</td>
         </tr>
         <tr>
-            <td><a href="#post-table-id"><code>POST /key/:table/:id</code></a></td>
+            <td><a href="#post-record"><code>POST /key/:table/:id</code></a></td>
             <td>Creates the specific record in the database</td>
         </tr>
         <tr>
-            <td><a href="#put-table-id"><code>PUT /key/:table/:id</code></a></td>
+            <td><a href="#put-record"><code>PUT /key/:table/:id</code></a></td>
             <td>Updates the specified record in the database</td>
         </tr>
         <tr>
-            <td><a href="#patch-table-id"><code>PATCH /key/:table/:id</code></a></td>
+            <td><a href="#patch-record"><code>PATCH /key/:table/:id</code></a></td>
             <td>Modifies the specified record in the database</td>
         </tr>
         <tr>
-            <td><a href="#delete-table-id"><code>DELETE /key/:table/:id</code></a></td>
+            <td><a href="#delete-record"><code>DELETE /key/:table/:id</code></a></td>
             <td>Deletes the specified record from the database</td>
         </tr>
         <tr>
@@ -103,7 +103,7 @@ This HTTP RESTful endpoint checks whether the database web server is running, re
 
 <br />
 
-## `GET /health`
+## `GET /health` {#health}
 
 This HTTP RESTful endpoint checks whether the database server and storage engine are running.
 
@@ -117,7 +117,7 @@ This HTTP RESTful endpoint returns the version of the SurrealDB database server.
 
 <br />
 
-## `GET /import`
+## `GET /import` {#import}
 
 This HTTP RESTful endpoint imports a set of SurrealQL queries into a specific Namespace and Database.
 
@@ -171,7 +171,7 @@ This HTTP RESTful endpoint imports a set of SurrealQL queries into a specific Na
 
 <br />
 
-## `GET /export`
+## `GET /export` {#export}
 
 This HTTP RESTful endpoint exports all data for a specific Namespace and Database.
 
@@ -216,7 +216,8 @@ This HTTP RESTful endpoint exports all data for a specific Namespace and Databas
 
 <br />
 
-## `POST /signin`
+## `POST /signin` {#signin}
+
 ```json title="Method and URL"
 POST /signin
 ```
@@ -285,7 +286,7 @@ curl -X POST -H "Accept: application/json" -d '{"user":"john.doe","pass":"123456
 
 <br />
 
-## `POST /signup`
+## `POST /signup` {#signup}
 
 This HTTP RESTful endpoint is used to create an account inside the SurrealDB database server.
 
@@ -632,7 +633,7 @@ DELETE FROM type::table($table);
 
 <br />
 
-## `GET /key/:table/:id` {#get-table-id}
+## `GET /key/:table/:id` {#get-record}
 
 This HTTP RESTful endpoint selects a specific record from the database.
 
@@ -691,7 +692,7 @@ SELECT * FROM type::thing($table, $id);
 
 <br />
 
-## `POST /key/:table/:id` {#post-table-id}
+## `POST /key/:table/:id` {#post-record}
 
 This HTTP RESTful endpoint creates a specific record in a table in the database.
 
@@ -750,7 +751,7 @@ CREATE type::thing($table, $id) CONTENT $body;
 
 <br />
 
-## `PUT /key/:table/:id` {#put-table-id}
+## `PUT /key/:table/:id` {#put-record}
 
 This HTTP RESTful endpoint updates a specific record in a table in the database.
 
@@ -813,7 +814,7 @@ UPDATE type::thing($table, $id) CONTENT $body;
 
 <br />
 
-## `PATCH /key/:table/:id` {#patch-table-id}
+## `PATCH /key/:table/:id` {#patch-record}
 
 This HTTP RESTful endpoint modifies a specific record in a table in the database.
 
@@ -876,7 +877,7 @@ UPDATE type::thing($table, $id) MERGE $body;
 
 <br />
 
-## `DELETE /key/:table/:id` {#delete-table-id}
+## `DELETE /key/:table/:id` {#delete-record}
 
 This HTTP RESTful endpoint deletes a single specific record from the database.
 

--- a/docs/integration/http.mdx
+++ b/docs/integration/http.mdx
@@ -195,15 +195,6 @@ This HTTP RESTful endpoint exports all data for a specific Namespace and Databas
         </tr>
         <tr>
             <td colspan="2">
-                <code>Accept</code>
-                <l className='yellow'>REQUIRED</l>
-            </td>
-            <td>
-                Sets the desired content-type of the response
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2">
                 <code>NS</code>
                 <l className='grey'>OPTIONAL</l>
             </td>

--- a/versioned_docs/version-nightly/integration/http.mdx
+++ b/versioned_docs/version-nightly/integration/http.mdx
@@ -69,23 +69,23 @@ The HTTP endpoints enable simple selection and modifications of all records or a
             <td>Deletes all records in a table from the database</td>
         </tr>
         <tr>
-            <td><a href="#get-table-id"><code>GET /key/:table/:id</code></a></td>
+            <td><a href="#get-record"><code>GET /key/:table/:id</code></a></td>
             <td>Selects the specific record from the database</td>
         </tr>
         <tr>
-            <td><a href="#post-table-id"><code>POST /key/:table/:id</code></a></td>
+            <td><a href="#post-record"><code>POST /key/:table/:id</code></a></td>
             <td>Creates the specific record in the database</td>
         </tr>
         <tr>
-            <td><a href="#put-table-id"><code>PUT /key/:table/:id</code></a></td>
+            <td><a href="#put-record"><code>PUT /key/:table/:id</code></a></td>
             <td>Updates the specified record in the database</td>
         </tr>
         <tr>
-            <td><a href="#patch-table-id"><code>PATCH /key/:table/:id</code></a></td>
+            <td><a href="#patch-record"><code>PATCH /key/:table/:id</code></a></td>
             <td>Modifies the specified record in the database</td>
         </tr>
         <tr>
-            <td><a href="#delete-table-id"><code>DELETE /key/:table/:id</code></a></td>
+            <td><a href="#delete-record"><code>DELETE /key/:table/:id</code></a></td>
             <td>Deletes the specified record from the database</td>
         </tr>
         <tr>
@@ -103,7 +103,7 @@ This HTTP RESTful endpoint checks whether the database web server is running, re
 
 <br />
 
-## `GET /health`
+## `GET /health` {#health}
 
 This HTTP RESTful endpoint checks whether the database server and storage engine are running.
 
@@ -117,7 +117,7 @@ This HTTP RESTful endpoint returns the version of the SurrealDB database server.
 
 <br />
 
-## `GET /import`
+## `GET /import` {#import}
 
 This HTTP RESTful endpoint imports a set of SurrealQL queries into a specific Namespace and Database.
 
@@ -171,7 +171,7 @@ This HTTP RESTful endpoint imports a set of SurrealQL queries into a specific Na
 
 <br />
 
-## `GET /export`
+## `GET /export` {#export}
 
 This HTTP RESTful endpoint exports all data for a specific Namespace and Database.
 
@@ -216,7 +216,8 @@ This HTTP RESTful endpoint exports all data for a specific Namespace and Databas
 
 <br />
 
-## `POST /signin`
+## `POST /signin` {#signin}
+
 ```json title="Method and URL"
 POST /signin
 ```
@@ -285,7 +286,7 @@ curl -X POST -H "Accept: application/json" -d '{"user":"john.doe","pass":"123456
 
 <br />
 
-## `POST /signup`
+## `POST /signup` {#signup}
 
 This HTTP RESTful endpoint is used to create an account inside the SurrealDB database server.
 
@@ -632,7 +633,7 @@ DELETE FROM type::table($table);
 
 <br />
 
-## `GET /key/:table/:id` {#get-table-id}
+## `GET /key/:table/:id` {#get-record}
 
 This HTTP RESTful endpoint selects a specific record from the database.
 
@@ -691,7 +692,7 @@ SELECT * FROM type::thing($table, $id);
 
 <br />
 
-## `POST /key/:table/:id` {#post-table-id}
+## `POST /key/:table/:id` {#post-record}
 
 This HTTP RESTful endpoint creates a specific record in a table in the database.
 
@@ -750,7 +751,7 @@ CREATE type::thing($table, $id) CONTENT $body;
 
 <br />
 
-## `PUT /key/:table/:id` {#put-table-id}
+## `PUT /key/:table/:id` {#put-record}
 
 This HTTP RESTful endpoint updates a specific record in a table in the database.
 
@@ -813,7 +814,7 @@ UPDATE type::thing($table, $id) CONTENT $body;
 
 <br />
 
-## `PATCH /key/:table/:id` {#patch-table-id}
+## `PATCH /key/:table/:id` {#patch-record}
 
 This HTTP RESTful endpoint modifies a specific record in a table in the database.
 
@@ -876,7 +877,7 @@ UPDATE type::thing($table, $id) MERGE $body;
 
 <br />
 
-## `DELETE /key/:table/:id` {#delete-table-id}
+## `DELETE /key/:table/:id` {#delete-record}
 
 This HTTP RESTful endpoint deletes a single specific record from the database.
 

--- a/versioned_docs/version-nightly/integration/http.mdx
+++ b/versioned_docs/version-nightly/integration/http.mdx
@@ -195,15 +195,6 @@ This HTTP RESTful endpoint exports all data for a specific Namespace and Databas
         </tr>
         <tr>
             <td colspan="2">
-                <code>Accept</code>
-                <l className='yellow'>REQUIRED</l>
-            </td>
-            <td>
-                Sets the desired content-type of the response
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2">
                 <code>NS</code>
                 <l className='grey'>OPTIONAL</l>
             </td>


### PR DESCRIPTION
Removes an unused header from the HTTP integration page, and fixes header link ids, for in-page navigation.