### PR TITLE
Docs: Update SurrealistMini component to include 'compact' parameter in URL

### DIFF
--- a/src/components/SurrealistMini/index.tsx
+++ b/src/components/SurrealistMini/index.tsx
@@ -17,7 +17,7 @@ export function SurrealistMini({
     props.variables = typeof props.variables == 'string' ? props.variables : JSON.stringify(props.variables);
     const stringified = Object.fromEntries(Object.entries(props).map(([k,v]) => [k, (v ?? '').toString()]));
     const search = new URLSearchParams(stringified).toString();
-    const url = _url ?? `https://dev.surrealist.app/mini?${search}`;
+    const url = (_url ?? `https://dev.surrealist.app/mini?${search}`) + '&compact';
     return (
         <iframe src={url} style={{width: '100%', height: height ?? '600px', border: 'none', borderRadius: '10px' }} />
     )


### PR DESCRIPTION
The `&compact` parameter removes the Surrealist header from the embeds so it looks neater. 