### PR TITLE
Indexes Doc : Updated distance keyword for hnsw index

### DIFF
--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/define/indexes.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/define/indexes.mdx
@@ -196,7 +196,7 @@ _Note:_ Keep in mind the in-memory nature of HNSW when considering system resour
 
 ```surql
 CREATE pts:3 SET point = [8,9,10,11];
-DEFINE INDEX mt_pts ON pts FIELDS point HNSW DIMENSION 4 DISTANCE EUCLIDEAN EFC 150 M 12;
+DEFINE INDEX mt_pts ON pts FIELDS point HNSW DIMENSION 4 DIST EUCLIDEAN EFC 150 M 12;
 SELECT id FROM pts WHERE point <|10,40|> [2,3,4,5];
 ```
 


### PR DESCRIPTION
Had some issues with executing the HNSW create index query.

Based on the code from surrealdb and test, it seems the keyword has to be DIST instead of DISTANCE.

Reference : https://github.com/surrealdb/surrealdb/blob/47054b28919993273dae13d00041d8c8137dd600/lib/tests/vector.rs#L225