### PR TITLE
fix params type for duration::from::* functions

### DIFF
--- a/docs/surrealql/functions/duration.mdx
+++ b/docs/surrealql/functions/duration.mdx
@@ -250,7 +250,7 @@ RETURN duration::years(300w);
 The `duration::years` function counts how many years fit into a duration.
 
 ```surql title="API DEFINITION"
-duration::from::days(number) -> duration
+duration::from::days(int) -> duration
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
@@ -267,7 +267,7 @@ RETURN duration::from::days(3);
 The `duration::from::hours` function converts a numeric amount of hours into a duration that represents hours.
 
 ```surql title="API DEFINITION"
-duration::from::hours(number) -> duration
+duration::from::hours(int) -> duration
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
@@ -284,7 +284,7 @@ RETURN duration::from::hours(3);
 The `duration::from::micros` function converts a numeric amount of microseconds into a duration that represents microseconds.
 
 ```surql title="API DEFINITION"
-duration::from::micros(number) -> duration
+duration::from::micros(int) -> duration
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
@@ -301,7 +301,7 @@ RETURN duration::from::micros(3);
 The `duration::from::millis` function converts a numeric amount of milliseconds into a duration that represents milliseconds.
 
 ```surql title="API DEFINITION"
-duration::from::millis(number) -> duration
+duration::from::millis(int) -> duration
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
@@ -318,7 +318,7 @@ RETURN duration::from::millis(3);
 The `duration::from::mins` function converts a numeric amount of minutes into a duration that represents minutes.
 
 ```surql title="API DEFINITION"
-duration::from::mins(number) -> duration
+duration::from::mins(int) -> duration
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
@@ -335,7 +335,7 @@ RETURN duration::from::mins(3);
 The `duration::from::nanos` function converts a numeric amount of nanoseconds into a duration that represents nanoseconds.
 
 ```surql title="API DEFINITION"
-duration::from::nanos(number) -> duration
+duration::from::nanos(int) -> duration
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
@@ -352,7 +352,7 @@ RETURN duration::from::nanos(3);
 The `duration::from::secs` function converts a numeric amount of seconds into a duration that represents seconds.
 
 ```surql title="API DEFINITION"
-duration::from::secs(number) -> duration
+duration::from::secs(int) -> duration
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
@@ -369,7 +369,7 @@ RETURN duration::from::secs(3);
 The `duration::from::days` function converts a numeric amount of weeks into a duration that represents weeks.
 
 ```surql title="API DEFINITION"
-duration::from::weeks(number) -> duration
+duration::from::weeks(int) -> duration
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 

--- a/versioned_docs/version-1.1.0/surrealql/functions/duration.mdx
+++ b/versioned_docs/version-1.1.0/surrealql/functions/duration.mdx
@@ -250,7 +250,7 @@ RETURN duration::years(300w);
 The `duration::years` function counts how many years fit into a duration.
 
 ```surql title="API DEFINITION"
-duration::from::days(number) -> duration
+duration::from::days(int) -> duration
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
@@ -267,7 +267,7 @@ RETURN duration::from::days(3);
 The `duration::from::hours` function converts a numeric amount of hours into a duration that represents hours.
 
 ```surql title="API DEFINITION"
-duration::from::hours(number) -> duration
+duration::from::hours(int) -> duration
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
@@ -284,7 +284,7 @@ RETURN duration::from::hours(3);
 The `duration::from::micros` function converts a numeric amount of microseconds into a duration that represents microseconds.
 
 ```surql title="API DEFINITION"
-duration::from::micros(number) -> duration
+duration::from::micros(int) -> duration
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
@@ -301,7 +301,7 @@ RETURN duration::from::micros(3);
 The `duration::from::millis` function converts a numeric amount of milliseconds into a duration that represents milliseconds.
 
 ```surql title="API DEFINITION"
