### PR TITLE
Issue #660 - Replace DEFINE DATABASE with DEFINE TOKEN under Requirements

### DIFF
--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/define/token.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/define/token.mdx
@@ -101,7 +101,7 @@ To avoid performing requests to the remote URL for each token that is verified, 
 - To `DEFINE TOKEN ... ON NAMESPACE ...` you must have root or namespace level access.
 - To `DEFINE TOKEN ... ON DATABASE ...` you must have root, namespace, or database level access.
 - To `DEFINE TOKEN ... ON SCOPE ...` you must have root, namespace, or database level access.
-- [You must select your namespace and/or database](/docs/surrealdb/surrealql/statements/use) before you can use the `DEFINE DATABASE` statement for database or namespace tokens.
+- [You must select your namespace and/or database](/docs/surrealdb/surrealql/statements/use) before you can use the `DEFINE TOKEN` statement for database or namespace tokens.
 
 ## Using `IF NOT EXISTS` clause <l className='purple'>Since 1.3.0</l>
 

--- a/doc-surrealdb_versioned_docs/version-2.x/surrealql/statements/define/token.mdx
+++ b/doc-surrealdb_versioned_docs/version-2.x/surrealql/statements/define/token.mdx
@@ -105,7 +105,7 @@ To avoid performing requests to the remote URL for each token that is verified, 
 - To `DEFINE TOKEN ... ON NAMESPACE ...` you must have root or namespace level access.
 - To `DEFINE TOKEN ... ON DATABASE ...` you must have root, namespace, or database level access.
 - To `DEFINE TOKEN ... ON SCOPE ...` you must have root, namespace, or database level access.
-- [You must select your namespace and/or database](/docs/surrealdb/2.x/surrealql/statements/use) before you can use the `DEFINE DATABASE` statement for database or namespace tokens.
+- [You must select your namespace and/or database](/docs/surrealdb/2.x/surrealql/statements/use) before you can use the `DEFINE TOKEN` statement for database or namespace tokens.
 
 ## Using `IF NOT EXISTS` clause <l className='purple'>Since 1.3.0</l>
 


### PR DESCRIPTION
closes #660

In the 'Requirements' section, `DEFINE DATABASE` was used instead of `DEFINE TOKEN`.
