### PR TITLE
Update fly.mdx to match change in fly cli

### DIFF
--- a/doc-surrealdb_versioned_docs/version-1.x/deployment/fly.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/deployment/fly.mdx
@@ -48,7 +48,7 @@ CMD ["start", "--bind", "0.0.0.0:8080", "file://data/srdb.db"]
 We will generate most of the content for the `fly.toml` configuration file using the `fly launch` utility. Please answer the questions with the guidelines given below.
 
 ```bash title="Generate Boilerplate fly.toml file"
-fly launch
+fly launch --no-deploy
 ```
 - `Choose an app name`: Choose what you like. It will end up as name.fly.dev, so it must be a unique name.
 - `Choose a region`: Choose what you like, usually a region close to your users.


### PR DESCRIPTION
Seems like fly.io changed their cli. You need to use `--no-deploy` flag now to get the same behavior as before.

On a side note, you can not get a sweet web gui to make edits after launching the first time.