### PR TITLE
Update .NET SDK documentation for v0.4.0

### DIFF
--- a/versioned_docs/version-1.1.x/integration/sdks/dotnet.mdx
+++ b/versioned_docs/version-1.1.x/integration/sdks/dotnet.mdx
@@ -58,6 +58,8 @@ using SurrealDb.Net.Models;
 using SurrealDb.Net.Models.Auth;
 using System.Text.Json;
 
+const string TABLE = "person";
+
 var db = new SurrealDbClient("ws://127.0.0.1:8000/rpc");
 
 await db.SignIn(new RootAuth { Username = "root", Password = "root" });
@@ -69,20 +71,19 @@ var person = new Person
 	Name = new() { FirstName = "Tobie", LastName = "Morgan Hitchcock" },
 	Marketing = true
 };
-var created = await db.Create("person", person);
+var created = await db.Create(TABLE, person);
 Console.WriteLine(ToJsonString(created));
 
 var updated = await db.Merge<ResponsibilityMerge, Person>(
-	new() { Id = ("person", "jaime"), Marketing = true }
+	new() { Id = (TABLE, "jaime"), Marketing = true }
 );
 Console.WriteLine(ToJsonString(updated));
 
-var people = await db.Select<Person>("person");
+var people = await db.Select<Person>(TABLE);
 Console.WriteLine(ToJsonString(people));
 
 var queryResponse = await db.Query(
-	"SELECT marketing, count() FROM type::table($table) GROUP BY marketing",
-	new Dictionary<string, object> { { "table", "person" } } 
+    $"SELECT marketing, count() FROM type::table({TABLE}) GROUP BY marketing"
 );
 var groups = queryResponse.GetValue<List<Group>>(0);
 Console.WriteLine(ToJsonString(groups));
@@ -179,8 +180,12 @@ The .NET SDK comes with a number of built-in functions.
     <td>Removes a parameter for this connection</td>
 </tr>
 <tr>
-    <td><a href="#query"> <code>await db.Query(sql, params)</code></a></td>
+    <td><a href="#query"> <code>await db.Query(sql)</code></a></td>
     <td>Runs a set of SurrealQL statements against the database</td>
+</tr>
+<tr>
+    <td><a href="#raw-query"> <code>await db.RawQuery(sql, params)</code></a></td>
+    <td>Runs a set of SurrealQL statements against the database, based on a raw SurrealQL query</td>
 </tr>
 <tr>
     <td><a href="#select"> <code>await db.Select&lt;T&gt;(resource)</code></a></td>
@@ -223,8 +228,12 @@ The .NET SDK comes with a number of built-in functions.
     <td>Listen for live query responses</td>
 </tr>
 <tr>
-    <td><a href="#live-query"> <code>await db.LiveQuery&lt;T&gt;(sql, params)</code></a></td>
+    <td><a href="#live-query"> <code>await db.LiveQuery&lt;T&gt;(sql)</code></a></td>
     <td>Initiate a live query from a SurrealQL statement</td>
+</tr>
+<tr>
+    <td><a href="#live-raw-query"> <code>await db.LiveRawQuery&lt;T&gt;(sql, params)</code></a></td>
+    <td>Initiate a live query from a SurrealQL statement, based on a raw SurrealQL query</td>
 </tr>
 <tr>
     <td><a href="#live-table"> <code>await db.LiveTable&lt;T&gt;(table, diff)</code></a></td>
@@ -786,10 +795,10 @@ await db.Set(key, val)
 await db.Set("name", new Name { FirstName = "Tobie", LastName = "Morgan Hitchcock" });
 
 // Use the variable in a subsequent query
-await db.Query("CREATE person SET name = $name");
+await db.Query($"CREATE person SET name = $name");
 
 // Use the variable in a subsequent query
-await db.Query("SELECT * FROM person WHERE name.first_name = $name.first_name");
+await db.Query($"SELECT * FROM person WHERE name.first_name = $name.first_name");
 ```
 
 <br />
@@ -844,7 +853,60 @@ await db.Unset("name");
 Runs a set of SurrealQL statements against the database.
 
 ```csharp title="Method Syntax"
