### PR TITLE
fix: replace `string::is::format` with `string::is::datetime`

### DIFF
--- a/versioned_docs/version-1.0.x/surrealql/functions/string.mdx
+++ b/versioned_docs/version-1.0.x/surrealql/functions/string.mdx
@@ -93,8 +93,8 @@ These functions can be used when working with and manipulating text and string v
     <td>Checks whether a value has only ascii characters</td>
   </tr>
   <tr>
-    <td><a href="#stringisformat"><code>string::is::format()</code></a></td>
-    <td>Checks whether a value matches a format format</td>
+    <td><a href="#stringisdatetime"><code>string::is::datetime()</code></a></td>
+    <td>Checks whether a string representation of a date and time matches a specified format</td>
   </tr>
   <tr>
     <td><a href="#stringisdomain"><code>string::is::domain()</code></a></td>
@@ -458,17 +458,17 @@ true
 
 <br />
 
-## `string::is::format`
+## `string::is::datetime`
 
-The `string::is::format` function checks whether a value matches a specified format.
+The `string::is::datetime` function checks whether a string representation of a date and time matches a specified format.
 
 ```surql title="API DEFINITION"
-string::is::format(string, string) -> bool
+string::is::datetime(string, string) -> bool
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
 ```surql
-RETURN string::is::format("2015-09-05 23:56:04", "%Y-%m-%d %H:%M:%S");
+RETURN string::is::datetime("2015-09-05 23:56:04", "%Y-%m-%d %H:%M:%S");
 
 true
 ```

--- a/versioned_docs/version-1.1.x/surrealql/functions/string.mdx
+++ b/versioned_docs/version-1.1.x/surrealql/functions/string.mdx
@@ -93,8 +93,8 @@ These functions can be used when working with and manipulating text and string v
     <td>Checks whether a value has only ascii characters</td>
   </tr>
   <tr>
-    <td><a href="#stringisformat"><code>string::is::format()</code></a></td>
-    <td>Checks whether a value matches a format format</td>
+    <td><a href="#stringisdatetime"><code>string::is::datetime()</code></a></td>
+    <td>Checks whether a string representation of a date and time matches a specified format</td>
   </tr>
   <tr>
     <td><a href="#stringisdomain"><code>string::is::domain()</code></a></td>
@@ -458,17 +458,17 @@ true
 
 <br />
 
-## `string::is::format`
+## `string::is::datetime`
 
-The `string::is::format` function checks whether a value matches a specified format.
+The `string::is::datetime` function checks whether a string representation of a date and time matches a specified format.
 
 ```surql title="API DEFINITION"
-string::is::format(string, string) -> bool
+string::is::datetime(string, string) -> bool
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/1.1.x/surrealql/statements/return) statement:
 
 ```surql
-RETURN string::is::format("2015-09-05 23:56:04", "%Y-%m-%d %H:%M:%S");
+RETURN string::is::datetime("2015-09-05 23:56:04", "%Y-%m-%d %H:%M:%S");
 
 true
 ```

--- a/versioned_docs/version-1.2.x/surrealql/functions/string.mdx
+++ b/versioned_docs/version-1.2.x/surrealql/functions/string.mdx
@@ -93,8 +93,8 @@ These functions can be used when working with and manipulating text and string v
     <td>Checks whether a value has only ascii characters</td>
   </tr>
   <tr>
-    <td><a href="#stringisformat"><code>string::is::format()</code></a></td>
-    <td>Checks whether a value matches a format format</td>
+    <td><a href="#stringisdatetime"><code>string::is::datetime()</code></a></td>
+    <td>Checks whether a string representation of a date and time matches a specified format</td>
   </tr>
   <tr>
     <td><a href="#stringisdomain"><code>string::is::domain()</code></a></td>
@@ -498,17 +498,17 @@ true
 
 <br />
 
-## `string::is::format`
+## `string::is::datetime`
 
-The `string::is::format` function checks whether a value matches a specified format.
+The `string::is::datetime` function checks whether a string representation of a date and time matches a specified format.
 
 ```surql title="API DEFINITION"
-string::is::format(string, string) -> bool
+string::is::datetime(string, string) -> bool
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
 ```surql
-RETURN string::is::format("2015-09-05 23:56:04", "%Y-%m-%d %H:%M:%S");
+RETURN string::is::datetime("2015-09-05 23:56:04", "%Y-%m-%d %H:%M:%S");
 
 true
 ```

--- a/versioned_docs/version-nightly/surrealql/functions/string.mdx
+++ b/versioned_docs/version-nightly/surrealql/functions/string.mdx
@@ -93,8 +93,8 @@ These functions can be used when working with and manipulating text and string v
     <td>Checks whether a value has only ascii characters</td>
   </tr>
   <tr>
-    <td><a href="#stringisformat"><code>string::is::format()</code></a></td>
-    <td>Checks whether a value matches a format format</td>
+    <td><a href="#stringisdatetime"><code>string::is::datetime()</code></a></td>
+    <td>Checks whether a string representation of a date and time matches a specified format</td>
   </tr>
   <tr>
     <td><a href="#stringisdomain"><code>string::is::domain()</code></a></td>
@@ -498,17 +498,17 @@ true
 
 <br />
 
-## `string::is::format`
+## `string::is::datetime`
 
-The `string::is::format` function checks whether a value matches a specified format.
+The `string::is::datetime` function checks whether a string representation of a date and time matches a specified format.
 
 ```surql title="API DEFINITION"
-string::is::format(string, string) -> bool
+string::is::datetime(string, string) -> bool
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
 ```surql
-RETURN string::is::format("2015-09-05 23:56:04", "%Y-%m-%d %H:%M:%S");
+RETURN string::is::datetime("2015-09-05 23:56:04", "%Y-%m-%d %H:%M:%S");
 
 true
 ```


### PR DESCRIPTION
Closes #327, closes https://github.com/surrealdb/surrealdb/issues/3463

This commit corrects a documentation error where `string::is::format` was listed instead of the actually implemented `string::is::datetime`. The change aligns the documentation with the codebase and clarifies the available string functions.