### PR TITLE
Fix wrong example for geometry<line>

### DIFF
--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/datamodel/geometries.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/datamodel/geometries.mdx
@@ -84,7 +84,7 @@ A GeoJSON LineString value for storing a geometric path.
 
 ```surql
 UPDATE city:london SET distance = {
-    type: "Line",
+    type: "LineString",
     coordinates: [[-0.118092, 51.509865],[0.1785278, 51.37692386]],
 };
 ```

--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/datamodel/geometries.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/datamodel/geometries.mdx
@@ -8,7 +8,7 @@ description: SurrealDB makes working with GeoJSON easy, with support for Point, 
 
 # Geometries
 
-SurrealDB makes working with GeoJSON easy, with support for `Point`, `Line`, `Polygon`, `MultiPoint`, `MultiLine`, `MultiPolygon`, and `Collection` values. SurrealQL automatically detects GeoJSON objects converting them into a single data type.
+SurrealDB makes working with GeoJSON easy, with support for `Point`, `LineString`, `Polygon`, `MultiPoint`, `MultiLine`, `MultiPolygon`, and `Collection` values. SurrealQL automatically detects GeoJSON objects converting them into a single data type.
 
 <table>
 <thead>
@@ -23,7 +23,7 @@ SurrealDB makes working with GeoJSON easy, with support for `Point`, `Line`, `Po
     <td scope="row" data-label="Description">A geolocation point with latitude and longitude</td>
   </tr>
   <tr>
-    <td scope="row" data-label="Type"><a href="#line"><code>Line</code></a></td>
+    <td scope="row" data-label="Type"><a href="#LineString"><code>LineString</code></a></td>
     <td scope="row" data-label="Description">A GeoJSON LineString value for storing a geometric path</td>
   </tr>
   <tr>
@@ -72,7 +72,7 @@ UPDATE city:london SET centre = {
 
 <br />
 
-## `Line`
+## `LineString`
 
 A GeoJSON LineString value for storing a geometric path.
 

--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/datamodel/index.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/datamodel/index.mdx
@@ -174,7 +174,7 @@ SurrealQL allows you to describe data with specific data types. These data types
                 <ul>
                     <li><code>geometry&lt;feature&gt;</code></li>
                     <li><code>geometry&lt;point&gt;</code></li>
-                    <li><code>geometry&lt;line&gt;</code></li>
+                    <li><code>geometry&lt;LineString&gt;</code></li>
                     <li><code>geometry&lt;polygon&gt;</code></li>
                     <li><code>geometry&lt;multipoint&gt;</code></li>
                     <li><code>geometry&lt;multiline&gt;</code></li>


### PR DESCRIPTION
"Line" is not an official GeoJson type, "LineString" ist the correct type. Using "Line" throws an error.