-await db.Query(sql, params)
+await db.Query(sql)
+```
+
+### Arguments
+<table>
+    <thead>
+        <tr>
+            <th colspan="2">Arguments</th>
+            <th>Description</th>
+        </tr>
+    </thead>  
+    <tbody>
+        <tr>
+            <td colspan="2">
+                <code>sql</code>
+                <l className='yellow'>REQUIRED</l>
+            </td>
+            <td>
+                Specifies the SurrealQL statements.
+            </td>
+        </tr>
+        <tr>
+            <td colspan="2">
+                <code>cancellationToken</code>
+                <l className='grey'>OPTIONAL</l>
+            </td>
+            <td>
+                The cancellationToken enables graceful cancellation of asynchronous operations.
+            </td>
+        </tr>
+    </tbody>
+</table>
+
+### Example usage
+```csharp
+// Execute query with params
+const string table = "person";
+var result = await db.Query($"CREATE person; SELECT * FROM type::table({table});");
+
+// Get the first result from the first query
+var created = result.GetValue<Person>(0);
+
+// Get all of the results from the second query
+var people = result.GetValue<List<Person>>(1);
+```
+
+<br />
+
+## `.RawQuery()` {#raw-query}
+
+Runs a set of SurrealQL statements against the database, based on a raw SurrealQL query.
+
+```csharp title="Method Syntax"
+await db.RawQuery(sql, params)
 ```
 
 ### Arguments
@@ -890,7 +952,7 @@ await db.Query(sql, params)
 ```csharp
 // Assign the variable on the connection
 var @params = new Dictionary<string, object> { { "table", "person" } };
-var result = await db.Query("CREATE person; SELECT * FROM type::table($table);", @params);
+var result = await db.RawQuery("CREATE person; SELECT * FROM type::table($table);", @params);
 
 // Get the first result from the first query
 var created = result.GetValue<Person>(0);
@@ -1521,7 +1583,55 @@ liveQuery
 Initiate a live query from a SurrealQL statement.
 
 ```csharp title="Method Syntax"
-await db.LiveQuery<T>(sql, params)
+await db.LiveQuery<T>(sql)
+```
+
+### Arguments
+<table>
+    <thead>
+        <tr>
+            <th colspan="2">Arguments</th>
+            <th>Description</th>
+        </tr>
+    </thead>  
+    <tbody>
+        <tr>
+            <td colspan="2">
+                <code>sql</code>
+                <l className='yellow'>REQUIRED</l>
+            </td>
+            <td>
+                Specifies the SurrealQL statements.
+            </td>
+        </tr>
+        <tr>
+            <td colspan="2">
+                <code>cancellationToken</code>
+                <l className='grey'>OPTIONAL</l>
+            </td>
+            <td>
+                The cancellationToken enables graceful cancellation of asynchronous operations.
+            </td>
+        </tr>
+    </tbody>
+</table>
+
+### Example usage
+```csharp
+const string table = "person"; 
+await using var liveQuery = await db.LiveQuery<Person>($"LIVE SELECT * FROM type::table({table});");
+
+// Consume the live query...
+```
+
+<br />
+
+## `.LiveRawQuery<T>()` {#live-raw-query}
+
+Initiate a live query from a SurrealQL statement, based on a raw SurrealQL query.
+
+```csharp title="Method Syntax"
+await db.LiveRawQuery<T>(sql, params)
 ```
 
 ### Arguments
@@ -1565,7 +1675,7 @@ await db.LiveQuery<T>(sql, params)
 
 ### Example usage
 ```csharp
-await using var liveQuery = await db.LiveQuery<Person>("LIVE SELECT * FROM person;");
+await using var liveQuery = await db.LiveRawQuery<Person>("LIVE SELECT * FROM person;");
 
 // Consume the live query...
 ```

