### PR TITLE
Docs: Update Nodejs sdk examples

### DIFF
--- a/versioned_docs/version-1.2.x/integration/sdks/nodejs.mdx
+++ b/versioned_docs/version-1.2.x/integration/sdks/nodejs.mdx
@@ -94,8 +94,8 @@ async function main() {
 
 		// Signin as a namespace, database, or root user
 		await db.signin({
-			user: 'root',
-			pass: 'root',
+			username: 'root',
+			password: 'root',
 		});
 
 		// Select a specific namespace / database
@@ -492,23 +492,23 @@ async db.signin({ ... })
 ```ts
 // Authenticate with a root user
 const token = await db.signin({
-	user: 'root',
-	pass: 'surrealdb',
+	username: 'root',
+	password: 'surrealdb',
 });
 
 // Authenticate with a Namespace user
 const token = await db.signin({
 	ns: 'surrealdb',
-	user: 'tobie',
-	pass: 'surrealdb',
+	username: 'tobie',
+	password: 'surrealdb',
 });
 
 // Authenticate with a Database user
 const token = await db.signin({
 	ns: 'surrealdb',
 	db: 'docs',
-	user: 'tobie',
-	pass: 'surrealdb',
+	username: 'tobie',
+	password: 'surrealdb',
 });
 
 // Authenticate with a Scope user


### PR DESCRIPTION
When I tried following the node.js sdk tutorial, I kept getting the following error:
```bash
ERROR [Error: data did not match any variant of untagged enum Credentials] {
  code: 'InvalidArg'
}
```

This seems to have been caused by the following lines:
```ts
 await db.signin({
            user: 'root',
            pass: 'root',
        });
```

Reverting it back to 
```ts
 await db.signin({
            username: 'root',
            password: 'root',
        });
```

fixed the issue and lead to the desired behavior.