### PR TITLE
Fixed future example

### DIFF
--- a/docs/surrealql/datamodel/futures.mdx
+++ b/docs/surrealql/datamodel/futures.mdx
@@ -22,7 +22,7 @@ Futures can be used to calculate values which dynamically change based on other 
 
 ```surql
 CREATE person SET
-	birthday = "2007-06-22",
+	birthday = <datetime> "2007-06-22",
 	can_drive = <future> { time::now() > birthday + 18y }
 ;
 ```


### PR DESCRIPTION
The date doesn't get automatically parsed as a datetime, since it lacks a time component. This will result in an error when attempting to add the duration to the string. Including the explicit cast to a datetime fixes it.

[Fixes #3235](https://github.com/surrealdb/surrealdb/issues/3235)