### PR TITLE
Docs: Update SurrealDB installation instructions for Windows

### DIFF
--- a/versioned_docs/version-1.0.x/installation/windows.mdx
+++ b/versioned_docs/version-1.0.x/installation/windows.mdx
@@ -20,7 +20,7 @@ import Version from '../../../src/components/Version';
 
 # Install on Windows
 
-Use this tutorial to install SurrealDB on Windows operating systems using the SurrealDB [install script](https://github.com/surrealdb/install.surrealdb.com), or using the third-party [Chocolatey](https://chocolatey.org/) or third-party [Scoop](https://scoop.sh/) package managers. Both the SurrealDB Database Server and the SurrealDB Command Line Tool are packaged and distributed as a single executable file, which is easy to install, and easy to uninstall.
+Use this tutorial to install SurrealDB on Windows operating systems using the SurrealDB [install script](https://github.com/surrealdb/install.surrealdb.com) or third-party package managers like [Scoop](https://scoop.sh/). Both the SurrealDB Database Server and the SurrealDB Command Line Tool are packaged and distributed as a single executable file, which is easy to install, and easy to uninstall.
 
 ## Installing SurrealDB using the install script
 
@@ -85,20 +85,6 @@ SUBCOMMANDS:
 	sql        Start an SQL REPL in your terminal with pipe support
 	help       Print this message or the help of the given subcommand(s)
 
-```
-
-## Installing SurrealDB using Chocolatey
-If you use the [chocolatey](https://chocolatey.org/) package manager, then you can quickly install SurrealDB with one command. This will install both the command-line tools, and the SurrealDB server as a single executable. If you don't use Homebrew, follow the instructions for Linux below to install SurrealDB.
-
-```bash
-choco install surrealdb
-```
-
-### Updating SurrealDB
-To ensure that you are using the latest version, update SurrealDB to version <Version /> using the following command.
-
-```bash
-choco update surrealdb
 ```
 
 ## Installing SurrealDB using Scoop

--- a/versioned_docs/version-1.1.x/installation/windows.mdx
+++ b/versioned_docs/version-1.1.x/installation/windows.mdx
@@ -20,7 +20,7 @@ import Version from '../../../src/components/Version';
 
 # Install on Windows
 
-Use this tutorial to install SurrealDB on Windows operating systems using the SurrealDB [install script](https://github.com/surrealdb/install.surrealdb.com), or using the third-party [Chocolatey](https://chocolatey.org/) or third-party [Scoop](https://scoop.sh/) package managers. Both the SurrealDB Database Server and the SurrealDB Command Line Tool are packaged and distributed as a single executable file, which is easy to install, and easy to uninstall.
+Use this tutorial to install SurrealDB on Windows operating systems using the SurrealDB [install script](https://github.com/surrealdb/install.surrealdb.com) or third-party package managers like [Scoop](https://scoop.sh/). Both the SurrealDB Database Server and the SurrealDB Command Line Tool are packaged and distributed as a single executable file, which is easy to install, and easy to uninstall.
 
 ## Installing SurrealDB using the install script
 
@@ -85,20 +85,6 @@ SUBCOMMANDS:
 	sql        Start an SQL REPL in your terminal with pipe support
 	help       Print this message or the help of the given subcommand(s)
 
-```
-
-## Installing SurrealDB using Chocolatey
-If you use the [chocolatey](https://chocolatey.org/) package manager, then you can quickly install SurrealDB with one command. This will install both the command-line tools, and the SurrealDB server as a single executable. If you don't use Homebrew, follow the instructions for Linux below to install SurrealDB.
-
-```bash
-choco install surrealdb
-```
-
-### Updating SurrealDB
-To ensure that you are using the latest version, update SurrealDB to version <Version /> using the following command.
-
-```bash
-choco update surrealdb
 ```
 
 ## Installing SurrealDB using Scoop

--- a/versioned_docs/version-1.2.x/installation/windows.mdx
+++ b/versioned_docs/version-1.2.x/installation/windows.mdx
@@ -4,6 +4,7 @@ sidebar_position: 4
 
 import ThemedImage from '@theme/ThemedImage';
 import useBaseUrl from '@docusaurus/useBaseUrl';
+import Version from '../../../src/components/Version';
 
 # Install on Windows
 
@@ -19,7 +20,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 # Install on Windows
 
-Use this tutorial to install SurrealDB on Windows operating systems using the SurrealDB [install script](https://github.com/surrealdb/install.surrealdb.com), or using the third-party [Chocolatey](https://chocolatey.org/) or third-party [Scoop](https://scoop.sh/) package managers. Both the SurrealDB Database Server and the SurrealDB Command Line Tool are packaged and distributed as a single executable file, which is easy to install, and easy to uninstall.
+Use this tutorial to install SurrealDB on Windows operating systems using the SurrealDB [install script](https://github.com/surrealdb/install.surrealdb.com) or third-party package managers like [Scoop](https://scoop.sh/). Both the SurrealDB Database Server and the SurrealDB Command Line Tool are packaged and distributed as a single executable file, which is easy to install, and easy to uninstall.
 
 ## Installing SurrealDB using the install script
 
@@ -30,7 +31,7 @@ iwr https://windows.surrealdb.com -useb | iex
 ```
 
 ### Updating SurrealDB
-To ensure that you are using the latest version, update SurrealDB to version `v1.0.0` using the following command.
+To ensure that you are using the latest version, update SurrealDB to version <Version /> using the following command.
 
 ```bash
 iwr https://windows.surrealdb.com -useb | iex
@@ -86,20 +87,6 @@ SUBCOMMANDS:
 
 ```
 
-## Installing SurrealDB using Chocolatey
-If you use the [chocolatey](https://chocolatey.org/) package manager, then you can quickly install SurrealDB with one command. This will install both the command-line tools, and the SurrealDB server as a single executable. If you don't use Homebrew, follow the instructions for Linux below to install SurrealDB.
-
-```bash
-choco install surrealdb
-```
-
-### Updating SurrealDB
-To ensure that you are using the latest version, update SurrealDB to version `v1.0.0` using the following command.
-
-```bash
-choco update surrealdb
-```
-
 ## Installing SurrealDB using Scoop
 If you use the [Scoop](https://scoop.sh/) package manager, then you can quickly install SurrealDB with one command. This will install both the command-line tools, and the SurrealDB server as a single executable.
 
@@ -109,7 +96,7 @@ scoop install surrealdb
 
 ### Updating SurrealDB
 
-To ensure that you are using the latest version, update SurrealDB to version `v1.0.0` using the following command.
+To ensure that you are using the latest version, update SurrealDB to version <Version /> using the following command.
 
 ```bash
 scoop update surrealdb

--- a/versioned_docs/version-nightly/installation/windows.mdx
+++ b/versioned_docs/version-nightly/installation/windows.mdx
@@ -4,6 +4,7 @@ sidebar_position: 4
 
 import ThemedImage from '@theme/ThemedImage';
 import useBaseUrl from '@docusaurus/useBaseUrl';
+import Version from '../../../src/components/Version';
 
 # Install on Windows
 
@@ -19,7 +20,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 
 # Install on Windows
 
-Use this tutorial to install SurrealDB on Windows operating systems using the SurrealDB [install script](https://github.com/surrealdb/install.surrealdb.com), or using the third-party [Chocolatey](https://chocolatey.org/) or third-party [Scoop](https://scoop.sh/) package managers. Both the SurrealDB Database Server and the SurrealDB Command Line Tool are packaged and distributed as a single executable file, which is easy to install, and easy to uninstall.
+Use this tutorial to install SurrealDB on Windows operating systems using the SurrealDB [install script](https://github.com/surrealdb/install.surrealdb.com) or third-party package managers like [Scoop](https://scoop.sh/). Both the SurrealDB Database Server and the SurrealDB Command Line Tool are packaged and distributed as a single executable file, which is easy to install, and easy to uninstall.
 
 ## Installing SurrealDB using the install script
 
@@ -30,7 +31,7 @@ iwr https://windows.surrealdb.com -useb | iex
 ```
 
 ### Updating SurrealDB
-To ensure that you are using the latest version, update SurrealDB to version `v1.0.0` using the following command.
+To ensure that you are using the latest version, update SurrealDB to version <Version /> using the following command.
 
 ```bash
 iwr https://windows.surrealdb.com -useb | iex
@@ -86,20 +87,6 @@ SUBCOMMANDS:
 
 ```
 
-## Installing SurrealDB using Chocolatey
-If you use the [chocolatey](https://chocolatey.org/) package manager, then you can quickly install SurrealDB with one command. This will install both the command-line tools, and the SurrealDB server as a single executable. If you don't use Homebrew, follow the instructions for Linux below to install SurrealDB.
-
-```bash
-choco install surrealdb
-```
-
-### Updating SurrealDB
-To ensure that you are using the latest version, update SurrealDB to version `v1.0.0` using the following command.
-
-```bash
-choco update surrealdb
-```
-
 ## Installing SurrealDB using Scoop
 If you use the [Scoop](https://scoop.sh/) package manager, then you can quickly install SurrealDB with one command. This will install both the command-line tools, and the SurrealDB server as a single executable.
 
@@ -109,7 +96,7 @@ scoop install surrealdb
 
 ### Updating SurrealDB
 
-To ensure that you are using the latest version, update SurrealDB to version `v1.0.0` using the following command.
+To ensure that you are using the latest version, update SurrealDB to version <Version /> using the following command.
 
 ```bash
 scoop update surrealdb


### PR DESCRIPTION
Removes Installing SurrealDB using Chocolatey as the versioning is not officially supported by SurrealDB. The latest version it has is v1.0.0-beta.9 

Similar PR for website [#477](https://github.com/surrealdb/www.surrealdb.com/pull/477)