### PR TITLE
Fix search

### DIFF
--- a/src/theme/SearchBar/index.tsx
+++ b/src/theme/SearchBar/index.tsx
@@ -7,6 +7,7 @@ function SearchBar(): JSX.Element | null {
     const dialogRef = useRef<HTMLDialogElement>();
     const [keywords, setKeywords] = useState('');
     const [results, setResults] = useState<Doc[]>([]);
+    const iterRef = useRef<number>(0);
 
     function debounce<F extends (...args: any[]) => void>(func: F, delay: number): (...args: Parameters<F>) => void {
         let inDebounce: NodeJS.Timeout | undefined;
@@ -21,11 +22,13 @@ function SearchBar(): JSX.Element | null {
     }
 
     const debouncedSearch = useCallback(debounce(async (value: string) => {
+        const iter = iterRef.current = iterRef.current + 1;
         if (!value) {
             setResults([]);
         } else if (value !== keywords) {
             try {
-                setResults(await search(value));
+                const res = await search(value);
+                if (iter == iterRef.current) setResults(res);
             } catch (err) {
                 console.error(err);
             }

--- a/src/theme/SearchBar/search.ts
+++ b/src/theme/SearchBar/search.ts
@@ -48,7 +48,6 @@ function getVersion(pathname: string) {
 }
 
 function validateUrl(url: string, version?: string) {
-	console.log(1, getVersion(url));
 	return getVersion(url) == version
 }
 

--- a/src/theme/SearchBar/search.ts
+++ b/src/theme/SearchBar/search.ts
@@ -83,7 +83,7 @@ const templatedQuery = (keywords: string) => {
 					OR h4 @5@ ${escaped}
 					OR content @6@ ${escaped}
 				-- )
-		ORDER BY score DESC LIMIT 100;
+		ORDER BY score DESC LIMIT 20;
 	`;
 };
 

--- a/src/theme/SearchBar/search.ts
+++ b/src/theme/SearchBar/search.ts
@@ -36,7 +36,6 @@ function getHostname() {
 	const mapped = {
 		'docs.surrealdb.com': 'main--surrealdb-docs.netlify.app',
 		'surrealdb-docs.netlify.app': 'main--surrealdb-docs.netlify.app',
-		'localhost': 'main--surrealdb-docs.netlify.app',
 	};
 
 	return mapped[location.hostname] || location.hostname;

--- a/src/theme/SearchBar/search.ts
+++ b/src/theme/SearchBar/search.ts
@@ -23,7 +23,6 @@ export async function search(keywords: string): Promise<Doc[]> {
     const docs = await query(sql);
 	const hostname = getHostname();
 	const version = getVersion(location.pathname);
-	console.log(version);
     const processed = docs
         .filter((match) => {
 			return match.offsets && match.hostname == hostname && validateUrl(match.url, version)


### PR DESCRIPTION
Due to an issue in the query planner, the score of every result would be zero. Solutino for the moment is to match the hostname on the clientside.

Additionally, we now match the version from the current URL against the url in the search result to guarantee correct and no duplicate results, and it could sometimes happen that an older search query would overwrite a newer one. This is fixed too