### PR TITLE
Docs: fix spelling

### DIFF
--- a/docs/surrealql/statements/define/database.mdx
+++ b/docs/surrealql/statements/define/database.mdx
@@ -18,7 +18,7 @@ The `DEFINE DATABASE` statement allows you to instantiate a named database, enab
 DEFINE DATABASE @name
 ```
 
-## Example usuage 
+## Example usage 
 Below shows how you can create a database using the DEFINE DATABASE statement.
 
 ```surql

--- a/docs/surrealql/statements/define/event.mdx
+++ b/docs/surrealql/statements/define/event.mdx
@@ -18,7 +18,7 @@ Events can be triggered after any change or modification to the data in a record
 DEFINE EVENT @name ON [ TABLE ] @table [ WHEN @expression ] THEN @expression
 ```
 
-## Example usuage 
+## Example usage
 
 Below is an example showing how to create an event which upon updating a user's email address will create an entry recording the change on an `event` table.
 

--- a/docs/surrealql/statements/define/field.mdx
+++ b/docs/surrealql/statements/define/field.mdx
@@ -28,7 +28,7 @@ DEFINE FIELD @name ON [ TABLE ] @table
 	] ]
 ```
 
-## Example usuage 
+## Example usage 
 
 The following expression shows the simplest way to use the `DEFINE FIELD` statement.
 

--- a/docs/surrealql/statements/define/function.mdx
+++ b/docs/surrealql/statements/define/function.mdx
@@ -23,7 +23,7 @@ DEFINE FUNCTION fn::@name(
 }
 ```
 
-## Example usuage 
+## Example usage 
 Below shows how you can define a custom function using the `DEFINE FUNCTION` statement, and how to call it.
 
 ```surql

--- a/docs/surrealql/statements/define/namespace.mdx
+++ b/docs/surrealql/statements/define/namespace.mdx
@@ -19,7 +19,7 @@ Let's say that you're using SurrealDB to create a multi-tenant SaaS application.
 DEFINE NAMESPACE @name
 ```
 
-## Example usuage 
+## Example usage 
 Below shows how you can create a namespace using the `DEFINE NAMESPACE` statement.
 
 ```surql

--- a/docs/surrealql/statements/define/param.mdx
+++ b/docs/surrealql/statements/define/param.mdx
@@ -18,7 +18,7 @@ The `DEFINE PARAM` statement allows you to define global (database-wide) paramet
 DEFINE PARAM $@name VALUE @value;
 ```
 
-## Example usuage 
+## Example usage 
 Below shows how you can create a namespace using the `DEFINE PARAM` statement.
 
 ```surql

--- a/docs/surrealql/statements/define/scope.mdx
+++ b/docs/surrealql/statements/define/scope.mdx
@@ -18,7 +18,7 @@ Setting scope access allows SurrealDB to operate as a web database. With scopes 
 DEFINE SCOPE @name SESSION @duration SIGNUP @expression SIGNIN @expression
 ```
 
-## Example usuage 
+## Example usage 
 Below shows how you can create a scope using the `DEFINE SCOPE` statement.
 
 ```surql

--- a/docs/surrealql/statements/define/table.mdx
+++ b/docs/surrealql/statements/define/table.mdx
@@ -32,7 +32,7 @@ DEFINE TABLE @name
 	] ]
 ```
 
-## Example usuage 
+## Example usage 
 Below shows how you can create a namespace using the `DEFINE TABLE` statement.
 
 ```surql

--- a/docs/surrealql/statements/define/user.mdx
+++ b/docs/surrealql/statements/define/user.mdx
@@ -33,7 +33,7 @@ Use the `DEFINE USER` statement to create system users on SurrealDB
 DEFINE TOKEN @name ON [ NAMESPACE | DATABASE | SCOPE @scope ] TYPE @type VALUE @value
 ```
 
-## Example usuage 
+## Example usage 
 The following example shows how you can create a `ROOT` user using the `DEFINE USER` statement.
 
 ```surql

--- a/versioned_docs/version-1.1.0/surrealql/statements/define/database.mdx
+++ b/versioned_docs/version-1.1.0/surrealql/statements/define/database.mdx
@@ -18,7 +18,7 @@ The `DEFINE DATABASE` statement allows you to instantiate a named database, enab
 DEFINE DATABASE @name
 ```
 
-## Example usuage 
+## Example usage 
 Below shows how you can create a database using the DEFINE DATABASE statement.
 
 ```surql

