### PR TITLE
Docs: Remove emoji characters

### DIFF
--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/functions/geo.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/functions/geo.mdx
@@ -34,11 +34,11 @@ These functions can be used when working with and analysing geospatial data.
       <td scope="row" data-label="Description">Calculates the distance between two geolocation points</td>
     </tr>
     <tr>
-      <td scope="row" data-label="Function"><a href="#geohashdecode"><code>geo::hash::decode()</code></a></td>
+      <td scope="row" data-label="Function"><a href="#geohashdecode"><code>geo::&#8203;hash::decode()</code></a></td>
       <td scope="row" data-label="Description">Decodes a geohash into a geometry point</td>
     </tr>
     <tr>
-      <td scope="row" data-label="Function"><a href="#geohashencode"><code>geo::hash::encode()</code></a></td>
+      <td scope="row" data-label="Function"><a href="#geohashencode"><code>geo::&#8203;hash::encode()</code></a></td>
       <td scope="row" data-label="Description">Encodes a geometry point into a geohash</td>
     </tr>
   </tbody>

--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/functions/ml.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/functions/ml.mdx
@@ -19,7 +19,7 @@ These functions can be used when calculating outputs from a trained machine lear
 	<tbody>
 		<tr>
 			<td scope="row" data-label="Function">
-				<a href="#ml">
+				<a href="ml#mlname-of-modelversion">
 					<code>
 						ml::name-of-model&lt;version&gt;()
 					</code>

--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/functions/object.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/functions/object.mdx
@@ -18,23 +18,23 @@ These functions can be used when working with, and manipulating data objects.
   </thead>
   <tbody>
     <tr>
-      <td scope="row" data-label="Function"><a href="#objectentries"><code>object::entries()</code></a><l className='purple'>Since 1.1.0</l></td>
+      <td scope="row" data-label="Function"><a href="#objectentries-since-110"><code>object::entries()</code></a><l className='purple'>Since 1.1.0</l></td>
       <td scope="row" data-label="Description">Transforms an object into an array with arrays of key-value combinations.</td>
     </tr>
     <tr>
-      <td scope="row" data-label="Function"><a href="#objectfromentries"><code>object::from_entries()</code></a><l className='purple'>Since 1.1.0</l></td>
+      <td scope="row" data-label="Function"><a href="#objectfromentries-since-110"><code>object::from_entries()</code></a><l className='purple'>Since 1.1.0</l></td>
       <td scope="row" data-label="Description">Transforms an array with arrays of key-value combinations into an object.</td>
     </tr>
     <tr>
-      <td scope="row" data-label="Function"><a href="#objectkeys"><code>object::keys()</code></a><l className='purple'>Since 1.1.0</l></td>
+      <td scope="row" data-label="Function"><a href="#objectkeys-since-110"><code>object::keys()</code></a><l className='purple'>Since 1.1.0</l></td>
       <td scope="row" data-label="Description">Returns an array with all the keys of an object.</td>
     </tr>
     <tr>
-      <td scope="row" data-label="Function"><a href="#objectlen"><code>object::len()</code></a><l className='purple'>Since 1.1.0</l></td>
+      <td scope="row" data-label="Function"><a href="#objectlen-since-110"><code>object::len()</code></a><l className='purple'>Since 1.1.0</l></td>
       <td scope="row" data-label="Description">Returns the amount of key-value pairs an object holds.</td>
     </tr>
     <tr>
-      <td scope="row" data-label="Function"><a href="#objectvalues"><code>object::values()</code></a><l className='purple'>Since 1.1.0</l></td>
+      <td scope="row" data-label="Function"><a href="#objectvalues-since-110"><code>object::values()</code></a><l className='purple'>Since 1.1.0</l></td>
       <td scope="row" data-label="Description">Returns an array with all the values of an object.</td>
     </tr>
   </tbody>

--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/functions/parse.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/functions/parse.mdx
@@ -18,11 +18,11 @@ These functions can be used when parsing email addresses and URL web addresses.
   </thead>
   <tbody>
     <tr>
