### PR TITLE
Extra parameter info and examples

### DIFF
--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/functions/script/arguments.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/functions/script/arguments.mdx
@@ -11,12 +11,12 @@ Additional arguments can be passed in to the function from SurrealDB, and these 
 
 ```surql 
 -- Create a new parameter
-LET $value = "SurrealDB";
+LET $val = "SurrealDB";
 -- Create a new parameter
 LET $words = ["awesome", "advanced", "cool"];
 -- Pass the parameter values into the function
-CREATE article SET summary = function($value, $words) {
-	const [value, words] = arguments;
-	return `${value} is ${words.join(', ')}`;
+CREATE article SET summary = function($val, $words) {
+	const [val, words] = arguments;
+	return `${val} is ${words.join(', ')}`;
 };
 ```

--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/parameters.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/parameters.mdx
@@ -13,10 +13,11 @@ Parameters can be used like variables to store a value which can then be used in
 
 ```surql
 -- Define the parameter
-LET $surname = "Morgan Hitchcock";
+LET $suffix = "Morgan Hitchcock";
 -- Use the parameter
-CREATE person SET name = "Tobie " + $surname;
-CREATE person SET name = "Jaime " + $surname;
+CREATE person SET name = "Tobie " + $suffix;
+-- (Another way to do the same)
+CREATE person SET name = string::join(" ", "Jaime", $suffix);
 ```
 
 ```bash title="Response"

--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/parameters.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/parameters.mdx
@@ -235,7 +235,7 @@ SELECT name,
 ```
 
 ```surql
-INSERT INTO person (name) VALUES ("John Doe"), ("John Doe"), ("Jane Doe"), ("Jane Doe");
+INSERT INTO person (name) VALUES ("John Doe"), ("John Doe"), ("Jane Doe");
 SELECT 
     *,
     (SELECT VALUE id FROM person WHERE $this.name = $parent.name) AS 
@@ -246,35 +246,26 @@ SELECT
 ```bash title="Response"
 [
     {
-        "id": "person:k6063ck2r2u4boeh8z21",
+        "id": "person:hwffcckiv61ylwiw43yf",
         "name": "John Doe",
         "people_with_same_name": [
-            "person:k6063ck2r2u4boeh8z21",
-            "person:nb5omnmmt1sw16vc70qf"
+            "person:hwffcckiv61ylwiw43yf",
+            "person:tmscoy7bjj20xki0fld5"
         ]
     },
     {
-        "id": "person:nb5omnmmt1sw16vc70qf",
+        "id": "person:tmscoy7bjj20xki0fld5",
         "name": "John Doe",
         "people_with_same_name": [
-            "person:k6063ck2r2u4boeh8z21",
-            "person:nb5omnmmt1sw16vc70qf"
+            "person:hwffcckiv61ylwiw43yf",
+            "person:tmscoy7bjj20xki0fld5"
         ]
     },
     {
-        "id": "person:neyeqeg7wjt4udn591j3",
+        "id": "person:y7mdf3912rf5gynvxc7q",
         "name": "Jane Doe",
         "people_with_same_name": [
-            "person:neyeqeg7wjt4udn591j3",
-            "person:ovctb3gbr3b7sqfbylcw"
-        ]
-    },
-    {
-        "id": "person:ovctb3gbr3b7sqfbylcw",
-        "name": "Jane Doe",
-        "people_with_same_name": [
-            "person:neyeqeg7wjt4udn591j3",
-            "person:ovctb3gbr3b7sqfbylcw"
+            "person:y7mdf3912rf5gynvxc7q"
         ]
     }
 ]

