### PR TITLE
feat(giscus): Adds Giscus to docs

### DIFF
--- a/docs/intro.mdx
+++ b/docs/intro.mdx
@@ -1,14 +1,12 @@
 ---
 sidebar_position: 1
 pagination_next: null
-enableComments: true
 ---
 
 import ThemedImage from '@theme/ThemedImage';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import SdkContainer from '../src/components/SDK/sdks_container.mdx';
 import Version from '../src/components/Version';
-import GiscusComponent from '@site/src/components/GiscusComponent';
 
 # Overview
 
@@ -46,5 +44,3 @@ To quickly test out SurrealDB and [SurrealQL](/docs/surrealql/overview) function
 Connect your application to your database with one of our official SDKs. The following SDKs are officially supported by SurrealDB. They are actively maintained, support new SurrealDB features, and receive bug fixes, performance enhancements, and security patches.
 
 <SdkContainer components={{sdk: () => <div>SdkContainer</div>}} />
-
-<GiscusComponent />

--- a/docs/intro.mdx
+++ b/docs/intro.mdx
@@ -1,12 +1,14 @@
 ---
 sidebar_position: 1
 pagination_next: null
+enableComments: true
 ---
 
 import ThemedImage from '@theme/ThemedImage';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import SdkContainer from '../src/components/SDK/sdks_container.mdx';
 import Version from '../src/components/Version';
+import GiscusComponent from '@site/src/components/GiscusComponent';
 
 # Overview
 
@@ -44,3 +46,5 @@ To quickly test out SurrealDB and [SurrealQL](/docs/surrealql/overview) function
 Connect your application to your database with one of our official SDKs. The following SDKs are officially supported by SurrealDB. They are actively maintained, support new SurrealDB features, and receive bug fixes, performance enhancements, and security patches.
 
 <SdkContainer components={{sdk: () => <div>SdkContainer</div>}} />
+
+<GiscusComponent />

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@fortawesome/free-regular-svg-icons": "^6.5.1",
     "@fortawesome/free-solid-svg-icons": "^6.5.1",
     "@fortawesome/react-fontawesome": "^0.2.0",
+    "@giscus/react": "^2.4.0",
     "@mdx-js/react": "^1.6.22",
     "clsx": "^1.2.1",
     "copy-text-to-clipboard": "^3.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@fortawesome/react-fontawesome':
         specifier: ^0.2.0
         version: 0.2.0(@fortawesome/fontawesome-svg-core@6.5.1)(react@17.0.2)
+      '@giscus/react':
+        specifier: ^2.4.0
+        version: 2.4.0(react-dom@17.0.2)(react@17.0.2)
       '@mdx-js/react':
         specifier: ^1.6.22
         version: 1.6.22(react@17.0.2)
@@ -2604,6 +2607,17 @@ packages:
       react: 17.0.2
     dev: false
 
+  /@giscus/react@2.4.0(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-y8d8qiZ2sBuaXRcgn/ZWfMlRs9bx26p62BU/HEKQQ+IfHo3B/kglgPjX/IqudwlX+DOlHUl1NvtFo9C8Eqo0eQ==}
+    peerDependencies:
+      react: ^16 || ^17 || ^18
+      react-dom: ^16 || ^17 || ^18
+    dependencies:
+      giscus: 1.4.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
   /@hapi/hoek@9.3.0:
     resolution: {integrity: sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==}
 
@@ -2664,6 +2678,16 @@ packages:
 
   /@leichtgewicht/ip-codec@2.0.4:
     resolution: {integrity: sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==}
+    dev: false
+
+  /@lit-labs/ssr-dom-shim@1.1.2:
+    resolution: {integrity: sha512-jnOD+/+dSrfTWYfSXBXlo5l5f0q1UuJo3tkbMDCYA2lKUYq79jaxqtGEvnRoh049nt1vdo1+45RinipU6FGY2g==}
+    dev: false
+
+  /@lit/reactive-element@2.0.2:
+    resolution: {integrity: sha512-SVOwLAWUQg3Ji1egtOt1UiFe4zdDpnWHyc5qctSceJ5XIu0Uc76YmGpIjZgx9YJ0XtdW0Jm507sDvjOu+HnB8w==}
+    dependencies:
+      '@lit-labs/ssr-dom-shim': 1.1.2
     dev: false
 
   /@mdx-js/mdx@1.6.22:
