### PR TITLE
Docs: Remove

### DIFF
--- a/versioned_docs/version-1.0.x/installation/macos.mdx
+++ b/versioned_docs/version-1.0.x/installation/macos.mdx
@@ -57,6 +57,10 @@ brew upgrade surrealdb/tap/surreal
 
 Once installed, you can run the SurrealDB command-line tool by using the `surreal` command. To check whether the install was successful run the following command in your terminal.
 
+```bash
+surreal help
+```
+
 The result should look similar to the output below, confirming that the SurrealDB command-line tool was installed successfully.
 
 ```bash

--- a/versioned_docs/version-1.0.x/installation/running/_category_.json
+++ b/versioned_docs/version-1.0.x/installation/running/_category_.json
@@ -1,8 +1,4 @@
 {
   "label": "Running",
-  "position": 5,
-  "link": {
-    "label": "running",
-    "path": "/running/overview"
-  }
+  "position": 5
 }

--- a/versioned_docs/version-1.0.x/installation/upgrading/_category_.json
+++ b/versioned_docs/version-1.0.x/installation/upgrading/_category_.json
@@ -1,8 +1,4 @@
 {
   "label": "Upgrading",
-  "position": 6,
-  "link": {
-    "label": "upgrading",
-    "path": "/upgrading/overview"
-  }
+  "position": 6
 }

--- a/versioned_docs/version-1.0.x/integration/websockets/_category_.json
+++ b/versioned_docs/version-1.0.x/integration/websockets/_category_.json
@@ -1,3 +1,0 @@
-{
-    "className": "hidden"
-}

--- a/versioned_docs/version-1.0.x/integration/websockets/binary.mdx
+++ b/versioned_docs/version-1.0.x/integration/websockets/binary.mdx
@@ -1,3 +1,0 @@
-import { Redirect } from '@docusaurus/router';
-
-<Redirect to="../websocket" />;

--- a/versioned_docs/version-1.0.x/integration/websockets/text.mdx
+++ b/versioned_docs/version-1.0.x/integration/websockets/text.mdx
@@ -1,3 +1,0 @@
-import { Redirect } from '@docusaurus/router';
-
-<Redirect to="../websocket" />;

--- a/versioned_docs/version-1.0.x/introduction/sql.mdx
+++ b/versioned_docs/version-1.0.x/introduction/sql.mdx
@@ -38,11 +38,6 @@ For more SurrealQL examples, see the [create](/docs/surrealql/statements/create)
 | CREATE TABLE person (     person_id SERIAL PRIMARY KEY,     name varchar(255) ) // SERIAL is PosgresSQL syntax | DEFINE TABLE person SCHEMAFULL; DEFINE FIELD name ON TABLE person TYPE string; // record id field is defined by default |
 | INSERT INTO person (name) VALUES ('John'), ('Jane')                                                            | INSERT INTO person (name) VALUES ('John'), ('Jane')                                                                     |
 | CREATE INDEX idx_name ON person (name)                                                                         | DEFINE INDEX idx_name  ON TABLE person COLUMNS name                                                                     |
-| column                                                                                                         | field                                                                                                                   |
-| index                                                                                                          | index                                                                                                                   |
-| primary key                                                                                                    | record id                                                                                                               |
-| transaction                                                                                                    | transaction                                                                                                             |
-| join                                                                                                           | record links, embedding and graph relations                                                                             |
 
 ### Read
 For more SurrealQL examples, see the [select](/docs/surrealql/statements/select), [live select](/docs/surrealql/statements/live-select) and [return](/docs/surrealql/statements/return) pages.

--- a/versioned_docs/version-1.1.x/installation/macos.mdx
+++ b/versioned_docs/version-1.1.x/installation/macos.mdx
@@ -103,6 +103,10 @@ brew upgrade surrealdb/tap/surreal
 ### Checking SurrealDB
 Once installed, you can run the SurrealDB command-line tool by using the `surreal` command. To check whether the install was successful run the following command in your terminal.
 
+```bash
+surreal help
+```
+
 The result should look similar to the output below, confirming that the SurrealDB command-line tool was installed successfully.
 
 ```bash

--- a/versioned_docs/version-1.1.x/installation/running/_category_.json
+++ b/versioned_docs/version-1.1.x/installation/running/_category_.json
@@ -1,8 +1,4 @@
 {
   "label": "Running",
-  "position": 4,
-  "link": {
-    "label": "running",
-    "path": "/running/overview"
-  }
+  "position": 6
 }

--- a/versioned_docs/version-1.1.x/installation/upgrading/_category_.json
+++ b/versioned_docs/version-1.1.x/installation/upgrading/_category_.json
@@ -1,8 +1,4 @@
 {
   "label": "Upgrading",
-  "position": 4,
-  "link": {
-    "label": "upgrading",
-    "path": "/upgrading/overview"
-  }
+  "position": 7
 }

