### PR TITLE
Change sum to mean for age in grouping example

### DIFF
--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/select.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/select.mdx
@@ -251,7 +251,7 @@ SELECT settings.published FROM article GROUP BY settings.published;
 SELECT gender, country, city FROM person GROUP BY gender, country, city;
 
 -- Group results with aggregate functions
-SELECT count() AS total, math::sum(age), gender, country FROM person GROUP BY gender, country;
+SELECT count() AS total, math::mean(age) AS average_age, gender, country FROM person GROUP BY gender, country;
 
 -- Get the total number of records in a table
 SELECT count() AS number_of_records FROM person GROUP ALL;

--- a/doc-surrealdb_versioned_docs/version-2.x/surrealql/statements/select.mdx
+++ b/doc-surrealdb_versioned_docs/version-2.x/surrealql/statements/select.mdx
@@ -252,7 +252,7 @@ SELECT settings.published FROM article GROUP BY settings.published;
 SELECT gender, country, city FROM person GROUP BY gender, country, city;
 
 -- Group results with aggregate functions
-SELECT count() AS total, math::sum(age), gender, country FROM person GROUP BY gender, country;
+SELECT count() AS total, math::mean(age) AS average_age, gender, country FROM person GROUP BY gender, country;
 
 -- Get the total number of records in a table
 SELECT count() AS number_of_records FROM person GROUP ALL;


### PR DESCRIPTION
Small fix: this example probably intended to give the average age over these `person` records, not the combined total of years.