### PR TITLE
Add example of pipe operator in CREATE

### DIFF
--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/create.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/create.mdx
@@ -136,6 +136,32 @@ CREATE townsperson, cat, dog SET
 ]
 ```
 
+The `||` syntax can be used to create a specified number of records. To use this syntax, add a colon and the number of records to create after the table name.
+
+```surql
+CREATE |townsperson:5|;
+```
+
+The `||` syntax can be combined with the method above using a comma to create multiple record types at the same time.
+
+```surql
+CREATE |townsperson:3|, |cat:2|, dog SET
+    created_at = time::now(),
+    name = "Just a " + meta::tb(id);
+```
+
+The `..` range syntax can also be used inside `||` to create multiple records with IDs ranging from the lower to the upper range.
+
+```surql
+CREATE |townsperson:1..5|;
+```
+
+```
+CREATE |townsperson:1..5|, |cat:1..2|, dog SET
+    created_at = time::now(),
+    name = "Just a " + meta::tb(id);
+```
+
 ### ONLY
 
 Using the `ONLY` clause after `CREATE` will return just the record object instead of the default, which returns the object inside of an array.

--- a/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/create.mdx
+++ b/doc-surrealdb_versioned_docs/version-1.x/surrealql/statements/create.mdx
@@ -156,7 +156,7 @@ The `..` range syntax can also be used inside `||` to create multiple records wi
 CREATE |townsperson:1..5|;
 ```
 
-```
+```surql
 CREATE |townsperson:1..5|, |cat:1..2|, dog SET
     created_at = time::now(),
     name = "Just a " + meta::tb(id);

--- a/doc-surrealdb_versioned_docs/version-2.x/surrealql/statements/create.mdx
+++ b/doc-surrealdb_versioned_docs/version-2.x/surrealql/statements/create.mdx
@@ -136,6 +136,32 @@ CREATE townsperson, cat, dog SET
 ]
 ```
 
+The `||` syntax can be used to create a specified number of records. To use this syntax, add a colon and the number of records to create after the table name.
+
+```surql
+CREATE |townsperson:5|;
+```
+
+The `||` syntax can be combined with the method above using a comma to create multiple record types at the same time.
+
+```surql
+CREATE |townsperson:3|, |cat:2|, dog SET
+    created_at = time::now(),
+    name = "Just a " + meta::tb(id);
+```
+
+The `..` range syntax can also be used inside `||` to create multiple records with IDs ranging from the lower to the upper range.
+
+```surql
+CREATE |townsperson:1..5|;
+```
+
+```
+CREATE |townsperson:1..5|, |cat:1..2|, dog SET
+    created_at = time::now(),
+    name = "Just a " + meta::tb(id);
+```
+
 ### ONLY
 
 Using the `ONLY` clause after `CREATE` will return just the record object instead of the default, which returns the object inside of an array.

--- a/doc-surrealdb_versioned_docs/version-2.x/surrealql/statements/create.mdx
+++ b/doc-surrealdb_versioned_docs/version-2.x/surrealql/statements/create.mdx
@@ -156,7 +156,7 @@ The `..` range syntax can also be used inside `||` to create multiple records wi
 CREATE |townsperson:1..5|;
 ```
 
-```
+```surql
 CREATE |townsperson:1..5|, |cat:1..2|, dog SET
     created_at = time::now(),
     name = "Just a " + meta::tb(id);

--- a/doc-surrealdb_versioned_docs/version-2.x/surrealql/statements/create.mdx
+++ b/doc-surrealdb_versioned_docs/version-2.x/surrealql/statements/create.mdx
@@ -136,7 +136,9 @@ CREATE townsperson, cat, dog SET
 ]
 ```
 
-The `||` syntax can be used to create a specified number of records. To use this syntax, add a colon and the number of records to create after the table name.
+The `| |` syntax can be used to create multiple records in a single execution. The number that follows the table name specifies the number of records created. The records created will have random IDs. 
+
+To use this syntax, add a colon and the number of records to create after the table name.
 
 ```surql
 CREATE |townsperson:5|;


### PR DESCRIPTION
Small PR: Adds some simple examples of the pipe operator (e.g. CREATE |townsperson:5|) to the section on creating multiple records using the syntax.