@@ -3161,6 +3185,10 @@ packages:
 
   /@types/stylis@4.2.1:
     resolution: {integrity: sha512-OSaMrXUKxVigGlKRrET39V2xdhzlztQ9Aqumn1WbCBKHOi9ry7jKSd7rkyj0GzmWaU960Rd+LpOFpLfx5bMQAg==}
+    dev: false
+
+  /@types/trusted-types@2.0.7:
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
     dev: false
 
   /@types/unist@2.0.7:
@@ -5090,6 +5118,12 @@ packages:
     engines: {node: '>=10'}
     dev: false
 
+  /giscus@1.4.0:
+    resolution: {integrity: sha512-Pll+pcclTx47NcFDw8nuka2Ja85Gc4XWpzSgL0rszOQaMQRQIV8UMR+zP4a+/N3tV2TXc1SZ537kWlsN6EsAaw==}
+    dependencies:
+      lit: 3.1.0
+    dev: false
+
   /github-slugger@1.5.0:
     resolution: {integrity: sha512-wIh+gKBI9Nshz2o46B0B3f5k/W+WI9ZAv6y5Dn5WJ5SK1t0TnDimB4WE5rmTD05ZAIn8HALCZVmCsvj0w0v0lw==}
     dev: false
@@ -5921,6 +5955,28 @@ packages:
 
   /lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+    dev: false
+
+  /lit-element@4.0.2:
+    resolution: {integrity: sha512-/W6WQZUa5VEXwC7H9tbtDMdSs9aWil3Ou8hU6z2cOKWbsm/tXPAcsoaHVEtrDo0zcOIE5GF6QgU55tlGL2Nihg==}
+    dependencies:
+      '@lit-labs/ssr-dom-shim': 1.1.2
+      '@lit/reactive-element': 2.0.2
+      lit-html: 3.1.0
+    dev: false
+
+  /lit-html@3.1.0:
+    resolution: {integrity: sha512-FwAjq3iNsaO6SOZXEIpeROlJLUlrbyMkn4iuv4f4u1H40Jw8wkeR/OUXZUHUoiYabGk8Y4Y0F/rgq+R4MrOLmA==}
+    dependencies:
+      '@types/trusted-types': 2.0.7
+    dev: false
+
+  /lit@3.1.0:
+    resolution: {integrity: sha512-rzo/hmUqX8zmOdamDAeydfjsGXbbdtAFqMhmocnh2j9aDYqbu0fjXygjCa0T99Od9VQ/2itwaGrjZz/ZELVl7w==}
+    dependencies:
+      '@lit/reactive-element': 2.0.2
+      lit-element: 4.0.2
+      lit-html: 3.1.0
     dev: false
 
   /loader-runner@4.3.0:

--- a/src/components/GiscusComponent/index.tsx
+++ b/src/components/GiscusComponent/index.tsx
@@ -10,7 +10,7 @@ export default function GiscusComponent() {
       repo="surrealdb/docs.surrealdb.com"
       repoId="MDEwOlJlcG9zaXRvcnkyMjc4MTY1NzM="
       category="General"
-      categoryId="IdOfDiscussionCategory" //id of the category above (General)
+      categoryId="DIC_kwDODZQ0fc4CayrW"
       mapping="url"                      // Important! To map comments to URL
       term="Welcome to @giscus/react component!"
       strict="0"

--- a/src/components/GiscusComponent/index.tsx
+++ b/src/components/GiscusComponent/index.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import Giscus from "@giscus/react";
+import { useColorMode } from '@docusaurus/theme-common';
+
+export default function GiscusComponent() {
+  const { colorMode } = useColorMode();
+
+  return (
+    <Giscus    
+      repo="surrealdb/docs.surrealdb.com"
+      repoId="MDEwOlJlcG9zaXRvcnkyMjc4MTY1NzM="
+      category="General"
+      categoryId="IdOfDiscussionCategory" //id of the category above (General)
+      mapping="url"                      // Important! To map comments to URL
+      term="Welcome to @giscus/react component!"
+      strict="0"
+      reactionsEnabled="1"
+      emitMetadata="1"
+      inputPosition="top"
+      theme={colorMode}
+      lang="en"
+      loading="lazy"
+      crossorigin="anonymous"
+      async
+    />
+  );
+}


### PR DESCRIPTION
It adds Giscus to our Docs. 

The way to add Github comments to any page is:

1. Make sure you add:
enableComments: true on top. Something like:
---
sidebar_position: 1
pagination_next: null
enableComments: true
---

2. import the component
import GiscusComponent from '@site/src/components/GiscusComponent';

3. Add the component to the bottom of the page
<GiscusComponent />