### PR TITLE
Fix mistake in geomterics data model documentation

### DIFF
--- a/docs/surrealql/datamodel/geometries.mdx
+++ b/docs/surrealql/datamodel/geometries.mdx
@@ -144,7 +144,6 @@ MultiLines can be used to store multiple geometry lines in a single value.
 :::
 
 ```surql
-UPDATE person:tobie SET locations = {
 UPDATE travel:yellowstone SET routes = {
 	type: "MultiLineString",
 	coordinates: [


### PR DESCRIPTION
Pretty certain copy-pasta from preceding in documentation example crept in

<img width="1222" alt="Screenshot 2023-12-13 at 16 42 59" src="https://github.com/surrealdb/docs.surrealdb.com/assets/10528835/f5c9c620-0f17-41e2-9760-5039f190b7b2">