--- a/versioned_docs/version-1.2.x/integration/sdks/dotnet.mdx
+++ b/versioned_docs/version-1.2.x/integration/sdks/dotnet.mdx
@@ -58,6 +58,8 @@ using SurrealDb.Net.Models;
 using SurrealDb.Net.Models.Auth;
 using System.Text.Json;
 
+const string TABLE = "person";
+
 var db = new SurrealDbClient("ws://127.0.0.1:8000/rpc");
 
 await db.SignIn(new RootAuth { Username = "root", Password = "root" });
@@ -69,20 +71,19 @@ var person = new Person
 	Name = new() { FirstName = "Tobie", LastName = "Morgan Hitchcock" },
 	Marketing = true
 };
-var created = await db.Create("person", person);
+var created = await db.Create(TABLE, person);
 Console.WriteLine(ToJsonString(created));
 
 var updated = await db.Merge<ResponsibilityMerge, Person>(
-	new() { Id = ("person", "jaime"), Marketing = true }
+	new() { Id = (TABLE, "jaime"), Marketing = true }
 );
 Console.WriteLine(ToJsonString(updated));
 
-var people = await db.Select<Person>("person");
+var people = await db.Select<Person>(TABLE);
 Console.WriteLine(ToJsonString(people));
 
 var queryResponse = await db.Query(
-	"SELECT marketing, count() FROM type::table($table) GROUP BY marketing",
-	new Dictionary<string, object> { { "table", "person" } } 
+    $"SELECT marketing, count() FROM type::table({TABLE}) GROUP BY marketing"
 );
 var groups = queryResponse.GetValue<List<Group>>(0);
 Console.WriteLine(ToJsonString(groups));
@@ -179,8 +180,12 @@ The .NET SDK comes with a number of built-in functions.
     <td>Removes a parameter for this connection</td>
 </tr>
 <tr>
-    <td><a href="#query"> <code>await db.Query(sql, params)</code></a></td>
+    <td><a href="#query"> <code>await db.Query(sql)</code></a></td>
     <td>Runs a set of SurrealQL statements against the database</td>
+</tr>
+<tr>
+    <td><a href="#raw-query"> <code>await db.RawQuery(sql, params)</code></a></td>
+    <td>Runs a set of SurrealQL statements against the database, based on a raw SurrealQL query</td>
 </tr>
 <tr>
     <td><a href="#select"> <code>await db.Select&lt;T&gt;(resource)</code></a></td>
@@ -223,8 +228,12 @@ The .NET SDK comes with a number of built-in functions.
     <td>Listen for live query responses</td>
 </tr>
 <tr>
-    <td><a href="#live-query"> <code>await db.LiveQuery&lt;T&gt;(sql, params)</code></a></td>
+    <td><a href="#live-query"> <code>await db.LiveQuery&lt;T&gt;(sql)</code></a></td>
     <td>Initiate a live query from a SurrealQL statement</td>
+</tr>
+<tr>
+    <td><a href="#live-raw-query"> <code>await db.LiveRawQuery&lt;T&gt;(sql, params)</code></a></td>
+    <td>Initiate a live query from a SurrealQL statement, based on a raw SurrealQL query</td>
 </tr>
 <tr>
     <td><a href="#live-table"> <code>await db.LiveTable&lt;T&gt;(table, diff)</code></a></td>
@@ -786,10 +795,10 @@ await db.Set(key, val)
 await db.Set("name", new Name { FirstName = "Tobie", LastName = "Morgan Hitchcock" });
 
 // Use the variable in a subsequent query
-await db.Query("CREATE person SET name = $name");
+await db.Query($"CREATE person SET name = $name");
 
 // Use the variable in a subsequent query
-await db.Query("SELECT * FROM person WHERE name.first_name = $name.first_name");
+await db.Query($"SELECT * FROM person WHERE name.first_name = $name.first_name");
 ```
 
 <br />
@@ -844,7 +853,60 @@ await db.Unset("name");
 Runs a set of SurrealQL statements against the database.
 
 ```csharp title="Method Syntax"
