### PR TITLE
SHOW on changefeed works with version stamp as well as datetime

### DIFF
--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/functions/search.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/functions/search.mdx
@@ -7,7 +7,7 @@ description: These functions are used in conjunction with the 'matches' operator
 
 # Search functions
 
-These functions are used in conjunction with the `@@` operator (the 'matches' operator) to either collect the relevance score or highlight the searched keywords within the content.
+These functions are used in conjunction with the [`@@` operator (the 'matches' operator)](/docs/surrealdb/surrealql/operators#matches) to either collect the relevance score or highlight the searched keywords within the content.
 
 <table>
   <thead>

--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/define/database.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/define/database.mdx
@@ -17,7 +17,7 @@ The `DEFINE DATABASE` statement allows you to instantiate a named database, enab
 ## Statement syntax
 
 ```surql title="SurrealQL Syntax"
-DEFINE DATABASE [ IF NOT EXISTS ] @name
+DEFINE DATABASE [ IF NOT EXISTS ] @name [CHANGEFEED @duration | @versionstamp [INCLUDE ORIGINAL] ]
 ```
 
 ## Example usage 
@@ -37,4 +37,20 @@ The `IF NOT EXISTS` clause can be used to define a database only if it does not 
 ```surql
 -- Create a DATABASE if it does not already exist
 DEFINE DATABASE IF NOT EXISTS app_vitalsense;
+```
+
+## Changefeeds
+
+A changefeed can be defined on a database, in which case all table events will show up on the changefeed without needing to be included in a [DEFINE TABLE](/docs/surrealdb/surrealql/statements/define/table) statement.
+
+```surql
+DEFINE DATABASE my_database CHANGEFEED 3d;
+
+CREATE reading SET story = "Once upon a time";
+CREATE reading SET story = "there was a database";
+CREATE company SET name = "SurrealDB", stories = (SELECT * FROM story);
+UPDATE reading SET story = story + "!";
+
+SHOW CHANGES FOR TABLE reading SINCE 1 LIMIT 10;
+SHOW CHANGES FOR TABLE company SINCE 1 LIMIT 10;
 ```

--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/define/table.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/define/table.mdx
@@ -62,97 +62,150 @@ DEFINE TABLE reading CHANGEFEED 3d;
 
 -- Create some records in the reading table
 CREATE reading SET story = "Once upon a time";
-CREATE reading SET story = "there was a database";
+CREATE reading SET story = "There was a database";
+UPDATE reading SET story = story + "!";
 
--- Replay changes to the reading table
+-- Replay changes to the reading table since a date
 SHOW CHANGES FOR TABLE reading SINCE "2023-09-07T01:23:52Z" LIMIT 10;
+-- Replay changes to the reading table since a version stamp
+SHOW CHANGES FOR TABLE reading SINCE 1 LIMIT 10;
 ```
 
 ```bash title="Response without INCLUDE ORIGINAL"
 [
-    {
-        "changes": [
-            {
-                "define_table": {
-                    "name": "reading"
-                }
-            }
-        ],
-        "versionstamp": 29
-    },
-    {
-        "changes": [
-            {
-                "update": {
-                    "id": "reading:h1gcbc7ykbpslellh2g2",
-                    "story": "Once upon a time"
-                }
-            }
-        ],
-        "versionstamp": 30
-    },
-    {
-        "changes": [
-            {
-                "update": {
-                    "id": "reading:l9qfcncklhnlklby1avf",
-                    "story": "there was a database"
-                }
-            }
-        ],
-        "versionstamp": 31
-    }
+	{
+		changes: [
+			{
+				define_table: {
+					name: 'reading'
+				}
+			}
+		],
+		versionstamp: 1
+	},
+	{
+		changes: [
+			{
+				update: {
+					id: reading:qwi8q40g0qjfzbs5ijg4,
+					story: 'Once upon a time'
+				}
+			}
+		],
+		versionstamp: 2
+	},
+	{
+		changes: [
+			{
+				update: {
+					id: reading:xsf4icl4toj0oc6o9a0x,
+					story: 'There was a database'
+				}
+			}
+		],
+		versionstamp: 3
+	},
+	{
+		changes: [
+			{
+				update: {
+					id: reading:qwi8q40g0qjfzbs5ijg4,
+					story: 'Once upon a time!'
+				}
+			},
+			{
+				update: {
+					id: reading:xsf4icl4toj0oc6o9a0x,
+					story: 'There was a database!'
+				}
+			}
+		],
+		versionstamp: 4
+	}
 ]
 ```
 
 ```bash title="Response with INCLUDE ORIGINAL"
 [
-    {
-        "changes": [
-            {
-                "define_table": {
-                    "name": "reading"
-                }
-            }
-        ],
-        "versionstamp": 29
-    },
-    {
-        "changes": [
-            {
-                "current": {
-                    "id": "reading:2j3rc2yw1jzspcuvfe9v",
-                    "story": "Once upon a time"
-                },
-                "update": [
-                    {
-                        "op": "replace",
-                        "path": "/",
-                        "value": null
-                    }
-                ]
-            }
-        ],
-        "versionstamp": 30
-    },
-    {
-        "changes": [
-            {
-                "current": {
-                    "id": "reading:iuiurhi0y2ka0by0skqi",
-                    "story": "there was a database"
-                },
-                "update": [
-                    {
-                        "op": "replace",
-                        "path": "/",
-                        "value": null
-                    }
-                ]
-            }
-        ],
-        "versionstamp": 31
-    }
+	[
+		{
+			changes: [
+				{
+					define_table: {
+						name: 'reading'
+					}
+				}
+			],
+			versionstamp: 1
+		},
+		{
+			changes: [
+				{
+					current: {
+						id: reading:bddej0x7ruhatec1qzt7,
+						story: 'Once upon a time'
+					},
+					update: [
+						{
+							op: 'replace',
+							path: '/',
+							value: NONE
+						}
+					]
+				}
+			],
+			versionstamp: 6
+		},
+		{
+			changes: [
+				{
+					current: {
+						id: reading:akpyfw169d3ujjki7f0a,
+						story: 'There was a database'
+					},
+					update: [
+						{
+							op: 'replace',
+							path: '/',
+							value: NONE
+						}
+					]
+				}
+			],
+			versionstamp: 15
+		},
+		{
+			changes: [
+				{
+					current: {
+						id: reading:akpyfw169d3ujjki7f0a,
+						story: 'There was a database!'
+					},
+					update: [
+						{
+							op: 'change',
+							path: '/story',
+							value: '@@ -17,5 +17,4 @@ base -!'
+						}
+					]
+				},
+				{
+					current: {
+						id: reading:bddej0x7ruhatec1qzt7,
+						story: 'Once upon a time!'
+					},
+					update: [
+						{
+							op: 'change',
+							path: '/story',
+							value: '@@ -13,5 +13,4 @@ time -!'
+						}
+					]
+				}
+			],
+			versionstamp: 21
+		}
+	]
 ]
 ```
 

--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/show.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/show.mdx
@@ -27,78 +27,11 @@ SHOW CHANGES FOR TABLE @tableName SINCE "@timestamp" | "@versionstamp" [LIMIT @n
 ### Basic usage
 
 The following example shows usage of the SHOW statement.
+<SurrealistMini
+url="https://dev.surrealist.app/mini?query=--+Define+the+change+feed+and+its+duration%0ADEFINE+TABLE+reading+CHANGEFEED+3d%3B%0A%0A--+Create+some+records+in+the+reading+table%0ACREATE+reading+SET+story+%3D+%22Once+upon+a+time%22%3B%0ACREATE+reading+SET+story+%3D+%22There+was+a+database%22%3B%0A--+Define+another+table+with+a+changefeed%0ADEFINE+TABLE+cat+CHANGEFEED+3d%3B%0ACREATE+cat+SET+story+%3D+%22And+there+was+a+cat%22%3B%0ACREATE+reading+SET+story+%3D+%22Fine%2C+there+was+a+database+and+also+a+cat%22%3B%0A%0A--+Replay+changes+to+the+reading+table+since+a+date%0ASHOW+CHANGES+FOR+TABLE+reading+SINCE+%222023-09-07T01%3A23%3A52Z%22+LIMIT+10%3B%0A--+Or+replay+changes+to+the+reading+table+beginning+at+a+version+stamp%0ASHOW+CHANGES+FOR+TABLE+reading+SINCE+1+LIMIT+10%3B&orientation=horizontal"
+/>
 
-```surql
--- Define the change feed and its duration
-DEFINE TABLE reading CHANGEFEED 3d;
 
--- Create some records in the reading table
-CREATE reading SET story = "Once upon a time";
-CREATE reading SET story = "There was a database";
--- Define another table with a changefeed
-DEFINE TABLE cat CHANGEFEED 3d;
-CREATE cat SET story = "And there was a cat";
-CREATE reading SET story = "Fine, there was a database and also a cat";
+From the example above, defining a `CHANGEFEED` on multiple tables still feeds their changes into a single database-wide changefeed. As a result, the `SHOW CHANGES FOR TABLE reading SINCE 1 LIMIT 10;` query above for the `reading` table does not show changes for `versionstamp` 4 and 5, which pertain to changes for the `cat` table.
 
--- Replay changes to the reading table since a date
-SHOW CHANGES FOR TABLE reading SINCE "2023-09-07T01:23:52Z" LIMIT 10;
--- Or replay changes to the reading table beginning at a version stamp
-SHOW CHANGES FOR TABLE reading SINCE 1 LIMIT 10;
-```
-
-:::note
-__Note:__ `SINCE <time>` needs to be after the time the `CHANGEFEED` was defined.
-:::
-
-Defining a `CHANGEFEED` on multiple tables still feeds their changes into a single database-wide changefeed. As a result, the `SHOW CHANGES FOR TABLE reading SINCE 1 LIMIT 10;` query above for the `reading` table does not show changes for `versionstamp` 4 and 5, which pertain to changes for the `cat` table.
-
-```bash
-[
-	[
-		{
-			changes: [
-				{
-					define_table: {
-						name: 'reading'
-					}
-				}
-			],
-			versionstamp: 1
-		},
-		{
-			changes: [
-				{
-					update: {
-						id: reading:9fvsk6nxzthdx4mjvxci,
-						story: 'Once upon a time'
-					}
-				}
-			],
-			versionstamp: 2
-		},
-		{
-			changes: [
-				{
-					update: {
-						id: reading:nj739p8mrc2hurq68g9b,
-						story: 'There was a database'
-					}
-				}
-			],
-			versionstamp: 3
-		},
-		{
-			changes: [
-				{
-					update: {
-						id: reading:34xgb6n99ico70wu8ebf,
-						story: 'Fine, there was a database and also a cat'
-					}
-				}
-			],
-			versionstamp: 6
-		}
-	]
-];
-```
 

--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/show.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/show.mdx
@@ -15,13 +15,13 @@ The `SHOW` statement can be used to replay changes made to a table.
 ### Statement syntax
 
 ```surql title="SurrealQL Syntax"
-SHOW CHANGES FOR TABLE @tableName [SINCE "@timestamp"] [LIMIT @number]
+SHOW CHANGES FOR TABLE @tableName SINCE "@timestamp" | "@versionstamp" [LIMIT @number]
 ```
 
 ## Example usage
 ### Basic usage
 
-The following expression shows usage of the SHOW statement.
+The following example shows usage of the SHOW statement.
 
 ```surql
 -- Define the change feed and its duration
@@ -29,46 +29,66 @@ DEFINE TABLE reading CHANGEFEED 3d;
 
 -- Create some records in the reading table
 CREATE reading SET story = "Once upon a time";
-CREATE reading SET story = "there was a database";
+CREATE reading SET story = "There was a database";
+UPDATE reading SET story = story + "!";
 
--- Replay changes to the reading table
+-- Replay changes to the reading table since a date
 SHOW CHANGES FOR TABLE reading SINCE "2023-09-07T01:23:52Z" LIMIT 10;
+-- Or replay changes to the reading table beginning at a version stamp
+SHOW CHANGES FOR TABLE reading SINCE 1 LIMIT 10;
 ```
 
-```bash title="Response"
+```bash title="Response to SINCE 1 LIMIT 10"
 [
-    {
-        "changes": [
-            {
-                "define_table": {
-                    "name": "reading"
-                }
-            }
-        ],
-        "versionstamp": 29
-    },
-    {
-        "changes": [
-            {
-                "update": {
-                    "id": "reading:h1gcbc7ykbpslellh2g2",
-                    "story": "Once upon a time"
-                }
-            }
-        ],
-        "versionstamp": 30
-    },
-    {
-        "changes": [
-            {
-                "update": {
-                    "id": "reading:l9qfcncklhnlklby1avf",
-                    "story": "there was a database"
-                }
-            }
-        ],
-        "versionstamp": 31
-    }
+	{
+		changes: [
+			{
+				define_table: {
+					name: 'reading'
+				}
+			}
+		],
+		versionstamp: 1
+	},
+	{
+		changes: [
+			{
+				update: {
+					id: reading:vfjzrs33worcmqzhd6is,
+					story: 'Once upon a time'
+				}
+			}
+		],
+		versionstamp: 2
+	},
+	{
+		changes: [
+			{
+				update: {
+					id: reading:6nwrgzygr195fea7hju3,
+					story: 'There was a database'
+				}
+			}
+		],
+		versionstamp: 3
+	},
+	{
+		changes: [
+			{
+				update: {
+					id: reading:6nwrgzygr195fea7hju3,
+					story: 'There was a database!'
+				}
+			},
+			{
+				update: {
+					id: reading:vfjzrs33worcmqzhd6is,
+					story: 'Once upon a time!'
+				}
+			}
+		],
+		versionstamp: 4
+	}
 ]
 ```
 

--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/show.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/show.mdx
@@ -30,7 +30,10 @@ DEFINE TABLE reading CHANGEFEED 3d;
 -- Create some records in the reading table
 CREATE reading SET story = "Once upon a time";
 CREATE reading SET story = "There was a database";
-UPDATE reading SET story = story + "!";
+-- Define another table with a changefeed
+DEFINE TABLE cat CHANGEFEED 3d;
+CREATE cat SET story = "And there was a cat";
+CREATE reading SET story = "Fine, there was a database and also a cat";
 
 -- Replay changes to the reading table since a date
 SHOW CHANGES FOR TABLE reading SINCE "2023-09-07T01:23:52Z" LIMIT 10;
@@ -38,60 +41,59 @@ SHOW CHANGES FOR TABLE reading SINCE "2023-09-07T01:23:52Z" LIMIT 10;
 SHOW CHANGES FOR TABLE reading SINCE 1 LIMIT 10;
 ```
 
-```bash title="Response to SINCE 1 LIMIT 10"
+:::note
+__Note:__ `SINCE <time>` needs to be after the time the `CHANGEFEED` was defined.
+:::
+
+Defining a `CHANGEFEED` on multiple tables still feeds their changes into a single database-wide changefeed. As a result, the `SHOW CHANGES FOR TABLE reading SINCE 1 LIMIT 10;` query above for the `reading` table does not show changes for `versionstamp` 4 and 5, which pertain to changes for the `cat` table.
+
+```bash
 [
-	{
-		changes: [
-			{
-				define_table: {
-					name: 'reading'
+	[
+		{
+			changes: [
+				{
+					define_table: {
+						name: 'reading'
+					}
 				}
-			}
-		],
-		versionstamp: 1
-	},
-	{
-		changes: [
-			{
-				update: {
-					id: reading:vfjzrs33worcmqzhd6is,
-					story: 'Once upon a time'
+			],
+			versionstamp: 1
+		},
+		{
+			changes: [
+				{
+					update: {
+						id: reading:9fvsk6nxzthdx4mjvxci,
+						story: 'Once upon a time'
+					}
 				}
-			}
-		],
-		versionstamp: 2
-	},
-	{
-		changes: [
-			{
-				update: {
-					id: reading:6nwrgzygr195fea7hju3,
-					story: 'There was a database'
+			],
+			versionstamp: 2
+		},
+		{
+			changes: [
+				{
+					update: {
+						id: reading:nj739p8mrc2hurq68g9b,
+						story: 'There was a database'
+					}
 				}
-			}
-		],
-		versionstamp: 3
-	},
-	{
-		changes: [
-			{
-				update: {
-					id: reading:6nwrgzygr195fea7hju3,
-					story: 'There was a database!'
+			],
+			versionstamp: 3
+		},
+		{
+			changes: [
+				{
+					update: {
+						id: reading:34xgb6n99ico70wu8ebf,
+						story: 'Fine, there was a database and also a cat'
+					}
 				}
-			},
-			{
-				update: {
-					id: reading:vfjzrs33worcmqzhd6is,
-					story: 'Once upon a time!'
-				}
-			}
-		],
-		versionstamp: 4
-	}
-]
+			],
+			versionstamp: 6
+		}
+	]
+];
 ```
 
-:::note
-__Note:__ `SINCE <time>` needs to be after the time the `CHANGEFEED` was defined. Also, when defining a `CHANGEFEED` on a table, it implicitly creates a `CHANGEFEED` on the database.
-:::

--- a/doc-surrealdb_versioned_docs/version-2.x/surrealql/statements/define/database.mdx
+++ b/doc-surrealdb_versioned_docs/version-2.x/surrealql/statements/define/database.mdx
@@ -12,12 +12,12 @@ The `DEFINE DATABASE` statement allows you to instantiate a named database, enab
 ## Requirements
 
 - You must be authenticated as a root or namespace user before you can use the `DEFINE DATABASE` statement.
-- [You must select your namespace](/docs/surrealdb/2.x/surrealql/statements/use) before you can use the `DEFINE DATABASE` statement.
+- [You must select your namespace](/docs/surrealdb/surrealql/statements/use) before you can use the `DEFINE DATABASE` statement.
 
 ## Statement syntax
 
 ```surql title="SurrealQL Syntax"
-DEFINE DATABASE [ IF NOT EXISTS ] @name [CHANGEFEED @duration | @versionstamp [INCLUDE ORIGINAL] ]
+DEFINE DATABASE [ IF NOT EXISTS ] @name
 ```
 
 ## Example usage 
@@ -37,83 +37,4 @@ The `IF NOT EXISTS` clause can be used to define a database only if it does not 
 ```surql
 -- Create a DATABASE if it does not already exist
 DEFINE DATABASE IF NOT EXISTS app_vitalsense;
-```
-
-## Changefeeds
-
-A changefeed can be defined on a database, in which case the changefeed will track changes made to every table in the database.
-
-```surql
-DEFINE DATABASE my_database CHANGEFEED 3d;
-
-CREATE reading SET story = "Once upon a time";
-CREATE reading SET story = "there was a database";
-CREATE company SET name = "SurrealDB", stories = (SELECT * FROM story);
-UPDATE reading SET story = story + "!";
-
-SHOW CHANGES FOR TABLE reading SINCE 1 LIMIT 10;
-SHOW CHANGES FOR TABLE company SINCE 1 LIMIT 10;
-```
-
-Note that this creates a single feed across the database, as the `versionstamp` in the output shows.
-
-```bash title="Response"
--- The changes for table `reading` shows up as versionstamp 1, 2, and 4
-[
-	{
-		changes: [
-			{
-				update: {
-					id: reading:gridlbp97uq2o2rzi649,
-					story: 'Once upon a time'
-				}
-			}
-		],
-		versionstamp: 1
-	},
-	{
-		changes: [
-			{
-				update: {
-					id: reading:ubfw5hk6rwduiwrueyzl,
-					story: 'there was a database'
-				}
-			}
-		],
-		versionstamp: 2
-	},
-	{
-		changes: [
-			{
-				update: {
-					id: reading:gridlbp97uq2o2rzi649,
-					story: 'Once upon a time!'
-				}
-			},
-			{
-				update: {
-					id: reading:ubfw5hk6rwduiwrueyzl,
-					story: 'there was a database!'
-				}
-			}
-		],
-		versionstamp: 4
-	}
-]
-
--- The change for table `company` shows up as versionstamp 3
-[
-	{
-		changes: [
-			{
-				update: {
-					id: company:z07x3si9gele5xm4hmsk,
-					name: 'SurrealDB',
-					stories: []
-				}
-			}
-		],
-		versionstamp: 3
-	}
-]
 ```

--- a/doc-surrealdb_versioned_docs/version-2.x/surrealql/statements/define/database.mdx
+++ b/doc-surrealdb_versioned_docs/version-2.x/surrealql/statements/define/database.mdx
@@ -17,7 +17,7 @@ The `DEFINE DATABASE` statement allows you to instantiate a named database, enab
 ## Statement syntax
 
 ```surql title="SurrealQL Syntax"
-DEFINE DATABASE [ IF NOT EXISTS ] @name
+DEFINE DATABASE [ IF NOT EXISTS ] @name [CHANGEFEED @duration | @versionstamp [INCLUDE ORIGINAL] ]
 ```
 
 ## Example usage 
@@ -37,4 +37,83 @@ The `IF NOT EXISTS` clause can be used to define a database only if it does not 
 ```surql
 -- Create a DATABASE if it does not already exist
 DEFINE DATABASE IF NOT EXISTS app_vitalsense;
+```
+
+## Changefeeds
+
+A changefeed can be defined on a database, in which case the changefeed will track changes made to every table in the database.
+
+```surql
+DEFINE DATABASE my_database CHANGEFEED 3d;
+
+CREATE reading SET story = "Once upon a time";
+CREATE reading SET story = "there was a database";
+CREATE company SET name = "SurrealDB", stories = (SELECT * FROM story);
+UPDATE reading SET story = story + "!";
+
+SHOW CHANGES FOR TABLE reading SINCE 1 LIMIT 10;
+SHOW CHANGES FOR TABLE company SINCE 1 LIMIT 10;
+```
+
+Note that this creates a single feed across the database, as the `versionstamp` in the output shows.
+
+```bash title="Response"
+-- The changes for table `reading` shows up as versionstamp 1, 2, and 4
+[
+	{
+		changes: [
+			{
+				update: {
+					id: reading:gridlbp97uq2o2rzi649,
+					story: 'Once upon a time'
+				}
+			}
+		],
+		versionstamp: 1
+	},
+	{
+		changes: [
+			{
+				update: {
+					id: reading:ubfw5hk6rwduiwrueyzl,
+					story: 'there was a database'
+				}
+			}
+		],
+		versionstamp: 2
+	},
+	{
+		changes: [
+			{
+				update: {
+					id: reading:gridlbp97uq2o2rzi649,
+					story: 'Once upon a time!'
+				}
+			},
+			{
+				update: {
+					id: reading:ubfw5hk6rwduiwrueyzl,
+					story: 'there was a database!'
+				}
+			}
+		],
+		versionstamp: 4
+	}
+]
+
+-- The change for table `company` shows up as versionstamp 3
+[
+	{
+		changes: [
+			{
+				update: {
+					id: company:z07x3si9gele5xm4hmsk,
+					name: 'SurrealDB',
+					stories: []
+				}
+			}
+		],
+		versionstamp: 3
+	}
+]
 ```


### PR DESCRIPTION
I noticed some tests today in the source code that had simple integers after `SINCE`, turns out that SHOW can show changes since a version stamp instead of a datetime! With that it's much easier to test out the behaviour (since you can't do something like `LET $time = time::now();` and then show `SINCE $now`).

Edit: Also noticed that DEFINE DATABASE doesn't show that a changefeed can be defined on the whole database, so added that.