### PR TITLE
Replace composite index by two indexes for FTS

### DIFF
--- a/versioned_docs/version-1.0.x/reference-guide/full-text-search.mdx
+++ b/versioned_docs/version-1.0.x/reference-guide/full-text-search.mdx
@@ -51,9 +51,9 @@ Your text field won't be "full text searchable" unless you define a [full-text 
 Depending on the use case, each field can be associated with a different analyser. 
 
 ```surql
--- Defining a full-text index on the 'title' and 'content' field of the 'book' table
-DEFINE INDEX book_idx ON book FIELDS title, content SEARCH ANALYZER 
-custom_analyzer BM25;
+-- Defining two full-text indexes on the 'title' and 'content' field of the 'book' table
+DEFINE INDEX book_idx ON book FIELDS title SEARCH ANALYZER custom_analyzer BM25;
+DEFINE INDEX book_idx ON book FIELDS content SEARCH ANALYZER custom_analyzer BM25;
 ```
 
 ## The MATCHES Operator

--- a/versioned_docs/version-1.0.x/reference-guide/full-text-search.mdx
+++ b/versioned_docs/version-1.0.x/reference-guide/full-text-search.mdx
@@ -52,7 +52,7 @@ Depending on the use case, each field can be associated with a different analyse
 
 ```surql
 -- Defining two full-text indexes on the 'title' and 'content' field of the 'book' table
-DEFINE INDEX book_idx ON book FIELDS title SEARCH ANALYZER custom_analyzer BM25;
+DEFINE INDEX book_title ON book FIELDS title SEARCH ANALYZER custom_analyzer BM25;
 DEFINE INDEX book_idx ON book FIELDS content SEARCH ANALYZER custom_analyzer BM25;
 ```
 

--- a/versioned_docs/version-1.0.x/reference-guide/full-text-search.mdx
+++ b/versioned_docs/version-1.0.x/reference-guide/full-text-search.mdx
@@ -53,7 +53,7 @@ Depending on the use case, each field can be associated with a different analyse
 ```surql
 -- Defining two full-text indexes on the 'title' and 'content' field of the 'book' table
 DEFINE INDEX book_title ON book FIELDS title SEARCH ANALYZER custom_analyzer BM25;
-DEFINE INDEX book_idx ON book FIELDS content SEARCH ANALYZER custom_analyzer BM25;
+DEFINE INDEX book_content ON book FIELDS content SEARCH ANALYZER custom_analyzer BM25;
 ```
 
 ## The MATCHES Operator

