### PR TITLE
Updating GH Repo link on docs site

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -178,7 +178,7 @@ const config = {
             position: 'right',
           },
           {
-            href: 'https://github.com/surrealdb',
+            href: 'https://github.com/surrealdb/docs.surrealdb.com',
             position: 'right',
             className: 'header-github-link',
             'aria-label': 'GitHub repository',


### PR DESCRIPTION
The GH icon the site goes to surrealdb org rather than the official GH docs repo. Adding a minor change to update the link. 