### PR TITLE
Increase length of FLEXIBLE example to show behaviour without it

### DIFF
--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/define/field.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/define/field.mdx
@@ -80,7 +80,7 @@ CREATE user SET
 };
 ```
 
-Without `FLEXIBLE`, the database will recognize that an object has been inserted (and the statement will not return an error), but has no way of knowing whether the fields inside conform to the strict schema. As a result, `metadata` will show up as an empty object.
+Without `FLEXIBLE`, the database will recognize that an object has been inserted, but has no way of knowing whether the fields inside conform to the strict schema. As a result, `metadata` will show up as an empty object. Note the difference between this and the `name` field. The `CREATE` statement will simply err if a string for `name` is not provided, while `metadata` will not err because *some* object has been passed in.
 
 ```surql
 [

--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/define/field.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/define/field.mdx
@@ -64,8 +64,8 @@ Flexible types allow you to have `SCHEMALESS` functionality on a `SCHEMAFULL` ta
 
 ```surql
 DEFINE TABLE user SCHEMAFULL;
+DEFINE FIELD name ON TABLE user TYPE string;
 DEFINE FIELD metadata ON TABLE user FLEXIBLE TYPE object;
-DEFINE FIELD friends ON TABLE user TYPE array<record>;
 ```
 
 Taking the following `CREATE` statement:

--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/define/field.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/define/field.mdx
@@ -60,10 +60,52 @@ DEFINE FIELD login_attempts ON TABLE user TYPE number;
 
 ### Flexible data types
 
-Flexible types allow you to have `SCHEMALESS` functionality on a `SCHEMAFULL` table. This is especially useful for working with nested objects.
+Flexible types allow you to have `SCHEMALESS` functionality on a `SCHEMAFULL` table. This is necessary for working with nested `object` types, which by nature do not have defined fields.
 
 ```surql
+DEFINE TABLE user SCHEMAFULL;
 DEFINE FIELD metadata ON TABLE user FLEXIBLE TYPE object;
+DEFINE FIELD friends ON TABLE user TYPE array<record>;
+```
+
+Taking the following `CREATE` statement:
+
+```surql
+CREATE user SET
+    name = "User1",
+    metadata = {
+        country_code: "ee",
+        time_zone: "EEST",
+        age: 25
+};
+```
+
+Without `FLEXIBLE`, the database will recognize that an object has been inserted (and the statement will not return an error), but has no way of knowing whether the fields inside conform to the strict schema. As a result, `metadata` will show up as an empty object.
+
+```surql
+[
+    {
+        "id": "user:6nv0vymyutpvajzrfjuw",
+        "metadata": {},
+        "name": "User1"
+    }
+]
+```
+
+With `FLEXIBLE`, the output will be as expected as the schema now flexibly allows any sort of object to be a field on the `user` table.
+
+```bash title="Response"
+[
+    {
+        "id": "user:4a9amtnwzrvbya6p9l8x",
+        "metadata": {
+            "age": 25,
+            "country_code": "ee",
+            "time_zone": "EEST"
+        },
+        "name": "User1"
+    }
+]
 ```
 
 ### Array type 

--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/define/field.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/define/field.mdx
@@ -80,7 +80,7 @@ CREATE user SET
 };
 ```
 
-Without `FLEXIBLE`, the database will recognize that an object has been inserted, but has no way of knowing whether the fields inside conform to the strict schema. As a result, `metadata` will show up as an empty object. Note the difference between this and the `name` field. The `CREATE` statement will simply err if a string for `name` is not provided, while `metadata` will not err because *some* object has been passed in.
+Without `FLEXIBLE`, the database will recognize that an object has been inserted, but has no way of knowing whether the fields inside conform to the strict schema. As a result, `metadata` will show up as an empty object. Note the difference between this and the `name` field. The `CREATE` statement will simply err if a string for `name` is not provided, while `metadata` will not err because _some_ object has been passed in.
 
 ```surql
 [


### PR DESCRIPTION
This PR lengthens the example using `FLEXIBLE` to show what happens when it is not included.

Also, I haven't been able to find another good use case for FLEXIBLE besides object types. Is there anything else? In the meantime I've changed the wording to suit this (from "especially useful" to "necessary") since I can't imagine anyone wanting a non-FLEXIBLE object type can only be empty on a SCHEMAFULL table.