### PR TITLE
Add object-based record ID queries

### DIFF
--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/datamodel/ids.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/datamodel/ids.mdx
@@ -55,13 +55,13 @@ CREATE temperature:17493 SET time = time::now(), celsius = 37.5;
 ```
 
 ### Object-based Record IDs
-Complex record IDs support dynamic expressions, allowing parameters, and function expressions to be used as values within the IDs. This is useful in a timeseries context, or for ensuring locality between specific records in a table. All object keys in SurrealDB are sorted alphabetically 
+Complex record IDs support dynamic expressions, allowing parameters, and function expressions to be used as values within the IDs. This is useful in a timeseries context, or for ensuring locality between specific records in a table. All object keys in SurrealDB are sorted alphabetically.
 
 ```surql
 // Set a new parameter
 LET $now = time::now();
 // Create a record with a complex ID using an object
-CREATE temperature:{ location: 'London', date: $now } SET
+CREATE weather:{ location: 'London', date: $now } SET
 	location = 'London',
 	date = $now,
 	temperature = 23.7
@@ -75,7 +75,7 @@ Similar to object-based record IDs, records in SurrealDB can store arrays of val
 // Set a new parameter
 LET $now = time::now();
 // Create a record with a complex ID using an array
-CREATE temperature:['London', $now] SET
+CREATE weather:['London', $now] SET
 	location = 'London',
 	date = $now,
 	temperature = 23.7
@@ -94,7 +94,7 @@ CREATE temperature:ulid() SET time = time::now(), celsius = 37.5;
 CREATE temperature:uuid() SET time = time::now(), celsius = 37.5;
 ```
 
-### Record ranges
+### Record ranges and querying complex IDs
 SurrealDB supports the ability to query a range of records, using the record ID. The record ID ranges, retrieve records using the natural sorting order of the record IDs. These range queries can be used to query a range of records in a timeseries context.
 
 ```surql
@@ -108,6 +108,98 @@ SELECT * FROM temperature:..['London', '2022-08-29T08:09:31'];
 SELECT * FROM temperature:['London', '2022-08-29T08:03:39']..;
 -- Select all temperature records with IDs between the specified range
 SELECT * FROM temperature:['London', '2022-08-29T08:03:39']..['London', '2022-08-29T08:09:31'];
+```
+
+Nested fields inside object-based Record IDs can be queried in the same way as a regular SurrealDB record.
+
+```surql
+INSERT INTO weather [
+	{
+		id: {
+			date: '2024-04-30T03:21:04Z',
+			location: 'London'
+		},
+		temperature: 18.2f
+	},
+	{
+		id: {
+			date: '2024-05-01T03:21:04Z',
+			location: 'London'
+		},
+		temperature: 20f
+	},
+	{
+		id: {
+			date: '2024-05-01T03:21:04Z',
+			location: 'Pärnu'
+		},
+		temperature: 18.1f
+	}
+];
+
+SELECT id.date AS date, temperature FROM weather WHERE id.location = 'London';
+```
+
+```bash title="Response"
+[
+	{
+		date: '2024-04-30T03:21:04Z',
+		temperature: 18.2f
+	},
+	{
+		date: '2024-05-01T03:21:04Z',
+		temperature: 20
+	}
+]
+```
+
+Record ranges queries can be used for object-based record IDs as well.
+
+```surql
+INSERT INTO weather [
+	{
+		id: {
+			date: '2024-04-30T03:21:04Z',
+			location: 'London'
+		},
+		temperature: 18.2f
+	},
+	{
+		id: {
+			date: '2024-05-01T03:21:04Z',
+			location: 'London'
+		},
+		temperature: 20f
+	},
+	{
+		id: {
+			date: '2024-05-01T03:21:04Z',
+			location: 'Pärnu'
+		},
+		temperature: 18.1f
+	}
+];
+
+SELECT * FROM weather:{ date: '2024-05-01T00:00:00Z' }..={ date: '2024-05-03T00:02:00Z'};
+```
+
+```bash title="Response"
+[
+	{
+		id: weather:{
+			date: '2024-05-01T03:21:04Z',
+			location: 'London'
+		},
+		temperature: 20
+	},
+	{
+		id: weather:{
+			date: '2024-05-01T03:21:04Z',
+			location: 'Pärnu'
+		},
+		temperature: 18.1f
+	}
+]
 ```
 
 ## Field names

--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/datamodel/ids.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/datamodel/ids.mdx
@@ -86,12 +86,12 @@ CREATE weather:['London', $now] SET
 Record IDs can be generated with a number of built-in ID generation functions. These allow for record IDs to be generated using cryptographically-secure randomly-generated identifiers (which are suitable for dispersion across a distributed datastore), sequentially incrementing `ULID` Record identifiers, and `UUID` version 7 Record identifiers.
 
 ```surql
-// Generate a random record ID
+// Generate a random record ID. Example: x4q9u1noyik9my4lta3s
 // Note: equivalent to `CREATE temperature:rand()`
 CREATE temperature SET time = time::now(), celsius = 37.5;
-// Generate a ULID-based record ID
+// Generate a ULID-based record ID. Example: 01HWPK2R0P1B5TPNZ70R2GGKCJ
 CREATE temperature:ulid() SET time = time::now(), celsius = 37.5;
-// Generate a UUIDv7-based record ID
+// Generate a UUIDv7-based record ID. Example: 018f2d31-6016-7498-a3c7-91738596576d
 CREATE temperature:uuid() SET time = time::now(), celsius = 37.5;
 ```
 

--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/datamodel/ids.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/datamodel/ids.mdx
@@ -83,11 +83,12 @@ CREATE weather:['London', $now] SET
 ```
 
 ### Generating Record IDs
-Record IDs can be generated with a number of built-in ID generation functions. These allow for record IDs to be generated using cryptographically-secure randomly-generated identifiers (which are suitable for dispersion across a distributed datastore), sequentially incrementing `ULID` Record identifiers, and `UUID` version 7 Record idenfitifiers.
+Record IDs can be generated with a number of built-in ID generation functions. These allow for record IDs to be generated using cryptographically-secure randomly-generated identifiers (which are suitable for dispersion across a distributed datastore), sequentially incrementing `ULID` Record identifiers, and `UUID` version 7 Record identifiers.
 
 ```surql
 // Generate a random record ID
-CREATE temperature:rand() SET time = time::now(), celsius = 37.5;
+// Note: equivalent to `CREATE temperature:rand()`
+CREATE temperature SET time = time::now(), celsius = 37.5;
 // Generate a ULID-based record ID
 CREATE temperature:ulid() SET time = time::now(), celsius = 37.5;
 // Generate a UUIDv7-based record ID


### PR DESCRIPTION
A user here https://github.com/surrealdb/surrealdb/issues/3928 would like to see some more examples of querying on object-based records.

* You can treat their inner fields as record fields, which is pretty neat
* Range queries on them work in the same way as the array examples

Also changed the `temperature` records to `weather` records since they have a `temperature` field and querying on `temperature` table's `temperature` field feels weird.

Anything else interesting to add?