### PR TITLE
Docs: Separate commands in Kubernetes deployment guide

### DIFF
--- a/versioned_docs/version-1.0.x/deployment/kubernetes.mdx
+++ b/versioned_docs/version-1.0.x/deployment/kubernetes.mdx
@@ -46,10 +46,25 @@ kind create cluster -n surreal-demo
 
 ### 2. Verify we can interact with the created cluster
 
-```bash
+```bash title="Verify cluster"
 kubectl config current-context
+```
+
+The output of this command should be:
+
+```bash title="Output"
 kind-surreal-demo
+```
+
+### 3. Verify the nodes are running
+
+```bash title="Verify nodes"
 kubectl get ns
+```
+
+The output of this command should be:
+
+```bash title="Output"
 NAME                 STATUS   AGE
 default              Active   79s
 kube-node-lease      Active   79s
@@ -85,8 +100,13 @@ helm install \
 
 3. Verify that the Pods are running:
 
-```bash
+```bash title="Verify Pods"
 kubectl get pods --namespace tidb-operator -l app.kubernetes.io/instance=tidb-operator
+```
+
+The output of this command should look like this:
+
+```bash title="Output"
 NAME                                       READY   STATUS    RESTARTS   AGE
 tidb-controller-manager-56f49794d7-hnfz7   1/1     Running   0          20s
 tidb-scheduler-8655bcbc86-66h2d            2/2     Running   0          20s
@@ -114,6 +134,11 @@ kubectl apply -n tikv -f https://raw.githubusercontent.com/pingcap/tidb-operator
 
 ```bash title="Verify TIDB Cluster"
 kubectl get -n tikv tidbcluster
+```
+
+The output of this command should look like this:
+
+```bash title="Output"
 NAME    READY   PD                  STORAGE   READY   DESIRE   TIKV   STORAGE   READY   DESIRE   TIDB   READY   DESIRE   AGE
 basic   False   pingcap/pd:v6.5.0   1Gi       1       1               1Gi               1                       1        41s
 $ kubectl get -n tikv tidbcluster
@@ -136,11 +161,19 @@ helm repo update
 
 ```bash title="Get TIKV PD service URL"
 kubectl get -n tikv svc/basic-pd
+```
+the output of this command should look like this:
+
+```bash title="Output"
 NAME       TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)    AGE
 basic-pd   ClusterIP   10.96.208.25   <none>        2379/TCP   10h
+```
+then set the TIKV_URL variable to the PD service URL:
 
+```bash title="Set TIKV_URL variable"
 export TIKV_URL=tikv://basic-pd.tikv:2379
 ```
+
 ### 3. Install the SurrealDB Helm chart with the TIKV_URL defined above and with auth disabled so we can create the initial credentials:
 
 ```bash title="Install SurrealDB HELM chart"
@@ -174,11 +207,15 @@ For this guide, we will use the Surreal CLI. Run the following commands to run s
 
 ```bash
 kubectl port-forward svc/surrealdb-tikv 8000
+```
+
+```bash title="Output"
 Forwarding from 127.0.0.1:8000 -> 8000
 Forwarding from [::1]:8000 -> 8000
 ```
 
 ### 2. Connect to the SurrealDB server using the CLI from another shell:
+
 ```bash 
 surreal sql --conn 'http://localhost:8000' --user root --pass surrealdb 
 ```
@@ -202,13 +239,26 @@ ns/db>
 
 The data created above has been persisted to the TiKV cluster. Let’s verify it by deleting the SurrealDB server and let Kubernetes recreate it.
 
-```bash
+```bash title="Get pod"
 kubectl get pod
+```
+
+The output of this command should look like this:
+
+```bash title="Output"
 NAME                              READY   STATUS    RESTARTS   AGE
 surrealdb-tikv-7488f6f654-lsrwp   1/1     Running   0          13m
+```
+
+```bash title="Delete pod"
 kubectl delete pod surrealdb-tikv-7488f6f654-lsrwp
-pod "surrealdb-tikv-7488f6f654-lsrwp" deleted
+```
+
+```bash title="Get pod"
 kubectl get pod
