### PR TITLE
Update the description in example of the use of DEFINE SCOPE

### DIFF
--- a/docs/surrealql/statements/define/scope.mdx
+++ b/docs/surrealql/statements/define/scope.mdx
@@ -19,7 +19,7 @@ DEFINE SCOPE @name SESSION @duration SIGNUP @expression SIGNIN @expression
 ```
 
 ## Example usuage 
-Below shows how you can create a namespace using the `DEFINE PARAM` statement.
+Below shows how you can create a scope using the `DEFINE SCOPE` statement.
 
 ```surql
 -- Enable scope authentication directly in SurrealDB


### PR DESCRIPTION
The description was written for `DEFINE PARAMS` yet the example is intended for `DEFINE SCOPE`