### PR TITLE
Add example of output to changefeeds

### DIFF
--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/define/table.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/define/table.mdx
@@ -26,7 +26,7 @@ DEFINE TABLE [ IF NOT EXISTS ] @name
 		[ WHERE @condition ]
 		[ GROUP [ BY ] @groups ]
 	]
-	[CHANGEFEED @duration]
+	[CHANGEFEED @duration [INCLUDE ORIGINAL] ]
 	[ PERMISSIONS [ NONE | FULL
 		| FOR select @expression
 		| FOR create @expression
@@ -52,10 +52,57 @@ The following example uses the `DROP` portion of the `DEFINE TABLE` statement. M
 -- Records that currently exist in the table will not automatically be deleted, you can still remove them manually.
 DEFINE TABLE reading DROP;
 ```
-The following expression shows how you can define a `CHANGEFEED` for a table. You create, update, delete records in the table as usual
+The following expression shows how you can define a `CHANGEFEED` for a table. After creating, updating, and deleting records in the table as usual, using `SHOW CHANGES FOR` will show the changes that have taken place during this time.
+
 ```surql
--- Add changefeed for table reading with a duration of 1 day
-DEFINE TABLE reading CHANGEFEED 1d;
+-- Define the change feed and its duration
+-- Optionally, append INCLUDE ORIGINAL to include info
+-- on the current record before a change took place
+DEFINE TABLE reading CHANGEFEED 3d;
+
+-- Create some records in the reading table
+CREATE reading SET story = "Once upon a time";
+CREATE reading SET story = "there was a database";
+
+-- Replay changes to the reading table
+SHOW CHANGES FOR TABLE reading SINCE "2023-09-07T01:23:52Z" LIMIT 10;
+```
+
+```bash title="Response"
+[
+    {
+        "changes": [
+            {
+                "define_table": {
+                    "name": "reading"
+                }
+            }
+        ],
+        "versionstamp": 29
+    },
+    {
+        "changes": [
+            {
+                "update": {
+                    "id": "reading:h1gcbc7ykbpslellh2g2",
+                    "story": "Once upon a time"
+                }
+            }
+        ],
+        "versionstamp": 30
+    },
+    {
+        "changes": [
+            {
+                "update": {
+                    "id": "reading:l9qfcncklhnlklby1avf",
+                    "story": "there was a database"
+                }
+            }
+        ],
+        "versionstamp": 31
+    }
+]
 ```
 
 ### Using `IF NOT EXISTS` clause <l className='purple'>Since 1.3.0</l>

--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/define/table.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/define/table.mdx
@@ -68,7 +68,7 @@ CREATE reading SET story = "there was a database";
 SHOW CHANGES FOR TABLE reading SINCE "2023-09-07T01:23:52Z" LIMIT 10;
 ```
 
-```bash title="Response"
+```bash title="Response without INCLUDE ORIGINAL"
 [
     {
         "changes": [
@@ -98,6 +98,57 @@ SHOW CHANGES FOR TABLE reading SINCE "2023-09-07T01:23:52Z" LIMIT 10;
                     "id": "reading:l9qfcncklhnlklby1avf",
                     "story": "there was a database"
                 }
+            }
+        ],
+        "versionstamp": 31
+    }
+]
+```
+
+```bash title="Response with INCLUDE ORIGINAL"
+[
+    {
+        "changes": [
+            {
+                "define_table": {
+                    "name": "reading"
+                }
+            }
+        ],
+        "versionstamp": 29
+    },
+    {
+        "changes": [
+            {
+                "current": {
+                    "id": "reading:2j3rc2yw1jzspcuvfe9v",
+                    "story": "Once upon a time"
+                },
+                "update": [
+                    {
+                        "op": "replace",
+                        "path": "/",
+                        "value": null
+                    }
+                ]
+            }
+        ],
+        "versionstamp": 30
+    },
+    {
+        "changes": [
+            {
+                "current": {
+                    "id": "reading:iuiurhi0y2ka0by0skqi",
+                    "story": "there was a database"
+                },
+                "update": [
+                    {
+                        "op": "replace",
+                        "path": "/",
+                        "value": null
+                    }
+                ]
             }
         ],
         "versionstamp": 31

--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/show.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/show.mdx
@@ -2,12 +2,12 @@
 sidebar_position: 20
 sidebar_label: SHOW
 title: SHOW statement | SurrealQL
-description: The SHOW statement can be used to replay changes made to the table.
+description: The SHOW statement can be used to replay changes made to a table.
 ---
 
 # `SHOW` statement
 
-The `SHOW` statement can be used to replay changes made to the table.
+The `SHOW` statement can be used to replay changes made to a table.
 
 ## Requirements
 - You must first [`DEFINE`](/docs/surrealdb/surrealql/statements/define/table#example-usage) a [Change Feed](https://surrealdb.com/cf).
@@ -21,20 +21,57 @@ SHOW CHANGES FOR TABLE @tableName [SINCE "@timestamp"] [LIMIT @number]
 ## Example usage
 ### Basic usage
 
-The following expression shows usage of Show statement.
+The following expression shows usage of the SHOW statement.
 
 ```surql
--- Define the change feed
-DEFINE TABLE reading CHANGEFEED 1d;
+-- Define the change feed and its duration
+DEFINE TABLE reading CHANGEFEED 3d;
 
 -- Create some records in the reading table
-CREATE reading set story = "Once upon a time";
-CREATE reading set story = "there was a database";
+CREATE reading SET story = "Once upon a time";
+CREATE reading SET story = "there was a database";
 
 -- Replay changes to the reading table
 SHOW CHANGES FOR TABLE reading SINCE "2023-09-07T01:23:52Z" LIMIT 10;
 ```
 
+```bash title="Response"
+[
+    {
+        "changes": [
+            {
+                "define_table": {
+                    "name": "reading"
+                }
+            }
+        ],
+        "versionstamp": 29
+    },
+    {
+        "changes": [
+            {
+                "update": {
+                    "id": "reading:h1gcbc7ykbpslellh2g2",
+                    "story": "Once upon a time"
+                }
+            }
+        ],
+        "versionstamp": 30
+    },
+    {
+        "changes": [
+            {
+                "update": {
+                    "id": "reading:l9qfcncklhnlklby1avf",
+                    "story": "there was a database"
+                }
+            }
+        ],
+        "versionstamp": 31
+    }
+]
+```
+
 :::note
-__Note:__ `SINCE <time>` needs to be after the time the `CHANGEFEED` was defined. Also, When defining a `CHANGEFEED` on a table, it implicitly creates a `CHANGEFEED` on the database
+__Note:__ `SINCE <time>` needs to be after the time the `CHANGEFEED` was defined. Also, when defining a `CHANGEFEED` on a table, it implicitly creates a `CHANGEFEED` on the database.
 :::


### PR DESCRIPTION
Adds an example of output for changefeeds in both the DEFINE TABLE and SHOW pages. Also:

* The new INCLUDE ORIGINAL option. ~~I got this to work in the CLI but Surrealist doesn't handle it yet so haven't added that to the output, but anyone should be able to use the same example and add INCLUDE ORIGINAL to see what it looks like so not too hard to see for oneself.~~ <-- Looks like I coincidentally got Surrealist to disconnect somehow and thought it couldn't handle INCLUDE ORIGINAL, but it can so have added the output of that.
* Changed the 1d to 3d. I misread that as `id` once or twice.

As an aside, getting a nice example for this took a while longer than expected as I wasn't able to use a parameter set in between the table creation and the changes:

```
DEFINE TABLE user CHANGEFEED 3d;
DEFINE PARAM $time = time::now();
CREATE user SET 
   name = "User989898";
UPDATE user SET
   name = "Lord of Salty"
   WHERE name = "User989898";

SHOW CHANGES FOR TABLE user SINCE $time LIMIT 10;
```

Seems like just a parser error though?