+```
+
+```bash title="Output"
 NAME                              READY   STATUS    RESTARTS   AGE
 surrealdb-tikv-7488f6f654-bnkjz   1/1     Running   0          4s
 ```

--- a/versioned_docs/version-1.1.x/deployment/kubernetes.mdx
+++ b/versioned_docs/version-1.1.x/deployment/kubernetes.mdx
@@ -46,10 +46,25 @@ kind create cluster -n surreal-demo
 
 ### 2. Verify we can interact with the created cluster
 
-```bash
+```bash title="Verify cluster"
 kubectl config current-context
+```
+
+The output of this command should be:
+
+```bash title="Output"
 kind-surreal-demo
+```
+
+### 3. Verify the nodes are running
+
+```bash title="Verify nodes"
 kubectl get ns
+```
+
+The output of this command should be:
+
+```bash title="Output"
 NAME                 STATUS   AGE
 default              Active   79s
 kube-node-lease      Active   79s
@@ -85,8 +100,12 @@ helm install \
 
 3. Verify that the Pods are running:
 
-```bash
+```bash title="Verify Pods"
 kubectl get pods --namespace tidb-operator -l app.kubernetes.io/instance=tidb-operator
+```
+The output of this command should look like this:
+
+```bash title="Output"
 NAME                                       READY   STATUS    RESTARTS   AGE
 tidb-controller-manager-56f49794d7-hnfz7   1/1     Running   0          20s
 tidb-scheduler-8655bcbc86-66h2d            2/2     Running   0          20s
@@ -114,6 +133,11 @@ kubectl apply -n tikv -f https://raw.githubusercontent.com/pingcap/tidb-operator
 
 ```bash title="Verify TIDB Cluster"
 kubectl get -n tikv tidbcluster
+```
+
+The output of this command should look like this:
+
+```bash title="Output"
 NAME    READY   PD                  STORAGE   READY   DESIRE   TIKV   STORAGE   READY   DESIRE   TIDB   READY   DESIRE   AGE
 basic   False   pingcap/pd:v6.5.0   1Gi       1       1               1Gi               1                       1        41s
 $ kubectl get -n tikv tidbcluster
@@ -136,11 +160,19 @@ helm repo update
 
 ```bash title="Get TIKV PD service URL"
 kubectl get -n tikv svc/basic-pd
+```
+the output of this command should look like this:
+
+```bash title="Output"
 NAME       TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)    AGE
 basic-pd   ClusterIP   10.96.208.25   <none>        2379/TCP   10h
+```
+then set the TIKV_URL variable to the PD service URL:
 
+```bash title="Set TIKV_URL variable"
 export TIKV_URL=tikv://basic-pd.tikv:2379
 ```
+
 ### 3. Install the SurrealDB Helm chart with the TIKV_URL defined above and with auth disabled so we can create the initial credentials:
 
 ```bash title="Install SurrealDB HELM chart"
@@ -174,6 +206,9 @@ For this guide, we will use the Surreal CLI. Run the following commands to run s
 
 ```bash
 kubectl port-forward svc/surrealdb-tikv 8000
+```
+
+```bash title="Output"
 Forwarding from 127.0.0.1:8000 -> 8000
 Forwarding from [::1]:8000 -> 8000
 ```
@@ -202,13 +237,26 @@ ns/db>
 
 The data created above has been persisted to the TiKV cluster. Let’s verify it by deleting the SurrealDB server and let Kubernetes recreate it.
 
-```bash
+```bash title="Get pod"
 kubectl get pod
+```
+
+The output of this command should look like this:
+
+```bash title="Output"
 NAME                              READY   STATUS    RESTARTS   AGE
 surrealdb-tikv-7488f6f654-lsrwp   1/1     Running   0          13m
+```
+
+```bash title="Delete pod"
 kubectl delete pod surrealdb-tikv-7488f6f654-lsrwp
-pod "surrealdb-tikv-7488f6f654-lsrwp" deleted
+```
+
+```bash title="Get pod"
 kubectl get pod
+```
+
+```bash title="Output"
 NAME                              READY   STATUS    RESTARTS   AGE
 surrealdb-tikv-7488f6f654-bnkjz   1/1     Running   0          4s
 ```

