### PR TITLE
Show why the dec suffix is preferred

### DIFF
--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/datamodel/numbers.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/datamodel/numbers.mdx
@@ -28,6 +28,16 @@ To opt into 128-bit decimal numbers when specifying numeric values, you can use 
 ```surql
 CREATE product SET price = 99.99dec;
 ```
+
+The `dec` suffix is an instruction to the parser and not a cast, and is thus preferred when making a decimal.
+
+```surql
+RETURN <decimal>3.8888888888888888;
+-- Creates the imprecise float 3.888888888888889 and casts it into a decimal as 3.888888888888889dec
+RETURN 3.8888888888888888dec;
+-- Uses the input 3.8888888888888888 to directly create a decimal
+```
+
 ## Using a specific numeric type
 To use a specific type when specifying numeric values, you can cast the value to a specific numeric type or use the appropriate suffix.
 

--- a/doc-surrealdb_versioned_docs/version-2.x/surrealql/datamodel/numbers.mdx
+++ b/doc-surrealdb_versioned_docs/version-2.x/surrealql/datamodel/numbers.mdx
@@ -28,6 +28,16 @@ To opt into 128-bit decimal numbers when specifying numeric values, you can use 
 ```surql
 CREATE product SET price = 99.99dec;
 ```
+
+The `dec` suffix is an instruction to the parser and not a cast, and is thus preferred when making a decimal.
+
+```surql
+RETURN <decimal>3.8888888888888888;
+-- Creates the imprecise float 3.888888888888889 and casts it into a decimal as 3.888888888888889dec
+RETURN 3.8888888888888888dec;
+-- Uses the input 3.8888888888888888 to directly create a decimal
+```
+
 ## Using a specific numeric type
 To use a specific type when specifying numeric values, you can cast the value to a specific numeric type or use the appropriate suffix.
 


### PR DESCRIPTION
Adds a small example on how the dec suffix differs from casting and why it is preferred.