### PR TITLE
Doc: Fix spelling

### DIFF
--- a/docs/surrealql/statements/define/event.mdx
+++ b/docs/surrealql/statements/define/event.mdx
@@ -18,7 +18,7 @@ Events can be triggered after any change or modification to the data in a record
 DEFINE EVENT @name ON [ TABLE ] @table [ WHEN @expression ] THEN @expression
 ```
 
-## Example usuage 
+## Example usage
 
 Below is an example showing how to create an event which upon updating a user's email address will create an entry recording the change on an `event` table.
 


### PR DESCRIPTION
The `DEFINE EVENT statement` page had a misspelling of `usuage` -> `usage`, and I removed the trailing space.