### PR TITLE
Using parameters in record ranges queries for object-based record IDs is currently not supported

### DIFF
--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/datamodel/ids.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/datamodel/ids.mdx
@@ -111,7 +111,7 @@ SELECT * FROM temperature:['London', '2022-08-29T08:03:39']..;
 SELECT * FROM temperature:['London', '2022-08-29T08:03:39']..['London', '2022-08-29T08:09:31'];
 ```
 
-Nested fields inside object-based Record IDs can be queried in the same way as a regular SurrealDB record.
+Nested fields inside object-based Record IDs can be queried in the same way as a regular SurrealDB record. 
 
 ```surql
 INSERT INTO weather [
@@ -154,7 +154,7 @@ SELECT id.date AS date, temperature FROM weather WHERE id.location = 'London';
 ]
 ```
 
-Record ranges queries can be used for object-based record IDs as well.
+Record ranges queries can be used for object-based record IDs as well. (Using parameters in record ranges queries for object-based record IDs is currently not supported.)
 
 ```surql
 INSERT INTO weather [


### PR DESCRIPTION
Add to documentation: "Using parameters in record ranges queries for object-based record IDs is currently not supported"