### PR TITLE
Issue #661 - Fix the DELETE live action in the table

### DIFF
--- a/doc-sdk-javascript_versioned_docs/version-1.x/core/streaming.mdx
+++ b/doc-sdk-javascript_versioned_docs/version-1.x/core/streaming.mdx
@@ -217,7 +217,7 @@ It's generally recommended to handle the `CLOSE` action first, as that clears ou
         </tr>
         <tr>
             <td colspan="1" scope="row" data-label="Action">
-                `CREATE`
+                `DELETE`
             </td>
             <td colspan="1" scope="row" data-label="Result">
                 `Result`


### PR DESCRIPTION
Fix for Issue #661 

CREATE was mistakenly used instead of DELETE.