### PR TITLE
fix: arguments for callback in db.live javascript sdk

### DIFF
--- a/doc-sdk-javascript_versioned_docs/version-1.x/setup.mdx
+++ b/doc-sdk-javascript_versioned_docs/version-1.x/setup.mdx
@@ -764,7 +764,7 @@ async db.live<T>(table, callback, diff)
 const queryUuid = await db.live(
 	"person",
 	// The callback function takes an object with the 'action' and 'result' properties
-	({ action, result }) => {
+	(action, result) => {
 		// action can be: 'CREATE', 'UPDATE', 'DELETE' or 'CLOSE'
 	    if (action === 'CLOSE') return;
 


### PR DESCRIPTION
The callback takes two arguments, `action` and `result` but not one argument/object with two fields `action` and `result` on it.