### PR TITLE
Add example using $input for ON DUPLICATE KEY UPDATE

### DIFF
--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/insert.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/insert.mdx
@@ -51,6 +51,15 @@ When using the `VALUES` clause, it is possible to update records which already e
 INSERT INTO product (name, url) VALUES ('Salesforce', 'salesforce.com') ON DUPLICATE KEY UPDATE tags += 'crm';
 ```
 
+Field names inside `ON DUPLICATE KEY UPDATE` refer to the fields of the existing record. To access the fields of the new record that was attempted to be inserted, prefix the field name with `$input`:
+
+```surql
+INSERT INTO city (id, population, at_year) VALUES ("Calgary", 1665000, 2024)
+ON DUPLICATE KEY UPDATE
+	population = $input.population,
+	at_year = $input.at_year;
+```
+
 Using the insert statement, it is possible to copy records easily between tables. The records being copied will have the same id in the new table, but the record id will signify the new table name.
 
 ```surql


### PR DESCRIPTION
INSERT documentation currently doesn't inform that the $input parameter is available.

e.g. CREATE a city:

```
CREATE city SET
id = "Calgary",
population = 1266000,
at_year = 2014;
```

INSERT INTO in this way accesses the already created object so nothing will be updated.

```
INSERT INTO city [
{
"id": "Calgary",
population: 1665000,
population_at: 2024
}
] ON DUPLICATE KEY UPDATE
population = population won't work (but $input.population will),
at_year = at_year won't work (but $input.at_year will);
```