### PR TITLE
Fix example needing NOINDEX

### DIFF
--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/select.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/select.mdx
@@ -390,15 +390,15 @@ The query planner can replace the standard table iterator with one or several in
 
 For instance, the cardinality of an index can be high, potentially even equal to the number of records in the table. The sum of the records iterated by several indexes may end up being larger than the number of records obtained by iterating over the table. In such cases, if there are different index possibilities, the most probable optimal choice would be to use the index known with the lowest cardinality.
 
-- `WITH NOINDEX` forces the query planner to use the table iterator.
 - `WITH INDEX @indexes ...` restricts the query planner to using only the specified index(es)
+- `WITH NOINDEX` forces the query planner to use the table iterator.
 
 ```surql
 -- forces the query planner to use the specified index(es):
-SELECT * FROM person WITH INDEX ft_email WHERE email='tobie@surrealdb.com' AND company='SurrealDB';
+SELECT * FROM person WITH INDEX ft_email WHERE email = 'tobie@surrealdb.com' AND company = 'SurrealDB';
 
 -- forces the usage of the table iterator
-SELECT name FROM person WITH INDEX idx_name WHERE job='engineer' AND genre = 'm';
+SELECT name FROM person WITH NOINDEX WHERE job = 'engineer' AND gender = 'm';
 ```
 
 ## The `ONLY` clause

--- a/doc-surrealdb_versioned_docs/version-2.x/surrealql/statements/select.mdx
+++ b/doc-surrealdb_versioned_docs/version-2.x/surrealql/statements/select.mdx
@@ -403,15 +403,15 @@ The query planner can replace the standard table iterator with one or several in
 
 For instance, the cardinality of an index can be high, potentially even equal to the number of records in the table. The sum of the records iterated by several indexes may end up being larger than the number of records obtained by iterating over the table. In such cases, if there are different index possibilities, the most probable optimal choice would be to use the index known with the lowest cardinality.
 
-- `WITH NOINDEX` forces the query planner to use the table iterator.
 - `WITH INDEX @indexes ...` restricts the query planner to using only the specified index(es)
+- `WITH NOINDEX` forces the query planner to use the table iterator.
 
 ```surql
 -- forces the query planner to use the specified index(es):
-SELECT * FROM person WITH INDEX ft_email WHERE email='tobie@surrealdb.com' AND company='SurrealDB';
+SELECT * FROM person WITH INDEX ft_email WHERE email = 'tobie@surrealdb.com' AND company = 'SurrealDB';
 
 -- forces the usage of the table iterator
-SELECT name FROM person WITH INDEX idx_name WHERE job='engineer' AND genre = 'm';
+SELECT name FROM person WITH NOINDEX WHERE job = 'engineer' AND gender = 'm';
 ```
 
 ## The `ONLY` clause


### PR DESCRIPTION
Found what is (I assume) a typo in an example that seems to be showing the use of NOINDEX but is actually specifying an index.

Also some small changes: spacing, changing genre to gender (genre is the correct word in French but I can't imagine a "genre" of employee), and putting the bullet points in the same order as the following examples.