### PR TITLE
Fix URL for Python Notebook example

### DIFF
--- a/doc-surrealdb_versioned_docs/version-1.x/integration/sdks/python.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/integration/sdks/python.mdx
@@ -123,7 +123,7 @@ Alternatively, you can run it in a notebook like Jupyter or VS code
 
 from surrealdb import Surreal
 
-db = Surreal("http://localhost:8000")
+db = Surreal("ws://localhost:8000/rpc")
 await db.connect()
 await db.signin({"user": "root", "pass": "root"})
 await db.use("test", "test")


### PR DESCRIPTION
Changed the URL used in the Python Notebook example to use WebSockets and point it to the `/rpc` endpoint.

Fixes https://github.com/surrealdb/docs.surrealdb.com/issues/553