### PR TITLE
removed excess bracket in select.mdx files

### DIFF
--- a/versioned_docs/version-1.0.x/surrealql/statements/select.mdx
+++ b/versioned_docs/version-1.0.x/surrealql/statements/select.mdx
@@ -24,7 +24,7 @@ SELECT [ VALUE ] @fields [ AS @alias ]
 			| COLLATE
 			| NUMERIC
 		] [ ASC | DESC ] ...
-	] ]
+	]
 	[ LIMIT [ BY ] @limit ]
 	[ START [ AT ] @start ]
 	[ FETCH @fields ... ]

--- a/versioned_docs/version-1.1.x/surrealql/statements/select.mdx
+++ b/versioned_docs/version-1.1.x/surrealql/statements/select.mdx
@@ -24,7 +24,7 @@ SELECT [ VALUE ] @fields [ AS @alias ]
 			| COLLATE
 			| NUMERIC
 		] [ ASC | DESC ] ...
-	] ]
+	]
 	[ LIMIT [ BY ] @limit ]
 	[ START [ AT ] @start ]
 	[ FETCH @fields ... ]

--- a/versioned_docs/version-nightly/surrealql/statements/select.mdx
+++ b/versioned_docs/version-nightly/surrealql/statements/select.mdx
@@ -24,7 +24,7 @@ SELECT [ VALUE ] @fields [ AS @alias ]
 			| COLLATE
 			| NUMERIC
 		] [ ASC | DESC ] ...
-	] ]
+	]
 	[ LIMIT [ BY ] @limit ]
 	[ START [ AT ] @start ]
 	[ FETCH @fields ... ]


### PR DESCRIPTION
In the SELECT SurrealQL Syntax example in the select.mdx documents on line 27 there was an excess bracket