### PR TITLE
Docs: Update connection URL

### DIFF
--- a/doc-surrealdb_versioned_docs/version-1.x/integration/sdks/javascript.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/integration/sdks/javascript.mdx
@@ -84,7 +84,7 @@ const db = new Surreal();
 async function main() {
 	try {
 		// Connect to the database
-		await db.connect('http://127.0.0.1:8000/rpc', {
+		await db.connect('ws://127.0.0.1:8000', {
 			// Set the namespace and database for the connection
 			namespace: 'test',
 			database: 'test',


### PR DESCRIPTION
Version 1 now uses WebSockets instead of the HTTP RPC endpoint.