### PR TITLE
Add 'Define a Schema in SurrealDB' to list of Tutorials

### DIFF
--- a/doc-surrealdb_versioned_docs/version-1.x/tutorials/index.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/tutorials/index.mdx
@@ -21,7 +21,8 @@ Within this section, you will find a collection of tutorials that cover a wide r
 
 To get started, select a tutorial from the sidebar or use the search functionality to find a specific topic of interest. Each tutorial provides clear instructions, code examples, and explanations to help you understand and use the feature effectively.
 
-- [ Working with SurrealDB over HTTP via Postman](/docs/surrealdb/tutorials/working-with-surrealdb-over-http-via-postman)
+- [Working with SurrealDB over HTTP via Postman](/docs/surrealdb/tutorials/working-with-surrealdb-over-http-via-postman)
 - [Integrate Auth0 as an Authentication provider](/docs/surrealdb/tutorials/integrate-auth0-as-authentication-provider)
 - [Integrate AWS Cognito as an Authentication Provider](/docs/surrealdb/tutorials/integrate-aws-cognito-as-authentication-provider)
 - [Connect to SurrealDB via Ngrok tunnel](/docs/surrealdb/tutorials/connect-to-surrealdb-via-ngrok-tunnel)
+- [Define a Schema in SurrealDB](/docs/surrealdb/tutorials/define-a-schema)

--- a/doc-surrealdb_versioned_docs/version-2.x/tutorials/index.mdx
+++ b/doc-surrealdb_versioned_docs/version-2.x/tutorials/index.mdx
@@ -21,7 +21,7 @@ Within this section, you will find a collection of tutorials that cover a wide r
 
 To get started, select a tutorial from the sidebar or use the search functionality to find a specific topic of interest. Each tutorial provides clear instructions, code examples, and explanations to help you understand and use the feature effectively.
 
-- [ Working with SurrealDB over HTTP via Postman](/docs/surrealdb/2.x/tutorials/working-with-surrealdb-over-http-via-postman)
+- [Working with SurrealDB over HTTP via Postman](/docs/surrealdb/2.x/tutorials/working-with-surrealdb-over-http-via-postman)
 - [Integrate Auth0 as an Authentication provider](/docs/surrealdb/2.x/tutorials/integrate-auth0-as-authentication-provider)
 - [Integrate AWS Cognito as an Authentication Provider](/docs/surrealdb/2.x/tutorials/integrate-aws-cognito-as-authentication-provider)
 - [Connect to SurrealDB via Ngrok tunnel](/docs/surrealdb/2.x/tutorials/connect-to-surrealdb-via-ngrok-tunnel)

--- a/doc-surrealdb_versioned_docs/version-2.x/tutorials/index.mdx
+++ b/doc-surrealdb_versioned_docs/version-2.x/tutorials/index.mdx
@@ -25,3 +25,4 @@ To get started, select a tutorial from the sidebar or use the search functionali
 - [Integrate Auth0 as an Authentication provider](/docs/surrealdb/2.x/tutorials/integrate-auth0-as-authentication-provider)
 - [Integrate AWS Cognito as an Authentication Provider](/docs/surrealdb/2.x/tutorials/integrate-aws-cognito-as-authentication-provider)
 - [Connect to SurrealDB via Ngrok tunnel](/docs/surrealdb/2.x/tutorials/connect-to-surrealdb-via-ngrok-tunnel)
+- [Define a Schema in SurrealDB](/docs/surrealdb/2.x/tutorials/define-a-schema)


### PR DESCRIPTION
Our new 'Define a Schema in SurrealDB' was listed on the contents on the left, but missing within the body of the Tutorials main page, adding it in here too.