### PR TITLE
Improve documentation of `exp` and `nbf` token claims

### DIFF
--- a/docs/surrealql/statements/define/token.mdx
+++ b/docs/surrealql/statements/define/token.mdx
@@ -121,6 +121,7 @@ The namespace token payload should at least include the following claims when us
 
 ```json title="JWT Payload"
 {
+  "exp": 2147483647,
   "tk": "token_name",
   "ns": "abcum"
 }
@@ -149,6 +150,7 @@ The database token payload should at least include the following claims when use
 
 ```json title="JWT Payload"
 {
+  "exp": 2147483647,
   "tk": "token_name",
   "ns": "abcum",
   "db": "app_vitalsense"
@@ -211,6 +213,7 @@ The scope token payload should at least include the following claims when used t
 
 ```json title="JWT Payload"
 {
+  "exp": 2147483647,
   "tk": "token_name",
   "ns": "abcum",
   "db": "app_vitalsense",

--- a/docs/surrealql/statements/define/token.mdx
+++ b/docs/surrealql/statements/define/token.mdx
@@ -74,6 +74,7 @@ The `DEFINE TOKEN` statement lets you specify the amount of permission granting 
 
 The following claims should be added to the JWT payload by the issuer of the token:
 
+- `exp`: The token expiration Unix time. The token will not be valid after.
 - `tk`: The name that you chose when defining the token.
 - `ns`: The namespace that the token is issued for.
 - `db`: The database that the token is issued for.
@@ -84,13 +85,13 @@ The names of these claims can be in all lowercase (i.e. `tk`) or all uppercase (
 The following optional claims are also processed by SurrealDB:
 
 - `id`: The identifier of the resource (e.g. user) associated with the token.
-- `exp`: The token expiration in Unix time.
+- `nbf`: The token acceptance Unix time. The token will not be valid before.
 
 The expected claims depend on the level at which the token was defined:
 
-- For tokens defined `ON NAMESPACE`: `tk`, `ns`.
-- For tokens defined `ON DATABASE`: `tk`,`ns`,`db`.
-- For tokens defined `ON SCOPE`: `tk`, `ns`,`db`, `sc`, optionally `id`.
+- For tokens defined `ON NAMESPACE`: `exp`, `tk`, `ns`.
+- For tokens defined `ON DATABASE`: `exp`, `tk`,`ns`,`db`.
+- For tokens defined `ON SCOPE`: `exp`, `tk`, `ns`,`db`, `sc`, optionally `id`.
 
 When calling any of the SurrealDB interfaces using a JWT, SurrealQL queries will gain access to the claims in the token through the `$token` variable. For example, if the token contains custom claims such as “name” or “email”, the values of those claims will be accessible through `$token.name` and `$token.email`.
 


### PR DESCRIPTION
Document that the `exp` token claim is always required and the `nbf` claim is always verified. [Source](https://github.com/surrealdb/surrealdb/blob/bc4ffcb4cf53a400287c864bc6121d9b1d7ea01c/lib/src/iam/verify.rs#L166-L179).