--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/parameters.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/parameters.mdx
@@ -62,62 +62,8 @@ let people = await surreal.query("SELECT * FROM article WHERE status INSIDE $sta
 ```
 
 ## Reserved variable names
-SurrealDB uses predefined variables. For that purpose, you can use those variables inside your query but you cannot declare new parameters using one of the following names:
 
-### $auth
-
-Represents the currently authenticated scope user.
-
-```surql
-DEFINE TABLE user SCHEMAFULL
-	PERMISSIONS
-		FOR select, update, delete WHERE id = $auth.id;
-```
-
-### $token
-
-Represents values held inside the JWT token used for the current session.
-
-```surql
-DEFINE TABLE user SCHEMAFULL
-  PERMISSIONS FOR select, update, delete, create
-  WHERE $scope = "users"
-  AND email = $token.email;
-```
-
-### $scope
-
-Represents the name of the scope of a currently authenticated scope user.
-
-```surql
-IF $scope = "admin" THEN
-	( SELECT * FROM account )
-ELSE IF $scope = "user" THEN
-	( SELECT * FROM $auth.account )
-ELSE
-	[]
-END
-```
-
-### $session
-
-Represents values from the session functions as an object.
-
-```surql
-CREATE user SET 
-    name = "Some User",
-    on_database = (SELECT VALUE db FROM ONLY $session);
-```
-
-```bash title="Response"
-[
-    {
-        "id": "user:wa3ajflozlqoyurc4i4v",
-        "name": "Some User",
-        "on_database": "database"
-    }
-]
-```
+SurrealDB automatically predefines certain variables depending on the type of operation being performed. For example, `$this` and `$parent` are automatically predefined for subqueries so that the fields of one can be compared to another if necessary. Other predefined variables like `$session` give access to parts of the current database configuration. You should not declare new parameters of your own using the same names as the predefined variables below.
 
 ### $before, $after
 
@@ -153,7 +99,6 @@ UPDATE cat SET nicknames += "Snuggles" WHERE name = "Mr. Meow" RETURN $before, $
 ### $value
 
 Represents the value after a mutation on a field (identical to $after in the case of an event).
-
 
 ```surql
 DEFINE EVENT email ON TABLE user WHEN $before.email != $after.email THEN (
@@ -278,4 +223,59 @@ Represents the type of table event triggered on an event.
 DEFINE EVENT user_created ON TABLE user WHEN $event = "CREATE" THEN (
     CREATE log SET table = "user", event = $event, created_at = time::now()
 );
+```
+
+### $auth
+
+Represents the currently authenticated scope user.
+
+```surql
+DEFINE TABLE user SCHEMAFULL
+	PERMISSIONS
+		FOR select, update, delete WHERE id = $auth.id;
+```
+
+### $token
+
+Represents values held inside the JWT token used for the current session.
+
+```surql
+DEFINE TABLE user SCHEMAFULL
+  PERMISSIONS FOR select, update, delete, create
+  WHERE $scope = "users"
+  AND email = $token.email;
+```
+
+### $scope
+
+Represents the name of the scope of a currently authenticated scope user.
+
+```surql
+IF $scope = "admin" THEN
+	( SELECT * FROM account )
+ELSE IF $scope = "user" THEN
+	( SELECT * FROM $auth.account )
+ELSE
+	[]
+END
+```
+
+### $session
+
+Represents values from the session functions as an object.
+
+```surql
+CREATE user SET 
+    name = "Some User",
+    on_database = (SELECT VALUE db FROM ONLY $session);
+```
+
+```bash title="Response"
+[
+    {
+        "id": "user:wa3ajflozlqoyurc4i4v",
+        "name": "Some User",
+        "on_database": "database"
+    }
+]
 ```

--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/parameters.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/parameters.mdx
@@ -7,18 +7,50 @@ description: Parameters can be used like variables to store a value which can th
 
 # Parameters
 
-Parameters can be used like variables to store a value which can then be used in a subsequent query. A parameter can store any value, including the result of a query. Parameters can be defined within the SQL, or can be passed in using the client libraries as request variables.
+Parameters can be used like variables to store a value which can then be used in subsequent queries. To define a parameter in SurrealQL, use the [`LET`](../surrealql/statements/let) statement. The name of the parameter should begin with a `$` character.
 
 ## Defining parameters within SurrealQL
 
-To define a parameter in SurrealQL, use the [`LET`](../surrealql/statements/let) statement. The name of the parameter should begin with a `$` character.
-
 ```surql
 -- Define the parameter
-LET $name = "tobie";
+LET $surname = "Morgan Hitchcock";
 -- Use the parameter
-CREATE person SET name = $name;
+CREATE person SET name = "Tobie " + $surname;
+CREATE person SET name = "Jaime " + $surname;
 ```
+
+```bash title="Response"
+[
+    {
+        "id": "person:3vs17lb9eso9m7gd8mml",
+        "name": "Tobie Morgan Hitchcock"
+    }
+]
+
+[
+    {
+        "id": "person:xh4zbns5mgmywe6bo1pi",
+        "name": "Jaime Morgan Hitchcock"
+    }
+]
+```
+
+A parameter can store any value, including the result of a query.
+
+```surql
+-- Assuming the CREATE statements from the previous example
+LET $founders = (SELECT * FROM person);
+RETURN $founders.name;
+```
+
+```bash title="Response"
+[
+    "Tobie Morgan Hitchcock",
+    "Jaime Morgan Hitchcock"
+]
+```
+
+Parameters can be defined using SurrealQL as shown above, or can be passed in using the client libraries as request variables.
 
 ## Defining parameters within client libraries
 SurrealDB's client libraries allow parameters to be passed in as JSON values, which are then converted to SurrealDB data types when the query is run. The following example show a variable being used within a SurrealQL query from the JavaScript library.
@@ -30,103 +62,152 @@ let people = await surreal.query("SELECT * FROM article WHERE status INSIDE $sta
 ```
 
 ## Reserved variable names
-SurrealDB uses predefined variables. For that purpose, you can use those variables inside your query but you cannot declare new parameters using one of the following name:
+SurrealDB uses predefined variables. For that purpose, you can use those variables inside your query but you cannot declare new parameters using one of the following names:
 
-<table>
-    <thead>
-        <tr>
-            <th colspan="2" scope="col">Name</th>
-            <th colspan="2" scope="col">Description</th>
-        </tr>
-    </thead>  
-    <tbody>
-        <tr>
-            <td colspan="2" scope="row" data-label="Name">
-                <code>$auth</code>
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-            Represents the currently authenticated scope user
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" scope="row" data-label="Name">
-                <code>$token</code>
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-                Represents values held inside the JWT token used for the current session
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" scope="row" data-label="Name">
-                <code>$scope</code>
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-                Represents the name of the scope of a currently authenticated scope user.
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" scope="row" data-label="Name">
-                <code>$session</code>
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-                Represents values from the session functions as an object
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" scope="row" data-label="Name">
-                <code>$before</code>
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-                Represents the value before a mutation on a field
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" scope="row" data-label="Name">
-                <code>$after</code>
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-                Represents the value after a mutation on a field
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" scope="row" data-label="Name">
-                <code>$value</code>
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-                Represents the value after a mutation on a field (identical to $after in the case of an event)
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" scope="row" data-label="Name">
-                <code>$input</code>
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-                Represents the initially inputted value in a field definition, as the value clause could have modified the $value variable
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" scope="row" data-label="Name">
-                <code>$this</code>
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-                Represents the current record in a subquery
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" scope="row" data-label="Name">
-                <code>$parent</code>
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-                Represents the parent record in a subquery
-            </td>
-        </tr>
-         <tr>
-            <td colspan="2" scope="row" data-label="Name">
-                <code>$event</code>
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-                Represents the type of table event triggered on an event.
-            </td>
-        </tr>
-    </tbody>
-</table>
+### $auth
+
+Represents the currently authenticated scope user.
+
+```surql
+DEFINE TABLE user SCHEMAFULL
+	PERMISSIONS
+		FOR select, update, delete WHERE id = $auth.id;
+```
+
+### $token
+
+Represents values held inside the JWT token used for the current session.
+
+```surql
+DEFINE TABLE user SCHEMAFULL
+  PERMISSIONS FOR select, update, delete, create
+  WHERE $scope = "users"
+  AND email = $token.email
+;
+```
+
+### $scope
+
+Represents the name of the scope of a currently authenticated scope user.
+
+```surql
+IF $scope = "admin" THEN
+	( SELECT * FROM account )
+ELSE IF $scope = "user" THEN
+	( SELECT * FROM $auth.account )
+ELSE
+	[]
+END
+```
+
+### $session
+
+Represents values from the session functions as an object.
+
+```surql
+CREATE user SET 
+    name = "Some User",
+    on_database = (SELECT VALUE db FROM ONLY $session);
+```
+
+```bash title="Response"
+[
+    {
+        "id": "user:wa3ajflozlqoyurc4i4v",
+        "name": "Some User",
+        "on_database": "database"
+    }
+]
+```
+
+### $before, $after
+
+Represent the values before and after a mutation on a field.
+
+```surql
+CREATE cat SET name = "Mr. Meow", nicknames = ["Mr. Cuddlebun"];
+UPDATE cat SET nicknames += "Snuggles" WHERE name = "Mr. Meow" RETURN $before, $after;
+```
+
+```bash title="Response"
+[
+    {
+        "after": {
+            "id": "cat:6p71csv2zqianixf0dkz",
+            "name": "Mr. Meow",
+            "nicknames": [
+                "Mr. Cuddlebun",
+                "Snuggles"
+            ]
+        },
+        "before": {
+            "id": "cat:6p71csv2zqianixf0dkz",
+            "name": "Mr. Meow",
+            "nicknames": [
+                "Mr. Cuddlebun"
+            ]
+        }
+    }
+]
+```
+
+### $value
+
+Represents the value after a mutation on a field (identical to $after in the case of an event).
+
+
+```surql
+DEFINE EVENT email ON TABLE user WHEN $before.email != $after.email THEN (
+	CREATE event SET 
+        user = $value.id,
+        time = time::now(),
+        value = $after.email,
+        action = 'email_changed'
+);
+```
+
+### $input
+
+Represents the initially inputted value in a field definition, as the value clause could have modified the $value variable.
+
+### $this
+
+Represents the current record in a subquery.
+
+### $parent
+
+Represents the parent record in a subquery.
+
+```surql
+CREATE user SET name = "User1", member_of = "group1";
+CREATE user SET name = "User2", member_of = "group1";
+CREATE user SET name = "User3", member_of = "group1";
+SELECT name, 
+    (SELECT VALUE name FROM user WHERE member_of = $parent.member_of)
+    AS group_members
+    FROM user
+    WHERE name = "User1";
+```
+
+```bash title="Response"
+[
+    {
+        "group_members": [
+            "User1",
+            "User3",
+            "User2"
+        ],
+        "name": "User1"
+    }
+]
+```
+
+### $event
+
+Represents the type of table event triggered on an event.
+
+```surql
+DEFINE EVENT user_created ON TABLE user WHEN $event = "CREATE" THEN (
+    CREATE log SET table = "user", event = $event, created_at = time::now()
+);
+```

--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/parameters.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/parameters.mdx
@@ -170,13 +170,45 @@ DEFINE EVENT email ON TABLE user WHEN $before.email != $after.email THEN (
 
 Represents the initially inputted value in a field definition, as the value clause could have modified the $value variable.
 
-### $this
+```surql
+CREATE city:london SET
+    population = 8900000,
+    year = 2019,
+    historical_data = [];
 
-Represents the current record in a subquery.
+INSERT INTO city [
+    { id: "london", population: 9600000, year: 2023 }
+]
+ON DUPLICATE KEY UPDATE
+-- Stick old data into historical_data
+historical_data += {
+    year: year,
+    population: population
+},
+-- Then update current record with the new input using $input
+population = $input.population,
+year = $input.year;
+```
 
-### $parent
+```bash output="Response"
+[
+    {
+        "historical_data": [
+            {
+                "population": 8900000,
+                "year": 2019
+            }
+        ],
+        "id": "city:london",
+        "population": 9600000,
+        "year": 2023
+    }
+]
+```
 
-Represents the parent record in a subquery.
+### $this, $parent
+
+`$this` represents the current record in a subquery, and `$parent` its parent.
 
 ```surql
 CREATE user SET name = "User1", member_of = "group1";
@@ -198,6 +230,72 @@ SELECT name,
             "User2"
         ],
         "name": "User1"
+    }
+]
+```
+
+```surql
+INSERT INTO person (name) VALUES ("John Doe"), ("John Doe"), ("Jane Doe"), ("Jane Doe");
+SELECT 
+    name, 
+    (SELECT * FROM person WHERE $this.name = $parent.name) AS 
+    people_with_same_name
+    FROM person;
+```
+
+```bash title="Response"
+[
+    {
+        "name": "John Doe",
+        "people_with_same_name": [
+            {
+                "id": "person:r69242yfg2v5zprtof99",
+                "name": "John Doe"
+            },
+            {
+                "id": "person:vivns18ltw93qxnz7gj9",
+                "name": "John Doe"
+            }
+        ]
+    },
+    {
+        "name": "Jane Doe",
+        "people_with_same_name": [
+            {
+                "id": "person:txczehzlubxlaqmjnfz3",
+                "name": "Jane Doe"
+            },
+            {
+                "id": "person:zx7movqqnegx6r7leeih",
+                "name": "Jane Doe"
+            }
+        ]
+    },
+    {
+        "name": "John Doe",
+        "people_with_same_name": [
+            {
+                "id": "person:r69242yfg2v5zprtof99",
+                "name": "John Doe"
+            },
+            {
+                "id": "person:vivns18ltw93qxnz7gj9",
+                "name": "John Doe"
+            }
+        ]
+    },
+    {
+        "name": "Jane Doe",
+        "people_with_same_name": [
+            {
+                "id": "person:txczehzlubxlaqmjnfz3",
+                "name": "Jane Doe"
+            },
+            {
+                "id": "person:zx7movqqnegx6r7leeih",
+                "name": "Jane Doe"
+            }
+        ]
     }
 ]
 ```

--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/parameters.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/parameters.mdx
@@ -237,8 +237,8 @@ SELECT name,
 ```surql
 INSERT INTO person (name) VALUES ("John Doe"), ("John Doe"), ("Jane Doe"), ("Jane Doe");
 SELECT 
-    name, 
-    (SELECT * FROM person WHERE $this.name = $parent.name) AS 
+    *,
+    (SELECT VALUE id FROM person WHERE $this.name = $parent.name) AS 
     people_with_same_name
     FROM person;
 ```
@@ -246,55 +246,35 @@ SELECT
 ```bash title="Response"
 [
     {
+        "id": "person:k6063ck2r2u4boeh8z21",
         "name": "John Doe",
         "people_with_same_name": [
-            {
-                "id": "person:r69242yfg2v5zprtof99",
-                "name": "John Doe"
-            },
-            {
-                "id": "person:vivns18ltw93qxnz7gj9",
-                "name": "John Doe"
-            }
+            "person:k6063ck2r2u4boeh8z21",
+            "person:nb5omnmmt1sw16vc70qf"
         ]
     },
     {
-        "name": "Jane Doe",
-        "people_with_same_name": [
-            {
-                "id": "person:txczehzlubxlaqmjnfz3",
-                "name": "Jane Doe"
-            },
-            {
-                "id": "person:zx7movqqnegx6r7leeih",
-                "name": "Jane Doe"
-            }
-        ]
-    },
-    {
+        "id": "person:nb5omnmmt1sw16vc70qf",
         "name": "John Doe",
         "people_with_same_name": [
-            {
-                "id": "person:r69242yfg2v5zprtof99",
-                "name": "John Doe"
-            },
-            {
-                "id": "person:vivns18ltw93qxnz7gj9",
-                "name": "John Doe"
-            }
+            "person:k6063ck2r2u4boeh8z21",
+            "person:nb5omnmmt1sw16vc70qf"
         ]
     },
     {
+        "id": "person:neyeqeg7wjt4udn591j3",
         "name": "Jane Doe",
         "people_with_same_name": [
-            {
-                "id": "person:txczehzlubxlaqmjnfz3",
-                "name": "Jane Doe"
-            },
-            {
-                "id": "person:zx7movqqnegx6r7leeih",
-                "name": "Jane Doe"
-            }
+            "person:neyeqeg7wjt4udn591j3",
+            "person:ovctb3gbr3b7sqfbylcw"
+        ]
+    },
+    {
+        "id": "person:ovctb3gbr3b7sqfbylcw",
+        "name": "Jane Doe",
+        "people_with_same_name": [
+            "person:neyeqeg7wjt4udn591j3",
+            "person:ovctb3gbr3b7sqfbylcw"
         ]
     }
 ]

--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/parameters.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/parameters.mdx
@@ -97,17 +97,23 @@ UPDATE cat SET nicknames += "Snuggles" WHERE name = "Mr. Meow" RETURN $before, $
 ]
 ```
 
-### $value
+### $auth
 
-Represents the value after a mutation on a field (identical to $after in the case of an event).
+Represents the currently authenticated scope user.
 
 ```surql
-DEFINE EVENT email ON TABLE user WHEN $before.email != $after.email THEN (
-	CREATE event SET 
-        user = $value.id,
-        time = time::now(),
-        value = $after.email,
-        action = 'email_changed'
+DEFINE TABLE user SCHEMAFULL
+    PERMISSIONS
+        FOR select, update, delete WHERE id = $auth.id;
+```
+
+### $event
+
+Represents the type of table event triggered on an event.
+
+```surql
+DEFINE EVENT user_created ON TABLE user WHEN $event = "CREATE" THEN (
+    CREATE log SET table = "user", event = $event, created_at = time::now()
 );
 ```
 
@@ -151,7 +157,7 @@ year = $input.year;
 ]
 ```
 
-### $this, $parent
+### $parent, $this
 
 `$this` represents the current record in a subquery, and `$parent` its parent.
 
@@ -216,48 +222,17 @@ SELECT
 ]
 ```
 
-### $event
-
-Represents the type of table event triggered on an event.
-
-```surql
-DEFINE EVENT user_created ON TABLE user WHEN $event = "CREATE" THEN (
-    CREATE log SET table = "user", event = $event, created_at = time::now()
-);
-```
-
-### $auth
-
-Represents the currently authenticated scope user.
-
-```surql
-DEFINE TABLE user SCHEMAFULL
-	PERMISSIONS
-		FOR select, update, delete WHERE id = $auth.id;
-```
-
-### $token
-
-Represents values held inside the JWT token used for the current session.
-
-```surql
-DEFINE TABLE user SCHEMAFULL
-  PERMISSIONS FOR select, update, delete, create
-  WHERE $scope = "users"
-  AND email = $token.email;
-```
-
 ### $scope
 
 Represents the name of the scope of a currently authenticated scope user.
 
 ```surql
 IF $scope = "admin" THEN
-	( SELECT * FROM account )
+    ( SELECT * FROM account )
 ELSE IF $scope = "user" THEN
-	( SELECT * FROM $auth.account )
+    ( SELECT * FROM $auth.account )
 ELSE
-	[]
+    []
 END
 ```
 
@@ -279,4 +254,29 @@ CREATE user SET
         "on_database": "database"
     }
 ]