--- a/versioned_docs/version-1.1.x/integration/websockets/_category_.json
+++ b/versioned_docs/version-1.1.x/integration/websockets/_category_.json
@@ -1,3 +1,0 @@
-{
-    "className": "hidden"
-}

--- a/versioned_docs/version-1.1.x/integration/websockets/binary.mdx
+++ b/versioned_docs/version-1.1.x/integration/websockets/binary.mdx
@@ -1,3 +1,0 @@
-import { Redirect } from '@docusaurus/router';
-
-<Redirect to="../websocket" />;

--- a/versioned_docs/version-1.1.x/integration/websockets/text.mdx
+++ b/versioned_docs/version-1.1.x/integration/websockets/text.mdx
@@ -1,3 +1,0 @@
-import { Redirect } from '@docusaurus/router';
-
-<Redirect to="../websocket" />;

--- a/versioned_docs/version-1.1.x/introduction/sql.mdx
+++ b/versioned_docs/version-1.1.x/introduction/sql.mdx
@@ -38,11 +38,6 @@ For more SurrealQL examples, see the [create](/docs/surrealql/statements/create)
 | CREATE TABLE person (     person_id SERIAL PRIMARY KEY,     name varchar(255) ) // SERIAL is PosgresSQL syntax | DEFINE TABLE person SCHEMAFULL; DEFINE FIELD name ON TABLE person TYPE string; // record id field is defined by default |
 | INSERT INTO person (name) VALUES ('John'), ('Jane')                                                            | INSERT INTO person (name) VALUES ('John'), ('Jane')                                                                     |
 | CREATE INDEX idx_name ON person (name)                                                                         | DEFINE INDEX idx_name  ON TABLE person COLUMNS name                                                                     |
-| column                                                                                                         | field                                                                                                                   |
-| index                                                                                                          | index                                                                                                                   |
-| primary key                                                                                                    | record id                                                                                                               |
-| transaction                                                                                                    | transaction                                                                                                             |
-| join                                                                                                           | record links, embedding and graph relations                                                                             |
 
 ### Read
 For more SurrealQL examples, see the [select](/docs/surrealql/statements/select), [live select](/docs/surrealql/statements/live-select) and [return](/docs/surrealql/statements/return) pages.

--- a/versioned_docs/version-1.2.x/installation/macos.mdx
+++ b/versioned_docs/version-1.2.x/installation/macos.mdx
@@ -103,6 +103,10 @@ brew upgrade surrealdb/tap/surreal
 ### Checking SurrealDB
 Once installed, you can run the SurrealDB command-line tool by using the `surreal` command. To check whether the install was successful run the following command in your terminal.
 
+```bash
+surreal help
+```
+
 The result should look similar to the output below, confirming that the SurrealDB command-line tool was installed successfully.
 
 ```bash

--- a/versioned_docs/version-1.2.x/installation/running/_category_.json
+++ b/versioned_docs/version-1.2.x/installation/running/_category_.json
@@ -1,8 +1,4 @@
 {
   "label": "Running",
-  "position": 4,
-  "link": {
-    "label": "running",
-    "path": "/running/overview"
-  }
+  "position": 6
 }

--- a/versioned_docs/version-1.2.x/installation/upgrading/_category_.json
+++ b/versioned_docs/version-1.2.x/installation/upgrading/_category_.json
@@ -1,8 +1,4 @@
 {
   "label": "Upgrading",
-  "position": 4,
-  "link": {
-    "label": "upgrading",
-    "path": "/upgrading/overview"
-  }
+  "position": 7
 }

--- a/versioned_docs/version-1.2.x/integration/websockets/_category_.json
+++ b/versioned_docs/version-1.2.x/integration/websockets/_category_.json
@@ -1,3 +1,0 @@
-{
-    "className": "hidden"
-}

--- a/versioned_docs/version-1.2.x/integration/websockets/binary.mdx
+++ b/versioned_docs/version-1.2.x/integration/websockets/binary.mdx
@@ -1,3 +1,0 @@
-import { Redirect } from '@docusaurus/router';
-
-<Redirect to="../websocket" />;

--- a/versioned_docs/version-1.2.x/integration/websockets/text.mdx
+++ b/versioned_docs/version-1.2.x/integration/websockets/text.mdx
@@ -1,3 +1,0 @@
-import { Redirect } from '@docusaurus/router';
-
-<Redirect to="../websocket" />;

--- a/versioned_docs/version-1.2.x/introduction/sql.mdx
+++ b/versioned_docs/version-1.2.x/introduction/sql.mdx
@@ -38,11 +38,6 @@ For more SurrealQL examples, see the [create](/docs/1.2.x/surrealql/statements/c
 | CREATE TABLE person (     person_id SERIAL PRIMARY KEY,     name varchar(255) ) // SERIAL is PosgresSQL syntax | DEFINE TABLE person SCHEMAFULL; DEFINE FIELD name ON TABLE person TYPE string; // record id field is defined by default |
 | INSERT INTO person (name) VALUES ('John'), ('Jane')                                                            | INSERT INTO person (name) VALUES ('John'), ('Jane')                                                                     |
 | CREATE INDEX idx_name ON person (name)                                                                         | DEFINE INDEX idx_name  ON TABLE person COLUMNS name                                                                     |
-| column                                                                                                         | field                                                                                                                   |
-| index                                                                                                          | index                                                                                                                   |
-| primary key                                                                                                    | record id                                                                                                               |
-| transaction                                                                                                    | transaction                                                                                                             |
-| join                                                                                                           | record links, embedding and graph relations                                                                             |
 
 ### Read
 For more SurrealQL examples, see the [select](/docs/1.2.x/surrealql/statements/select), [live select](/docs/1.2.x/surrealql/statements/live-select) and [return](/docs/1.2.x/surrealql/statements/return) pages.

--- a/versioned_docs/version-nightly/installation/macos.mdx
+++ b/versioned_docs/version-nightly/installation/macos.mdx
@@ -103,6 +103,10 @@ brew upgrade surrealdb/tap/surreal
 ### Checking SurrealDB
 Once installed, you can run the SurrealDB command-line tool by using the `surreal` command. To check whether the install was successful run the following command in your terminal.
 
+```bash
+surreal help
+```
+
 The result should look similar to the output below, confirming that the SurrealDB command-line tool was installed successfully.
 
 ```bash

