### PR TITLE
Fix typo for WITH NOINDEX example

### DIFF
--- a/docs/surrealql/statements/select.mdx
+++ b/docs/surrealql/statements/select.mdx
@@ -392,5 +392,5 @@ For instance, the cardinality of an index can be high, potentially even equal to
 SELECT * FROM person WITH INDEX ft_email WHERE email='tobie@surrealdb.com' AND company='SurrealDB';
 
 -- forces the usage of the table iterator
-SELECT name FROM person WITH INDEX idx_name WHERE job='engineer' AND genre = 'm';
+SELECT name FROM person WITH INDEX NOINDEX WHERE job='engineer' AND genre = 'm';
 ```


### PR DESCRIPTION
The comment reads `--force the usage of the table iterator` but according to the doc above, that should require the keyword `NOINDEX,` not `idx_name` as currently shown.