### PR TITLE
Docs: Update type casting examples 

### DIFF
--- a/versioned_docs/version-1.0.x/surrealql/datamodel/casting.mdx
+++ b/versioned_docs/version-1.0.x/surrealql/datamodel/casting.mdx
@@ -82,13 +82,6 @@ SELECT * FROM <int> 53;
 53
 ```
 
-```surql
-SELECT * FROM <int> false;
-
-0
-
-```
-
 <br />
 
 ## `<float>`

--- a/versioned_docs/version-1.0.x/surrealql/datamodel/casting.mdx
+++ b/versioned_docs/version-1.0.x/surrealql/datamodel/casting.mdx
@@ -2,7 +2,7 @@
 sidebar_position: 13
 ---
 
-# Casting 
+# Casting
 
 # Casting
 
@@ -63,18 +63,7 @@ true
 ```
 
 ```surql
-SELECT * FROM <bool> "some truthy value";
-
-true
-```
-
-```surql
-SELECT * FROM <bool> 1.375;
-
-true
-```
-```surql
-SELECT * FROM <bool> 1.375;
+SELECT * FROM <bool> "false";
 
 false
 ```
@@ -88,26 +77,9 @@ The &lt;int&gt; casting function converts a value into an integer.
 
 
 ```surql
-SELECT * FROM <int> 13.572948467293847293841093845679289;
+SELECT * FROM <int> 53;
 
-13
-```
-```surql
-SELECT * FROM <int> "13.572948467293847293841093845679289";
-
-13 
-```
-
-```surql 
-SELECT * FROM <int> "some truthy value";
-
-0
-```
-
-```surql
-SELECT * FROM <int> true;
-
-1
+53
 ```
 
 ```surql
@@ -132,24 +104,6 @@ SELECT * FROM <float> 13.572948467293847293841093845679289;
 SELECT * FROM <float> "13.572948467293847293841093845679289";
 
 13.572948467293847
-```
-
-```surql
-SELECT * FROM <float> "some truthy value";
-
-0.0
-```
-
-```surql
-SELECT * FROM <float> true;
-
-1.0
-```
-
-```surql
-SELECT * FROM <float> false;
-
-0.0
 ```
 
 <br />
@@ -191,22 +145,12 @@ SELECT * FROM <number> "13.572948467293847293841093845679289";
 
 "13.572948467293847293841093845679289"
 ```
-```surql
-SELECT * FROM <number> "some truthy value";
 
-"0"
-```
 ```surql
 SELECT * FROM <number> 1.193847193847193847193487E11;
 
 "119384719384.7193847193487"
 ```
-```surql
-SELECT * FROM <number> true;
-
-"1"
-```
-
 
 <br />
 
@@ -224,20 +168,11 @@ SELECT * FROM <decimal> "13.572948467293847293841093845679289";
 
 "13.572948467293847293841093845679289"
 ```
-```surql
-SELECT * FROM <decimal> "some truthy value";
 
-"0"
-```
 ```surql
 SELECT * FROM <decimal> 1.193847193847193847193487E11;
 
 "119384719384.7193847193487"
-```
-```surql
-SELECT * FROM <decimal> true;
-
-"1"
 ```
 
 
@@ -248,7 +183,7 @@ SELECT * FROM <decimal> true;
 The &lt;datetime&gt; casting function converts a value into a datetime.
 
 ```surql
-SELECT * FROM <datetime> "2022-06-07 will be parsed";
+SELECT * FROM <datetime> "2022-06-07";
 
 "2022-06-07"
 ```
@@ -260,7 +195,7 @@ SELECT * FROM <datetime> "2022-06-07 will be parsed";
 The &lt;duration&gt; casting function converts a value into a duration.
 
 ```surql
-SELECT * FROM <duration> "1h30m will be parsed";
+SELECT * FROM <duration> "1h30m";
 
 "1h30m"
 ```

--- a/versioned_docs/version-1.1.x/surrealql/datamodel/casting.mdx
+++ b/versioned_docs/version-1.1.x/surrealql/datamodel/casting.mdx
@@ -63,18 +63,7 @@ true
 ```
 
 ```surql
-SELECT * FROM <bool> "some truthy value";
-
-true
-```
-
-```surql
-SELECT * FROM <bool> 1.375;
-
-true
-```
-```surql
-SELECT * FROM <bool> 1.375;
+SELECT * FROM <bool> "false";
 
 false
 ```
@@ -88,26 +77,9 @@ The &lt;int&gt; casting function converts a value into an integer.
 
 
 ```surql
-SELECT * FROM <int> 13.572948467293847293841093845679289;
+SELECT * FROM <int> 53;
 
-13
-```
-```surql
-SELECT * FROM <int> "13.572948467293847293841093845679289";
-
-13 
-```
-
-```surql 
-SELECT * FROM <int> "some truthy value";
-
-0
-```
-
-```surql
-SELECT * FROM <int> true;
-
-1
+53
 ```
 
 ```surql
@@ -132,24 +104,6 @@ SELECT * FROM <float> 13.572948467293847293841093845679289;
 SELECT * FROM <float> "13.572948467293847293841093845679289";
 
 13.572948467293847
-```
-
-```surql
-SELECT * FROM <float> "some truthy value";
-
-0.0
-```
-
-```surql
-SELECT * FROM <float> true;
-
-1.0
-```
-
-```surql
-SELECT * FROM <float> false;
-
-0.0
 ```
 
 <br />
@@ -191,22 +145,12 @@ SELECT * FROM <number> "13.572948467293847293841093845679289";
 
 "13.572948467293847293841093845679289"
 ```