--- a/versioned_docs/version-1.2.x/deployment/kubernetes.mdx
+++ b/versioned_docs/version-1.2.x/deployment/kubernetes.mdx
@@ -46,10 +46,25 @@ kind create cluster -n surreal-demo
 
 ### 2. Verify we can interact with the created cluster
 
-```bash
+```bash title="Verify cluster"
 kubectl config current-context
+```
+
+The output of this command should be:
+
+```bash title="Output"
 kind-surreal-demo
+```
+
+### 3. Verify the nodes are running
+
+```bash title="Verify nodes"
 kubectl get ns
+```
+
+The output of this command should be:
+
+```bash title="Output"
 NAME                 STATUS   AGE
 default              Active   79s
 kube-node-lease      Active   79s
@@ -85,8 +100,13 @@ helm install \
 
 3. Verify that the Pods are running:
 
-```bash
+```bash title="Verify Pods"
 kubectl get pods --namespace tidb-operator -l app.kubernetes.io/instance=tidb-operator
+```
+
+The output of this command should look like this:
+
+```bash title="Output"
 NAME                                       READY   STATUS    RESTARTS   AGE
 tidb-controller-manager-56f49794d7-hnfz7   1/1     Running   0          20s
 tidb-scheduler-8655bcbc86-66h2d            2/2     Running   0          20s
@@ -114,6 +134,11 @@ kubectl apply -n tikv -f https://raw.githubusercontent.com/pingcap/tidb-operator
 
 ```bash title="Verify TIDB Cluster"
 kubectl get -n tikv tidbcluster
+```
+
+The output of this command should look like this:
+
+```bash title="Output"
 NAME    READY   PD                  STORAGE   READY   DESIRE   TIKV   STORAGE   READY   DESIRE   TIDB   READY   DESIRE   AGE
 basic   False   pingcap/pd:v6.5.0   1Gi       1       1               1Gi               1                       1        41s
 $ kubectl get -n tikv tidbcluster
@@ -136,11 +161,19 @@ helm repo update
 
 ```bash title="Get TIKV PD service URL"
 kubectl get -n tikv svc/basic-pd
+```
+the output of this command should look like this:
+
+```bash title="Output"
 NAME       TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)    AGE
 basic-pd   ClusterIP   10.96.208.25   <none>        2379/TCP   10h
+```
+then set the TIKV_URL variable to the PD service URL:
 
+```bash title="Set TIKV_URL variable"
 export TIKV_URL=tikv://basic-pd.tikv:2379
 ```
+
 ### 3. Install the SurrealDB Helm chart with the TIKV_URL defined above and with auth disabled so we can create the initial credentials:
 
 ```bash title="Install SurrealDB HELM chart"
@@ -174,6 +207,9 @@ For this guide, we will use the Surreal CLI. Run the following commands to run s
 
 ```bash
 kubectl port-forward svc/surrealdb-tikv 8000
+```
+
+```bash title="Output"
 Forwarding from 127.0.0.1:8000 -> 8000
 Forwarding from [::1]:8000 -> 8000
 ```
@@ -202,13 +238,26 @@ ns/db>
 
 The data created above has been persisted to the TiKV cluster. Let’s verify it by deleting the SurrealDB server and let Kubernetes recreate it.
 
-```bash
+```bash title="Get pod"
 kubectl get pod
+```
+
+The output of this command should look like this:
+
+```bash title="Output"
 NAME                              READY   STATUS    RESTARTS   AGE
 surrealdb-tikv-7488f6f654-lsrwp   1/1     Running   0          13m
+```
+
+```bash title="Delete pod"
 kubectl delete pod surrealdb-tikv-7488f6f654-lsrwp
-pod "surrealdb-tikv-7488f6f654-lsrwp" deleted
+```
+
+```bash title="Get pod"
 kubectl get pod