--- a/versioned_docs/version-1.1.x/reference-guide/full-text-search.mdx
+++ b/versioned_docs/version-1.1.x/reference-guide/full-text-search.mdx
@@ -50,9 +50,9 @@ To make a text field searchable, you need to set up a [full-text index](/docs/su
 Depending on the use case, each field can be associated with a different analyser. 
 
 ```surql
--- Defining a full-text index on the 'title' and 'content' field of the 'book' table
-DEFINE INDEX book_idx ON book FIELDS title, content SEARCH ANALYZER 
-custom_analyzer BM25;
+-- Defining two full-text indexes on the 'title' and 'content' field of the 'book' table
+DEFINE INDEX book_idx ON book FIELDS title SEARCH ANALYZER custom_analyzer BM25;
+DEFINE INDEX book_idx ON book FIELDS content SEARCH ANALYZER custom_analyzer BM25;
 ```
 
 ## The MATCHES Operator

--- a/versioned_docs/version-1.1.x/reference-guide/full-text-search.mdx
+++ b/versioned_docs/version-1.1.x/reference-guide/full-text-search.mdx
@@ -51,7 +51,7 @@ Depending on the use case, each field can be associated with a different analyse
 
 ```surql
 -- Defining two full-text indexes on the 'title' and 'content' field of the 'book' table
-DEFINE INDEX book_idx ON book FIELDS title SEARCH ANALYZER custom_analyzer BM25;
+DEFINE INDEX book_title ON book FIELDS title SEARCH ANALYZER custom_analyzer BM25;
 DEFINE INDEX book_idx ON book FIELDS content SEARCH ANALYZER custom_analyzer BM25;
 ```
 

--- a/versioned_docs/version-1.1.x/reference-guide/full-text-search.mdx
+++ b/versioned_docs/version-1.1.x/reference-guide/full-text-search.mdx
@@ -52,7 +52,7 @@ Depending on the use case, each field can be associated with a different analyse
 ```surql
 -- Defining two full-text indexes on the 'title' and 'content' field of the 'book' table
 DEFINE INDEX book_title ON book FIELDS title SEARCH ANALYZER custom_analyzer BM25;
-DEFINE INDEX book_idx ON book FIELDS content SEARCH ANALYZER custom_analyzer BM25;
+DEFINE INDEX book_content ON book FIELDS content SEARCH ANALYZER custom_analyzer BM25;
 ```
 
 ## The MATCHES Operator

--- a/versioned_docs/version-1.2.x/reference-guide/full-text-search.mdx
+++ b/versioned_docs/version-1.2.x/reference-guide/full-text-search.mdx
@@ -51,9 +51,9 @@ To make a text field searchable, you need to set up a [full-text index](/docs/su
 Depending on the use case, each field can be associated with a different analyser. 
 
 ```surql
--- Defining a full-text index on the 'title' and 'content' field of the 'book' table
-DEFINE INDEX book_idx ON book FIELDS title, content SEARCH ANALYZER 
-custom_analyzer BM25;
+-- Defining two full-text indexes on the 'title' and 'content' field of the 'book' table
+DEFINE INDEX book_idx ON book FIELDS title SEARCH ANALYZER custom_analyzer BM25;
+DEFINE INDEX book_idx ON book FIELDS content SEARCH ANALYZER custom_analyzer BM25;
 ```
 
 ## The MATCHES Operator

--- a/versioned_docs/version-1.2.x/reference-guide/full-text-search.mdx
+++ b/versioned_docs/version-1.2.x/reference-guide/full-text-search.mdx
@@ -52,7 +52,7 @@ Depending on the use case, each field can be associated with a different analyse
 
 ```surql
 -- Defining two full-text indexes on the 'title' and 'content' field of the 'book' table
-DEFINE INDEX book_idx ON book FIELDS title SEARCH ANALYZER custom_analyzer BM25;
+DEFINE INDEX book_title ON book FIELDS title SEARCH ANALYZER custom_analyzer BM25;
 DEFINE INDEX book_idx ON book FIELDS content SEARCH ANALYZER custom_analyzer BM25;
 ```
 

--- a/versioned_docs/version-1.2.x/reference-guide/full-text-search.mdx
+++ b/versioned_docs/version-1.2.x/reference-guide/full-text-search.mdx
@@ -53,7 +53,7 @@ Depending on the use case, each field can be associated with a different analyse
 ```surql
 -- Defining two full-text indexes on the 'title' and 'content' field of the 'book' table
 DEFINE INDEX book_title ON book FIELDS title SEARCH ANALYZER custom_analyzer BM25;
-DEFINE INDEX book_idx ON book FIELDS content SEARCH ANALYZER custom_analyzer BM25;
+DEFINE INDEX book_content ON book FIELDS content SEARCH ANALYZER custom_analyzer BM25;
 ```
 
 ## The MATCHES Operator

--- a/versioned_docs/version-nightly/reference-guide/full-text-search.mdx
+++ b/versioned_docs/version-nightly/reference-guide/full-text-search.mdx
@@ -50,9 +50,9 @@ To make a text field searchable, you need to set up a [full-text index](/docs/su
 Depending on the use case, each field can be associated with a different analyser. 
 
 ```surql
--- Defining a full-text index on the 'title' and 'content' field of the 'book' table
-DEFINE INDEX book_idx ON book FIELDS title, content SEARCH ANALYZER 
-custom_analyzer BM25;
+-- Defining two full-text indexes on the 'title' and 'content' field of the 'book' table
+DEFINE INDEX book_idx ON book FIELDS title SEARCH ANALYZER custom_analyzer BM25;
+DEFINE INDEX book_idx ON book FIELDS content SEARCH ANALYZER custom_analyzer BM25;
 ```
 
 ## The MATCHES Operator

--- a/versioned_docs/version-nightly/reference-guide/full-text-search.mdx
+++ b/versioned_docs/version-nightly/reference-guide/full-text-search.mdx
@@ -51,7 +51,7 @@ Depending on the use case, each field can be associated with a different analyse
 
 ```surql
 -- Defining two full-text indexes on the 'title' and 'content' field of the 'book' table
-DEFINE INDEX book_idx ON book FIELDS title SEARCH ANALYZER custom_analyzer BM25;
+DEFINE INDEX book_title ON book FIELDS title SEARCH ANALYZER custom_analyzer BM25;
 DEFINE INDEX book_idx ON book FIELDS content SEARCH ANALYZER custom_analyzer BM25;
 ```
 

--- a/versioned_docs/version-nightly/reference-guide/full-text-search.mdx
+++ b/versioned_docs/version-nightly/reference-guide/full-text-search.mdx
@@ -52,7 +52,7 @@ Depending on the use case, each field can be associated with a different analyse
 ```surql
 -- Defining two full-text indexes on the 'title' and 'content' field of the 'book' table
 DEFINE INDEX book_title ON book FIELDS title SEARCH ANALYZER custom_analyzer BM25;
-DEFINE INDEX book_idx ON book FIELDS content SEARCH ANALYZER custom_analyzer BM25;
+DEFINE INDEX book_content ON book FIELDS content SEARCH ANALYZER custom_analyzer BM25;
 ```
 
 ## The MATCHES Operator


### PR DESCRIPTION
Actually the documention is misleading

https://github.com/surrealdb/surrealdb/issues/3530

> In fact, the main usage of composite indexes is for unique indexes, when you want to ensure that there are not two records in the same table having the same composite content.
> 
> By extension, it is possible to build a composite index with FTS in SurrealDB, but that does not really make sense, as there is no possibility to query it. In a future release, we will clarify this behavior.