### PR TITLE
fix: typo `DEFINE TOKEN` to `DEFINE USER`

### DIFF
--- a/docs/surrealql/statements/define/user.mdx
+++ b/docs/surrealql/statements/define/user.mdx
@@ -30,7 +30,7 @@ Use the `DEFINE USER` statement to create system users on SurrealDB
 ## Statement syntax
 
 ```surql title="SurrealQL Syntax"
-DEFINE TOKEN @name ON [ NAMESPACE | DATABASE | SCOPE @scope ] TYPE @type VALUE @value
+DEFINE USER @name ON [ NAMESPACE | DATABASE | SCOPE @scope ] TYPE @type VALUE @value
 ```
 
 ## Example usuage 


### PR DESCRIPTION
This may be intentional, but I believe this is a typo.