### PR TITLE
Update JavaScript SDK docs for ``RecordId`` & ``Table``

### DIFF
--- a/doc-surrealdb_versioned_docs/version-1.x/integration/sdks/javascript.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/integration/sdks/javascript.mdx
@@ -77,7 +77,7 @@ bun install surrealdb.js
 Create a new app.js file and add the following code to try out some basic operations using the SurrealDB SDK.
 
 ```ts
-import { Surreal } from 'surrealdb.js';
+import { Surreal, RecordId, Table } from 'surrealdb.js';
 
 const db = new Surreal();
 
@@ -111,7 +111,7 @@ async function main() {
 		});
 
 		// Update a person record with a specific id
-		const updated = await db.merge('person:jaime', {
+		const updated = await db.merge(new RecordId('person', 'jaime'), {
 			marketing: true,
 		});
 
@@ -120,9 +120,9 @@ async function main() {
 
 		// Perform a custom advanced query
 		const groups = await db.query(
-			'SELECT marketing, count() FROM type::table($tb) GROUP BY marketing',
+			'SELECT marketing, count() FROM $tb GROUP BY marketing',
 			{
-				tb: 'person',
+				tb: new Table('person'),
 			}
 		);
 	} catch (e) {
@@ -927,8 +927,10 @@ type Person = {
 
 // Assign the variable on the connection
 const result = await db.query<[Person[], Person[]]>(
-	'CREATE person SET name = "John"; SELECT * FROM type::table($tb);',
-	{ tb: 'person' }
+	'CREATE person SET name = "John"; SELECT * FROM $tb;',
+	{
+		tb: new Table('person'),
+	},
 );
 
 // Get the first result from the first query
@@ -981,7 +983,7 @@ type Person = {
 const people = await db.select<Person>('person');
 
 // Select a specific record from a table
-const [person] = await db.select<Person>('person:h5wxrf2ewk8xjxosxtyc');
+const [person] = await db.select<Person>(new RecordId('person','h5wxrf2ewk8xjxosxtyc');
 ```
 
 ### Translated query
@@ -1046,7 +1048,7 @@ type Person = {
 const [person] = await db.create<Person>('person');
 
 // Create a record with a specific ID
-const [record] = await db.create<Person>('person:tobie', {
+const [record] = await db.create<Person>(new RecordId('person','tobie'), {
 	name: 'Tobie',
 	settings: {
 		active: true,
@@ -1058,7 +1060,7 @@ const [record] = await db.create<Person>('person:tobie', {
 const [record] = await db.create<
 	Person,
 	Pick<Person, 'name'>
->('person:tobie', {
+>(new RecordId('person','tobie'), {
 	name: 'Tobie',
 });
 ```
@@ -1224,7 +1226,7 @@ type Person = {
 const people = await db.update<Person>('person');
 
 // Update a record with a specific ID
-const [person] = await db.update<Person>('person:tobie', {
+const [person] = await db.update<Person>(new RecordId('person','tobie'), {
 	name: 'Tobie',
 	settings: {
 		active: true,
@@ -1236,7 +1238,7 @@ const [person] = await db.update<Person>('person:tobie', {
 const [record] = await db.update<
 	Person,
 	Pick<Person, 'name'>
->('person:tobie', {
+>(new RecordId('person','tobie'), {
 	name: 'Tobie',
 });
 ```
@@ -1310,7 +1312,7 @@ const people = await db.merge<Person>('person', {
 });
 
 // Update a record with a specific ID
-const [person] = await db.merge<Person>('person:tobie', {
+const [person] = await db.merge<Person>(new RecordId('person','tobie'), {
 	updated_at: new Date(),
 	settings: {
 		active: true,
@@ -1321,7 +1323,7 @@ const [person] = await db.merge<Person>('person:tobie', {
 const [record] = await db.merge<
 	Person,
 	Pick<Person, 'name'>
->('person:tobie', {
+>(new RecordId('person','tobie'), {
 	name: 'Tobie',
 });
 ```
@@ -1385,7 +1387,7 @@ const people = await db.patch('person', [
 ]);
 
 // Update a record with a specific ID
-const [person] = await db.patch('person:tobie', [
+const [person] = await db.patch(new RecordId('person','tobie'), [
 	{ op: 'replace', path: '/settings/active', value: false },
 	{ op: 'add', path: '/tags', value: ['developer', 'engineer'] },
 	{ op: 'remove', path: '/temp' },
@@ -1436,7 +1438,7 @@ async db.delete<T>(thing)
 await db.delete('person');
 
 // Delete a specific record from a table
-await db.delete('person:h5wxrf2ewk8xjxosxtyc');
+await db.delete(new RecordId('person','h5wxrf2ewk8xjxosxtyc'));
 ```
 
 ### Translated query


### PR DESCRIPTION
Updated the JavaScript SDK docs to include ``RecordId`` and ``Table``. Using the ``"table:id"`` string syntax for ``.create()``, ``.delete()``, ``.select()``, ``.merge()``, and ``.update()`` no longer works for specific records. The old way to define a table still variable works, but I wanted to keep more inline with the [Getting Started Guide](https://github.com/surrealdb/surrealdb.js/#getting-started).