-      <td scope="row" data-label="Function"><a href="#parseemailhost"><code>parse::email::host()</code></a></td>
+      <td scope="row" data-label="Function"><a href="#parseemailhost"><code>parse::&#8203;email::host()</code></a></td>
       <td scope="row" data-label="Description">Parses and returns an email host from an email address</td>
     </tr>
     <tr>
-      <td scope="row" data-label="Function"><a href="#parseemailuser"><code>parse::email::user()</code></a></td>
+      <td scope="row" data-label="Function"><a href="#parseemailuser"><code>parse::&#8203;email::user()</code></a></td>
       <td scope="row" data-label="Description">Parses and returns an email username from an email address</td>
     </tr>
     <tr>

--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/functions/time.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/functions/time.mdx
@@ -94,7 +94,7 @@ These functions can be used when working with and manipulating datetime values.
       <td scope="row" data-label="Description">Extracts the year as a number from a datetime</td>
     </tr>
     <tr>
-      <td scope="row" data-label="Function"><a href="#timefrommicros"><code>time::from::micros()</code></a><l className='purple'>Since 1.1.0</l></td>
+      <td scope="row" data-label="Function"><a href="#timefrommicros-since-110"><code>time::from::micros()</code></a><l className='purple'>Since 1.1.0</l></td>
       <td scope="row" data-label="Description">Calculates a datetimes based on an amount of microseconds since January 1, 1970 0:00:00 UTC.</td>
     </tr>
     <tr>
@@ -440,7 +440,7 @@ RETURN time::from::micros(1000000);
 
 <br />
 
-## `time::from::millis` <l className='purple'>Since 1.1.0</l>
+## `time::from::millis`
 
 The `time::from::millis` function calculates a datetime based on an amount of milliseconds since January 1, 1970 0:00:00 UTC.
 

--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/functions/type.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/functions/type.mdx
@@ -114,7 +114,7 @@ These functions can be used for generating and coercing data to specific data ty
       <td scope="row" data-label="Description">Checks if given value is of type line</td>
     </tr>
     <tr>
-      <td scope="row" data-label="Function"><a href="#typeisnone"><code>type::is::none()</code></a> <l className='purple'>Since 1.1.0</l></td>
+      <td scope="row" data-label="Function"><a href="#typeisnone-since-110"><code>type::is::none()</code></a> <l className='purple'>Since 1.1.0</l></td>
       <td scope="row" data-label="Description">Checks if given value is of type none</td>
     </tr>
     <tr>

--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/functions/vector.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/functions/vector.mdx
@@ -78,7 +78,7 @@ A collection of essential vector operations that provide foundational functional
       <td scope="row" data-label="Description">Computes the Minkowski distance between two vectors</td>
     </tr>
     <tr>
-      <td scope="row" data-label="Function"><a href="#vectorsimilaritycosine"><code>vector::similarity::cosine()</code></a></td>
+      <td scope="row" data-label="Function"><a href="vector#vectorsimilaritycosine"><code>vector::similarity::cosine()</code></a></td>
       <td scope="row" data-label="Description">Computes the Cosine similarity between two vectors</td>
     </tr>
     <tr>
@@ -360,9 +360,9 @@ RETURN vector::distance::minkowski([10, 20, 15, 10, 5], [12, 24, 18, 8, 7], 3);
 
 <br />
 
-## `vector::distance::cosine`
+## `vector::similarity::cosine`
 
-The `vector::distance::cosine` function computes the Cosine similarity between two vectors, indicating the cosine of the angle between them, which is a measure of how closely two vectors are oriented to each other.
+The `vector::similarity::cosine` function computes the Cosine similarity between two vectors, indicating the cosine of the angle between them, which is a measure of how closely two vectors are oriented to each other.
 
 
 ```surql title="API DEFINITION"


### PR DESCRIPTION
Docusaurus auto adds emojis when special key words are written after a `::` which causes emojis. This PR adds a zero-width space to remove that behaviour. 