### PR TITLE
Change datamodel sort alphabetic in navigation menu

### DIFF
--- a/versioned_docs/version-1.0.x/surrealql/datamodel/arrays.mdx
+++ b/versioned_docs/version-1.0.x/surrealql/datamodel/arrays.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 9
+sidebar_position: 2
 ---
 
 # Arrays

--- a/versioned_docs/version-1.0.x/surrealql/datamodel/casting.mdx
+++ b/versioned_docs/version-1.0.x/surrealql/datamodel/casting.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 13
+sidebar_position: 4
 ---
 
 # Casting

--- a/versioned_docs/version-1.0.x/surrealql/datamodel/datetimes.mdx
+++ b/versioned_docs/version-1.0.x/surrealql/datamodel/datetimes.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 5
 ---
 
 # Datetimes

--- a/versioned_docs/version-1.0.x/surrealql/datamodel/formatters.mdx
+++ b/versioned_docs/version-1.0.x/surrealql/datamodel/formatters.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 6
 ---
 
 # Formatters

--- a/versioned_docs/version-1.0.x/surrealql/datamodel/futures.mdx
+++ b/versioned_docs/version-1.0.x/surrealql/datamodel/futures.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 12
+sidebar_position: 7
 ---
 
 # Futures

--- a/versioned_docs/version-1.0.x/surrealql/datamodel/geometries.mdx
+++ b/versioned_docs/version-1.0.x/surrealql/datamodel/geometries.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 10
+sidebar_position: 8
 ---
 
 # Geometries

--- a/versioned_docs/version-1.0.x/surrealql/datamodel/ids.mdx
+++ b/versioned_docs/version-1.0.x/surrealql/datamodel/ids.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 11
 ---
 
 # Record IDs

--- a/versioned_docs/version-1.0.x/surrealql/datamodel/numbers.mdx
+++ b/versioned_docs/version-1.0.x/surrealql/datamodel/numbers.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 9
 ---
 
 # Numbers

--- a/versioned_docs/version-1.0.x/surrealql/datamodel/objects.mdx
+++ b/versioned_docs/version-1.0.x/surrealql/datamodel/objects.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8
+sidebar_position: 10
 ---
 
 # Objects

--- a/versioned_docs/version-1.0.x/surrealql/datamodel/records.mdx
+++ b/versioned_docs/version-1.0.x/surrealql/datamodel/records.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 11
+sidebar_position: 12
 ---
 
 # Record links

--- a/versioned_docs/version-1.0.x/surrealql/datamodel/strings.mdx
+++ b/versioned_docs/version-1.0.x/surrealql/datamodel/strings.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 13
 ---
 
 # Strings

--- a/versioned_docs/version-1.1.x/surrealql/datamodel/arrays.mdx
+++ b/versioned_docs/version-1.1.x/surrealql/datamodel/arrays.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 9
+sidebar_position: 2
 ---
 
 # Arrays

--- a/versioned_docs/version-1.1.x/surrealql/datamodel/casting.mdx
+++ b/versioned_docs/version-1.1.x/surrealql/datamodel/casting.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 13
+sidebar_position: 4
 ---
 
 # Casting

--- a/versioned_docs/version-1.1.x/surrealql/datamodel/datetimes.mdx
+++ b/versioned_docs/version-1.1.x/surrealql/datamodel/datetimes.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 5
 ---
 
 # Datetimes

--- a/versioned_docs/version-1.1.x/surrealql/datamodel/formatters.mdx
+++ b/versioned_docs/version-1.1.x/surrealql/datamodel/formatters.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 6
 ---
 
 # Formatters

--- a/versioned_docs/version-1.1.x/surrealql/datamodel/futures.mdx
+++ b/versioned_docs/version-1.1.x/surrealql/datamodel/futures.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 12
+sidebar_position: 7
 ---
 
 # Futures

--- a/versioned_docs/version-1.1.x/surrealql/datamodel/geometries.mdx
+++ b/versioned_docs/version-1.1.x/surrealql/datamodel/geometries.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 10
+sidebar_position: 8
 ---
 
 # Geometries

--- a/versioned_docs/version-1.1.x/surrealql/datamodel/ids.mdx
+++ b/versioned_docs/version-1.1.x/surrealql/datamodel/ids.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 11
 ---
 
 # Record IDs

--- a/versioned_docs/version-1.1.x/surrealql/datamodel/numbers.mdx
+++ b/versioned_docs/version-1.1.x/surrealql/datamodel/numbers.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 9
 ---
 
 # Numbers

--- a/versioned_docs/version-1.1.x/surrealql/datamodel/objects.mdx
+++ b/versioned_docs/version-1.1.x/surrealql/datamodel/objects.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8
+sidebar_position: 10
 ---
 
 # Objects

--- a/versioned_docs/version-1.1.x/surrealql/datamodel/records.mdx
+++ b/versioned_docs/version-1.1.x/surrealql/datamodel/records.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 11
+sidebar_position: 12
 ---
 
 # Record links

--- a/versioned_docs/version-1.1.x/surrealql/datamodel/strings.mdx
+++ b/versioned_docs/version-1.1.x/surrealql/datamodel/strings.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 13
 ---
 
 # Strings

