### PR TITLE
[Update http.mdx] Removed "sc":"user_scope" from /signin body 

### DIFF
--- a/versioned_docs/version-1.1.x/integration/http.mdx
+++ b/versioned_docs/version-1.1.x/integration/http.mdx
@@ -265,7 +265,7 @@ The following headers can be used to customise the query and the response.
 
 ### Example with Scope user
 ```bash title="Request"
-curl -X POST -H "Accept: application/json" -d '{"ns":"test","db":"test","sc":"user_scope","user":"john.doe","pass":"123456"}' http://localhost:8000/signin
+curl -X POST -H "Accept: application/json" -d '{"ns":"test","db":"test","user":"john.doe","pass":"123456"}' http://localhost:8000/signin
 ```
 
 ```json title="Response"


### PR DESCRIPTION
Adding "sc":"user_scope" in /signin body is not working in version 1.1.1
log:
```
% curl -X POST -H "Accept: application/json" -d '{"ns":"test","db":"test","sc":"user_scope","user":"root","pass":"root"}' http://localhost:8000/signin
{"code":400,"details":"Request problems detected","description":"There is a problem with your request. Refer to the documentation for further information.","information":"There was a problem with the database: The scope does not exist"}
```