### PR TITLE
Removed unwanted '3' char

### DIFF
--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/let.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/let.mdx
@@ -7,7 +7,7 @@ description: The LET statement sets and stores a value which can then be used in
 
 # `LET` statement
 
-3 A parameter can store any value, including the result of a query.
+A parameter can store any value, including the result of a query.
 
 ### Statement syntax
 

--- a/doc-surrealdb_versioned_docs/version-2.x/surrealql/statements/let.mdx
+++ b/doc-surrealdb_versioned_docs/version-2.x/surrealql/statements/let.mdx
@@ -7,7 +7,7 @@ description: The LET statement sets and stores a value which can then be used in
 
 # `LET` statement
 
-3 A parameter can store any value, including the result of a query.
+A parameter can store any value, including the result of a query.
 
 ### Statement syntax
 


### PR DESCRIPTION
In both versions of the documentation, the number 3 is accidentally introduced at the beginning of the description