### PR TITLE
fix typo

### DIFF
--- a/docs/cli/start.mdx
+++ b/docs/cli/start.mdx
@@ -61,7 +61,7 @@ The start command starts a SurrealDB server in memory, on disk, or in a distribu
         </tr>
         <tr>
             <td colspan="2">
-                <code>-auth</code>
+                <code>--auth</code>
                 <l className='grey'>OPTIONAL</l>
             </td>
             <td>


### PR DESCRIPTION
The docs missed one dash in the cli args