### PR TITLE
Improve record access documentation

### DIFF
--- a/doc-surrealdb_versioned_docs/version-2.x/surrealql/statements/define/access/record.mdx
+++ b/doc-surrealdb_versioned_docs/version-2.x/surrealql/statements/define/access/record.mdx
@@ -54,7 +54,7 @@ Since the origin of the claims in the JWT is verified, those claims can be used 
 
 Bear in mind that table and field permissions only apply to [record users](/docs/surrealdb/2.x/security/authentication#record-users), which must use tokens that are verified by a `RECORD` access method. Access provided by namespace and database tokens defined in a `JWT` access method is equivalent to access from [system users](/docs/surrealdb/2.x/security/authentication#system-users), which is above fine-grained permissions. When application users will be the ones directly authenticating with JWT, defining a `RECORD` access method `WITH JWT` is most likely the right choice.
 
-The following example shows how record access with a token can be used to grant authorization by verifying that the “email” claim in the token matches the email used as the index of a user table:
+The following example shows how record access with a token can be used to grant authorization either by verifying that the `id` claim in the token (which is used to populate the `$auth` reserved parameter) matches the record that is being queried from the `user` table or if the `privileged` claim is set to `true` in the token:
 
 ```surql
 -- Specify the namespace and database for the token
@@ -81,16 +81,12 @@ DEFINE TABLE user SCHEMAFULL
   -- The record of the user being queried must match the one identified in the token
   -- Only matching records will be changed or returned
   AND id = $auth.id
+  -- Allow privileged tokens to query any user
+  OR $token.privileged = true
 ;
-
-DEFINE INDEX email ON user FIELDS email UNIQUE;
-DEFINE FIELD email ON user TYPE string ASSERT string::is::email($value);
-DEFINE FIELD name ON user TYPE string;
-DEFINE FIELD nickname ON user TYPE string;
-DEFINE FIELD picture ON user TYPE string;
 ```
 
-You may also use permissions clauses to perform additional verification on other JWT claims (e.g. verifying that the iss claim matches a specific principal using $token.iss) that may be required or recommended by a the provider of the token.
+You may also use permissions clauses to perform additional verification on other JWT claims that may be required or recommended by the provider of the token, such as verifying that the `iss` claim matches a specific principal using `$token.iss`. However, this kind of logic may be better suited for the [`AUTHENTICATE`](/docs/surrealdb/2.x/surrealql/statements/define/access/record#with-authenticate-clause) clause, which is only executed when the token is validated before an authenticated session is established instead of in every query and for each record.
 
 The token payload should at least include the following claims when used to authenticate as a record user in SurrealDB.
 
@@ -172,9 +168,11 @@ ALGORITHM HS512 KEY "secret";
 
 The authenticate clause can be used to change the record identifier returned by the `SIGNIN` and `SIGNUP` clauses or replace the identifier provided in the token when authenticating `WITH JWT`. This clause can also be used to log or stop authentication attempts from record users, as it is always executed across signin, signup and token authentication. The clause always expects a record identifier to be returned and will otherwise fail.
 
+Unlike the [`PERMISSIONS`](/docs/surrealdb/2.x/surrealql/statements/define/table#defining-permissions) clause, the `AUTHENTICATE` clause is executed only at the time of authentication, resulting in increased performance for queries that only need to be validated at that point. On the other hand, permissions queries are executed in every query and for each record, ensuring that any authorization conditions are verified at the time of the query. The `AUTHENTICATE` clause is a good fit for validating specific conditions that are not expected to change during the lifetime of the session such as the presence of any required token claims.
+
 #### Example: External authentication providers
 
-Replacing the record identifier that will be used to establish the session is especially useful in scenarios where the token used to authenticate the session does not contain one. This is common when using an external authentication provider, which may only have knowledge of generic user identifiers such as an email address or UUID.
+Replacing the record identifier that will be used to establish the session is specially useful in scenarios where the token used to authenticate the session does not contain one. This is common when using an external authentication provider, which may only have knowledge of generic user identifiers such as an email address or UUID.
 
 In the below example, we check if the session may already be tied to an existing user by using the `$auth` reserved parameter, which contains the record identifier of the authenticated user. If we can select the `id` field from `$auth`, it means that the token already contained the `id` for a record that exists in the database. If that is not the case, we can check if the token contains a different claim that we can rely on to uniquely identifies users. In this case we check for an email address. If the `email` claim is present in the token, we try to retrieve the user from the `user` table by their email address. If none of the queries return a record, the `AUTHENTICATE` clause will fail with a generic error. You can also choose to `THROW` a custom error as shown in the next example.
 

--- a/doc-surrealdb_versioned_docs/version-2.x/surrealql/statements/define/access/record.mdx
+++ b/doc-surrealdb_versioned_docs/version-2.x/surrealql/statements/define/access/record.mdx
@@ -172,7 +172,7 @@ Unlike the [`PERMISSIONS`](/docs/surrealdb/2.x/surrealql/statements/define/table
 
 #### Example: External authentication providers
 
-Replacing the record identifier that will be used to establish the session is specially useful in scenarios where the token used to authenticate the session does not contain one. This is common when using an external authentication provider, which may only have knowledge of generic user identifiers such as an email address or UUID.
+Replacing the record identifier that will be used to establish the session is especially useful in scenarios where the token used to authenticate the session does not contain one. This is common when using an external authentication provider, which may only have knowledge of generic user identifiers such as an email address or UUID.
 
 In the below example, we check if the session may already be tied to an existing user by using the `$auth` reserved parameter, which contains the record identifier of the authenticated user. If we can select the `id` field from `$auth`, it means that the token already contained the `id` for a record that exists in the database. If that is not the case, we can check if the token contains a different claim that we can rely on to uniquely identifies users. In this case we check for an email address. If the `email` claim is present in the token, we try to retrieve the user from the `user` table by their email address. If none of the queries return a record, the `AUTHENTICATE` clause will fail with a generic error. You can also choose to `THROW` a custom error as shown in the next example.
 

--- a/doc-surrealdb_versioned_docs/version-2.x/surrealql/statements/define/access/record.mdx
+++ b/doc-surrealdb_versioned_docs/version-2.x/surrealql/statements/define/access/record.mdx
@@ -54,7 +54,7 @@ Since the origin of the claims in the JWT is verified, those claims can be used 
 
 Bear in mind that table and field permissions only apply to [record users](/docs/surrealdb/2.x/security/authentication#record-users), which must use tokens that are verified by a `RECORD` access method. Access provided by namespace and database tokens defined in a `JWT` access method is equivalent to access from [system users](/docs/surrealdb/2.x/security/authentication#system-users), which is above fine-grained permissions. When application users will be the ones directly authenticating with JWT, defining a `RECORD` access method `WITH JWT` is most likely the right choice.
 
-The following example shows how record access with a token can be used to grant authorization either by verifying that the `id` claim in the token (which is used to populate the `$auth` reserved parameter) matches the record that is being queried from the `user` table or if the `privileged` claim is set to `true` in the token:
+The following example shows how record access with a token can be used to grant authorization either by verifying that the `id` claim in the token (which is used to populate the [`$auth`](/docs/surrealdb/2.x/surrealql/parameters#auth) reserved parameter) matches the record that is being queried from the `user` table or if the `privileged` claim is set to `true` in the token:
 
 ```surql
 -- Specify the namespace and database for the token

--- a/doc-surrealdb_versioned_docs/version-2.x/surrealql/statements/define/access/record.mdx
+++ b/doc-surrealdb_versioned_docs/version-2.x/surrealql/statements/define/access/record.mdx
@@ -86,7 +86,7 @@ DEFINE TABLE user SCHEMAFULL
 ;
 ```
 
-You may also use permissions clauses to perform additional verification on other JWT claims that may be required or recommended by the provider of the token, such as verifying that the `iss` claim matches a specific principal using `$token.iss`. However, this kind of logic may be better suited for the [`AUTHENTICATE`](/docs/surrealdb/2.x/surrealql/statements/define/access/record#with-authenticate-clause) clause, which is only executed when the token is validated before an authenticated session is established instead of in every query and for each record.
+You may also use permissions clauses to perform additional verification on other JWT claims that may be required or recommended by the provider of the token, such as verifying that the `iss` claim matches a specific principal using `$token.iss`. However, this kind of logic may be better suited for the [`AUTHENTICATE`](#with-authenticate-clause) clause, which is only executed when the token is validated before an authenticated session is established instead of in every query and for each record.
 
 The token payload should at least include the following claims when used to authenticate as a record user in SurrealDB.
 


### PR DESCRIPTION
Improve documentation by removing text that is no longer current, fixing some orthographic errors and considering the differences between `PERMISSIONS` and `AUTHENTICATE` for validating authorization conditions.