### PR TITLE
Update SurrealDB SDK connection to use WebSockets

### DIFF
--- a/versioned_docs/version-1.0.x/integration/sdks/nodejs.mdx
+++ b/versioned_docs/version-1.0.x/integration/sdks/nodejs.mdx
@@ -54,6 +54,10 @@ pnpm install surrealdb.node
 
 Create a new app.js file and add the following code to try out some basic operations using the SurrealDB SDK.
 
+:::note
+__NOTE:__ Currently, the connection for this SDK is only available via WebSockets. ```ws://``` is the only supported protocols.
+:::
+
 ```ts
 const { default: Surreal } = require('surrealdb.node');
 
@@ -63,7 +67,7 @@ async function main() {
 
 	try {
 		// Connect to the database
-		await db.connect('http://127.0.0.1:8000/rpc');
+		await db.connect('ws://127.0.0.1:8000');
 
 		// Signin as a namespace, database, or root user
 		await db.signin({
@@ -251,7 +255,7 @@ async db.connect(url, options)
 ### Example usage
 ```ts
 // Connect to a local endpoint
-await db.connect('http://127.0.0.1:8000/rpc');
+await db.connect('ws://127.0.0.1:8000');
 
 // Connect to a remote endpoint
 await db.connect('https://cloud.surrealdb.com/rpc');

--- a/versioned_docs/version-1.1.x/integration/sdks/nodejs.mdx
+++ b/versioned_docs/version-1.1.x/integration/sdks/nodejs.mdx
@@ -77,6 +77,10 @@ bun install surrealdb.node
 
 Create a new app.js file and add the following code to try out some basic operations using the SurrealDB SDK.
 
+:::note
+__NOTE:__ Currently, the connection for this SDK is only available via WebSockets. ```ws://``` is the only supported protocols.
+:::
+
 ```ts
 const { default: Surreal } = require('surrealdb.node');
 
@@ -86,7 +90,7 @@ async function main() {
 
 	try {
 		// Connect to the database
-		await db.connect('http://127.0.0.1:8000/rpc');
+		await db.connect('ws://127.0.0.1:8000');
 
 		// Signin as a namespace, database, or root user
 		await db.signin({
@@ -274,7 +278,7 @@ async db.connect(url, options)
 ### Example usage
 ```ts
 // Connect to a local endpoint
-await db.connect('http://127.0.0.1:8000/rpc');
+await db.connect('ws://127.0.0.1:8000');
 
 // Connect to a remote endpoint
 await db.connect('https://cloud.surrealdb.com/rpc');

--- a/versioned_docs/version-1.2.x/integration/sdks/nodejs.mdx
+++ b/versioned_docs/version-1.2.x/integration/sdks/nodejs.mdx
@@ -77,6 +77,10 @@ bun install surrealdb.node
 
 Create a new app.js file and add the following code to try out some basic operations using the SurrealDB SDK.
 
+:::note
+__NOTE:__ Currently, the connection for this SDK is only available via WebSockets. ```ws://``` is the only supported protocols.
+:::
+
 ```ts
 const { default: Surreal } = require('surrealdb.node');
 
@@ -86,7 +90,7 @@ async function main() {
 
 	try {
 		// Connect to the database
-		await db.connect('http://127.0.0.1:8000/rpc');
+		await db.connect('ws://127.0.0.1:8000');
 
 		// Signin as a namespace, database, or root user
 		await db.signin({
@@ -274,7 +278,7 @@ async db.connect(url, options)
 ### Example usage
 ```ts
 // Connect to a local endpoint
-await db.connect('http://127.0.0.1:8000/rpc');
+await db.connect('ws://127.0.0.1:8000');
 
 // Connect to a remote endpoint
 await db.connect('https://cloud.surrealdb.com/rpc');

--- a/versioned_docs/version-nightly/integration/sdks/nodejs.mdx
+++ b/versioned_docs/version-nightly/integration/sdks/nodejs.mdx
@@ -77,6 +77,10 @@ bun install surrealdb.node
 
 Create a new app.js file and add the following code to try out some basic operations using the SurrealDB SDK.
 
+:::note
+__NOTE:__ Currently, the connection for this SDK is only available via WebSockets. ```ws://``` is the only supported protocols.
+:::
+
 ```ts
 const { default: Surreal } = require('surrealdb.node');
 
@@ -86,7 +90,7 @@ async function main() {
 
 	try {
 		// Connect to the database
-		await db.connect('http://127.0.0.1:8000/rpc');
+		await db.connect('ws://127.0.0.1:8000');
 
 		// Signin as a namespace, database, or root user
 		await db.signin({
@@ -274,7 +278,7 @@ async db.connect(url, options)
 ### Example usage
 ```ts
 // Connect to a local endpoint
-await db.connect('http://127.0.0.1:8000/rpc');
+await db.connect('ws://127.0.0.1:8000');
 
 // Connect to a remote endpoint
 await db.connect('https://cloud.surrealdb.com/rpc');


### PR DESCRIPTION
`Http` and `Https` connects aren't available yet for the Node SDK causing this error: 

```
error: There was a problem with the underlying datastore: Cannot connect to the `HTTP` remote engine as it is not enabled in this build of SurrealDB
 code: "GenericFailure"
```

This PR Removes the option from the docs and also adds a note 

Resolves #317 