### PR TITLE
Rename time.mdx to datetimes.mdx

### DIFF
--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/datamodel/datetimes.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/datamodel/datetimes.mdx
@@ -1,14 +1,12 @@
 ---
 sidebar_position: 14
-sidebar_label: Time
-title: Time | SurrealQL
+sidebar_label: Datetimes
+title: Datetimes | SurrealQL
 description: SurrealDB has native support for datetimes with nanosecond precision. SurrealDB automatically parses and understands datetimes which are written as strings in the SurrealQL language.
 
 ---
 
-# Time
-
-## Datetimes
+# Datetimes
 
 SurrealDB has native support for datetimes with nanosecond precision. SurrealDB automatically parses and understands datetimes which are written as strings in the SurrealQL language. Times must also be formatted in an [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601) format.
 
@@ -149,4 +147,4 @@ Durations can be specified in any of the following units:
 </table>
 
 ## Next steps
-You've now seen how to store, modify, and handle dates and times in SurrealDB. For more advanced functionality, take a look at the [time](/docs/surrealdb/2.x/surrealql/functions/database/time) functions, which enable extracting, altering, rounding, and grouping datetimes into specific time intervals.
+You've now seen how to store, modify, and handle dates and times in SurrealDB. For more advanced functionality, take a look at the [time](/docs/surrealdb/surrealql/functions/database/time) functions, which enable extracting, altering, rounding, and grouping datetimes into specific time intervals.

--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/functions/database/rand.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/functions/database/rand.mdx
@@ -272,14 +272,14 @@ RETURN rand::string(10, 15);
 
 ## `rand::time`
 
-The `rand::time` function generates a random [`datetime`](/docs/surrealdb/surrealql/datamodel/time#datetimes).
+The `rand::time` function generates a random [`datetime`](/docs/surrealdb/surrealql/datamodel/datetimes).
 
 
 
 ```surql title="API DEFINITION"
 rand::time() -> datetime
 ```
-The rand::time function generates a random [`datetime`](/docs/surrealdb/surrealql/datamodel/time#datetimes), between two unix timestamps.
+The rand::time function generates a random [`datetime`](/docs/surrealdb/surrealql/datamodel/datetimes), between two unix timestamps.
 
 ```surql title="API DEFINITION"
 rand::time(number, number) -> datetime

--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/functions/script/type-conversion.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/functions/script/type-conversion.mdx
@@ -15,7 +15,7 @@ CREATE user:test SET created_at = function() {
 };
 ```
 
-In addition, a number of special classes are included within the JavaScript functions for the additional types which are not built into JavaScript. These enable the creation of [`duration`](/docs/surrealdb/surrealql/datamodel/time#durations-and-datetimes) values, [`record`](/docs/surrealdb/surrealql/datamodel/ids) ids, and [`UUID`](/docs/surrealdb/surrealql/datamodel/strings#uuid) values from within JavaScript.
+In addition, a number of special classes are included within the JavaScript functions for the additional types which are not built into JavaScript. These enable the creation of [`duration`](/docs/surrealdb/surrealql/datamodel/datetimes#durations-and-datetimes) values, [`record`](/docs/surrealdb/surrealql/datamodel/ids) ids, and [`UUID`](/docs/surrealdb/surrealql/datamodel/strings#uuid) values from within JavaScript.
 
 Any values of these types passed into embedded scripting functions are also represented with these special classes.
 

--- a/doc-surrealdb_versioned_docs/version-2.x/surrealql/datamodel/datetimes.mdx
+++ b/doc-surrealdb_versioned_docs/version-2.x/surrealql/datamodel/datetimes.mdx
@@ -1,14 +1,13 @@
 ---
 sidebar_position: 14
-sidebar_label: Time
-title: Time | SurrealQL
+sidebar_label: Datetimes
+title: Datetimes | SurrealQL
 description: SurrealDB has native support for datetimes with nanosecond precision. SurrealDB automatically parses and understands datetimes which are written as strings in the SurrealQL language.
 
 ---
 
-# Time
 
-## Datetimes
+# Datetimes
 
 SurrealDB has native support for datetimes with nanosecond precision. SurrealDB automatically parses and understands datetimes which are written as strings in the SurrealQL language. Times must also be formatted in an [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601) format.
 
@@ -149,4 +148,4 @@ Durations can be specified in any of the following units:
 </table>
 
 ## Next steps
-You've now seen how to store, modify, and handle dates and times in SurrealDB. For more advanced functionality, take a look at the [time](/docs/surrealdb/surrealql/functions/database/time) functions, which enable extracting, altering, rounding, and grouping datetimes into specific time intervals.
+You've now seen how to store, modify, and handle dates and times in SurrealDB. For more advanced functionality, take a look at the [time](/docs/surrealdb/2.x/surrealql/functions/database/time) functions, which enable extracting, altering, rounding, and grouping datetimes into specific time intervals.

--- a/doc-surrealdb_versioned_docs/version-2.x/surrealql/functions/database/rand.mdx
+++ b/doc-surrealdb_versioned_docs/version-2.x/surrealql/functions/database/rand.mdx
@@ -272,14 +272,14 @@ RETURN rand::string(10, 15);
 
 ## `rand::time`
 
-The `rand::time` function generates a random [`datetime`](/docs/surrealdb/surrealql/datamodel/time#datetimes).
+The `rand::time` function generates a random [`datetime`](/docs/surrealdb/2.x/surrealql/datamodel/datetimes).
 
 
 
 ```surql title="API DEFINITION"
 rand::time() -> datetime
 ```
-The rand::time function generates a random [`datetime`](/docs/surrealdb/surrealql/datamodel/time#datetimes), between two unix timestamps.
+The rand::time function generates a random [`datetime`](/docs/surrealdb/2.x/surrealql/datamodel/datetimes), between two unix timestamps.
 
 ```surql title="API DEFINITION"
 rand::time(number, number) -> datetime

--- a/doc-surrealdb_versioned_docs/version-2.x/surrealql/functions/script/type-conversion.mdx
+++ b/doc-surrealdb_versioned_docs/version-2.x/surrealql/functions/script/type-conversion.mdx
@@ -15,7 +15,7 @@ CREATE user:test SET created_at = function() {
 };
 ```
 
-In addition, a number of special classes are included within the JavaScript functions for the additional types which are not built into JavaScript. These enable the creation of [`duration`](/docs/surrealdb/surrealql/datamodel/time#durations-and-datetimes) values, [`record`](/docs/surrealdb/surrealql/datamodel/ids) ids, and [`UUID`](/docs/surrealdb/surrealql/datamodel/strings#uuid) values from within JavaScript.
+In addition, a number of special classes are included within the JavaScript functions for the additional types which are not built into JavaScript. These enable the creation of [`duration`](/docs/surrealdb/surrealql/datamodel/datetimes#durations-and-datetimes) values, [`record`](/docs/surrealdb/surrealql/datamodel/ids) ids, and [`UUID`](/docs/surrealdb/surrealql/datamodel/strings#uuid) values from within JavaScript.
 
 Any values of these types passed into embedded scripting functions are also represented with these special classes.
 


### PR DESCRIPTION
Since we don't have a `<time>` type in SurrealDB this page was a bit misleading. 