--- a/versioned_docs/version-1.1.0/surrealql/statements/define/event.mdx
+++ b/versioned_docs/version-1.1.0/surrealql/statements/define/event.mdx
@@ -18,7 +18,7 @@ Events can be triggered after any change or modification to the data in a record
 DEFINE EVENT @name ON [ TABLE ] @table [ WHEN @expression ] THEN @expression
 ```
 
-## Example usuage 
+## Example usage 
 
 Below is an example showing how to create an event which upon updating a user's email address will create an entry recording the change on an `event` table.
 

--- a/versioned_docs/version-1.1.0/surrealql/statements/define/field.mdx
+++ b/versioned_docs/version-1.1.0/surrealql/statements/define/field.mdx
@@ -28,7 +28,7 @@ DEFINE FIELD @name ON [ TABLE ] @table
 	] ]
 ```
 
-## Example usuage 
+## Example usage 
 
 The following expression shows the simplest way to use the `DEFINE FIELD` statement.
 

--- a/versioned_docs/version-1.1.0/surrealql/statements/define/function.mdx
+++ b/versioned_docs/version-1.1.0/surrealql/statements/define/function.mdx
@@ -23,7 +23,7 @@ DEFINE FUNCTION fn::@name(
 }
 ```
 
-## Example usuage 
+## Example usage 
 Below shows how you can define a custom function using the `DEFINE FUNCTION` statement, and how to call it.
 
 ```surql

--- a/versioned_docs/version-1.1.0/surrealql/statements/define/namespace.mdx
+++ b/versioned_docs/version-1.1.0/surrealql/statements/define/namespace.mdx
@@ -19,7 +19,7 @@ Let's say that you're using SurrealDB to create a multi-tenant SaaS application.
 DEFINE NAMESPACE @name
 ```
 
-## Example usuage 
+## Example usage 
 Below shows how you can create a namespace using the `DEFINE NAMESPACE` statement.
 
 ```surql

--- a/versioned_docs/version-1.1.0/surrealql/statements/define/param.mdx
+++ b/versioned_docs/version-1.1.0/surrealql/statements/define/param.mdx
@@ -18,7 +18,7 @@ The `DEFINE PARAM` statement allows you to define global (database-wide) paramet
 DEFINE PARAM $@name VALUE @value;
 ```
 
-## Example usuage 
+## Example usage 
 Below shows how you can create a namespace using the `DEFINE PARAM` statement.
 
 ```surql

--- a/versioned_docs/version-1.1.0/surrealql/statements/define/scope.mdx
+++ b/versioned_docs/version-1.1.0/surrealql/statements/define/scope.mdx
@@ -18,7 +18,7 @@ Setting scope access allows SurrealDB to operate as a web database. With scopes 
 DEFINE SCOPE @name SESSION @duration SIGNUP @expression SIGNIN @expression
 ```
 
-## Example usuage 
+## Example usage 
 Below shows how you can create a namespace using the `DEFINE PARAM` statement.
 
 ```surql

--- a/versioned_docs/version-1.1.0/surrealql/statements/define/table.mdx
+++ b/versioned_docs/version-1.1.0/surrealql/statements/define/table.mdx
@@ -32,7 +32,7 @@ DEFINE TABLE @name
 	] ]
 ```
 
-## Example usuage 
+## Example usage 
 Below shows how you can create a namespace using the `DEFINE TABLE` statement.
 
 ```surql

--- a/versioned_docs/version-1.1.0/surrealql/statements/define/user.mdx
+++ b/versioned_docs/version-1.1.0/surrealql/statements/define/user.mdx
@@ -33,7 +33,7 @@ Use the `DEFINE USER` statement to create system users on SurrealDB
 DEFINE TOKEN @name ON [ NAMESPACE | DATABASE | SCOPE @scope ] TYPE @type VALUE @value
 ```
 
-## Example usuage 
+## Example usage 
 The following example shows how you can create a `ROOT` user using the `DEFINE USER` statement.
 
 ```surql

--- a/versioned_docs/version-nightly/surrealql/statements/define/database.mdx
+++ b/versioned_docs/version-nightly/surrealql/statements/define/database.mdx
@@ -18,7 +18,7 @@ The `DEFINE DATABASE` statement allows you to instantiate a named database, enab
 DEFINE DATABASE @name
 ```
 
-## Example usuage 
+## Example usage 
 Below shows how you can create a database using the DEFINE DATABASE statement.
 
 ```surql

