### PR TITLE
Docs: Clarify a bit more on SurrealQL running options in the getting started guide 

### DIFF
--- a/doc-surrealdb_versioned_docs/version-1.x/introduction/start.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/introduction/start.mdx
@@ -57,7 +57,7 @@ There are two main ways to use SurrealQL:
 1. **Surrealist**: A graphical user interface (GUI) that can be accessed via a web browser or used as a desktop application.
 2. **SurrealDB CLI**: A command-line interface that allows you to interact with SurrealQL directly from the terminal.
 
-For more information, you can visit [Surrealist](https://Surrealist.app), and the [SurrealDB CLI documentation](/docs/surrealdb/cli/).```
+For more information, you can visit [Surrealist](https://Surrealist.app), and the [SurrealDB CLI documentation](/docs/surrealdb/cli/).
 
 <Tabs groupId="running-surrealql">
   <TabItem value="npm" label="Using Surrealist" default>

--- a/doc-surrealdb_versioned_docs/version-1.x/introduction/start.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/introduction/start.mdx
@@ -52,7 +52,7 @@ Here's what each segment of this command does:
 
 [SurrealQL](/docs/surrealdb/surrealql/) is the query language for SurrealDB which can be used to query data from your SurrealDB database. While this is not a requirement for getting started, it is helpful to familiarise yourself with some commands.
 
-There are a few different ways to use SurrealQL, including using the [Surrealist](https://Surrealist.app) or using the SurrealDB CLI.
+There are a few different ways to use SurrealQL. The [Surrealist app](https://Surrealist.app) is a GUI that can be used in a web browser or as a desktop app, and the [SurrealDB CLI](https://surrealdb.com/docs/surrealdb/cli/) can be used from the command-line.
 
 <Tabs groupId="running-surrealql">
   <TabItem value="npm" label="Using Surrealist" default>
@@ -63,7 +63,7 @@ For the sake of this guide, we recommend using a sandbox connection. Once you ha
 
 </TabItem>
 <TabItem value="CLI" label="Using CLI">
-Once you have your [database running](/docs/surrealdb/cli/start), you can use the SurrealDB CLI to run your queries. To do so, run the following commands:
+Once you have your [database running](/docs/surrealdb/cli/start), you can use the [SurrealDB CLI](https://surrealdb.com/docs/surrealdb/cli/) to run your queries. To do so, run the following commands:
 
 1. Running without relying on an external server
 

--- a/doc-surrealdb_versioned_docs/version-1.x/introduction/start.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/introduction/start.mdx
@@ -52,7 +52,12 @@ Here's what each segment of this command does:
 
 [SurrealQL](/docs/surrealdb/surrealql/) is the query language for SurrealDB which can be used to query data from your SurrealDB database. While this is not a requirement for getting started, it is helpful to familiarise yourself with some commands.
 
-There are a few different ways to use SurrealQL. The [Surrealist app](https://Surrealist.app) is a GUI that can be used in a web browser or as a desktop app, and the [SurrealDB CLI](https://surrealdb.com/docs/surrealdb/cli/) can be used from the command-line.
+There are two main ways to use SurrealQL:
+
+1. **Surrealist**: A graphical user interface (GUI) that can be accessed via a web browser or used as a desktop application.
+2. **SurrealDB CLI**: A command-line interface that allows you to interact with SurrealQL directly from the terminal.
+
+For more information, you can visit [Surrealist](https://Surrealist.app), and the [SurrealDB CLI documentation](/docs/surrealdb/cli/).```
 
 <Tabs groupId="running-surrealql">
   <TabItem value="npm" label="Using Surrealist" default>
@@ -63,7 +68,7 @@ For the sake of this guide, we recommend using a sandbox connection. Once you ha
 
 </TabItem>
 <TabItem value="CLI" label="Using CLI">
-Once you have your [database running](/docs/surrealdb/cli/start), you can use the [SurrealDB CLI](https://surrealdb.com/docs/surrealdb/cli/) to run your queries. To do so, run the following commands:
+Once you have your [database running](/docs/surrealdb/cli/start), you can use the [SurrealDB CLI](/docs/surrealdb/cli/) to run your queries. To do so, run the following commands:
 
 1. Running without relying on an external server
 

--- a/doc-surrealdb_versioned_docs/version-2.x/introduction/start.mdx
+++ b/doc-surrealdb_versioned_docs/version-2.x/introduction/start.mdx
@@ -51,7 +51,12 @@ Here's what each segment of this command does:
 
 [SurrealQL](/docs/surrealdb/2.x/surrealql/) is the query language for SurrealDB which can be used to query data from your SurrealDB database. While this is not a requirement for getting started, it is helpful to familiarise yourself with some commands.
 
-There are a few different ways to use SurrealQL. The [Surrealist app](https://Surrealist.app) is a GUI that can be used in a web browser or as a desktop app, and the [SurrealDB CLI](https://surrealdb.com/docs/surrealdb/cli/) can be used from the command-line.
+There are two main ways to use SurrealQL:
+
+1. **Surrealist**: A graphical user interface (GUI) that can be accessed via a web browser or used as a desktop application.
+2. **SurrealDB CLI**: A command-line interface that allows you to interact with SurrealQL directly from the terminal.
+
+For more information, you can visit [Surrealist](https://Surrealist.app) and the [SurrealDB CLI documentation](/docs/surrealdb/2.x/cli/).
 
 <Tabs groupId="running-surrealql">
   <TabItem value="npm" label="Using Surrealist" default>
@@ -62,7 +67,7 @@ For the sake of this guide, we recommend using a sandbox connection. Once you ha
 
 </TabItem>
 <TabItem value="CLI" label="Using CLI">
-Once you have your [database running](/docs/surrealdb/2.x/cli/start), you can use the [SurrealDB CLI](https://surrealdb.com/docs/surrealdb/cli/) to run your queries. To do so, run the following commands:
+Once you have your [database running](/docs/surrealdb/2.x/cli/start), you can use the [SurrealDB CLI](/docs/surrealdb/2.x/cli/) to run your queries. To do so, run the following commands:
 
 1. Running without relying on an external server
 

--- a/doc-surrealdb_versioned_docs/version-2.x/introduction/start.mdx
+++ b/doc-surrealdb_versioned_docs/version-2.x/introduction/start.mdx
@@ -51,7 +51,7 @@ Here's what each segment of this command does:
 
 [SurrealQL](/docs/surrealdb/2.x/surrealql/) is the query language for SurrealDB which can be used to query data from your SurrealDB database. While this is not a requirement for getting started, it is helpful to familiarise yourself with some commands.
 
-There are a few different ways to use SurrealQL, including using the [Surrealist](https://Surrealist.app) or using the SurrealDB CLI.
+There are a few different ways to use SurrealQL. The [Surrealist app](https://Surrealist.app) is a GUI that can be used in a web browser or as a desktop app, and the [SurrealDB CLI](https://surrealdb.com/docs/surrealdb/cli/) can be used from the command-line.
 
 <Tabs groupId="running-surrealql">
   <TabItem value="npm" label="Using Surrealist" default>
@@ -62,7 +62,7 @@ For the sake of this guide, we recommend using a sandbox connection. Once you ha
 
 </TabItem>
 <TabItem value="CLI" label="Using CLI">
-Once you have your [database running](/docs/surrealdb/2.x/cli/start), you can use the SurrealDB CLI to run your queries. To do so, run the following commands:
+Once you have your [database running](/docs/surrealdb/2.x/cli/start), you can use the [SurrealDB CLI](https://surrealdb.com/docs/surrealdb/cli/) to run your queries. To do so, run the following commands:
 
 1. Running without relying on an external server
 


### PR DESCRIPTION
This commit updates the 1.x and 2.x documentation, within the "Introduction" section, on the "Getting Started" page ("start.mdx"), making the following changes:

* Expands on the difference between the Surrealist app and the SurrealDB CLI.
* Replaces the phrase "the Surrealist" with "the Surrealist app".
* Adds links to the SurrealDB CLI documentation.