### PR TITLE
fix(doc-126-sidebar): It removes the version tag in the sidebar

### DIFF
--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -2506,3 +2506,9 @@ hr {
   height: 100%;
   object-fit: contain; /* This will ensure that the video scales correctly and isn't cropped */
 }
+
+.table-of-contents {
+  l {
+    display: none; // It removes the version tag in the sidebar
+  }
+}


### PR DESCRIPTION
Removes the version tag from the sidebar only.