### PR TITLE
Add documention about overflowing numeric record-ids

### DIFF
--- a/versioned_docs/version-nightly/surrealql/datamodel/ids.mdx
+++ b/versioned_docs/version-nightly/surrealql/datamodel/ids.mdx
@@ -34,7 +34,9 @@ CREATE article SET id = "10";
 ```
 
 ## Numeric Record IDs
-If a numeric value is specified without any decimal point suffix and is within the range `-9223372036854775808` to `9223372036854775807` then the value will be parsed, stored, and treated as a 64-bit integer.
+If a numeric value is specified without any decimal point suffix and is within the range `-9223372036854775808` to `9223372036854775807` then the value will be parsed, stored, and treated as a 64-bit signed integer.
+
+If the numeric number is outside the range of a signed 64-bit integer it will be treated as a string.
 
 ```surql
 CREATE temperature:17493 SET time = time::now(), celsius = 37.5;


### PR DESCRIPTION
This PR adds a line in the numeric record-id section about the behaviour when record-id's overflow 64-bit signed integers.