### PR TITLE
Require namespacing Auth0 claims and explain how

### DIFF
--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/define/token.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/define/token.mdx
@@ -124,7 +124,7 @@ The following claims should be added to the JWT payload by the issuer of the tok
 - `db`: The database that the token is issued for.
 - `sc`: The scope that the token is issued for.
 
-The names of these claims can be in all lowercase (i.e. `tk`) or all uppercase (i.e. `TK`), and can be optionally prefaced with the `https://surrealdb.com` namespace (e.g. `https://surrealdb.com/tk`) in order to separate claims directed to SurrealDB from claims directed to other services. When using a namespace, the claim name can also be used without abbreviation, such as in `https://surrealdb.com/token`, `https://surrealdb.com/scope`...
+The names of these claims can be in all lowercase (i.e. `tk`) or all uppercase (i.e. `TK`), and can be optionally prefaced with the `https://surrealdb.com` namespace (e.g. `https://surrealdb.com/tk`) in order to separate claims directed to SurrealDB from claims directed to other services. When using a namespace, the claim name can also be used without abbreviation, such as in `https://surrealdb.com/token` or `https://surrealdb.com/scope`. Even when present in the token with a namespace prefix, [SurrealDB claims](https://github.com/surrealdb/surrealdb/blob/main/core/src/iam/token.rs) are directly accessible via the `$token` parameter (e.g. `$token.sc`), whereas custom claims will need to include the namespace prefix (e.g. `$token['https://surrealdb.com/pet_name']`) to be accessed in the same way.
 
 The following optional claims are also processed by SurrealDB:
 

--- a/doc-surrealdb_versioned_docs/version-1.x/tutorials/integrate-auth0-as-authentication-provider.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/tutorials/integrate-auth0-as-authentication-provider.mdx
@@ -60,7 +60,7 @@ When completing the actions above, make sure to keep the following information h
 
 ### Creating a custom Auth0 action to add claims for SurrealDB
 
-Now, Auth0 is ready to perform authentication and issue tokens for your application. However, SurrealDB expects these tokens to contain some specific claims. Auth0 allows adding custom claims through its “actions” and “flows” features.
+Now, Auth0 is ready to perform authentication and issue tokens for your application. However, SurrealDB expects these tokens to contain some specific claims. Auth0 allows adding custom claims through its “actions” and “flows” features. Since Auth0 [requires claims for an API audience to be namespaced](https://auth0.com/docs/troubleshoot/product-lifecycle/past-migrations/custom-claims-migration#restricted-token-audience), these claims will need to have the `https://surrealdb.com/` prefix.
 
 To add custom claims, you must [create an Auth0 action](https://auth0.com/docs/customize/actions/write-your-first-action#create-an-action) with the “Login / Post Login” trigger.
 
@@ -71,22 +71,22 @@ exports.onExecutePostLogin = async (event, api) => {
   if (event.authorization) {
     // The claims in this block are expected by SurrealDB.
     // These values should match your SurrealDB installation.
-    api.accessToken.setCustomClaim(`ns`, "test");
-    api.accessToken.setCustomClaim(`db`, "test");
+    api.accessToken.setCustomClaim(`https://surrealdb.com/ns`, "test");
+    api.accessToken.setCustomClaim(`https://surrealdb.com/db`, "test");
     // These values correspond to the names of the SCOPE and TOKEN resources 
     // which will be created in SurrealDB during the next section.
-    api.accessToken.setCustomClaim(`sc`, "user");
-    api.accessToken.setCustomClaim(`tk`, "auth0");
+    api.accessToken.setCustomClaim(`https://surrealdb.com/sc`, "user");
+    api.accessToken.setCustomClaim(`https://surrealdb.com/tk`, "auth0");
 
     // In this block, we will add additional claims which are not required by SurrealDB.
     // These claims can be used from SurrealQL to implement application logic.
     // In this example, we will add the data that we will store for each user.
     // We will also use some of this data to perform authorization.
-    api.accessToken.setCustomClaim(`email`, event.user.email);
-    api.accessToken.setCustomClaim(`email_verified`, event.user.email_verified);
-    api.accessToken.setCustomClaim(`name`, event.user.name);
-    api.accessToken.setCustomClaim(`nickname`, event.user.nickname);
-    api.accessToken.setCustomClaim(`picture`, event.user.picture);
+    api.accessToken.setCustomClaim(`https://surrealdb.com/email`, event.user.email);
+    api.accessToken.setCustomClaim(`https://surrealdb.com/email_verified`, event.user.email_verified);
+    api.accessToken.setCustomClaim(`https://surrealdb.com/name`, event.user.name);
+    api.accessToken.setCustomClaim(`https://surrealdb.com/nickname`, event.user.nickname);
+    api.accessToken.setCustomClaim(`https://surrealdb.com/picture`, event.user.picture);
   }
 };
 ```
@@ -147,9 +147,9 @@ DEFINE TABLE user SCHEMAFULL
     -- It contains the domain generated when when creating the application in Auth0.
     AND $token.aud CONTAINS "https://<YOUR_AUTH0_DOMAIN>/userinfo"
     -- The email claim must match the email of the user being queried.
-    AND email = $token.email
+    AND email = $token['https://surrealdb.com/email']
     -- The email must be verified as belonging to the user.
-    AND $token.email_verified = true
+    AND $token['https://surrealdb.com/email_verified'] = true
 ;
 
 -- In this example, we will use the email as the primary identifier for a user.

--- a/doc-surrealdb_versioned_docs/version-2.x/surrealql/statements/define/token.mdx
+++ b/doc-surrealdb_versioned_docs/version-2.x/surrealql/statements/define/token.mdx
@@ -124,7 +124,7 @@ The following claims should be added to the JWT payload by the issuer of the tok
 - `db`: The database that the token is issued for.
 - `sc`: The scope that the token is issued for.
 
-The names of these claims can be in all lowercase (i.e. `tk`) or all uppercase (i.e. `TK`), and can be optionally prefaced with the `https://surrealdb.com` namespace (e.g. `https://surrealdb.com/tk`) in order to separate claims directed to SurrealDB from claims directed to other services. When using a namespace, the claim name can also be used without abbreviation, such as in `https://surrealdb.com/token`, `https://surrealdb.com/scope`...
+The names of these claims can be in all lowercase (i.e. `tk`) or all uppercase (i.e. `TK`), and can be optionally prefaced with the `https://surrealdb.com` namespace (e.g. `https://surrealdb.com/tk`) in order to separate claims directed to SurrealDB from claims directed to other services. When using a namespace, the claim name can also be used without abbreviation, such as in `https://surrealdb.com/token` or `https://surrealdb.com/scope`. Even when present in the token with a namespace prefix, [SurrealDB claims](https://github.com/surrealdb/surrealdb/blob/main/core/src/iam/token.rs) are directly accessible via the `$token` parameter (e.g. `$token.sc`), whereas custom claims will need to include the namespace prefix (e.g. `$token['https://surrealdb.com/pet_name']`) to be accessed in the same way.
 
 The following optional claims are also processed by SurrealDB:
 

--- a/doc-surrealdb_versioned_docs/version-2.x/tutorials/integrate-auth0-as-authentication-provider.mdx
+++ b/doc-surrealdb_versioned_docs/version-2.x/tutorials/integrate-auth0-as-authentication-provider.mdx
@@ -60,7 +60,7 @@ When completing the actions above, make sure to keep the following information h
 
 ### Creating a custom Auth0 action to add claims for SurrealDB
 
-Now, Auth0 is ready to perform authentication and issue tokens for your application. However, SurrealDB expects these tokens to contain some specific claims. Auth0 allows adding custom claims through its “actions” and “flows” features.
+Now, Auth0 is ready to perform authentication and issue tokens for your application. However, SurrealDB expects these tokens to contain some specific claims. Auth0 allows adding custom claims through its “actions” and “flows” features. Since Auth0 [requires claims for an API audience to be namespaced](https://auth0.com/docs/troubleshoot/product-lifecycle/past-migrations/custom-claims-migration#restricted-token-audience), these claims will need to have the `https://surrealdb.com/` prefix.
 
 To add custom claims, you must [create an Auth0 action](https://auth0.com/docs/customize/actions/write-your-first-action#create-an-action) with the “Login / Post Login” trigger.
 
@@ -71,22 +71,22 @@ exports.onExecutePostLogin = async (event, api) => {
   if (event.authorization) {
     // The claims in this block are expected by SurrealDB.
     // These values should match your SurrealDB installation.
-    api.accessToken.setCustomClaim(`ns`, "test");
-    api.accessToken.setCustomClaim(`db`, "test");
+    api.accessToken.setCustomClaim(`https://surrealdb.com/ns`, "test");
+    api.accessToken.setCustomClaim(`https://surrealdb.com/db`, "test");
     // These values correspond to the names of the SCOPE and TOKEN resources 
     // which will be created in SurrealDB during the next section.
-    api.accessToken.setCustomClaim(`sc`, "user");
-    api.accessToken.setCustomClaim(`tk`, "auth0");
+    api.accessToken.setCustomClaim(`https://surrealdb.com/sc`, "user");
+    api.accessToken.setCustomClaim(`https://surrealdb.com/tk`, "auth0");
 
     // In this block, we will add additional claims which are not required by SurrealDB.
     // These claims can be used from SurrealQL to implement application logic.
     // In this example, we will add the data that we will store for each user.
     // We will also use some of this data to perform authorization.
-    api.accessToken.setCustomClaim(`email`, event.user.email);
-    api.accessToken.setCustomClaim(`email_verified`, event.user.email_verified);
-    api.accessToken.setCustomClaim(`name`, event.user.name);
-    api.accessToken.setCustomClaim(`nickname`, event.user.nickname);
-    api.accessToken.setCustomClaim(`picture`, event.user.picture);
+    api.accessToken.setCustomClaim(`https://surrealdb.com/email`, event.user.email);
+    api.accessToken.setCustomClaim(`https://surrealdb.com/email_verified`, event.user.email_verified);
+    api.accessToken.setCustomClaim(`https://surrealdb.com/name`, event.user.name);
+    api.accessToken.setCustomClaim(`https://surrealdb.com/nickname`, event.user.nickname);
+    api.accessToken.setCustomClaim(`https://surrealdb.com/picture`, event.user.picture);
   }
 };
 ```
@@ -147,9 +147,9 @@ DEFINE TABLE user SCHEMAFULL
     -- It contains the domain generated when when creating the application in Auth0.
     AND $token.aud CONTAINS "https://<YOUR_AUTH0_DOMAIN>/userinfo"
     -- The email claim must match the email of the user being queried.
-    AND email = $token.email
+    AND email = $token['https://surrealdb.com/email']
     -- The email must be verified as belonging to the user.
-    AND $token.email_verified = true
+    AND $token['https://surrealdb.com/email_verified'] = true
 ;
 
 -- In this example, we will use the email as the primary identifier for a user.


### PR DESCRIPTION
Updates the Auth0 tutorial to use [namespaced claims](https://auth0.com/docs/troubleshoot/product-lifecycle/past-migrations/custom-claims-migration#restricted-claims). Explains the current behavior of the `$token` parameter with regards to claims that were provided with a namespace prefix. Closes #543.