-await db.Query(sql, params)
+await db.Query(sql)
+```
+
+### Arguments
+<table>
+    <thead>
+        <tr>
+            <th colspan="2">Arguments</th>
+            <th>Description</th>
+        </tr>
+    </thead>  
+    <tbody>
+        <tr>
+            <td colspan="2">
+                <code>sql</code>
+                <l className='yellow'>REQUIRED</l>
+            </td>
+            <td>
+                Specifies the SurrealQL statements.
+            </td>
+        </tr>
+        <tr>
+            <td colspan="2">
+                <code>cancellationToken</code>
+                <l className='grey'>OPTIONAL</l>
+            </td>
+            <td>
+                The cancellationToken enables graceful cancellation of asynchronous operations.
+            </td>
+        </tr>
+    </tbody>
+</table>
+
+### Example usage
+```csharp
+// Execute query with params
+const string table = "person";
+var result = await db.Query($"CREATE person; SELECT * FROM type::table({table});");
+
+// Get the first result from the first query
+var created = result.GetValue<Person>(0);
+
+// Get all of the results from the second query
+var people = result.GetValue<List<Person>>(1);
+```
+
+<br />
+
+## `.RawQuery()` {#raw-query}
+
+Runs a set of SurrealQL statements against the database, based on a raw SurrealQL query.
+
+```csharp title="Method Syntax"
+await db.RawQuery(sql, params)
 ```
 
 ### Arguments
@@ -890,7 +952,7 @@ await db.Query(sql, params)
 ```csharp
 // Assign the variable on the connection
 var @params = new Dictionary<string, object> { { "table", "person" } };
-var result = await db.Query("CREATE person; SELECT * FROM type::table($table);", @params);
+var result = await db.RawQuery("CREATE person; SELECT * FROM type::table($table);", @params);
 
 // Get the first result from the first query
 var created = result.GetValue<Person>(0);
@@ -1521,7 +1583,55 @@ liveQuery
 Initiate a live query from a SurrealQL statement.
 
 ```csharp title="Method Syntax"
-await db.LiveQuery<T>(sql, params)
+await db.LiveQuery<T>(sql)
+```
+
+### Arguments
+<table>
+    <thead>
+        <tr>
+            <th colspan="2">Arguments</th>
+            <th>Description</th>
+        </tr>
+    </thead>  
+    <tbody>
+        <tr>
+            <td colspan="2">
+                <code>sql</code>
+                <l className='yellow'>REQUIRED</l>
+            </td>
+            <td>
+                Specifies the SurrealQL statements.
+            </td>
+        </tr>
+        <tr>
+            <td colspan="2">
+                <code>cancellationToken</code>
+                <l className='grey'>OPTIONAL</l>
+            </td>
+            <td>
+                The cancellationToken enables graceful cancellation of asynchronous operations.
+            </td>
+        </tr>
+    </tbody>
+</table>
+
+### Example usage
+```csharp
+const string table = "person"; 
+await using var liveQuery = await db.LiveQuery<Person>($"LIVE SELECT * FROM type::table({table});");
+
+// Consume the live query...
+```
+
+<br />
+
+## `.LiveRawQuery<T>()` {#live-raw-query}
+
+Initiate a live query from a SurrealQL statement, based on a raw SurrealQL query.
+
+```csharp title="Method Syntax"
+await db.LiveRawQuery<T>(sql, params)
 ```
 
 ### Arguments
@@ -1565,7 +1675,7 @@ await db.LiveQuery<T>(sql, params)
 
 ### Example usage
 ```csharp
-await using var liveQuery = await db.LiveQuery<Person>("LIVE SELECT * FROM person;");
+await using var liveQuery = await db.LiveRawQuery<Person>("LIVE SELECT * FROM person;");
 
 // Consume the live query...
 ```