-duration::from::millis(number) -> duration
+duration::from::millis(int) -> duration
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
@@ -318,7 +318,7 @@ RETURN duration::from::millis(3);
 The `duration::from::mins` function converts a numeric amount of minutes into a duration that represents minutes.
 
 ```surql title="API DEFINITION"
-duration::from::mins(number) -> duration
+duration::from::mins(int) -> duration
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
@@ -335,7 +335,7 @@ RETURN duration::from::mins(3);
 The `duration::from::nanos` function converts a numeric amount of nanoseconds into a duration that represents nanoseconds.
 
 ```surql title="API DEFINITION"
-duration::from::nanos(number) -> duration
+duration::from::nanos(int) -> duration
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
@@ -352,7 +352,7 @@ RETURN duration::from::nanos(3);
 The `duration::from::secs` function converts a numeric amount of seconds into a duration that represents seconds.
 
 ```surql title="API DEFINITION"
-duration::from::secs(number) -> duration
+duration::from::secs(int) -> duration
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
@@ -369,7 +369,7 @@ RETURN duration::from::secs(3);
 The `duration::from::days` function converts a numeric amount of weeks into a duration that represents weeks.
 
 ```surql title="API DEFINITION"
-duration::from::weeks(number) -> duration
+duration::from::weeks(int) -> duration
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 

--- a/versioned_docs/version-nightly/surrealql/functions/duration.mdx
+++ b/versioned_docs/version-nightly/surrealql/functions/duration.mdx
@@ -250,7 +250,7 @@ RETURN duration::years(300w);
 The `duration::years` function counts how many years fit into a duration.
 
 ```surql title="API DEFINITION"
-duration::from::days(number) -> duration
+duration::from::days(int) -> duration
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
@@ -267,7 +267,7 @@ RETURN duration::from::days(3);
 The `duration::from::hours` function converts a numeric amount of hours into a duration that represents hours.
 
 ```surql title="API DEFINITION"
-duration::from::hours(number) -> duration
+duration::from::hours(int) -> duration
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
@@ -284,7 +284,7 @@ RETURN duration::from::hours(3);
 The `duration::from::micros` function converts a numeric amount of microseconds into a duration that represents microseconds.
 
 ```surql title="API DEFINITION"
-duration::from::micros(number) -> duration
+duration::from::micros(int) -> duration
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
@@ -301,7 +301,7 @@ RETURN duration::from::micros(3);
 The `duration::from::millis` function converts a numeric amount of milliseconds into a duration that represents milliseconds.
 
 ```surql title="API DEFINITION"
-duration::from::millis(number) -> duration
+duration::from::millis(int) -> duration
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
@@ -318,7 +318,7 @@ RETURN duration::from::millis(3);
 The `duration::from::mins` function converts a numeric amount of minutes into a duration that represents minutes.
 
 ```surql title="API DEFINITION"
-duration::from::mins(number) -> duration
+duration::from::mins(int) -> duration
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
@@ -335,7 +335,7 @@ RETURN duration::from::mins(3);
 The `duration::from::nanos` function converts a numeric amount of nanoseconds into a duration that represents nanoseconds.
 
 ```surql title="API DEFINITION"
-duration::from::nanos(number) -> duration
+duration::from::nanos(int) -> duration
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
@@ -352,7 +352,7 @@ RETURN duration::from::nanos(3);
 The `duration::from::secs` function converts a numeric amount of seconds into a duration that represents seconds.
 
 ```surql title="API DEFINITION"
-duration::from::secs(number) -> duration
+duration::from::secs(int) -> duration
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
@@ -369,7 +369,7 @@ RETURN duration::from::secs(3);
 The `duration::from::days` function converts a numeric amount of weeks into a duration that represents weeks.
 
 ```surql title="API DEFINITION"
-duration::from::weeks(number) -> duration
+duration::from::weeks(int) -> duration
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 


### PR DESCRIPTION
- fix the type for `duration::from::*` functions to be `int` instead of `number`