--- a/versioned_docs/version-nightly/installation/running/_category_.json
+++ b/versioned_docs/version-nightly/installation/running/_category_.json
@@ -1,8 +1,4 @@
 {
   "label": "Running",
-  "position": 4,
-  "link": {
-    "label": "running",
-    "path": "/running/overview"
-  }
+  "position": 6
 }

--- a/versioned_docs/version-nightly/installation/upgrading/_category_.json
+++ b/versioned_docs/version-nightly/installation/upgrading/_category_.json
@@ -1,8 +1,4 @@
 {
   "label": "Upgrading",
-  "position": 4,
-  "link": {
-    "label": "upgrading",
-    "path": "/upgrading/overview"
-  }
+  "position": 7
 }

--- a/versioned_docs/version-nightly/integration/websockets/_category_.json
+++ b/versioned_docs/version-nightly/integration/websockets/_category_.json
@@ -1,3 +1,0 @@
-{
-    "className": "hidden"
-}

--- a/versioned_docs/version-nightly/integration/websockets/binary.mdx
+++ b/versioned_docs/version-nightly/integration/websockets/binary.mdx
@@ -1,3 +1,0 @@
-import { Redirect } from '@docusaurus/router';
-
-<Redirect to="../websocket" />;

--- a/versioned_docs/version-nightly/integration/websockets/text.mdx
+++ b/versioned_docs/version-nightly/integration/websockets/text.mdx
@@ -1,3 +1,0 @@
-import { Redirect } from '@docusaurus/router';
-
-<Redirect to="../websocket" />;

--- a/versioned_docs/version-nightly/introduction/sql.mdx
+++ b/versioned_docs/version-nightly/introduction/sql.mdx
@@ -38,11 +38,7 @@ For more SurrealQL examples, see the [create](/docs/surrealql/statements/create)
 | CREATE TABLE person (     person_id SERIAL PRIMARY KEY,     name varchar(255) ) // SERIAL is PosgresSQL syntax | DEFINE TABLE person SCHEMAFULL; DEFINE FIELD name ON TABLE person TYPE string; // record id field is defined by default |
 | INSERT INTO person (name) VALUES ('John'), ('Jane')                                                            | INSERT INTO person (name) VALUES ('John'), ('Jane')                                                                     |
 | CREATE INDEX idx_name ON person (name)                                                                         | DEFINE INDEX idx_name  ON TABLE person COLUMNS name                                                                     |
-| column                                                                                                         | field                                                                                                                   |
-| index                                                                                                          | index                                                                                                                   |
-| primary key                                                                                                    | record id                                                                                                               |
-| transaction                                                                                                    | transaction                                                                                                             |
-| join                                                                                                           | record links, embedding and graph relations                                                                             |
+
 
 ### Read
 For more SurrealQL examples, see the [select](/docs/surrealql/statements/select), [live select](/docs/surrealql/statements/live-select) and [return](/docs/surrealql/statements/return) pages.


### PR DESCRIPTION
Addresses some small issues from #306 

This PR:

- removes duplicates from the Introduction/sql page 
-  Added command for `surreal help` to last paragraph
- rearranges the file weight so that we have folders lower
- removes unused binary docs from websocket 