--- a/versioned_docs/version-nightly/integration/sdks/dotnet.mdx
+++ b/versioned_docs/version-nightly/integration/sdks/dotnet.mdx
@@ -58,6 +58,8 @@ using SurrealDb.Net.Models;
 using SurrealDb.Net.Models.Auth;
 using System.Text.Json;
 
+const string TABLE = "person";
+
 var db = new SurrealDbClient("ws://127.0.0.1:8000/rpc");
 
 await db.SignIn(new RootAuth { Username = "root", Password = "root" });
@@ -69,20 +71,19 @@ var person = new Person
 	Name = new() { FirstName = "Tobie", LastName = "Morgan Hitchcock" },
 	Marketing = true
 };
-var created = await db.Create("person", person);
+var created = await db.Create(TABLE, person);
 Console.WriteLine(ToJsonString(created));
 
 var updated = await db.Merge<ResponsibilityMerge, Person>(
-	new() { Id = ("person", "jaime"), Marketing = true }
+	new() { Id = (TABLE, "jaime"), Marketing = true }
 );
 Console.WriteLine(ToJsonString(updated));
 
-var people = await db.Select<Person>("person");
+var people = await db.Select<Person>(TABLE);
 Console.WriteLine(ToJsonString(people));
 
 var queryResponse = await db.Query(
-	"SELECT marketing, count() FROM type::table($table) GROUP BY marketing",
-	new Dictionary<string, object> { { "table", "person" } } 
+    $"SELECT marketing, count() FROM type::table({TABLE}) GROUP BY marketing"
 );
 var groups = queryResponse.GetValue<List<Group>>(0);
 Console.WriteLine(ToJsonString(groups));
@@ -179,8 +180,12 @@ The .NET SDK comes with a number of built-in functions.
     <td>Removes a parameter for this connection</td>
 </tr>
 <tr>
-    <td><a href="#query"> <code>await db.Query(sql, params)</code></a></td>
+    <td><a href="#query"> <code>await db.Query(sql)</code></a></td>
     <td>Runs a set of SurrealQL statements against the database</td>
+</tr>
+<tr>
+    <td><a href="#raw-query"> <code>await db.RawQuery(sql, params)</code></a></td>
+    <td>Runs a set of SurrealQL statements against the database, based on a raw SurrealQL query</td>
 </tr>
 <tr>
     <td><a href="#select"> <code>await db.Select&lt;T&gt;(resource)</code></a></td>
@@ -223,8 +228,12 @@ The .NET SDK comes with a number of built-in functions.
     <td>Listen for live query responses</td>
 </tr>
 <tr>
-    <td><a href="#live-query"> <code>await db.LiveQuery&lt;T&gt;(sql, params)</code></a></td>
+    <td><a href="#live-query"> <code>await db.LiveQuery&lt;T&gt;(sql)</code></a></td>
     <td>Initiate a live query from a SurrealQL statement</td>
+</tr>
+<tr>
+    <td><a href="#live-raw-query"> <code>await db.LiveRawQuery&lt;T&gt;(sql, params)</code></a></td>
+    <td>Initiate a live query from a SurrealQL statement, based on a raw SurrealQL query</td>
 </tr>
 <tr>
     <td><a href="#live-table"> <code>await db.LiveTable&lt;T&gt;(table, diff)</code></a></td>
@@ -786,10 +795,10 @@ await db.Set(key, val)
 await db.Set("name", new Name { FirstName = "Tobie", LastName = "Morgan Hitchcock" });
 
 // Use the variable in a subsequent query
-await db.Query("CREATE person SET name = $name");
+await db.Query($"CREATE person SET name = $name");
 
 // Use the variable in a subsequent query
-await db.Query("SELECT * FROM person WHERE name.first_name = $name.first_name");
+await db.Query($"SELECT * FROM person WHERE name.first_name = $name.first_name");
 ```
 
 <br />
@@ -844,7 +853,60 @@ await db.Unset("name");
 Runs a set of SurrealQL statements against the database.
 
 ```csharp title="Method Syntax"
