### PR TITLE
Correct 'minimum' typo in Architecture Docs Page

### DIFF
--- a/doc-surrealdb_versioned_docs/version-1.x/introduction/architecture.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/introduction/architecture.mdx
@@ -49,5 +49,5 @@ The HA deployment of your storage layer (TiKV, or FoundationDB) is the stateful 
 The rules governing the availability guarantees are covered in the documentation of those systems.
 SurrealDB clusters do not have state at the time of writing.
 Any necessary communication is either avoided by design, or communicated via the storage layer which maintains consistency.
-This makes deploying SurrealDB really convenient, since your fault tolerance is equal to the number of replicas (minus 1, the bare minum number of instances).
+This makes deploying SurrealDB really convenient, since your fault tolerance is equal to the number of replicas (minus 1, the bare minimum number of instances).
 Even though we do have bootstrapping, by design nodes can come and go as they please without much interference.


### PR DESCRIPTION
Correct 'minimum' typo in last paragraph.