+```
+
+### $token
+
+Represents values held inside the JWT token used for the current session.
+
+```surql
+DEFINE TABLE user SCHEMAFULL
+  PERMISSIONS FOR select, update, delete, create
+  WHERE $scope = "users"
+  AND email = $token.email;
+```
+
+### $value
+
+Represents the value after a mutation on a field (identical to $after in the case of an event).
+
+```surql
+DEFINE EVENT email ON TABLE user WHEN $before.email != $after.email THEN (
+    CREATE event SET 
+        user = $value.id,
+        time = time::now(),
+        value = $after.email,
+        action = 'email_changed'
+);
 ```

--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/parameters.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/parameters.mdx
@@ -82,8 +82,7 @@ Represents values held inside the JWT token used for the current session.
 DEFINE TABLE user SCHEMAFULL
   PERMISSIONS FOR select, update, delete, create
   WHERE $scope = "users"
-  AND email = $token.email
-;
+  AND email = $token.email;
 ```
 
 ### $scope

--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/define/event.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/define/event.mdx
@@ -72,7 +72,10 @@ DEFINE EVENT user_deleted ON TABLE user WHEN $event = "DELETE" THEN (
 -- You can combine multiple events based on your use cases.
 -- Here we are creating a log when a user is created, updated or deleted.
 DEFINE EVENT user_event ON TABLE user WHEN $event = "CREATE" OR $event = "UPDATE" OR $event = "DELETE" THEN (
-    CREATE log SET table = "user", event = $event, created_at = time::now()
+    CREATE log SET
+        table = "user",
+        event = $event,
+        happened_at = time::now()
 );
 ```
 

--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/index.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/index.mdx
@@ -1,0 +1,1 @@
+# Statements

--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/index.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/index.mdx
@@ -4,10 +4,10 @@ SurrealDB has a variety of statements that let you configure and query a databas
 
 ## Statement parameters
 
-A number of parameters prefixed with `$` are automatically available within a statement that provide access to relevant context inside the statement. For example:
+A number of parameters prefixed with `$` are automatically available within a statement that provide access to relevant context inside the statement. These are known as reserved variable names. For example:
 
 * `$before` and `$after` can be accessed in statements that mutate values to see the values before and after an update,
 * `$session` provides context on the current session,
 * `$parent` provides access to the value in a primary query while inside a subquery.
 
-For a full list of these automatically generated parameters, see the [parameters](/docs/surrealdb/surrealql/parameters) page.
+For a full list of these automatically generated parameters, see the [parameters](/docs/surrealdb/surrealql/parameters#reserved-variable-names) page.

--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/index.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/index.mdx
@@ -6,8 +6,8 @@ SurrealDB has a variety of statements that let you configure and query a databas
 
 A number of parameters prefixed with `$` are automatically available within a statement that provide access to relevant context inside the statement. These are known as reserved variable names. For example:
 
-* `$before` and `$after` can be accessed in statements that mutate values to see the values before and after an update,
-* `$session` provides context on the current session,
-* `$parent` provides access to the value in a primary query while inside a subquery.
+* [$before](/docs/surrealdb/surrealql/parameters#before-after) and [$after](/docs/surrealdb/surrealql/parameters#before-after) can be accessed in statements that mutate values to see the values before and after an update,
+* [$session](/docs/surrealdb/surrealql/parameters#session) provides context on the current session,
+* [$parent](/docs/surrealdb/surrealql/parameters#this-parent) provides access to the value in a primary query while inside a subquery.
 
 For a full list of these automatically generated parameters, see the [parameters](/docs/surrealdb/surrealql/parameters#reserved-variable-names) page.

--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/index.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/index.mdx
@@ -1,1 +1,13 @@
 # Statements
+
+SurrealDB has a variety of statements that let you configure and query a database: `CREATE`, `INSERT`, `UPDATE`, and so on.
+
+## Statement parameters
+
+A number of parameters prefixed with `$` are automatically available within a statement that provide access to relevant context inside the statement. For example:
+
+* `$before` and `$after` can be accessed in statements that mutate values to see the values before and after an update,
+* `$session` provides context on the current session,
+* `$parent` provides access to the value in a primary query while inside a subquery.
+
+For a full list of these automatically generated parameters, see the [parameters](/docs/surrealdb/surrealql/parameters) page.


### PR DESCRIPTION
Inside the parameters page:

* Rewrites the intro and a bunch of other places
* Enlargens the original Tobie example to one in which setting a variable is useful
* Moves the reserved variable names out from a table into their own subsections with an example for each. Related ones are combined ($before and $after, $this and $parent)

After this the question is how to get people to notice the page (since parameters.mdx is pretty far down). Here adding an index.mdx to statements along with a quick blurb informing that statements have parameters floating around and a link to the full parameters page felt best.