### PR TITLE
Fetch and display latest surrealdb version

### DIFF
--- a/docs/installation/linux.mdx
+++ b/docs/installation/linux.mdx
@@ -4,6 +4,7 @@ sidebar_position: 3
 
 import ThemedImage from '@theme/ThemedImage';
 import useBaseUrl from '@docusaurus/useBaseUrl';
+import Version from '../../src/components/Version';
 
 # Install on Linux
 
@@ -29,7 +30,7 @@ curl -sSf https://install.surrealdb.com | sh
 ```
 
 ### Updating SurrealDB
-To ensure that you are using the latest version, update SurrealDB to version `v1.0.0` using the following command.
+To ensure that you are using the latest version, update SurrealDB to version <Version /> using the following command.
 
 ```bash
 curl -sSf https://install.surrealdb.com | sh

--- a/docs/installation/macos.mdx
+++ b/docs/installation/macos.mdx
@@ -4,6 +4,7 @@ sidebar_position: 2
 
 import ThemedImage from '@theme/ThemedImage';
 import useBaseUrl from '@docusaurus/useBaseUrl';
+import Version from '../../src/components/Version';
 
 # Install on macOS
 
@@ -31,7 +32,7 @@ curl -sSf https://install.surrealdb.com | sh
 ```
 
 ### Updating SurrealDB
-To ensure that you are using the latest version, update SurrealDB to version `v1.0.0` using the following command.
+To ensure that you are using the latest version, update SurrealDB to version <Version /> using the following command.
 
 ```bash
 curl -sSf https://install.surrealdb.com | sh
@@ -45,7 +46,7 @@ brew install surrealdb/tap/surreal
 ```
 
 ### Updating SurrealDB
-To ensure that you are using the latest version, update SurrealDB to version `v1.0.0` using the following command.
+To ensure that you are using the latest version, update SurrealDB to version <Version /> using the following command.
 
 ```bash
 brew upgrade surrealdb/tap/surreal

--- a/docs/installation/windows.mdx
+++ b/docs/installation/windows.mdx
@@ -4,6 +4,7 @@ sidebar_position: 4
 
 import ThemedImage from '@theme/ThemedImage';
 import useBaseUrl from '@docusaurus/useBaseUrl';
+import Version from '../../src/components/Version';
 
 # Install on Windows
 
@@ -30,7 +31,7 @@ iwr https://windows.surrealdb.com -useb | iex
 ```
 
 ### Updating SurrealDB
-To ensure that you are using the latest version, update SurrealDB to version `v1.0.0` using the following command.
+To ensure that you are using the latest version, update SurrealDB to version <Version /> using the following command.
 
 ```bash
 iwr https://windows.surrealdb.com -useb | iex
@@ -94,7 +95,7 @@ choco install surrealdb
 ```
 
 ### Updating SurrealDB
-To ensure that you are using the latest version, update SurrealDB to version `v1.0.0` using the following command.
+To ensure that you are using the latest version, update SurrealDB to version <Version /> using the following command.
 
 ```bash
 choco update surrealdb
@@ -109,7 +110,7 @@ scoop install surrealdb
 
 ### Updating SurrealDB
 
