### PR TITLE
Extra info examples, connect info and define pages

### DIFF
--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/define/_category_.json
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/define/_category_.json
@@ -1,7 +1,4 @@
 {
   "label": "DEFINE",
-  "position": 7,
-  "link": {
-    "label": "Overview"
-  }
+  "position": 7
 }

--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/define/index.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/define/index.mdx
@@ -53,3 +53,49 @@ DEFINE [
 		[ UNIQUE | SEARCH ANALYZER @analyzer [ BM25 [(@k1, @b)] ] [ HIGHLIGHTS ] ]
 ]
 ```
+
+The [INFO](/docs/surrealdb/surrealql/statements/info) command can be used to see which definition statements currently exist.
+
+An example of defining a field on a table, followed by an `INFO` command for the same table:
+
+```surql
+DEFINE FIELD name ON TABLE person TYPE string;
+INFO FOR TABLE person;
+```
+
+```bash output="Response"
+{
+    "events": {},
+    "fields": {
+        "name": "DEFINE FIELD name ON person TYPE string PERMISSIONS FULL"
+    },
+    "indexes": {},
+    "lives": {},
+    "tables": {}
+}
+```
+
+An example of defining a user and a table for a database, followed by an `INFO` command for the current database:
+
+```surql
+DEFINE USER db_user ON DATABASE PASSWORD "strongpassword" ROLES OWNER;
+DEFINE TABLE person SCHEMAFULL;
+INFO FOR DB;
+```
+
+```bash output="Response"
+{
+    "analyzers": {},
+    "functions": {},
+    "models": {},
+    "params": {},
+    "scopes": {},
+    "tables": {
+        "person": "DEFINE TABLE person TYPE ANY SCHEMAFULL PERMISSIONS NONE"
+    },
+    "tokens": {},
+    "users": {
+        "db_user": "DEFINE USER db_user ON DATABASE PASSHASH '$argon2id$v=19$m=19456,t=2,p=1$P5nVYXOMvk6rEz67kjL5Dg$0T/XNmgIaB+lK0IPspg1l8LruzNK96jd/PvktRCB/ww' ROLES OWNER"
+    }
+}
+```

--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/define/index.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/define/index.mdx
@@ -7,7 +7,7 @@ description: The DEFINE statement can be used to specify authentication access a
 
 # DEFINE statement
 
-The DEFINE statement can be used to specify items including authentication access and behaviour, global parameters, table configurations, table events, schema definitions, and indexes.
+The DEFINE statement can be used to specify  instructions to the schema such as  authentication access and behaviour, global parameters, table configurations, table events, analyzers, and indexes.
 
 ```surql title="SurrealQL Syntax"
 DEFINE [
@@ -54,7 +54,7 @@ DEFINE [
 ]
 ```
 
-The counterpart to `DEFINE` is the [INFO](/docs/surrealdb/surrealql/statements/info) command, which can be used to see which definition statements currently exist.
+The [INFO](/docs/surrealdb/surrealql/statements/info) statement can be used to see which definition statements currently exist in a database connection.
 
 An example of defining a field on a table, followed by an `INFO` command for the same table:
 

--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/define/index.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/define/index.mdx
@@ -1,6 +1,16 @@
 ---
+sidebar_position: 1
+sidebar_label: Overview
 title: DEFINE statement | SurrealQL
 description: The DEFINE statement can be used to specify authentication access and behaviour, global parameters, table configurations, table events, schema definitions, and indexes.
+---
+
+---
+sidebar_position: 1
+sidebar_label: Data types
+title: Data types | SurrealQL
+description: SurrealQL allows you to describe data with specific data types. These data types are used to validate data and to generate the appropriate database schema.
+
 ---
 
 # DEFINE statement

--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/define/index.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/define/index.mdx
@@ -5,14 +5,6 @@ title: DEFINE statement | SurrealQL
 description: The DEFINE statement can be used to specify authentication access and behaviour, global parameters, table configurations, table events, schema definitions, and indexes.
 ---
 
----
-sidebar_position: 1
-sidebar_label: Data types
-title: Data types | SurrealQL
-description: SurrealQL allows you to describe data with specific data types. These data types are used to validate data and to generate the appropriate database schema.
-
----
-
 # DEFINE statement
 
 The DEFINE statement can be used to specify authentication access and behaviour, global parameters, table configurations, table events, schema definitions, and indexes.

--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/define/index.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/define/index.mdx
@@ -7,7 +7,7 @@ description: The DEFINE statement can be used to specify authentication access a
 
 # DEFINE statement
 
-The DEFINE statement can be used to specify authentication access and behaviour, global parameters, table configurations, table events, schema definitions, and indexes.
+The DEFINE statement can be used to specify items including authentication access and behaviour, global parameters, table configurations, table events, schema definitions, and indexes.
 
 ```surql title="SurrealQL Syntax"
 DEFINE [
@@ -54,7 +54,7 @@ DEFINE [
 ]
 ```
 
-The [INFO](/docs/surrealdb/surrealql/statements/info) command can be used to see which definition statements currently exist.
+The counterpart to `DEFINE` is the [INFO](/docs/surrealdb/surrealql/statements/info) command, which can be used to see which definition statements currently exist.
 
 An example of defining a field on a table, followed by an `INFO` command for the same table:
 

--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/define/index.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/define/index.mdx
@@ -1,6 +1,4 @@
 ---
-sidebar_position: 1
-sidebar_label: Overview
 title: DEFINE statement | SurrealQL
 description: The DEFINE statement can be used to specify authentication access and behaviour, global parameters, table configurations, table events, schema definitions, and indexes.
 ---

--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/info.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/info.mdx
@@ -14,10 +14,13 @@ INFO FOR [
 	ROOT
 	| NS | NAMESPACE
 	| DB | DATABASE
-	| SCOPE @scope
 	| TABLE @table
+	| USER @user [ON @level]
+	| SCOPE @scope
 ];
 ```
+
+The information returned from an `INFO` command is an object containing items that almost always correspond to a matching [DEFINE](/docs/surrealdb/surrealql/statements/define) statement. For example, the `INFO FOR NS` command returns the information on the databases, tokens, and users of a namespace, which are defined with `DEFINE DATABASE`, `DEFINE TOKEN`, and `DEFINE USER` statements.
 
 ## Example usage
 
@@ -33,6 +36,17 @@ The top-level ROOT command returns information regarding the namespaces which ex
 
 ```surql
 INFO FOR ROOT;
+```
+
+```bash title="Sample output"
+{
+    "namespaces": {
+        "ns": "DEFINE NAMESPACE ns"
+    },
+    "users": {
+        "example": "DEFINE USER example ON ROOT PASSHASH '$argon2id$v=19$m=19456,t=2,p=1$S8ggGUFSZY9B6+ZUJADNAw$jcFYLOrx1tq+/YlVk63QNZcP+VbsGD8lpFPvM59aZF4' ROLES OWNER"
+    }
+}
 ```
 
 ### Namespace information
@@ -51,6 +65,18 @@ The `NS` or `NAMESPACE` command returns information regarding the users, tokens,
 INFO FOR NS;
 ```
 
+```bash title="Sample output"
+{
+    "databases": {
+        "db": "DEFINE DATABASE db"
+    },
+    "tokens": {},
+    "users": {
+        "ns_user": "DEFINE USER ns_user ON NAMESPACE PASSHASH '$argon2id$v=19$m=19456,t=2,p=1$da30XYKIjHauYbW6CyqgXQ$4rnHoGa3itfY6LarGE/KwoZE+N+AXrydklDXUFUZXGQ' ROLES OWNER"
+    }
+}
+```
+
 ### Database information
 
 The `DB` or `DATABASE` command returns information regarding the users, tokens, and scopes, and tables under the Database in use.
@@ -67,20 +93,21 @@ The `DB` or `DATABASE` command returns information regarding the users, tokens, 
 INFO FOR DB;
 ```
 
-### Scope information
-
-The `SCOPE` command returns information regarding the tokens configured under a specific Scope.
-
-:::note
-<em> NOTE: </em> You must be authenticated as a top-level root user, a namespace user, or a database user to execute this command.
-::: 
-
-:::note
-<em> NOTE: </em> You must have a NAMESPACE and a DATABASE selected before running this command.
-::: 
-
-```surql
-INFO FOR SCOPE user;
+```bash title="Sample output"
+{
+    "analyzers": {},
+    "functions": {},
+    "models": {},
+    "params": {},
+    "scopes": {},
+    "tables": {
+        "person": "DEFINE TABLE person TYPE ANY SCHEMALESS PERMISSIONS NONE"
+    },
+    "tokens": {},
+    "users": {
+        "db_user": "DEFINE USER db_user ON DATABASE PASSHASH '$argon2id$v=19$m=19456,t=2,p=1$FhgETjyVbEZmcLiCHf5fCA$zXOb8b0lIzIRrtaLPpWXHlWylC4VFBsfr4SWPF3WBKE' ROLES OWNER"
+    }
+}
 ```
 
 ### Table information
@@ -97,4 +124,66 @@ The `TABLE` command returns information regarding the events, fields, indexes, a
 
 ```surql
 INFO FOR TABLE user;
+```
+
+```bash title="Sample output"
+{
+    "events": {},
+    "fields": {
+        "name": "DEFINE FIELD name ON user TYPE string PERMISSIONS FULL"
+    },
+    "indexes": {},
+    "lives": {},
+    "tables": {}
+}
+```
+
+### User information
+
+The `USER` command returns information for a user on either the root, namespace, or database level.
+
+:::note
+<em> NOTE: </em> You must be authenticated as a user equal to or greater than the level of the user you are attempting to obtain information for to execute this command.
+::: 
+
+```surql
+INFO FOR USER root ON ROOT;
+INFO FOR USER ns_user ON NAMESPACE;
+INFO FOR USER db_user ON DATABASE;
+```
+
+If a level after `ON` is not specified, the `INFO` command will default to the database level. Thus, the following two commands are equivalent.
+
+```surql
+INFO FOR USER db_user ON DATABASE;
+INFO FOR USER db_user;
+```
+
+```bash title="Sample output"
+"DEFINE USER db_user ON DATABASE PASSHASH '$argon2id$v=19$m=19456,t=2,p=1$LvgY4ZdWBt5YR+TXd6SNJg$INeqLI5l9vhDtkDGOR2otZMsJHQcT60HtBGgT6F5I9s' ROLES OWNER"
+```
+
+### Scope information
+
+The `SCOPE` command returns information regarding the tokens configured under a specific Scope.
+
+:::note
+<em> NOTE: </em> You must be authenticated as a top-level root user, a namespace user, or a database user to execute this command.
+::: 
+
+:::note
+<em> NOTE: </em> You must have a NAMESPACE and a DATABASE selected before running this command.
+::: 
+
+```surql
+INFO FOR SCOPE users;
+```
+
+```bash title="Sample output"
+{
+    "tokens": {
+        "example": "DEFINE TOKEN example ON SCOPE users TYPE HS512 VALUE 'example'",
+		"example2": "DEFINE TOKEN example2 ON SCOPE users TYPE HS512 VALUE 'another_example_token'",
+    }
+}
 ```

--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/info.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/info.mdx
@@ -26,9 +26,9 @@ The information returned from an `INFO` command is an object containing items th
 
 There are a number of different `INFO` commands for retrieving the configuration at the different levels of the database.
 
-### System information
+### System (root) information
 
-The top-level ROOT command returns information regarding the namespaces which exists within the SurrealDB system.
+The top-level ROOT command returns information regarding the users and namespaces which exists within the SurrealDB system.
 
 :::note
 <em> NOTE: </em> You must be authenticated as a top-level root user to execute this command.
@@ -53,7 +53,7 @@ INFO FOR ROOT;
 
 ### Namespace information
 
-The `NS` or `NAMESPACE` command returns information regarding the users, tokens, and databases under the Namespace in use.
+The `NS` or `NAMESPACE` command returns information regarding the users, tokens, and databases under the namespace in use.
 
 :::note
 <em> NOTE: </em> You must be authenticated as a top-level root user, or a namespace user to execute this command.
@@ -83,7 +83,7 @@ INFO FOR NS;
 
 ### Database information
 
-The `DB` or `DATABASE` command returns information regarding the users, tokens, and scopes, and tables under the Database in use.
+The `DB` or `DATABASE` command returns information regarding the users, tokens, scopes, tables, params, models, functions, and analyzers under the database in use.
 
 :::note
 <em> NOTE: </em> You must be authenticated as a top-level root user, a namespace user, or a database user to execute this command.
@@ -118,7 +118,7 @@ INFO FOR DB;
 
 ### Table information
 
-The `TABLE` command returns information regarding the events, fields, indexes, and foreign table configurations on a specific Table.
+The `TABLE` command returns information regarding the events, fields, tables, and live statement configurations on a specific table.
 
 :::note
 <em> NOTE: </em> You must be authenticated as a top-level root user, a namespace user, or a database user to execute this command.
@@ -148,7 +148,7 @@ INFO FOR TABLE user;
 
 ### User information
 
-The `USER` command returns information for a user on either the root, namespace, or database level.
+The `USER` command returns information for a user [defined](/docs/surrealdb/surrealql/statements/define/user) on either the root, namespace, or database level.
 
 :::note
 <em> NOTE: </em> You must be authenticated as a user equal to or greater than the level of the user you are attempting to obtain information for to execute this command.
@@ -175,7 +175,7 @@ INFO FOR USER db_user;
 
 ### Scope information
 
-The `SCOPE` command returns information regarding the tokens configured under a specific Scope.
+The `SCOPE` command returns information regarding the [tokens defined](/docs/surrealdb/surrealql/statements/define/token) under a specific [scope](/docs/surrealdb/surrealql/statements/define/scope).
 
 :::note
 <em> NOTE: </em> You must be authenticated as a top-level root user, a namespace user, or a database user to execute this command.

--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/info.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/info.mdx
@@ -26,8 +26,9 @@ The information returned from an `INFO` command is an object containing items th
 
 There are a number of different `INFO` commands for retrieving the configuration at the different levels of the database.
 
-### System (root) information
+## System  information
 
+### Root information 
 The top-level ROOT command returns information regarding the users and namespaces which exists within the SurrealDB system.
 
 :::note

--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/info.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/info.mdx
@@ -34,6 +34,8 @@ The top-level ROOT command returns information regarding the namespaces which ex
 <em> NOTE: </em> You must be authenticated as a top-level root user to execute this command.
 ::: 
 
+#### Examples
+
 ```surql
 INFO FOR ROOT;
 ```
@@ -60,6 +62,8 @@ The `NS` or `NAMESPACE` command returns information regarding the users, tokens,
 :::note
 <em> NOTE: </em> You must have a NAMESPACE selected before running this command.
 ::: 
+
+#### Examples
 
 ```surql
 INFO FOR NS;
@@ -88,6 +92,8 @@ The `DB` or `DATABASE` command returns information regarding the users, tokens, 
 :::note
 <em> NOTE: </em> You must have a NAMESPACE and a DATABASE selected before running this command.
 ::: 
+
+#### Examples
 
 ```surql
 INFO FOR DB;
@@ -122,6 +128,8 @@ The `TABLE` command returns information regarding the events, fields, indexes, a
 <em> NOTE: </em> You must have a NAMESPACE and a DATABASE selected before running this command.
 ::: 
 
+#### Examples
+
 ```surql
 INFO FOR TABLE user;
 ```
@@ -145,6 +153,8 @@ The `USER` command returns information for a user on either the root, namespace,
 :::note
 <em> NOTE: </em> You must be authenticated as a user equal to or greater than the level of the user you are attempting to obtain information for to execute this command.
 ::: 
+
+#### Examples
 
 ```surql
 INFO FOR USER root ON ROOT;
@@ -174,6 +184,8 @@ The `SCOPE` command returns information regarding the tokens configured under a 
 :::note
 <em> NOTE: </em> You must have a NAMESPACE and a DATABASE selected before running this command.
 ::: 
+
+#### Examples
 
 ```surql
 INFO FOR SCOPE users;


### PR DESCRIPTION
* INFO FOR works for USER as well, but this isn't shown in the syntax (PR adds syntax)
* INFO and DEFINE are almost always counterparts to each other (with the exception of MODEL and LIVE, every item inside INFO has a matching DEFINE statement). Makes this point clear
* Adds examples of output for INFO
* Some formatting (including where DEFINE still needed an extra click because a separate page was specified in the category.json page)
* Some rewriting