### PR TITLE
Fix icons on docs SDKs page

### DIFF
--- a/src/components/SDK/sdks_container.mdx
+++ b/src/components/SDK/sdks_container.mdx
@@ -296,12 +296,12 @@ import SDKClientBoxes from './SDKClientBoxes.mdx';
     },
     {
       icon: <ThemedImage
-            alt="Nuxt.js"
+            alt="Nest.js"
             width="35"
             className="devicon"
             sources={{
-              light: useBaseUrl('img/light/nuxtjs.png'),
-              dark: useBaseUrl('img/nuxtjs-icon.png'),
+              light: useBaseUrl('img/light/nestjs.png'),
+              dark: useBaseUrl('img/nestjs-icon.png'),
             }}
           />,
       label: 'Nest.js',

--- a/src/components/SDK/sdks_container.mdx
+++ b/src/components/SDK/sdks_container.mdx
@@ -218,7 +218,7 @@ import SDKClientBoxes from './SDKClientBoxes.mdx';
     },
     {
       icon: <ThemedImage
-            alt="Javascript"
+            alt="Ember.js"
             width="35"
             className="devicon"
             sources={{


### PR DESCRIPTION
Fix alt tag for ember icon and replace nest.js icon correct image instead of nuxt's icon