-await db.Query(sql, params)
+await db.Query(sql)
+```
+
+### Arguments
+<table>
+    <thead>
+        <tr>
+            <th colspan="2">Arguments</th>
+            <th>Description</th>
+        </tr>
+    </thead>  
+    <tbody>
+        <tr>
+            <td colspan="2">
+                <code>sql</code>
+                <l className='yellow'>REQUIRED</l>
+            </td>
+            <td>
+                Specifies the SurrealQL statements.
+            </td>
+        </tr>
+        <tr>
+            <td colspan="2">
+                <code>cancellationToken</code>
+                <l className='grey'>OPTIONAL</l>
+            </td>
+            <td>
+                The cancellationToken enables graceful cancellation of asynchronous operations.
+            </td>
+        </tr>
+    </tbody>
+</table>
+
+### Example usage
+```csharp
+// Execute query with params
+const string table = "person";
+var result = await db.Query($"CREATE person; SELECT * FROM type::table({table});");
+
+// Get the first result from the first query
+var created = result.GetValue<Person>(0);
+
+// Get all of the results from the second query
+var people = result.GetValue<List<Person>>(1);
+```
+
+<br />
+
+## `.RawQuery()` {#raw-query}
+
+Runs a set of SurrealQL statements against the database, based on a raw SurrealQL query.
+
+```csharp title="Method Syntax"
+await db.RawQuery(sql, params)
 ```
 
 ### Arguments
@@ -890,7 +952,7 @@ await db.Query(sql, params)
 ```csharp
 // Assign the variable on the connection
 var @params = new Dictionary<string, object> { { "table", "person" } };
-var result = await db.Query("CREATE person; SELECT * FROM type::table($table);", @params);
+var result = await db.RawQuery("CREATE person; SELECT * FROM type::table($table);", @params);
 
 // Get the first result from the first query
 var created = result.GetValue<Person>(0);
@@ -1521,7 +1583,55 @@ liveQuery
 Initiate a live query from a SurrealQL statement.
 
 ```csharp title="Method Syntax"
-await db.LiveQuery<T>(sql, params)
+await db.LiveQuery<T>(sql)
+```
+
+### Arguments
+<table>
+    <thead>
+        <tr>
+            <th colspan="2">Arguments</th>
+            <th>Description</th>
+        </tr>
+    </thead>  
+    <tbody>
+        <tr>
+            <td colspan="2">
+                <code>sql</code>
+                <l className='yellow'>REQUIRED</l>
+            </td>
+            <td>
+                Specifies the SurrealQL statements.
+            </td>
+        </tr>
+        <tr>
+            <td colspan="2">
+                <code>cancellationToken</code>
+                <l className='grey'>OPTIONAL</l>
+            </td>
+            <td>
+                The cancellationToken enables graceful cancellation of asynchronous operations.
+            </td>
+        </tr>
+    </tbody>
+</table>
+
+### Example usage
+```csharp
+const string table = "person"; 
+await using var liveQuery = await db.LiveQuery<Person>($"LIVE SELECT * FROM type::table({table});");
+
+// Consume the live query...
+```
+
+<br />
+
+## `.LiveRawQuery<T>()` {#live-raw-query}
+
+Initiate a live query from a SurrealQL statement, based on a raw SurrealQL query.
+
+```csharp title="Method Syntax"
+await db.LiveRawQuery<T>(sql, params)
 ```
 
 ### Arguments
@@ -1565,7 +1675,7 @@ await db.LiveQuery<T>(sql, params)
 
 ### Example usage
 ```csharp
-await using var liveQuery = await db.LiveQuery<Person>("LIVE SELECT * FROM person;");
+await using var liveQuery = await db.LiveRawQuery<Person>("LIVE SELECT * FROM person;");
 
 // Consume the live query...
 ```


### PR DESCRIPTION
This PR does the following: 

- Added a TABLE variable in the example
- Introduces RawQuery and LiveRawQuery functions
- Adds examples for `db.Query` and `db.LiveQuery`