### PR TITLE
Geo updates and fixes

### DIFF
--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/datamodel/geometries.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/datamodel/geometries.mdx
@@ -66,8 +66,17 @@ In addition, SurrealDB supports entering GeoJSON points using the traditional fo
 ```surql
 UPDATE city:london SET centre = {
     type: "Point",
-    coordinates: [-0.118092, 51.509865],
+    coordinates: [-0.118092, 51.509865]
 };
+```
+
+```bash title="Response"
+[
+	{
+		centre: (-0.118092, 51.509865),
+		id: city:london
+	}
+]
 ```
 
 <br />
@@ -75,8 +84,6 @@ UPDATE city:london SET centre = {
 ## `LineString`
 
 A GeoJSON LineString value for storing a geometric path.
-
-
 
 :::note
  <em> INFO: </em> No other properties must be present in the LineString object.
@@ -94,8 +101,6 @@ UPDATE city:london SET distance = {
 ## `Polygon`
 
 A GeoJSON Polygon value for storing a geometric area.
-
-
 
 :::note
  <em> INFO: </em> No other properties must be present in the Polygon object.
@@ -116,9 +121,7 @@ UPDATE city:london SET boundary = {
 
 ## `MultiPoint`
 
-MultiPoints can be used to store multiple geometry points in a single value.
-
-
+A MultiPoint can be used to store multiple geometry points in a single value.
 
 :::note
  <em> INFO: </em> No other properties must be present in the MultiPoint object.
@@ -136,9 +139,9 @@ UPDATE person:tobie SET locations = {
 
 <br />
 
-## `MultiLine`
+## `MultiLineString`
 
-MultiLines can be used to store multiple geometry lines in a single value.
+A MultiLineString can be used to store multiple geometry lines in a single value.
 
 
 :::note
@@ -159,7 +162,7 @@ UPDATE travel:yellowstone SET routes = {
 
 ## `MultiPolygon`
 
-MultiPolygons can be used to store multiple geometry polygons in a single value.
+A MultiPolygon can be used to store multiple geometry polygons in a single value.
 
 
 :::note
@@ -182,10 +185,9 @@ UPDATE university:oxford SET locations = {
 
 <br />
 
-## `Collection`
+## `GeometryCollection`
 
-Collections can be used to store multiple different geometry types in a single value.
-
+A GeometryCollection can be used to store multiple different geometry types in a single value.
 
 :::note
  <em> INFO: </em>No other properties must be present in the Collection object.

--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/functions/geo.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/functions/geo.mdx
@@ -115,7 +115,7 @@ geo::bearing(point, point) -> number
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:
 
 ```surql
--- LET used her for readability
+-- LET used here for readability
 LET $paris = (2.358058597411099, 48.861109346459536);
 LET $le_puy_en_velay = (3.883428431947686, 45.04383588468415);
 RETURN geo::bearing($paris, $le_puy_en_velay);

--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/functions/geo.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/functions/geo.mdx
@@ -75,16 +75,16 @@ The following example shows this function, and its output, when used in a [`RETU
 RETURN geo::area({
   type: "Polygon",
   coordinates: [[
-    [1.48899, 42.65347],
-    [1.78436, 42.57674],
-    [1.55204, 42.43498], 
-    [1.44651, 42.44106]
+    [-111.0690, 45.0032],
+    [-104.0838, 44.9893],
+    [-104.0910, 40.9974], 
+    [-111.0672, 40.9862]
   ]]
 });
 ```
 
 ```bash title="Response"
-249552791347.80392
+253317731850.3478f
 ```
 If the argument is not a geometry type, then an [`EMPTY`](/docs/surrealdb/surrealql/datamodel/none_and_null) value will be returned:
 
@@ -115,11 +115,13 @@ geo::bearing(point, point) -> number
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:
 
 ```surql
--- LET simply used for readability
+-- LET used her for readability
 LET $paris = (2.358058597411099, 48.861109346459536);
 LET $le_puy_en_velay = (3.883428431947686, 45.04383588468415);
 RETURN geo::bearing($paris, $le_puy_en_velay);
+```
 
+```bash title="Response"
 164.18154786094604
 ```
 
@@ -166,13 +168,7 @@ RETURN geo::centroid({
 The return value is a mountainous region somewhere in Austria:
 
 ```bash title="Response"
-{
-    "type": "Point",
-    "coordinates": [
-        13.483896437936192,
-        47.07117241195589
-    ]
-}
+(13.483896437936192, 47.07117241195589)
 ```
 
 <ThemedImage
@@ -210,7 +206,7 @@ RETURN geo::distance($london, $harare);
 ```
 
 ```bash title="Response"
-8268604.251890702
+8268604.251890702f
 ```
 
 <ThemedImage
@@ -243,15 +239,10 @@ The following example shows this function, and its output, when used in a [`RETU
 
 ```surql
 RETURN geo::hash::decode("mpuxk4s24f51");
+```
 
-
-{
-	"type": "Point",
-	"coordinates": [
-		51.50986494496465,
-		-0.11809204705059528
-	]
-}
+```bash title="Response"
+(51.50986494496465, -0.11809204705059528)
 ```
 If the argument is not a geolocation point, then an [`EMPTY`](/docs/surrealdb/surrealql/datamodel/none_and_null) value will be returned:
 

--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/operators.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/operators.mdx
@@ -177,7 +177,7 @@ A variety of operators in SurrealQL allow for complex manipulation of data, and 
 Checks whether both of two values are truthy.
 
 ```surql
-SELECT * FROM 10 AND 20 AND 30;
+RETURN 10 AND 20 AND 30;
 
 30
 ```
@@ -189,7 +189,7 @@ SELECT * FROM 10 AND 20 AND 30;
 Checks whether either of two values are truthy.
 
 ```surql
-SELECT * FROM 0 OR false OR 10;
+RETURN 0 OR false OR 10;
 
 10
 ```
@@ -201,7 +201,7 @@ SELECT * FROM 0 OR false OR 10;
 Check whether either of two values are truthy and not `NULL`.
 
 ```surql
-SELECT * FROM NULL ?? 0 ?? false ?? 10;
+RETURN NULL ?? 0 ?? false ?? 10;
 
 0
 ```
@@ -213,7 +213,7 @@ SELECT * FROM NULL ?? 0 ?? false ?? 10;
 Check whether either of two values are truthy.
 
 ```surql
-SELECT * FROM NULL ?: 0 ?: false ?: 10;
+RETURN NULL ?: 0 ?: false ?: 10;
 
 10
 ```
@@ -225,42 +225,42 @@ SELECT * FROM NULL ?: 0 ?: false ?: 10;
 Check whether two values are equal.
 
 ```surql
-SELECT * FROM true = "true";
+RETURN true = "true";
 
 false
 ```
 ```surql
-SELECT * FROM 10 = "10";
+RETURN 10 = "10";
 
 false
 ```
 ```surql
-SELECT * FROM 10 = 10.00;
+RETURN 10 = 10.00;
 
 true
 ```
 ```surql
-SELECT * FROM 10 = "10.3";
+RETURN 10 = "10.3";
 
 false
 ```
 ```surql
-SELECT * FROM [1, 2, 3] = [1, 2, 3];
+RETURN [1, 2, 3] = [1, 2, 3];
 
 true
 ```
 ```surql
-SELECT * FROM [1, 2, 3] = [1, 2, 3, 4];
+RETURN [1, 2, 3] = [1, 2, 3, 4];
 
 false
 ```
 ```surql
-SELECT * FROM { this: "object" } = { this: "object" };
+RETURN { this: "object" } = { this: "object" };
 
 true
 ```
 ```surql
-SELECT * FROM { this: "object" } = { another: "object" };
+RETURN { this: "object" } = { another: "object" };
 
 false
 ```
@@ -272,17 +272,17 @@ false
 Check whether two values are equal.
 
 ```surql
-SELECT * FROM 10 != "15";
+RETURN 10 != "15";
 
 true
 ```
 ```surql
-SELECT * FROM 10 != "test";
+RETURN 10 != "test";
 
 true
 ```
 ```surql
-SELECT * FROM [1, 2, 3] != [3, 4, 5];
+RETURN [1, 2, 3] != [3, 4, 5];
 
 true
 ```
@@ -294,17 +294,17 @@ true
 Check whether two values are exact. This operator also checks that each value has the same type.
 
 ```surql
-SELECT * FROM 10 == 10;
+RETURN 10 == 10;
 
 true
 ```
 ```surql
-SELECT * FROM 10 == "10";
+RETURN 10 == "10";
 
 false
 ```
 ```surql
-SELECT * FROM true == "true";
+RETURN true == "true";
 
 false
 ```
@@ -316,7 +316,7 @@ false
 Check whether any value in an array equals another value.
 
 ```surql
-SELECT * FROM [10, 15, 20] ?= 10;
+RETURN [10, 15, 20] ?= 10;
 
 true
 ```
@@ -328,7 +328,7 @@ true
 Check whether all values in an array equals another value.
 
 ```surql
-SELECT * FROM [10, 10, 10] *= 10;
+RETURN [10, 10, 10] *= 10;
 
 true
 ```
@@ -340,17 +340,17 @@ true
 Compare two values for equality using fuzzy matching.
 
 ```surql
-SELECT * FROM "test text" ~ "Test";
+RETURN "test text" ~ "Test";
 
 true
 ```
 ```surql
-SELECT * FROM "true" ~ true;
+RETURN "true" ~ true;
 
 false
 ```
 ```surql
-SELECT * FROM ["test", "thing"] ~ "test";
+RETURN ["test", "thing"] ~ "test";
 
 false
 ```
@@ -362,12 +362,12 @@ false
 Compare two values for inequality using fuzzy matching.
 
 ```surql
-SELECT * FROM "other text" !~ "test";
+RETURN "other text" !~ "test";
 
 true
 ```
 ```surql
-SELECT * FROM "test text" !~ "Test";
+RETURN "test text" !~ "Test";
 
 false
 ``` 
@@ -379,12 +379,12 @@ false
 Check whether any value in a set is equal to a value using fuzzy matching.
 
 ```surql
-SELECT * FROM ["true", "test", "text"] ?~ true;
+RETURN ["true", "test", "text"] ?~ true;
 
 false
 ```
 ```surql
-SELECT * FROM [1, 2, 3] ?~ "2";
+RETURN [1, 2, 3] ?~ "2";
 
 false
 ``` 
@@ -396,12 +396,12 @@ false
 Check whether all values in a set are equal to a value using fuzzy matching.
 
 ```surql
-SELECT * FROM ["TRUE", true, "true", "TrUe"] *~ true;
+RETURN ["TRUE", true, "true", "TrUe"] *~ true;
 
 false
 ```
 ```surql
-SELECT * FROM ["TEST", "test", "text"] *~ "test";
+RETURN ["TEST", "test", "text"] *~ "test";
 
 false
 ``` 
@@ -413,7 +413,7 @@ false
 Check whether a value is less than another value.
 
 ```surql
-SELECT * FROM 10 < 15;
+RETURN 10 < 15;
 
 true
 ```
@@ -425,7 +425,7 @@ true
 Check whether a value is less than or equal to another value.
 
 ```surql
-SELECT * FROM 10 <= 15;
+RETURN 10 <= 15;
 
 true
 ```
@@ -437,7 +437,7 @@ true
 Check whether a value is less than another value.
 
 ```surql
-SELECT * FROM 15 > 10;
+RETURN 15 > 10;
 
 true
 ```
@@ -449,7 +449,7 @@ true
 Check whether a value is less than or equal to another value.
 
 ```surql
-SELECT * FROM 15 >= 10;
+RETURN 15 >= 10;
 
 true
 ```
@@ -461,17 +461,17 @@ true
 Add two values together.
 
 ```surql
-SELECT * FROM 10 + 10;
+RETURN 10 + 10;
 
 20
 ```
 ```surql
-SELECT * FROM "test" + " " + "this";
+RETURN "test" + " " + "this";
 
 "test this"
 ```
 ```surql
-SELECT * FROM 13h + 30m;
+RETURN 13h + 30m;
 
 "13h30m"
 ```
@@ -483,12 +483,12 @@ SELECT * FROM 13h + 30m;
 Subtracts a value from another value.
 
 ```surql
-SELECT * FROM 20 - 10;
+RETURN 20 - 10;
 
 10
 ```
 ```surql
-SELECT * FROM 2m - 1m;
+RETURN 2m - 1m;
 
 "1m"
 ```
@@ -500,7 +500,7 @@ SELECT * FROM 2m - 1m;
 Multiplies a value by another value.
 
 ```surql
-SELECT * FROM 20 * 2;
+RETURN 20 * 2;
 
 40
 ```
@@ -512,7 +512,7 @@ SELECT * FROM 20 * 2;
 Divides a value with another value.
 
 ```surql
-SELECT * FROM 20 / 2;
+RETURN 20 / 2;
 
 10
 ```
@@ -524,7 +524,7 @@ SELECT * FROM 20 / 2;
 Raises a base value by another value.
 
 ```surql
-SELECT * FROM 20 ** 3;
+RETURN 20 ** 3;
 
 8000
 ```
@@ -536,17 +536,17 @@ SELECT * FROM 20 ** 3;
 Check whether a value contains another value.
 
 ```surql
-SELECT * FROM [10, 20, 30] CONTAINS 10;
+RETURN [10, 20, 30] CONTAINS 10;
 
 true
 ```
 ```surql
-SELECT * FROM "this is some text" CONTAINS "text";
+RETURN "this is some text" CONTAINS "text";
 
 true
 ```
 ```surql
-SELECT * FROM {
+RETURN {
 	type: "Polygon",
 	coordinates: [[
 		[-0.38314819, 51.37692386], [0.1785278, 51.37692386],
@@ -565,17 +565,17 @@ true
 Check whether a value does not contain another value.
 
 ```surql
-SELECT * FROM [10, 20, 30] CONTAINSNOT 15;
+RETURN [10, 20, 30] CONTAINSNOT 15;
 
 true
 ```
 ```surql
-SELECT * FROM "this is some text" CONTAINSNOT "other";
+RETURN "this is some text" CONTAINSNOT "other";
 
 true
 ```
 ```surql
-SELECT * FROM {
+RETURN {
 	type: "Polygon",
 	coordinates: [[
 		[-0.38314819, 51.37692386], [0.1785278, 51.37692386],
@@ -594,7 +594,7 @@ true
 Check whether a value contains all of multiple values.
 
 ```surql
-SELECT * FROM [10, 20, 30] CONTAINSALL [10, 20, 10];
+RETURN [10, 20, 30] CONTAINSALL [10, 20, 10];
 
 true
 ```
@@ -606,7 +606,7 @@ true
 Check whether a value contains any of multiple values.
 
 ```surql
-SELECT * FROM [10, 20, 30] CONTAINSANY [10, 15, 25];
+RETURN [10, 20, 30] CONTAINSANY [10, 15, 25];
 
 true
 ```
@@ -618,17 +618,17 @@ true
 Check whether a value is contained within another value.
 
 ```surql
-SELECT * FROM 10 INSIDE [10, 20, 30];
+RETURN 10 INSIDE [10, 20, 30];
 
 true
 ```
 ```surql
-SELECT * FROM "text" INSIDE "this is some text";
+RETURN "text" INSIDE "this is some text";
 
 true
 ```
 ```surql
-SELECT * FROM (-0.118092, 51.509865) INSIDE {
+RETURN (-0.118092, 51.509865) INSIDE {
 	type: "Polygon",
 	coordinates: [[
 		[-0.38314819, 51.37692386], [0.1785278, 51.37692386],
@@ -647,17 +647,17 @@ true
 Check whether a value is not contained within another value.
 
 ```surql
-SELECT * FROM 15 NOTINSIDE [10, 20, 30];
+RETURN 15 NOTINSIDE [10, 20, 30];
 
 true
 ```
 ```surql
-SELECT * FROM "other" NOTINSIDE "this is some text";
+RETURN "other" NOTINSIDE "this is some text";
 
 true
 ```
 ```surql
-SELECT * FROM (-0.518092, 53.509865) NOTINSIDE {
+RETURN (-0.518092, 53.509865) NOTINSIDE {
 	type: "Polygon",
 	coordinates: [[
 		[-0.38314819, 51.37692386], [0.1785278, 51.37692386],
@@ -676,7 +676,7 @@ true
 Check whether all of multiple values are contained within another value.
 
 ```surql
-SELECT * FROM [10, 20, 10] ALLINSIDE [10, 20, 30];
+RETURN [10, 20, 10] ALLINSIDE [10, 20, 30];
 
 true
 ```
@@ -688,7 +688,7 @@ true
 Check whether any of multiple values are contained within another value.
 
 ```surql
-SELECT * FROM [10, 15, 25] ANYINSIDE [10, 20, 30];
+RETURN [10, 15, 25] ANYINSIDE [10, 20, 30];
 
 true
 ```
@@ -700,7 +700,7 @@ true
 Check whether none of multiple values are contained within another value.
 
 ```surql
-SELECT * FROM [15, 25, 35] NONEINSIDE [10, 20, 30];
+RETURN [15, 25, 35] NONEINSIDE [10, 20, 30];
 
 true
 ```
@@ -711,7 +711,7 @@ true
 Check whether a geometry value is outside another geometry value.
 
 ```surql
-SELECT * FROM (-0.518092, 53.509865) OUTSIDE {
+RETURN (-0.518092, 53.509865) OUTSIDE {
 	type: "Polygon",
 	coordinates: [[
 		[-0.38314819, 51.37692386], [0.1785278, 51.37692386],
@@ -729,7 +729,7 @@ true
 Check whether a geometry value intersects another geometry value.
 
 ```surql
-SELECT * FROM {
+RETURN {
 	type: "Polygon",
 	coordinates: [[
 		[-0.38314819, 51.37692386], [0.1785278, 51.37692386],


### PR DESCRIPTION
Some small fixes and updates for geo functions and types:

* The output for functions like centroid no longer look like JSON objects, but just a tuple of two points (though type::is::geometry still returns true for them)
* Changes some type names to match the GeoJSON names
* Fixes the Wyoming example (somehow has coordinates for somewhere in Europe)
* Output: Floats now have an f at the end
* Also small opinionated change: found some more geo examples on the operators page which work fine, but having SELECT * FROM everywhere where a simple RETURN would have worked seems needlessly verbose.