### PR TITLE
fix: permanent horizontal scrollbar on sidebar

### DIFF
--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -2469,4 +2469,7 @@ hr {
 
 .doc-sidebar-container {
   overflow-y: auto;
+  >div {
+	width: unset;
+  }
 }


### PR DESCRIPTION
On windows 11 - 64bit When browsing on chrome there was a horizontal scrollbar showing. It seemed that the docusaurus adds a width with a defined variable as value. But the width is already defined on the parent `.theme-doc-sidebar-container`. So by unsetting the width on the  only div that lives inside `.doc-sidebar-container` fixes the scrollbar issue.

I have checked the issue against the browsers: `Firefox`, `Chrome`, `Brave` and `Edge` and it seems it's fixed. But not sure how it will affect Mac OSX.

Also note, the mobile version of the sidebar doesn't get affected at all by this change. At least on my android pixel 7 phone ( chrome )