+```
+
+```bash title="Output"
 NAME                              READY   STATUS    RESTARTS   AGE
 surrealdb-tikv-7488f6f654-bnkjz   1/1     Running   0          4s
 ```

--- a/versioned_docs/version-nightly/deployment/kubernetes.mdx
+++ b/versioned_docs/version-nightly/deployment/kubernetes.mdx
@@ -46,10 +46,25 @@ kind create cluster -n surreal-demo
 
 ### 2. Verify we can interact with the created cluster
 
-```bash
+```bash title="Verify cluster"
 kubectl config current-context
+```
+
+The output of this command should be:
+
+```bash title="Output"
 kind-surreal-demo
+```
+
+### 3. Verify the nodes are running
+
+```bash title="Verify nodes"
 kubectl get ns
+```
+
+The output of this command should be:
+
+```bash title="Output"
 NAME                 STATUS   AGE
 default              Active   79s
 kube-node-lease      Active   79s
@@ -85,8 +100,13 @@ helm install \
 
 3. Verify that the Pods are running:
 
-```bash
+```bash title="Verify Pods"
 kubectl get pods --namespace tidb-operator -l app.kubernetes.io/instance=tidb-operator
+```
+
+The output of this command should look like this:
+
+```bash title="Output"
 NAME                                       READY   STATUS    RESTARTS   AGE
 tidb-controller-manager-56f49794d7-hnfz7   1/1     Running   0          20s
 tidb-scheduler-8655bcbc86-66h2d            2/2     Running   0          20s
@@ -114,6 +134,11 @@ kubectl apply -n tikv -f https://raw.githubusercontent.com/pingcap/tidb-operator
 
 ```bash title="Verify TIDB Cluster"
 kubectl get -n tikv tidbcluster
+```
+
+The output of this command should look like this:
+
+```bash title="Output"
 NAME    READY   PD                  STORAGE   READY   DESIRE   TIKV   STORAGE   READY   DESIRE   TIDB   READY   DESIRE   AGE
 basic   False   pingcap/pd:v6.5.0   1Gi       1       1               1Gi               1                       1        41s
 $ kubectl get -n tikv tidbcluster
@@ -136,11 +161,19 @@ helm repo update
 
 ```bash title="Get TIKV PD service URL"
 kubectl get -n tikv svc/basic-pd
+```
+the output of this command should look like this:
+
+```bash title="Output"
 NAME       TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)    AGE
 basic-pd   ClusterIP   10.96.208.25   <none>        2379/TCP   10h
+```
+then set the TIKV_URL variable to the PD service URL:
 
+```bash title="Set TIKV_URL variable"
 export TIKV_URL=tikv://basic-pd.tikv:2379
 ```
+
 ### 3. Install the SurrealDB Helm chart with the TIKV_URL defined above and with auth disabled so we can create the initial credentials:
 
 ```bash title="Install SurrealDB HELM chart"
@@ -174,6 +207,9 @@ For this guide, we will use the Surreal CLI. Run the following commands to run s
 
 ```bash
 kubectl port-forward svc/surrealdb-tikv 8000
+```
+
+```bash title="Output"
 Forwarding from 127.0.0.1:8000 -> 8000
 Forwarding from [::1]:8000 -> 8000
 ```
@@ -202,13 +238,26 @@ ns/db>
 
 The data created above has been persisted to the TiKV cluster. Let’s verify it by deleting the SurrealDB server and let Kubernetes recreate it.
 
-```bash
+```bash title="Get pod"
 kubectl get pod
+```
+
+The output of this command should look like this:
+
+```bash title="Output"
 NAME                              READY   STATUS    RESTARTS   AGE
 surrealdb-tikv-7488f6f654-lsrwp   1/1     Running   0          13m
+```
+
+```bash title="Delete pod"
 kubectl delete pod surrealdb-tikv-7488f6f654-lsrwp
-pod "surrealdb-tikv-7488f6f654-lsrwp" deleted
+```
+
+```bash title="Get pod"
 kubectl get pod
+```
+
+```bash title="Output"
 NAME                              READY   STATUS    RESTARTS   AGE
 surrealdb-tikv-7488f6f654-bnkjz   1/1     Running   0          4s
 ```


### PR DESCRIPTION
The commands in code block were together with the outputs which will throw and error in terminal. 
This PR separates the commands from the outputs. 