-```surql
-SELECT * FROM <number> "some truthy value";
 
-"0"
-```
 ```surql
 SELECT * FROM <number> 1.193847193847193847193487E11;
 
 "119384719384.7193847193487"
 ```
-```surql
-SELECT * FROM <number> true;
-
-"1"
-```
-
 
 <br />
 
@@ -224,20 +168,11 @@ SELECT * FROM <decimal> "13.572948467293847293841093845679289";
 
 "13.572948467293847293841093845679289"
 ```
-```surql
-SELECT * FROM <decimal> "some truthy value";
 
-"0"
-```
 ```surql
 SELECT * FROM <decimal> 1.193847193847193847193487E11;
 
 "119384719384.7193847193487"
-```
-```surql
-SELECT * FROM <decimal> true;
-
-"1"
 ```
 
 
@@ -248,7 +183,7 @@ SELECT * FROM <decimal> true;
 The &lt;datetime&gt; casting function converts a value into a datetime.
 
 ```surql
-SELECT * FROM <datetime> "2022-06-07 will be parsed";
+SELECT * FROM <datetime> "2022-06-07";
 
 "2022-06-07"
 ```
@@ -260,7 +195,7 @@ SELECT * FROM <datetime> "2022-06-07 will be parsed";
 The &lt;duration&gt; casting function converts a value into a duration.
 
 ```surql
-SELECT * FROM <duration> "1h30m will be parsed";
+SELECT * FROM <duration> "1h30m";
 
 "1h30m"
 ```

--- a/versioned_docs/version-1.1.x/surrealql/datamodel/casting.mdx
+++ b/versioned_docs/version-1.1.x/surrealql/datamodel/casting.mdx
@@ -82,13 +82,6 @@ SELECT * FROM <int> 53;
 53
 ```
 
-```surql
-SELECT * FROM <int> false;
-
-0
-
-```
-
 <br />
 
 ## `<float>`

--- a/versioned_docs/version-nightly/surrealql/datamodel/casting.mdx
+++ b/versioned_docs/version-nightly/surrealql/datamodel/casting.mdx
@@ -63,18 +63,7 @@ true
 ```
 
 ```surql
-SELECT * FROM <bool> "some truthy value";
-
-true
-```
-
-```surql
-SELECT * FROM <bool> 1.375;
-
-true
-```
-```surql
-SELECT * FROM <bool> 1.375;
+SELECT * FROM <bool> "false";
 
 false
 ```
@@ -88,26 +77,9 @@ The &lt;int&gt; casting function converts a value into an integer.
 
 
 ```surql
-SELECT * FROM <int> 13.572948467293847293841093845679289;
+SELECT * FROM <int> 53;
 
-13
-```
-```surql
-SELECT * FROM <int> "13.572948467293847293841093845679289";
-
-13 
-```
-
-```surql 
-SELECT * FROM <int> "some truthy value";
-
-0
-```
-
-```surql
-SELECT * FROM <int> true;
-
-1
+53
 ```
 
 ```surql
@@ -132,24 +104,6 @@ SELECT * FROM <float> 13.572948467293847293841093845679289;
 SELECT * FROM <float> "13.572948467293847293841093845679289";
 
 13.572948467293847
-```
-
-```surql
-SELECT * FROM <float> "some truthy value";
-
-0.0
-```
-
-```surql
-SELECT * FROM <float> true;
-
-1.0
-```
-
-```surql
-SELECT * FROM <float> false;
-
-0.0
 ```
 
 <br />
@@ -191,22 +145,12 @@ SELECT * FROM <number> "13.572948467293847293841093845679289";
 
 "13.572948467293847293841093845679289"
 ```
-```surql
-SELECT * FROM <number> "some truthy value";
 
-"0"
-```
 ```surql
 SELECT * FROM <number> 1.193847193847193847193487E11;
 
 "119384719384.7193847193487"
 ```
-```surql
-SELECT * FROM <number> true;
-
-"1"
-```
-
 
 <br />
 
@@ -224,20 +168,11 @@ SELECT * FROM <decimal> "13.572948467293847293841093845679289";
 
 "13.572948467293847293841093845679289"
 ```
-```surql
-SELECT * FROM <decimal> "some truthy value";
 
-"0"
-```
 ```surql
 SELECT * FROM <decimal> 1.193847193847193847193487E11;
 
 "119384719384.7193847193487"
-```
-```surql
-SELECT * FROM <decimal> true;
-
-"1"
 ```
 
 
@@ -248,7 +183,7 @@ SELECT * FROM <decimal> true;
 The &lt;datetime&gt; casting function converts a value into a datetime.
 
 ```surql
-SELECT * FROM <datetime> "2022-06-07 will be parsed";
+SELECT * FROM <datetime> "2022-06-07";
 
 "2022-06-07"
 ```
@@ -260,7 +195,7 @@ SELECT * FROM <datetime> "2022-06-07 will be parsed";
 The &lt;duration&gt; casting function converts a value into a duration.
 
 ```surql
-SELECT * FROM <duration> "1h30m will be parsed";
+SELECT * FROM <duration> "1h30m";
 
 "1h30m"
 ```

--- a/versioned_docs/version-nightly/surrealql/datamodel/casting.mdx
+++ b/versioned_docs/version-nightly/surrealql/datamodel/casting.mdx
@@ -82,13 +82,6 @@ SELECT * FROM <int> 53;
 53
 ```
 
-```surql
-SELECT * FROM <int> false;
-
-0
-
-```
-
 <br />
 
 ## `<float>`


### PR DESCRIPTION
Remove examples that don't parse correctly. 

Ties to https://github.com/surrealdb/surrealdb/issues/3046  and https://github.com/surrealdb/surrealdb/issues/2907