-To ensure that you are using the latest version, update SurrealDB to version `v1.0.0` using the following command.
+To ensure that you are using the latest version, update SurrealDB to version <Version /> using the following command.
 
 ```bash
 scoop update surrealdb

--- a/docs/intro.mdx
+++ b/docs/intro.mdx
@@ -5,7 +5,8 @@ pagination_next: null
 
 import ThemedImage from '@theme/ThemedImage';
 import useBaseUrl from '@docusaurus/useBaseUrl';
-import SdkContainer from '../src/components/SDK/sdks_container.mdx'
+import SdkContainer from '../src/components/SDK/sdks_container.mdx';
+import Version from '../src/components/Version';
 
 # Overview
 
@@ -35,7 +36,7 @@ SurrealDB makes building and scaling realtime apps dramatically quicker and easi
 
 To quickly test out SurrealDB and [SurrealQL](/docs/surrealql/overview) functionality, we've included [demo dataset](/docs/surrealql/demo) which you can download and [<code>import</code> ](/docs/cli/import)into your SurrealDB instance.
 
-<span>The current version of SurrealDB </span><span> is <a href='https://surrealdb.com/releases'> <code> v1.0.0 </code> </a></span>
+<span>The current version of SurrealDB </span><span> is <a href='https://surrealdb.com/releases'> <Version /> </a></span>
 
 
 ## SDKs

--- a/src/components/Version/index.tsx
+++ b/src/components/Version/index.tsx
@@ -1,0 +1,24 @@
+import React, { useState, useEffect } from "react";
+
+function Version(): JSX.Element | null {
+  const [version, setVersion] = useState(null);
+
+  useEffect(() => {
+    const fetchVersion = async () => {
+      const result = await fetch("https://crates.io/api/v1/crates/surrealdb/versions");
+      const data = await result.json();
+
+      setVersion(data["versions"][0]["num"]);
+    };
+
+    fetchVersion();
+  }, []);
+
+  if (!version) {
+    return null;
+  }
+
+  return <code>v{version}</code>;
+}
+
+export default React.memo(Version);

--- a/versioned_docs/version-1.1.0/installation/linux.mdx
+++ b/versioned_docs/version-1.1.0/installation/linux.mdx
@@ -4,6 +4,7 @@ sidebar_position: 3
 
 import ThemedImage from '@theme/ThemedImage';
 import useBaseUrl from '@docusaurus/useBaseUrl';
+import Version from '../../../src/components/Version';
 
 # Install on Linux
 
@@ -29,7 +30,7 @@ curl -sSf https://install.surrealdb.com | sh
 ```
 
 ### Updating SurrealDB
-To ensure that you are using the latest version, update SurrealDB to version `v1.0.0` using the following command.
+To ensure that you are using the latest version, update SurrealDB to version <Version /> using the following command.
 
 ```bash
 curl -sSf https://install.surrealdb.com | sh

--- a/versioned_docs/version-1.1.0/installation/macos.mdx
+++ b/versioned_docs/version-1.1.0/installation/macos.mdx
@@ -4,6 +4,7 @@ sidebar_position: 2
 
 import ThemedImage from '@theme/ThemedImage';
 import useBaseUrl from '@docusaurus/useBaseUrl';
+import Version from '../../../src/components/Version';
 
 # Install on macOS
 
@@ -30,7 +31,7 @@ curl -sSf https://install.surrealdb.com | sh
 ```
 
 ### Updating SurrealDB
-To ensure that you are using the latest version, update SurrealDB to version `v1.0.0` using the following command.
+To ensure that you are using the latest version, update SurrealDB to version <Version /> using the following command.
 
 ```bash
 curl -sSf https://install.surrealdb.com | sh
@@ -93,7 +94,7 @@ brew install surrealdb/tap/surreal
 ```
 
 ### Updating SurrealDB
-To ensure that you are using the latest version, update SurrealDB to version `v1.0.0` using the following command.
+To ensure that you are using the latest version, update SurrealDB to version <Version /> using the following command.
 
 ```bash
 brew upgrade surrealdb/tap/surreal

--- a/versioned_docs/version-1.1.0/installation/windows.mdx
+++ b/versioned_docs/version-1.1.0/installation/windows.mdx
@@ -4,6 +4,7 @@ sidebar_position: 4
 
 import ThemedImage from '@theme/ThemedImage';
 import useBaseUrl from '@docusaurus/useBaseUrl';
+import Version from '../../../src/components/Version';
 
 # Install on Windows
 
@@ -30,7 +31,7 @@ iwr https://windows.surrealdb.com -useb | iex
 ```
 
 ### Updating SurrealDB
-To ensure that you are using the latest version, update SurrealDB to version `v1.0.0` using the following command.
+To ensure that you are using the latest version, update SurrealDB to version <Version /> using the following command.
 
 ```bash
 iwr https://windows.surrealdb.com -useb | iex
@@ -94,7 +95,7 @@ choco install surrealdb
 ```
 
 ### Updating SurrealDB
-To ensure that you are using the latest version, update SurrealDB to version `v1.0.0` using the following command.
+To ensure that you are using the latest version, update SurrealDB to version <Version /> using the following command.
 
 ```bash
 choco update surrealdb
@@ -109,7 +110,7 @@ scoop install surrealdb
 
 ### Updating SurrealDB
 
-To ensure that you are using the latest version, update SurrealDB to version `v1.0.0` using the following command.
+To ensure that you are using the latest version, update SurrealDB to version <Version /> using the following command.
 
 ```bash
 scoop update surrealdb

--- a/versioned_docs/version-1.1.0/intro.mdx
+++ b/versioned_docs/version-1.1.0/intro.mdx
@@ -4,7 +4,8 @@ sidebar_position: 1
 
 import ThemedImage from '@theme/ThemedImage';
 import useBaseUrl from '@docusaurus/useBaseUrl';
