### PR TITLE
feat(404page): It redirects to last known path

### DIFF
--- a/src/theme/NotFound.js
+++ b/src/theme/NotFound.js
@@ -1,10 +1,13 @@
 import React from 'react';
-import NotFound from '@theme-original/NotFound';
+import { useLocation } from '@docusaurus/router';
+import { Redirect } from '@docusaurus/router';
 
-export default function NotFoundWrapper(props) {
-  return (
-    <>
-      <NotFound {...props} />
-    </>
-  );
+export default function NotFound() {
+  
+  const location = useLocation();
+  const { pathname } = location;
+  const lastSlashIndex = pathname.lastIndexOf('/');
+  const redirectTo = pathname.slice(0, lastSlashIndex);
+
+  return <Redirect to={redirectTo} />;
 }


### PR DESCRIPTION
It redirects the 404 page errors to the last known path, so for example if a user types:
https://docs.surrealdb.com/docs/installation/macos/sdsdsd
it will go to 
https://docs.surrealdb.com/docs/installation/macos

If the user types a complete random route it redirects to our main url:
https://docs.surrealdb.com/docs/intro