### PR TITLE
Correct type::field(s), other small changes/typo fixes

### DIFF
--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/functions/type.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/functions/type.mdx
@@ -166,7 +166,7 @@ These functions can be used for generating and coercing data to specific data ty
 
 ## `type::bool`
 
-The ` type::bool` function returns a boolean value.
+The `type::bool` function returns a boolean value.
 
 ```surql title="API DEFINITION"
 type::bool(any) -> bool
@@ -185,7 +185,7 @@ This is the equivalent of using [`<bool>`](/docs/surrealdb/surrealql/datamodel/c
 
 ## `type::datetime`
 
-The ` type::datetime` function converts a value into a datetime.
+The `type::datetime` function converts a value into a datetime.
 
 ```surql title="API DEFINITION"
 type::datetime(any) -> datetime
@@ -195,7 +195,7 @@ The following example shows this function, and its output, when used in a [`RETU
 ```surql
 RETURN type::datetime("2022-04-27T18:12:27+00:00");
 
-"2022-04-27T18:12:27Z"
+'2022-04-27T18:12:27Z'
 ```
 
 This is the equivalent of using [`<datetime>`](/docs/surrealdb/surrealql/datamodel/casting#datetime) to cast a value to a datetime.
@@ -212,9 +212,9 @@ type::decimal(any) -> decimal
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:
 
 ```surql
-RETURN type::decimal("12345");
+RETURN type::decimal("12345.6789");
 
-12345.00
+12345.6789dec
 ```
 
 This is the equivalent of using [`<decimal>`](/docs/surrealdb/surrealql/datamodel/casting#decimal) to cast a value to a datetime.
@@ -223,7 +223,7 @@ This is the equivalent of using [`<decimal>`](/docs/surrealdb/surrealql/datamode
 
 ## `type::duration`
 
-The ` type::duration` function converts a value into a duration.
+The `type::duration` function converts a value into a duration.
 
 ```surql title="API DEFINITION"
 type::duration(any) -> duration
@@ -242,7 +242,7 @@ This is the equivalent of using [`<duration>`](/docs/surrealdb/surrealql/datamod
 
 ## `type::field`
 
-The `type::field` projects a single field within a SELECT statement
+The `type::field` function projects a single field within a SELECT statement.
 
 ```surql title="API DEFINITION"
 type::field($field)
@@ -251,24 +251,16 @@ The following example shows this function, and its output:
 
 ```surql
 CREATE person:test SET title = 'Mr', name.first = 'Tobie', name.last = 'Morgan Hitchcock';
-
 LET $param = 'name.first';
-
-SELECT type::field($param), type::field('name.last') FROM person;
-
-SELECT VALUE { 'firstname': type::field($param), lastname: type::field('name.last') } FROM person;
-
-SELECT VALUE [type::field($param), type::field('name.last')] FROM person;
-
+SELECT type::field($param), type::field('name.last'), type::field('title') FROM person;
 
 [
 	{
-		id: person:test,
-		title: 'Mr',
 		name: {
 			first: 'Tobie',
-			last: 'Morgan Hitchcock',
-	    }
+			last: 'Morgan Hitchcock'
+		},
+		title: 'Mr'
 	}
 ]
 ```
@@ -277,7 +269,7 @@ SELECT VALUE [type::field($param), type::field('name.last')] FROM person;
 
 ## `type::fields`
 
-The `type::fields` projects a single field within a SELECT statement
+The `type::fields` function projects multiple fields within a SELECT statement.
 
 ```surql title="API DEFINITION"
 type::fields($fields)
@@ -286,24 +278,16 @@ The following example shows this function, and its output:
 
 ```surql
 CREATE person:test SET title = 'Mr', name.first = 'Tobie', name.last = 'Morgan Hitchcock';
-
-LET $param = ['name.first', 'name.last'];
-
-SELECT type::fields($param), type::fields(['title']) FROM person;
-
-SELECT VALUE { 'names': type::fields($param) } FROM person;
-
-SELECT VALUE type::fields($param) FROM person;
-
+LET $names = ['name.first', 'name.last'];
+SELECT type::fields($names), type::field('title') FROM person;
 
 [
 	{
-		id: person:test,
-		title: 'Mr',
 		name: {
 			first: 'Tobie',
-			last: 'Morgan Hitchcock',
-		}
+			last: 'Morgan Hitchcock'
+		},
+		title: 'Mr'
 	}
 ]
 ```
@@ -320,9 +304,9 @@ type::float(any) -> float
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:
 
 ```surql
-RETURN type::float("12345");
+RETURN type::float("12345.6789");
 
-12345.0
+12345.6789f
 ```
 This is the equivalent of using [`<float>`](/docs/surrealdb/surrealql/datamodel/casting#float) to cast a value to a datetime.
 
@@ -376,13 +360,7 @@ The following example shows this function, and its output, when used in a [`RETU
 ```surql
 RETURN type::point([ 51.509865, -0.118092 ]);
 
-{
-	"type": "Point",
-	"coordinates": [
-		-0.10231019499999999,
-		51.49576478
-	]
-}
+(51.509865, -0.118092)
 ```
 
 <br />
@@ -407,7 +385,7 @@ This is the equivalent of using [`<string>`](/docs/surrealdb/surrealql/datamodel
 
 ## `type::table`
 
-The `type::table` function converts a value into a string.
+The `type::table` function converts a value into a table.
 
 ```surql title="API DEFINITION"
 type::table(any) -> table
@@ -416,8 +394,9 @@ The following example shows this function, and its output, when used in a [`RETU
 
 ```surql
 LET $table = "person";
+RETURN [type::table("person"), type::table(person:some_person_id)];
 
-RETURN type::table($table);
+[person, person]
 ```
 
 <br />


### PR DESCRIPTION
Some typo fixes and related changes for the `type` functions page. The output has also changed in a few places (such as appending `dec` for a decimal) and points which now show up as a tuple of two items. Also cut the queries in type::field(s) to a single one that matches the output.