### PR TITLE
fix: pointers in string function lookup table point towards correct location

### DIFF
--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/functions/string.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/functions/string.mdx
@@ -134,43 +134,43 @@ These functions can be used when working with and manipulating text and string v
       <td scope="row" data-label="Description">Checks whether a value is a UUID</td>
     </tr>
     <tr>
-      <td scope="row" data-label="Function"><a href="#stringsemvercompare"><code>string::semver::compare()</code></a> <l className='purple'>Since 1.2.0</l></td>
+      <td scope="row" data-label="Function"><a href="#stringsemvercompare-since-120"><code>string::semver::compare()</code></a> <l className='purple'>Since 1.2.0</l></td>
       <td scope="row" data-label="Description">Performs a comparison between two semver strings</td>
     </tr>
     <tr>
-      <td scope="row" data-label="Function"><a href="#stringsemvermajor"><code>string::semver::major()</code></a><l className='purple'>Since 1.2.0</l></td>
+      <td scope="row" data-label="Function"><a href="#stringsemvermajor-since-120"><code>string::semver::major()</code></a><l className='purple'>Since 1.2.0</l></td>
       <td scope="row" data-label="Description">Extract the major version from a semver string</td>
     </tr>
     <tr>
-      <td scope="row" data-label="Function"><a href="#stringsemverminor"><code>string::semver::minor()</code></a><l className='purple'>Since 1.2.0</l></td>
+      <td scope="row" data-label="Function"><a href="#stringsemverminor-since-120"><code>string::semver::minor()</code></a><l className='purple'>Since 1.2.0</l></td>
       <td scope="row" data-label="Description">Extract the minor version from a semver string</td>
     </tr>
     <tr>
-      <td scope="row" data-label="Function"><a href="#stringsemverpatch"><code>string::semver::patch()</code></a><l className='purple'>Since 1.2.0</l></td>
+      <td scope="row" data-label="Function"><a href="#stringsemverpatch-since-120"><code>string::semver::patch()</code></a><l className='purple'>Since 1.2.0</l></td>
       <td scope="row" data-label="Description">Extract the patch version from a semver string</td>
     </tr>
     <tr>
-      <td scope="row" data-label="Function"><a href="#stringsemverincmajor"><code>string::semver::inc::major()</code></a><l className='purple'>Since 1.2.0</l></td>
+      <td scope="row" data-label="Function"><a href="#stringsemverincmajor-since-120"><code>string::semver::inc::major()</code></a><l className='purple'>Since 1.2.0</l></td>
       <td scope="row" data-label="Description">Increment the major version of a semver string</td>
     </tr>
     <tr>
-      <td scope="row" data-label="Function"><a href="#stringsemverincminor"><code>string::semver::inc::minor()</code></a><l className='purple'>Since 1.2.0</l></td>
+      <td scope="row" data-label="Function"><a href="#stringsemverincminor-since-120"><code>string::semver::inc::minor()</code></a><l className='purple'>Since 1.2.0</l></td>
       <td scope="row" data-label="Description">Increment the minor version of a semver string</td>
     </tr>
     <tr>
-      <td scope="row" data-label="Function"><a href="#stringsemverincpatch"><code>string::semver::inc::patch()</code></a><l className='purple'>Since 1.2.0</l></td>
+      <td scope="row" data-label="Function"><a href="#stringsemverincpatch-since-120"><code>string::semver::inc::patch()</code></a><l className='purple'>Since 1.2.0</l></td>
       <td scope="row" data-label="Description">Increment the patch version of a semver string</td>
     </tr>
     <tr>
-      <td scope="row" data-label="Function"><a href="#stringsemversetmajor"><code>string::semver::set::major()</code></a><l className='purple'>Since 1.2.0</l></td>
+      <td scope="row" data-label="Function"><a href="#stringsemversetmajor-since-120"><code>string::semver::set::major()</code></a><l className='purple'>Since 1.2.0</l></td>
       <td scope="row" data-label="Description">Set the major version of a semver string</td>
     </tr>
     <tr>
-      <td scope="row" data-label="Function"><a href="#stringsemversetminor"><code>string::semver::set::minor()</code></a><l className='purple'>Since 1.2.0</l></td>
+      <td scope="row" data-label="Function"><a href="#stringsemversetminor-since-120"><code>string::semver::set::minor()</code></a><l className='purple'>Since 1.2.0</l></td>
       <td scope="row" data-label="Description">Set the minor version of a semver string</td>
     </tr>
     <tr>
-      <td scope="row" data-label="Function"><a href="#stringsemversetpatch"><code>string::semver::set::patch()</code></a><l className='purple'>Since 1.2.0</l></td>
+      <td scope="row" data-label="Function"><a href="#stringsemversetpatch-since-120"><code>string::semver::set::patch()</code></a><l className='purple'>Since 1.2.0</l></td>
       <td scope="row" data-label="Description">Set the patch version of a semver string</td>
     </tr>
   </tbody>


### PR DESCRIPTION
Closes issue: #418 

Made pointers in the strings function lookup table like: `#stringsemvercompare` and `#stringsemverincminor` point to `#stringsemvercompare-since-120` and `#stringsemverincminor-since-120` respectively