### PR TITLE
Add UNSET to UPDATE

### DIFF
--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/update.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/update.mdx
@@ -20,7 +20,7 @@ UPDATE [ ONLY ] @targets
 	[ CONTENT @value
 	  | MERGE @value
 	  | PATCH @value
-	  | SET @field = @value ...
+	  | [ SET @field = @value, ... | UNSET @field ]
 	]
 	[ WHERE @condition ]
 	[ RETURN NONE | RETURN BEFORE | RETURN AFTER | RETURN DIFF | RETURN @statement_param, ... ]
@@ -60,6 +60,10 @@ UPDATE webpage:home SET click_count += 1;
 
 -- Update a document and remove a tag from an array
 UPDATE person:tobie SET interests -= 'Java';
+
+-- Remove a field by setting it to NONE or using the UNSET keyword
+UPDATE webpage:home SET click_count = NONE;
+UPDATE user:one UNSET email, address;
 ```
 
 The update statement supports conditional matching of records using a `WHERE` clause. If the expression in the `WHERE` clause evaluates to true, then the respective record will be updated.

--- a/doc-surrealdb_versioned_docs/version-2.x/surrealql/statements/update.mdx
+++ b/doc-surrealdb_versioned_docs/version-2.x/surrealql/statements/update.mdx
@@ -20,7 +20,7 @@ UPDATE [ ONLY ] @targets
 	[ CONTENT @value
 	  | MERGE @value
 	  | PATCH @value
-	  | SET @field = @value ...
+	  | [ SET @field = @value, ... | UNSET @field ]
 	]
 	[ WHERE @condition ]
 	[ RETURN NONE | RETURN BEFORE | RETURN AFTER | RETURN DIFF | RETURN @statement_param, ... ]
@@ -64,6 +64,10 @@ UPDATE webpage:home SET click_count += 1;
 
 -- Update a document and remove a tag from an array
 UPDATE person:tobie SET interests -= 'Java';
+
+-- Remove a field by setting it to NONE or using the UNSET keyword
+UPDATE webpage:home SET click_count = NONE;
+UPDATE user:one UNSET email, address;
 ```
 
 The update statement supports conditional matching of records using a `WHERE` clause. If the expression in the `WHERE` clause evaluates to true, then the respective record will be updated.


### PR DESCRIPTION
We don't have any examples of UNSET even though it's a keyword. That said, it's not particularly exciting or hard to understand so probably just adding to the syntax and a single example should be enough. As far as I can tell the main draw to using it is being able to unset multiple fields instead of using `= NONE` for each and every one. Anywhere else this should go?