### PR TITLE
fix: remove displayed new emoji

### DIFF
--- a/doc-sdk-rust_versioned_docs/version-1.x/setup.mdx
+++ b/doc-sdk-rust_versioned_docs/version-1.x/setup.mdx
@@ -152,7 +152,7 @@ The Rust SDK comes with a number of built-in functions.
             <td scope="row" data-label="Description">Connects to a specific database endpoint, saving the connection on the static client</td>
         </tr>
         <tr>
-            <td scope="row" data-label="Function"><a href="#new"><code>Surreal::&#8203;new::&lt;T&gt;(endpoint)</code></a></td>
+            <td scope="row" data-label="Function"><a href="#new"><code>{"Surreal::new::<T>(endpoint)"}</code></a></td>
             <td scope="row" data-label="Description">Connects to a local or remote database endpoint</td>
         </tr>
         <tr>

--- a/doc-surrealdb_versioned_docs/version-1.x/embedding/rust.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/embedding/rust.mdx
@@ -165,7 +165,7 @@ The Rust SDK comes with a number of built-in functions.
             <td scope="row" data-label="Description">Connects to a specific database endpoint, saving the connection on the static client</td>
         </tr>
         <tr>
-            <td scope="row" data-label="Function"><a href="#new"><code>Surreal::new::&lt;T&gt;(endpoint)</code></a></td>
+            <td scope="row" data-label="Function"><a href="#new"><code>{"Surreal::new::<T>(endpoint)"}</code></a></td>
             <td scope="row" data-label="Description">Connects to a local or remote database endpoint</td>
         </tr>
         <tr>
@@ -298,7 +298,7 @@ DB.connect::<Wss>("cloud.surrealdb.com").await?;
 Connects to a local or remote database endpoint.
 
 ```rust title="Method Syntax"
-Surreal::new:: <T>(endpoint)
+Surreal::new::<T>(endpoint)
 ```
 
 ### Arguments

--- a/doc-surrealdb_versioned_docs/version-2.x/embedding/rust.mdx
+++ b/doc-surrealdb_versioned_docs/version-2.x/embedding/rust.mdx
@@ -165,7 +165,7 @@ The Rust SDK comes with a number of built-in functions.
             <td scope="row" data-label="Description">Connects to a specific database endpoint, saving the connection on the static client</td>
         </tr>
         <tr>
-            <td scope="row" data-label="Function"><a href="#new"><code>Surreal::new::&lt;T&gt;(endpoint)</code></a></td>
+            <td scope="row" data-label="Function"><a href="#new"><code>{"Surreal::new::<T>(endpoint)"}</code></a></td>
             <td scope="row" data-label="Description">Connects to a local or remote database endpoint</td>
         </tr>
         <tr>
@@ -298,7 +298,7 @@ DB.connect::<Wss>("cloud.surrealdb.com").await?;
 Connects to a local or remote database endpoint.
 
 ```rust title="Method Syntax"
-Surreal::new:: <T>(endpoint)
+Surreal::new::<T>(endpoint)
 ```
 
 ### Arguments


### PR DESCRIPTION
This PR will remove the NEW emoji and simply display text like it should:

![image](https://github.com/surrealdb/docs.surrealdb.com/assets/6053067/e9726301-83dd-4208-b110-e6b142b37e7f)
