### PR TITLE
fix: nodejs example incorrect import

### DIFF
--- a/doc-surrealdb_versioned_docs/version-1.x/integration/sdks/nodejs.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/integration/sdks/nodejs.mdx
@@ -81,7 +81,7 @@ __NOTE:__ Currently, the connection for this SDK is only available via WebSocket
 :::
 
 ```ts
-const { default: Surreal } = require('surrealdb.node');
+const { Surreal } = require('surrealdb.node');
 
 const db = new Surreal();
 


### PR DESCRIPTION
Running the nodejs example currently gives `TypeError: Surreal is not a constructor` because of a nonexistent default import. After changing to named import it works.

Resolves surrealdb/surrealdb.node#24