### PR TITLE
Fix nodejs `db.signin()` example

### DIFF
--- a/docs/integration/sdks/nodejs.mdx
+++ b/docs/integration/sdks/nodejs.mdx
@@ -67,8 +67,8 @@ async function main() {
 
 		// Signin as a namespace, database, or root user
 		await db.signin({
-			user: 'root',
-			pass: 'root',
+			username: 'root',
+			password: 'root',
 		});
 
 		// Select a specific namespace / database


### PR DESCRIPTION
I was trying the example from the website and getting this error: 
`[Error: data did not match any variant of untagged enum Credentials`

as it turns out the params name from the website is incorrect