### PR TITLE
Rewrite RETURN syntax

### DIFF
--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/create.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/create.mdx
@@ -20,7 +20,7 @@ CREATE [ ONLY ] @targets
 	[ CONTENT @value
 	  | SET @field = @value ...
 	]
-	[ RETURN [ NONE | BEFORE | AFTER | DIFF | @projections ... ]
+	[ RETURN NONE | RETURN BEFORE | RETURN AFTER | RETURN DIFF | RETURN @statement_param, ... ]
 	[ TIMEOUT @duration ]
 	[ PARALLEL ]
 ;

--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/delete.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/delete.mdx
@@ -14,7 +14,7 @@ The `DELETE` statement can be used to delete records from the database.
 ```surql title="SurrealQL Syntax"
 DELETE [ ONLY ] @targets
 	[ WHERE @condition ]
-	[ RETURN [ NONE | BEFORE | AFTER | DIFF | @projections ... ]
+	[ RETURN NONE | RETURN BEFORE | RETURN AFTER | RETURN DIFF | RETURN @statement_param, ... ]
 	[ TIMEOUT @duration ]
 	[ PARALLEL ]
 ;

--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/relate.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/relate.mdx
@@ -47,7 +47,7 @@ RELATE [ ONLY ] @from_record -> @table -> @to_record
 	[ CONTENT @value
 	  | SET @field = @value ...
 	]
-	[ RETURN [ NONE | BEFORE | AFTER | DIFF | @fields ... ]
+	[ RETURN NONE | RETURN BEFORE | RETURN AFTER | RETURN DIFF | RETURN @statement_param, ... ]
 	[ TIMEOUT @duration ]
 	[ PARALLEL ]
 ;

--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/update.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/update.mdx
@@ -23,7 +23,7 @@ UPDATE [ ONLY ] @targets
 	  | SET @field = @value ...
 	]
 	[ WHERE @condition ]
-	[ RETURN [ NONE | BEFORE | AFTER | DIFF | @projections ... ]
+	[ RETURN NONE | RETURN BEFORE | RETURN AFTER | RETURN DIFF | RETURN @statement_param, ... ]
 	[ TIMEOUT @duration ]
 	[ PARALLEL ]
 ;


### PR DESCRIPTION
The current RETURN syntax inside CREATE, DELETE and UPDATE looks like this:

```
	[ RETURN [ NONE | BEFORE | AFTER | DIFF | @projections ... ]
```

Some issues with this we noticed are:

* The square brackets after RETURN makes it looks like NONE the rest are option (i.e. that you can just use RETURN on its own)
* The word `projections` is pretty rarely used so doesn't give a good idea of what can be returned
* No indication that they can be divided by commas
* It's missing a closing `]`

The PR changes it to this which is longer but looked surprisingly clear when I gave a few other syntaxes a try.

```
       [ RETURN NONE | RETURN BEFORE | RETURN AFTER | RETURN DIFF | RETURN @statement_param, ... ]
```