--- a/versioned_docs/version-1.2.x/surrealql/datamodel/arrays.mdx
+++ b/versioned_docs/version-1.2.x/surrealql/datamodel/arrays.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 9
+sidebar_position: 2
 ---
 
 # Arrays

--- a/versioned_docs/version-1.2.x/surrealql/datamodel/casting.mdx
+++ b/versioned_docs/version-1.2.x/surrealql/datamodel/casting.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 13
+sidebar_position: 4
 ---
 
 # Casting

--- a/versioned_docs/version-1.2.x/surrealql/datamodel/datetimes.mdx
+++ b/versioned_docs/version-1.2.x/surrealql/datamodel/datetimes.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 5
 ---
 
 # Datetimes

--- a/versioned_docs/version-1.2.x/surrealql/datamodel/formatters.mdx
+++ b/versioned_docs/version-1.2.x/surrealql/datamodel/formatters.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 6
 ---
 
 # Formatters

--- a/versioned_docs/version-1.2.x/surrealql/datamodel/futures.mdx
+++ b/versioned_docs/version-1.2.x/surrealql/datamodel/futures.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 12
+sidebar_position: 7
 ---
 
 # Futures

--- a/versioned_docs/version-1.2.x/surrealql/datamodel/geometries.mdx
+++ b/versioned_docs/version-1.2.x/surrealql/datamodel/geometries.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 10
+sidebar_position: 8
 ---
 
 # Geometries

--- a/versioned_docs/version-1.2.x/surrealql/datamodel/ids.mdx
+++ b/versioned_docs/version-1.2.x/surrealql/datamodel/ids.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 11
 ---
 
 # Record IDs

--- a/versioned_docs/version-1.2.x/surrealql/datamodel/numbers.mdx
+++ b/versioned_docs/version-1.2.x/surrealql/datamodel/numbers.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 9
 ---
 
 # Numbers

--- a/versioned_docs/version-1.2.x/surrealql/datamodel/objects.mdx
+++ b/versioned_docs/version-1.2.x/surrealql/datamodel/objects.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8
+sidebar_position: 10
 ---
 
 # Objects

--- a/versioned_docs/version-1.2.x/surrealql/datamodel/records.mdx
+++ b/versioned_docs/version-1.2.x/surrealql/datamodel/records.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 11
+sidebar_position: 12
 ---
 
 # Record links

--- a/versioned_docs/version-1.2.x/surrealql/datamodel/strings.mdx
+++ b/versioned_docs/version-1.2.x/surrealql/datamodel/strings.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 13
 ---
 
 # Strings

--- a/versioned_docs/version-nightly/surrealql/datamodel/arrays.mdx
+++ b/versioned_docs/version-nightly/surrealql/datamodel/arrays.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 9
+sidebar_position: 2
 ---
 
 # Arrays

--- a/versioned_docs/version-nightly/surrealql/datamodel/casting.mdx
+++ b/versioned_docs/version-nightly/surrealql/datamodel/casting.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 13
+sidebar_position: 4
 ---
 
 # Casting

--- a/versioned_docs/version-nightly/surrealql/datamodel/datetimes.mdx
+++ b/versioned_docs/version-nightly/surrealql/datamodel/datetimes.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 5
 ---
 
 # Datetimes

--- a/versioned_docs/version-nightly/surrealql/datamodel/formatters.mdx
+++ b/versioned_docs/version-nightly/surrealql/datamodel/formatters.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 6
 ---
 
 # Formatters

--- a/versioned_docs/version-nightly/surrealql/datamodel/futures.mdx
+++ b/versioned_docs/version-nightly/surrealql/datamodel/futures.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 12
+sidebar_position: 7
 ---
 
 # Futures

--- a/versioned_docs/version-nightly/surrealql/datamodel/geometries.mdx
+++ b/versioned_docs/version-nightly/surrealql/datamodel/geometries.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 10
+sidebar_position: 8
 ---
 
 # Geometries

--- a/versioned_docs/version-nightly/surrealql/datamodel/ids.mdx
+++ b/versioned_docs/version-nightly/surrealql/datamodel/ids.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 11
 ---
 
 # Record IDs

--- a/versioned_docs/version-nightly/surrealql/datamodel/numbers.mdx
+++ b/versioned_docs/version-nightly/surrealql/datamodel/numbers.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 9
 ---
 
 # Numbers

--- a/versioned_docs/version-nightly/surrealql/datamodel/objects.mdx
+++ b/versioned_docs/version-nightly/surrealql/datamodel/objects.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8
+sidebar_position: 10
 ---
 
 # Objects

--- a/versioned_docs/version-nightly/surrealql/datamodel/records.mdx
+++ b/versioned_docs/version-nightly/surrealql/datamodel/records.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 11
+sidebar_position: 12
 ---
 
 # Record links

--- a/versioned_docs/version-nightly/surrealql/datamodel/strings.mdx
+++ b/versioned_docs/version-nightly/surrealql/datamodel/strings.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 13
 ---
 
 # Strings


### PR DESCRIPTION
I have found some inconsistencies when using the documentation. I was looking at more navigation menu's to see if there were sorted as well or not. Found out that quite some has a sorted menu. Since the `Data Model` was quite hard to navigate because it wasn't sorted. So for this PR will resolve this issue.

I've applied these changes to all versions from 1.0.x all the way to 1.2.x and even nightly. I will hear if there are some changes need to be made regarding the sort.