--- a/versioned_docs/version-nightly/surrealql/statements/define/event.mdx
+++ b/versioned_docs/version-nightly/surrealql/statements/define/event.mdx
@@ -18,7 +18,7 @@ Events can be triggered after any change or modification to the data in a record
 DEFINE EVENT @name ON [ TABLE ] @table [ WHEN @expression ] THEN @expression
 ```
 
-## Example usuage 
+## Example usage 
 
 Below is an example showing how to create an event which upon updating a user's email address will create an entry recording the change on an `event` table.
 

--- a/versioned_docs/version-nightly/surrealql/statements/define/field.mdx
+++ b/versioned_docs/version-nightly/surrealql/statements/define/field.mdx
@@ -28,7 +28,7 @@ DEFINE FIELD @name ON [ TABLE ] @table
 	] ]
 ```
 
-## Example usuage 
+## Example usage 
 
 The following expression shows the simplest way to use the `DEFINE FIELD` statement.
 

--- a/versioned_docs/version-nightly/surrealql/statements/define/function.mdx
+++ b/versioned_docs/version-nightly/surrealql/statements/define/function.mdx
@@ -23,7 +23,7 @@ DEFINE FUNCTION fn::@name(
 }
 ```
 
-## Example usuage 
+## Example usage 
 Below shows how you can define a custom function using the `DEFINE FUNCTION` statement, and how to call it.
 
 ```surql

--- a/versioned_docs/version-nightly/surrealql/statements/define/namespace.mdx
+++ b/versioned_docs/version-nightly/surrealql/statements/define/namespace.mdx
@@ -19,7 +19,7 @@ Let's say that you're using SurrealDB to create a multi-tenant SaaS application.
 DEFINE NAMESPACE @name
 ```
 
-## Example usuage 
+## Example usage 
 Below shows how you can create a namespace using the `DEFINE NAMESPACE` statement.
 
 ```surql

--- a/versioned_docs/version-nightly/surrealql/statements/define/param.mdx
+++ b/versioned_docs/version-nightly/surrealql/statements/define/param.mdx
@@ -18,7 +18,7 @@ The `DEFINE PARAM` statement allows you to define global (database-wide) paramet
 DEFINE PARAM $@name VALUE @value;
 ```
 
-## Example usuage 
+## Example usage 
 Below shows how you can create a namespace using the `DEFINE PARAM` statement.
 
 ```surql

--- a/versioned_docs/version-nightly/surrealql/statements/define/scope.mdx
+++ b/versioned_docs/version-nightly/surrealql/statements/define/scope.mdx
@@ -18,7 +18,7 @@ Setting scope access allows SurrealDB to operate as a web database. With scopes 
 DEFINE SCOPE @name SESSION @duration SIGNUP @expression SIGNIN @expression
 ```
 
-## Example usuage 
+## Example usage 
 Below shows how you can create a namespace using the `DEFINE PARAM` statement.
 
 ```surql

--- a/versioned_docs/version-nightly/surrealql/statements/define/table.mdx
+++ b/versioned_docs/version-nightly/surrealql/statements/define/table.mdx
@@ -32,7 +32,7 @@ DEFINE TABLE @name
 	] ]
 ```
 
-## Example usuage 
+## Example usage 
 Below shows how you can create a namespace using the `DEFINE TABLE` statement.
 
 ```surql

--- a/versioned_docs/version-nightly/surrealql/statements/define/user.mdx
+++ b/versioned_docs/version-nightly/surrealql/statements/define/user.mdx
@@ -33,7 +33,7 @@ Use the `DEFINE USER` statement to create system users on SurrealDB
 DEFINE TOKEN @name ON [ NAMESPACE | DATABASE | SCOPE @scope ] TYPE @type VALUE @value
 ```
 
-## Example usuage 
+## Example usage 
 The following example shows how you can create a `ROOT` user using the `DEFINE USER` statement.
 
 ```surql


### PR DESCRIPTION
The `DEFINE EVENT statement` page had a misspelling of `usuage` -> `usage`, and I removed the trailing space.

Note: This is my second attempt at this PR because the first time I didn't realize that a vscode extension was mucking everything up :)