### PR TITLE
More accurate celsius to fahrenheit

### DIFF
--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/select.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/select.mdx
@@ -98,7 +98,7 @@ SELECT array::distinct(tags) FROM article;
 SELECT array::group(tags) AS tags FROM article GROUP ALL;
 
 -- Use mathematical calculations in a select expression
-SELECT ( ( celsius * 2 ) + 30 ) AS fahrenheit FROM temperature;
+SELECT (( celsius * 1.8 ) + 32) AS fahrenheit FROM temperature;
 
 -- Return boolean expressions with an alias
 SELECT rating >= 4 as positive FROM review;

--- a/doc-surrealdb_versioned_docs/version-2.x/surrealql/statements/select.mdx
+++ b/doc-surrealdb_versioned_docs/version-2.x/surrealql/statements/select.mdx
@@ -99,7 +99,7 @@ SELECT array::distinct(tags) FROM article;
 SELECT array::group(tags) AS tags FROM article GROUP ALL;
 
 -- Use mathematical calculations in a select expression
-SELECT ( ( celsius * 2 ) + 30 ) AS fahrenheit FROM temperature;
+SELECT (( celsius * 1.8 ) + 32) AS fahrenheit FROM temperature;
 
 -- Return boolean expressions with an alias
 SELECT rating >= 4 as positive FROM review;


### PR DESCRIPTION
celsius*2+30 is a useful quick approximation to convert to fahrenheit, but this is the actual formula.