### PR TITLE
Add documention about <array<T>> and <record> casting

### DIFF
--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/datamodel/casting.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/datamodel/casting.mdx
@@ -54,6 +54,10 @@ In the SurrealDB type system, values can be converted to other values efficientl
       <td scope="row" data-label="Type"><a href="#arrayt"><code>&lt;array&lt;T&gt;&gt;</code></a></td>
       <td scope="row" data-label="Description">Casts the subsequent value into an array of <code>T</code></td>
     </tr>
+    <tr>
+      <td scope="row" data-label="Type"><a href="#record"><code>&lt;record&gt;</code></a></td>
+      <td scope="row" data-label="Description">Casts the subsequent value into a record</td>
+    </tr>
   </tbody>
 </table>
 
@@ -216,6 +220,20 @@ SELECT * FROM <array<int>> ["42", "314", "271", "137", "141"];
 SELECT * FROM <array<string>> [42, 314, 271, 137, 141];
 
 ["42", "314", "271", "137", "141"]
+```
+
+<br />
+
+## `<record>`
+
+The &lt;record&gt; casting function converts a value into a record.
+
+Keep in mind when using this casting function that if the equivalent record id does not exist, it will not return anything.
+
+```surql
+SELECT id FROM <record> (s"person:hrebrffwm4sr2yifglta");;
+
+{ id: person:hrebrffwm4sr2yifglta }
 ```
 
 <br /><br />

--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/datamodel/casting.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/datamodel/casting.mdx
@@ -50,6 +50,10 @@ In the SurrealDB type system, values can be converted to other values efficientl
       <td scope="row" data-label="Type"><a href="#duration"><code>&lt;duration&gt;</code></a></td>
       <td scope="row" data-label="Description">Casts the subsequent value into a duration</td>
     </tr>
+    <tr>
+      <td scope="row" data-label="Type"><a href="#arrayt"><code>&lt;array&lt;T&gt;&gt;</code></a></td>
+      <td scope="row" data-label="Description">Casts the subsequent value into an array of <code>T</code></td>
+    </tr>
   </tbody>
 </table>
 
@@ -192,6 +196,26 @@ The &lt;duration&gt; casting function converts a value into a duration.
 SELECT * FROM <duration> "1h30m";
 
 "1h30m"
+```
+
+<br />
+
+## `<array<T>>`
+
+The &lt;array&lt;T&gt;&gt; casting function converts a value into an array of <code>T</code>.
+
+When using this casting function, the value must be an array and each element in the array will be cast to <code>T</code>.
+
+```surql
+SELECT * FROM <array<int>> ["42", "314", "271", "137", "141"];
+
+[42, 314, 271, 137, 141]
+```
+
+```surql
+SELECT * FROM <array<string>> [42, 314, 271, 137, 141];
+
+["42", "314", "271", "137", "141"]
 ```
 
 <br /><br />


### PR DESCRIPTION
Following the issue #292, this PR aims to include <array<T>> and <record> casting in the documentation.

The issue also mentions detailing the `.bind` function in Rust's SDK, but since the time I wrote the issue to now I come to realize there isn't really anything wrong with this part of the documentation, but rather a misunderstand from my part three months ago.