### PR TITLE
Update define-a-schema.mdx to fix syntax error.

### DIFF
--- a/doc-surrealdb_versioned_docs/version-1.x/tutorials/define-a-schema.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/tutorials/define-a-schema.mdx
@@ -54,7 +54,7 @@ DEFINE TABLE user SCHEMAFULL;
 -- Define some fields.
 DEFINE FIELD firstName ON TABLE user TYPE string;
 DEFINE FIELD lastName ON TABLE user TYPE string;
-DEFINE FIELD email ON TABLE user TYPE string;
+DEFINE FIELD email ON TABLE user TYPE string
   ASSERT string::is::email($value);
 ```
 


### PR DESCRIPTION
'There was a problem with the database: Parse error: Failed to parse query at line 5 column 12 expected query to end
  |
5 | ASSERT string::is::email($value);
  |        ^ perhaps missing a semicolon on the previous statement?
'