### PR TITLE
Fixed typo in Rust SDK Update examples

### DIFF
--- a/docs/embedding/rust.mdx
+++ b/docs/embedding/rust.mdx
@@ -822,7 +822,7 @@ UPDATE $resource CONTENT $data;
 
 <br />
 
-## `.update().nerge()` {#update-merge}
+## `.update().merge()` {#update-merge}
 
 Modifies all records in a table, or a specific record, in the database.
 


### PR DESCRIPTION
Fixed a typo in the word merge. The example had the example written, ".update().nerge()", when the correct text would be, ".update().merge()".