### PR TITLE
array::clump: remove reference to Rust method, have example show when…

### DIFF
--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/functions/array.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/functions/array.mdx
@@ -420,7 +420,7 @@ The following example shows this function, and its output, when used in a [`RETU
 ```surql
 RETURN array::clump([1, 2, 3, 4, 5], 2);
 
-[ [0, 1], [2, 3], [5] ]
+[ [1, 2], [3, 4], [5] ]
 ```
 
 <br />

--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/functions/array.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/functions/array.mdx
@@ -410,7 +410,7 @@ RETURN array::concat([1,2,3,4], [3,4,5,6]);
 
 ## `array::clump`
 
-The `array::clump` function returns the original array split into sub-arrays of `size`. Similar to `slice::chunks`
+The `array::clump` function returns the original array split into sub-arrays of `size`.
 
 ```surql title="API DEFINITION"
 array::clump(array, value) -> array
@@ -418,9 +418,9 @@ array::clump(array, value) -> array
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:
 
 ```surql
-RETURN array::clump([0, 1, 2, 3], 2);
+RETURN array::clump([1, 2, 3, 4, 5], 2);
 
-[ [0, 1], [2, 3] ]
+[ [0, 1], [2, 3], [5] ]
 ```
 
 <br />


### PR DESCRIPTION
The array::clump function ends with a note that it is `Similar to slice::chunks`, which is a method that only Rust developers will be familiar with. This PR removes that note while also demonstrating the behaviour when the number of items of an array doesn't evenly divide into the chunk (er, clump) size.

I was going to add an example of when a clump size of 0 is specified (because in Rust that will lead to a panic) but looks like the function at the moment just calls chunks without checking for 0 so the output when 0 is specified will depend on how this bug gets fixed. I assume it will either return an empty array or an error message when fixed.

https://github.com/surrealdb/surrealdb/issues/3757