-import SdkContainer from '../../src/components/SDK/sdks_container.mdx'
+import SdkContainer from '../../src/components/SDK/sdks_container.mdx';
+import Version from '../../src/components/Version';
 
 # Overview
 
@@ -34,7 +35,7 @@ SurrealDB makes building and scaling realtime apps dramatically quicker and easi
 
 To quickly test out SurrealDB and [SurrealQL](/docs/nightly/surrealql/overview) functionality, we've included [demo dataset](/docs/nightly/surrealql/demo) which you can download and [<code>import</code> ](/docs/nightly/cli/import)into your SurrealDB instance.
 
-<span>The current version of SurrealDB </span><span> is <a href='https://surrealdb.com/releases'> <code> v1.0.0 </code> </a></span>
+<span>The current version of SurrealDB </span><span> is <a href='https://surrealdb.com/releases'> <Version /> </a></span>
 
 
 ## SDKs

--- a/versioned_docs/version-nightly/installation/linux.mdx
+++ b/versioned_docs/version-nightly/installation/linux.mdx
@@ -4,6 +4,7 @@ sidebar_position: 3
 
 import ThemedImage from '@theme/ThemedImage';
 import useBaseUrl from '@docusaurus/useBaseUrl';
+import Version from '../../../src/components/Version';
 
 # Install on Linux
 
@@ -29,7 +30,7 @@ curl -sSf https://install.surrealdb.com | sh
 ```
 
 ### Updating SurrealDB
-To ensure that you are using the latest version, update SurrealDB to version `v1.0.0` using the following command.
+To ensure that you are using the latest version, update SurrealDB to version <Version /> using the following command.
 
 ```bash
 curl -sSf https://install.surrealdb.com | sh

--- a/versioned_docs/version-nightly/installation/macos.mdx
+++ b/versioned_docs/version-nightly/installation/macos.mdx
@@ -4,6 +4,7 @@ sidebar_position: 2
 
 import ThemedImage from '@theme/ThemedImage';
 import useBaseUrl from '@docusaurus/useBaseUrl';
+import Version from '../../../src/components/Version';
 
 # Install on macOS
 
@@ -30,7 +31,7 @@ curl -sSf https://install.surrealdb.com | sh
 ```
 
 ### Updating SurrealDB
-To ensure that you are using the latest version, update SurrealDB to version `v1.0.0` using the following command.
+To ensure that you are using the latest version, update SurrealDB to version <Version /> using the following command.
 
 ```bash
 curl -sSf https://install.surrealdb.com | sh
@@ -93,7 +94,7 @@ brew install surrealdb/tap/surreal
 ```
 
 ### Updating SurrealDB
-To ensure that you are using the latest version, update SurrealDB to version `v1.0.0` using the following command.
+To ensure that you are using the latest version, update SurrealDB to version <Version /> using the following command.
 
 ```bash
 brew upgrade surrealdb/tap/surreal

--- a/versioned_docs/version-nightly/intro.mdx
+++ b/versioned_docs/version-nightly/intro.mdx
@@ -4,7 +4,8 @@ sidebar_position: 1
 
 import ThemedImage from '@theme/ThemedImage';
 import useBaseUrl from '@docusaurus/useBaseUrl';
-import SdkContainer from '../../src/components/SDK/sdks_container.mdx'
+import SdkContainer from '../../src/components/SDK/sdks_container.mdx';
+import Version from '../../src/components/Version';
 
 # Overview
 
@@ -34,7 +35,7 @@ SurrealDB makes building and scaling realtime apps dramatically quicker and easi
 
 To quickly test out SurrealDB and [SurrealQL](/docs/nightly/surrealql/overview) functionality, we've included [demo dataset](/docs/nightly/surrealql/demo) which you can download and [<code>import</code> ](/docs/nightly/cli/import)into your SurrealDB instance.
 
-<span>The current version of SurrealDB </span><span> is <a href='https://surrealdb.com/releases'> <code> v1.0.0 </code> </a></span>
+<span>The current version of SurrealDB </span><span> is <a href='https://surrealdb.com/releases'> <Version /> </a></span>
 
 
 ## SDKs


### PR DESCRIPTION
I noticed that current displayed version is `v1.0.0` when the current version is `v1.0.2`. This PR adds a new `Version` component that will fetch the current version from `crates.io` API, having the ability to display the current version dynamically.