### PR TITLE
More info on RELATE behaviour

### DIFF
--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/define/indexes.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/define/indexes.mdx
@@ -59,8 +59,8 @@ As we defined a `UNIQUE` index on the `email` column, a duplicate entry for that
 -- Create a user record and set an email ID. 
 CREATE user:1 SET email = 'test@surrealdb.com';
 ```
-```
--- Output:
+
+```bash title="Response"
 [
     {
         "email": "test@surrealdb.com",
@@ -74,8 +74,8 @@ Creating another record with the same email ID will throw an error.
 -- Create another user record and set the same email ID.
 CREATE user:2 SET email = 'test@surrealdb.com';
 ```
-```surql
--- Output:
+
+```bash title="Response"
 Database index `userEmailIndex` already contains 'test@surrealdb.com', 
 with record `user:1`
 ```

--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/relate.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/relate.mdx
@@ -14,14 +14,14 @@ This allows you to traverse related records efficiently without needing to pull 
 Edges created using the RELATE statement are nearly identical to tables created using other statements.
 The key differences are that
 
-- Edge tables have two required fields `in` and `out`, which specify the directions of the relationships.
+- Edge tables have two required fields `in` and `out`, which specify the directions of the relationships. These cannot be modified by schema declarations.
 - Edge tables are deleted once there are no existing relationships left.
 
-Edge tables behave like normal tables in terms of [updating](/docs/surrealdb/surrealql/statements/update), [defining a schema](/docs/surrealdb/surrealql/statements/define/table) or [indexes](/docs/surrealdb/surrealql/statements/define/indexes).
+Otherwise, edge tables behave like normal tables in terms of [updating](/docs/surrealdb/surrealql/statements/update), [defining a schema](/docs/surrealdb/surrealql/statements/define/table) or [indexes](/docs/surrealdb/surrealql/statements/define/indexes).
 
-[Record link](/docs/surrealdb/surrealql/datamodel/records) are the alternative option when connecting data.
-The key differences are that graph relations
+[Record links](/docs/surrealdb/surrealql/datamodel/records) are the alternative option when connecting data, and simply consist of a field with record IDs that serve as uni-directional links. The key differences are that graph relations
 
+- Are kept in a separate table as opposed to a field inside a record.
 - Offer bi-directional querying.
 - Offer referential integrity.
 - Allow you to store data alongside the relationship.
@@ -78,6 +78,62 @@ Edge tables are bi-directional by default. To enforce unidirectional relationshi
 ```surql
 DEFINE FIELD in ON TABLE wrote TYPE record<person>;
 DEFINE FIELD out ON TABLE wrote TYPE record<article>;
+```
+
+### Always two there are - no more, no less
+
+A `RELATE` statement that involves an array instead of a single id will not fail. Instead, it will create a graph edge for each record in the array:
+
+```surql
+INSERT INTO cat (id) VALUES ("mr_meow", "mrs_meow", "kitten");
+RELATE [cat:mr_meow, cat:mrs_meow]->parent_of->cat:kitten;
+```
+
+```bash title="Response"
+[
+    {
+        "id": "parent_of:7ypx27tgoa9lrsa4s6fm",
+        "in": "cat:mr_meow",
+        "out": "cat:kitten"
+    },
+    {
+        "id": "parent_of:mw08ri5e1jgh78wp1c1p",
+        "in": "cat:mrs_meow",
+        "out": "cat:kitten"
+    }
+]
+```
+
+Similarly, a `RELATE` statement that involves two arrays will return a number of graph edges equal to their product (in this case 2 * 2):
+
+```surql
+CREATE cat:kitten2;
+RELATE [cat:mr_meow, cat:mrs_meow]->parent_of->[cat:kitten, cat:kitten2];
+```
+
+```bash title="Response"
+[
+    {
+        "id": "parent_of:kvgu19yulq347b8xksxw",
+        "in": "cat:mr_meow",
+        "out": "cat:kitten"
+    },
+    {
+        "id": "parent_of:xxvj5pkxci3k9bqm6br9",
+        "in": "cat:mr_meow",
+        "out": "cat:kitten2"
+    },
+    {
+        "id": "parent_of:e4xwvecwwm6sxq1xe0yr",
+        "in": "cat:mrs_meow",
+        "out": "cat:kitten"
+    },
+    {
+        "id": "parent_of:ub9t2mm948jfuup6r6c4",
+        "in": "cat:mrs_meow",
+        "out": "cat:kitten2"
+    }
+]
 ```
 
 ### Adding data using `SET` and `CONTENT`
@@ -263,6 +319,7 @@ RELATE person:tobie->bought->product:iphone;
 ```
 
 ```bash title="Response"
+
 [
 	{
 		"id": "bought:ctwsll49k37a7rmqz9rr",

--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/relate.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/relate.mdx
@@ -14,8 +14,22 @@ This allows you to traverse related records efficiently without needing to pull 
 Edges created using the RELATE statement are nearly identical to tables created using other statements.
 The key differences are that
 
-- Edge tables have two required fields `in` and `out`, which specify the directions of the relationships. These cannot be modified by schema declarations.
 - Edge tables are deleted once there are no existing relationships left.
+- Edge tables have two required fields `in` and `out`, which specify the directions of the relationships. These cannot be modified in schema declarations except to specify that they must be of a certain record type.
+
+Thus, the following field declarations will work:
+
+```surql
+DEFINE FIELD in ON TABLE wrote TYPE record<author>;
+DEFINE FIELD out ON TABLE wrote TYPE record<book>;
+```
+
+But this will be ignored:
+
+```surql
+DEFINE FIELD in ON TABLE wrote TYPE string;
+DEFINE FIELD out ON TABLE wrote TYPE int;
+```
 
 Otherwise, edge tables behave like normal tables in terms of [updating](/docs/surrealdb/surrealql/statements/update), [defining a schema](/docs/surrealdb/surrealql/statements/define/table) or [indexes](/docs/surrealdb/surrealql/statements/define/indexes).
 


### PR DESCRIPTION
I noticed some interesting behaviour in RELATE today that seems good to add. Namely:

* You can't change the type of in and out,
* Specify that in and out can only be single values, but you can still use multiple values in RELATE, it will just create multiple graph edges equal to the product of the inputs

I chose the title Always two there are - no more, no less. Is that having too much fun for a documentation page? Could make this a drier title if so.