### PR TITLE
Add example of multiple record type creation

### DIFF
--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/create.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/create.mdx
@@ -114,8 +114,9 @@ Multiple records or even multiple record types can be created by separating reco
 CREATE townsperson, cat, dog SET
     created_at = time::now(),
     name = "Just a " + meta::tb(id);
+```
 
---Output
+```bash title="Output"
 [
     {
         "created_at": "2024-03-19T03:12:05.079Z",

--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/create.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/create.mdx
@@ -107,7 +107,7 @@ CREATE person:100 CONTENT {
 
 ### Creating multiple records
 
-Multiple record types can be created by separating record names by commas.
+Multiple records or even multiple record types can be created by separating record names by commas.
 
 ```surql
 --Note: meta::tb(id) returns just the table name portion of a record ID

--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/create.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/create.mdx
@@ -112,7 +112,7 @@ Multiple record types can be created by separating record names by commas.
 ```surql
 --Note: meta::tb(id) returns just the table name portion of a record ID
 CREATE townsperson, cat, dog SET
-	created_at = time::now(),
+    created_at = time::now(),
     name = "Just a " + meta::tb(id);
 
 --Output

--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/create.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/create.mdx
@@ -103,7 +103,39 @@ CREATE person:100 CONTENT {
 };
 ```
 
-## Clauses and Options
+## Options and clauses
+
+### Creating multiple records
+
+Multiple record types can be created by separating record names by commas.
+
+```surql
+--Note: meta::tb(id) returns just the table name portion of a record ID
+CREATE townsperson, cat, dog SET
+	created_at = time::now(),
+    name = "Just a " + meta::tb(id);
+
+--Output
+[
+    {
+        "created_at": "2024-03-19T03:12:05.079Z",
+        "id": "townsperson:p37ha2lngckp3v8tvf2j",
+        "name": "Just a townsperson"
+    },
+    {
+        "created_at": "2024-03-19T03:12:05.080Z",
+        "id": "cat:p1pwbjaq96nhhnuohjtc",
+        "name": "Just a cat"
+    },
+    {
+        "created_at": "2024-03-19T03:12:05.080Z",
+        "id": "dog:01vcxgdpuctdk354hzkp",
+        "name": "Just a dog"
+    }
+]
+```
+
+### ONLY
 
 Using the `ONLY` clause after `CREATE` will return just the record object instead of the default, which returns the object inside of an array.
 
@@ -111,6 +143,7 @@ Using the `ONLY` clause after `CREATE` will return just the record object instea
 -- Create just a single record
 CREATE ONLY person:tobie SET name = 'Tobie', company = 'SurrealDB', skills = ['Rust', 'Go', 'JavaScript'];
 ```
+
 ### Return Values
 
 By default, the create statement returns the record once the changes have been made. To change what is returned, we can use the `RETURN` clause, specifying either `NONE`, `BEFORE`, `AFTER`, `DIFF`, or a comma-separated list of specific fields to return.


### PR DESCRIPTION
This page contains a `CREATE ONLY` example, but when reading it for the first time I didn't know how to create more than one record (tried an array, range, etc.) Comma-separated is doable so have added that example right before `CREATE ONLY` is mentioned.