### PR TITLE
Update relate query explanations

### DIFF
--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/relate.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/relate.mdx
@@ -148,16 +148,16 @@ Select every product that was purchased by a person who purchased a product that
 Alternatively, you can break it down in steps
 
 ```surql
--- Focusing on Tobie
+-- Starting with Tobie
 person:tobie
 
--- Which products did he purchase?
+-- and his purchased products
 ->purchased->product
 
--- which persons also purchased those products?
+-- that were also purchased by persons
 <-purchased<-person
 
--- and what did they purchase?
+-- what are all of those persons' purchased products?
 ->purchased->product
 ```
 

--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/relate.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/relate.mdx
@@ -14,7 +14,7 @@ This allows you to traverse related records efficiently without needing to pull 
 Edges created using the RELATE statement are nearly identical to tables created using other statements.
 The key differences are that
 
-- Edge tables have two required fields in and out, which specify the directions of the relationships.
+- Edge tables have two required fields `in` and `out`, which specify the directions of the relationships.
 - Edge tables are deleted once there are no existing relationships left.
 
 Edge tables behave like normal tables in terms of [updating](/docs/surrealdb/surrealql/statements/update), [defining a schema](/docs/surrealdb/surrealql/statements/define/table) or [indexes](/docs/surrealdb/surrealql/statements/define/indexes).
@@ -59,7 +59,8 @@ RELATE person:l19zjikkw1p1h9o6ixrg->wrote->article:8nkk6uj4yprt49z7y3zm;
 ```
 
 There is no relationship information stored in either the person or article table.
-Instead, an edge table (in this case a table called wrote) stores the relationship information. As you see, the structure `in -> id -> out` mirrors the record IDs from the `RELATE` statement, with the addition of the automatically generated ID for the wrote edge table.
+
+Instead, an edge table (in this case a table called `wrote`) stores the relationship information. The structure `in -> id -> out` mirrors the record IDs from the `RELATE` statement, with the addition of the automatically generated ID for the wrote edge table.
 
 By default, the edge table gets created as a schemaless table when you execute the `RELATE` statement. You can however make the table schemafull by either [defining a schema](/docs/surrealdb/surrealql/statements/define/table) before or after executing the RELATE statement.
 
@@ -79,6 +80,8 @@ DEFINE FIELD out ON TABLE wrote TYPE record<article>;
 
 ### Adding data using `SET` and `CONTENT`
 
+Graph edges are standalone tables that can hold other fields besides the default `in`, `out`, and `id`. These can be added during a `RELATE` statement or during an `UPDATE` in the same manner as any other SurrealDB table.
+
 Let's look at the two ways you can add record data in the `RELATE` statement. Both of these queries will produce the same result.
 
 ```surql
@@ -92,6 +95,22 @@ RELATE person:l19zjikkw1p1h9o6ixrg->wrote->article:8nkk6uj4yprt49z7y3zm
 			written: time::now()
 		}
 	};
+```
+
+Here is an example of a graph edge being updated in the same way as any other SurrealDB record:
+
+```surql
+-- Add a small synopsis composed of the table name and article ID
+UPDATE wrote SET
+    description = meta::tb(out) + ' written by ' + <string>in;
+
+--Output
+    {
+        "id": "wrote:s51jjewpw953ahysbhak",
+        "in": "person:l19zjikkw1p1h9o6ixrg",
+        "out": "article:8nkk6uj4yprt49z7y3zm",
+        "description": "article written by person:l19zjikkw1p1h9o6ixrg"
+    }
 ```
 
 ### Creating a single relation with the ONLY keyword

--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/relate.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/relate.mdx
@@ -48,7 +48,9 @@ For table names we prioritise readability, such that normal tables are singular,
 
 ```surql
 RELATE person:l19zjikkw1p1h9o6ixrg->wrote->article:8nkk6uj4yprt49z7y3zm;
+```
 
+```bash title="Response"
 [
 	{
 		"id": "wrote:ctwsll49k37a7rmqz9rr",
@@ -103,8 +105,9 @@ Here is an example of a graph edge being updated in the same way as any other Su
 -- Add a small synopsis composed of the table name and article ID
 UPDATE wrote SET
     description = meta::tb(out) + ' written by ' + <string>in;
+```
 
---Output
+```bash title="Response"
     {
         "id": "wrote:s51jjewpw953ahysbhak",
         "in": "person:l19zjikkw1p1h9o6ixrg",
@@ -257,8 +260,9 @@ For example the graph edge below:
 
 ```surql
 RELATE person:tobie->bought->product:iphone;
+```
 
-
+```bash title="Response"
 [
 	{
 		"id": "bought:ctwsll49k37a7rmqz9rr",

--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/relate.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/relate.mdx
@@ -122,7 +122,7 @@ RELATE ONLY person:l19zjikkw1p1h9o6ixrg->wrote->article:8nkk6uj4yprt49z7y3zm;
 ## Basics of querying graphs
 Let's look at how the above gets queried, for more examples see the [SELECT docs](/docs/surrealdb/surrealql/statements/select).
 
-For the questions below, each of the queries will give you the same answer.
+For the questions below, each of the queries will give you the same answer. Note that whether `->` and `<-` are parsed as `in` or `out` depends on their direction in relation to the graph edge `wrote`. An arrow pointing towards `wrote` corresponds to `in`, and vice versa.
 
 ```surql
 -- Who wrote the articles?


### PR DESCRIPTION
This PR started out as a quick change to the "Tobie's purchased products" bit to make it easier to read, but decided to add a bit more:

* Clarify that graph edges can be UPDATEd like any other table
* A small hint that whether -> and <- are `in` or `out` depends on their direction in relation to the graph edge. (Was something that tripped me up in the beginning as I was reading `->` as `in` and `<-` as `out` at first and couldn't make sense of the long graph query doing that)

One note is that the examples in this page sort of assume a strict schema (as otherwise the queries returning the same results wouldn't return the same result if multiple record types were found at `in` or `out`) and the example I added with a small synopsis is the same. Was considering explaining all of that minutiae as well but decided against it as that would make the page overwhelming.