### PR TITLE
Add section on interaction between fields to DEFINE FIELD/TABLE

### DIFF
--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/define/field.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/define/field.mdx
@@ -295,5 +295,6 @@ DEFINE FIELD first_name ON TABLE person TYPE string ASSERT string::len($value) <
 DEFINE FIELD last_name  ON TABLE person TYPE string ASSERT string::len($value) < 20;
 DEFINE FIELD name       ON TABLE person             VALUE $this.first_name + ' ' + $this.last_name;
 
+// Creates a user with name "Bob Bobson"
 CREATE person SET first_name = "Bob", last_name = "Bobson";
 ```

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/define/field.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/define/field.mdx
@@ -298,3 +298,19 @@ DEFINE FIELD name       ON TABLE person             VALUE $this.first_name + ' '
 // Creates a `person` with the name "Bob Bobson"
 CREATE person SET first_name = "Bob", last_name = "Bobson";
 ```
+
+:::note
+___NOTE:___ DEFINE FIELD statements are computed in alphabetical order.
+:::
+
+```surql
+DEFINE TABLE person SCHEMAFULL;
+
+DEFINE FIELD first_name ON TABLE person TYPE string VALUE string::lowercase($value);
+DEFINE FIELD surname    ON TABLE person TYPE string VALUE string::lowercase($value);
+DEFINE FIELD full_name  ON TABLE person             VALUE $this.first_name + ' ' + $this.surname;
+
+// `full_name` is determined before `surname`
+// Creates a `person` with `full_name` of "bob Bobson", not "bob bobson"
+CREATE person SET first_name = "Bob", surname = "Bobson";
+```

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/define/field.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/define/field.mdx
@@ -286,7 +286,7 @@ DEFINE FIELD countrycode ON user TYPE string
 
 ## Interacting with other fields of the same record
 
-While a `DEFINE TABLE` statement represents a template for any subsequent records to be created, a `DEFINE FIELD` statement pertains to concrete field data of a record. As such, access to both the field itself and its parent record are granted inside `DEFINE FIELD` through the `$value` and `$this` parameters, respectively.
+While a `DEFINE TABLE` statement represents a template for any subsequent records to be created, a `DEFINE FIELD` statement pertains to concrete field data of a record. As such, access to both the field itself and its parent record are granted inside `DEFINE FIELD` through the [`$value`](/docs/surrealdb/surrealql/parameters#value) and [`$this`](/docs/surrealdb/surrealql/parameters#parent-this) parameters, respectively.
 
 ```surql
 DEFINE TABLE person SCHEMAFULL;

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/define/field.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/define/field.mdx
@@ -284,7 +284,7 @@ DEFINE FIELD countrycode ON user TYPE string
 ;
 ```
 
-## Interacting with other fields of the same record inside a DEFINE FIELD statement
+## Interacting with other fields of the same record
 
 While a `DEFINE TABLE` statement represents a template for any subsequent records to be created, a `DEFINE FIELD` statement pertains to concrete field data of a record. As such, access to both the field itself and its parent record are granted inside `DEFINE FIELD` through the `$value` and `$this` parameters, respectively.
 

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/define/field.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/define/field.mdx
@@ -295,6 +295,6 @@ DEFINE FIELD first_name ON TABLE person TYPE string ASSERT string::len($value) <
 DEFINE FIELD last_name  ON TABLE person TYPE string ASSERT string::len($value) < 20;
 DEFINE FIELD name       ON TABLE person             VALUE $this.first_name + ' ' + $this.last_name;
 
-// Creates a user with name "Bob Bobson"
+// Creates a `person` with the name "Bob Bobson"
 CREATE person SET first_name = "Bob", last_name = "Bobson";
 ```

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/define/field.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/define/field.mdx
@@ -291,26 +291,27 @@ While a `DEFINE TABLE` statement represents a template for any subsequent record
 ```surql
 DEFINE TABLE person SCHEMAFULL;
 
-DEFINE FIELD first_name ON TABLE person TYPE string ASSERT string::len($value) < 20;
-DEFINE FIELD last_name  ON TABLE person TYPE string ASSERT string::len($value) < 20;
+DEFINE FIELD first_name ON TABLE person TYPE string VALUE string::lowercase($value);
+DEFINE FIELD last_name  ON TABLE person TYPE string VALUE string::lowercase($value);
 DEFINE FIELD name       ON TABLE person             VALUE $this.first_name + ' ' + $this.last_name;
 
-// Creates a `person` with the name "Bob Bobson"
-CREATE person SET first_name = "Bob", last_name = "Bobson";
+// Creates a `person` with the name "bob bobson"
+CREATE person SET first_name = "BOB", last_name = "BOBSON";
 ```
 
-:::note
-___NOTE:___ DEFINE FIELD statements are computed in alphabetical order.
-:::
+As `DEFINE FIELD` statements are computed in alphabetical order, be sure to keep this in mind when using fields that rely on the values of others.
+
+The following example is identical to the above except that `full_name` has been chosen for the previous field `name`. The `full_name` field will be calculated after `first_name`, but before `last_name`.
 
 ```surql
 DEFINE TABLE person SCHEMAFULL;
 
 DEFINE FIELD first_name ON TABLE person TYPE string VALUE string::lowercase($value);
-DEFINE FIELD surname    ON TABLE person TYPE string VALUE string::lowercase($value);
-DEFINE FIELD full_name  ON TABLE person             VALUE $this.first_name + ' ' + $this.surname;
+DEFINE FIELD last_name  ON TABLE person TYPE string VALUE string::lowercase($value);
+DEFINE FIELD full_name  ON TABLE person             VALUE $this.first_name + ' ' + $this.last_name;
 
-// `full_name` is determined before `surname`
-// Creates a `person` with `full_name` of "bob Bobson", not "bob bobson"
-CREATE person SET first_name = "Bob", surname = "Bobson";
+// Creates a `person` with `full_name` of "bob BOBSON", not "bob bobson"
+CREATE person SET first_name = "Bob", last_name = "Bobson";
 ```
+
+A good rule of thumb is to organize your `DEFINE FIELD` statements in alphabetical order.

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/define/field.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/define/field.mdx
@@ -283,3 +283,17 @@ DEFINE FIELD countrycode ON user TYPE string
 	VALUE $value OR $before OR 'GBR'
 ;
 ```
+
+## Interacting with other fields of the same record inside a DEFINE FIELD statement
+
+While a `DEFINE TABLE` statement represents a template for any subsequent records to be created, a `DEFINE FIELD` statement pertains to concrete field data of a record. As such, access to both the field itself and its parent record are granted inside `DEFINE FIELD` through the `$value` and `$this` parameters, respectively.
+
+```surql
+DEFINE TABLE person SCHEMAFULL;
+
+DEFINE FIELD first_name ON TABLE person TYPE string ASSERT string::len($value) < 20;
+DEFINE FIELD last_name  ON TABLE person TYPE string ASSERT string::len($value) < 20;
+DEFINE FIELD name       ON TABLE person             VALUE $this.first_name + ' ' + $this.last_name;
+
+CREATE person SET first_name = "Bob", last_name = "Bobson";
+```

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/define/table.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/define/table.mdx
@@ -225,6 +225,20 @@ CREATE user SET firstName = 'Jamie', lastName = 'Hitchcock', email = 'Jamie.Hitc
 -- 2: Statement will fail because the value for email was not valid.
 ```
 
+### Interaction between fields
+
+While a `DEFINE TABLE` statement represents a template for any subsequent records to be created, a `DEFINE FIELD` statement pertains to concrete field data of a record. As such, access to both the field itself and its parent record are granted inside `DEFINE FIELD` through the `$value` and `$this` parameters, respectively.
+
+```surql
+DEFINE TABLE person SCHEMAFULL;
+
+DEFINE FIELD first_name ON TABLE person TYPE string ASSERT string::len($value) < 20;
+DEFINE FIELD last_name  ON TABLE person TYPE string ASSERT string::len($value) < 20;
+DEFINE FIELD name       ON TABLE person             VALUE $this.first_name + ' ' + $this.last_name;
+
+CREATE person SET first_name = "Bob", last_name = "Bobson";
+```
+
 ### Pre-computed table views
 
 In SurrealDB, like in other databases, you can create views. The way you create views is using the `DEFINE TABLE` statement like you would for any other table, then adding the `AS` clause at the end with your `SELECT` query.

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/define/table.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/define/table.mdx
@@ -236,6 +236,7 @@ DEFINE FIELD first_name ON TABLE person TYPE string ASSERT string::len($value) <
 DEFINE FIELD last_name  ON TABLE person TYPE string ASSERT string::len($value) < 20;
 DEFINE FIELD name       ON TABLE person             VALUE $this.first_name + ' ' + $this.last_name;
 
+// Creates a user with name "Bob Bobson"
 CREATE person SET first_name = "Bob", last_name = "Bobson";
 ```
 

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/define/table.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/define/table.mdx
@@ -236,7 +236,7 @@ DEFINE FIELD first_name ON TABLE person TYPE string ASSERT string::len($value) <
 DEFINE FIELD last_name  ON TABLE person TYPE string ASSERT string::len($value) < 20;
 DEFINE FIELD name       ON TABLE person             VALUE $this.first_name + ' ' + $this.last_name;
 
-// Creates a user with name "Bob Bobson"
+// Creates a `person` with the name "Bob Bobson"
 CREATE person SET first_name = "Bob", last_name = "Bobson";
 ```
 


### PR DESCRIPTION
Slimming down a previous draft PR here https://github.com/surrealdb/docs.surrealdb.com/pull/702 to only add a section on both DEFINE TABLE and DEFINE FIELD to help users understand the interaction between the two.

Interesting behaviours:

* A DEFINE TABLE statement represents a template for a record that doesn't exist yet, which is why ASSERT can't be done here as a user might expect (so no ASSERT type::is::string($this.name) or somesuch)
* The parameter $this refers to a parent record inside a DEFINE FIELD statement. But a new user to databases may get confused by the term record and wonder if this means there is a DEFINE RECORD statement somewhere...on the other hand, experienced users won't like the term "parent table" since a table is a template and not something that holds actual data. So the solution seems to be to make the paragraph for each page a bit didactic (yet still short) to explain the overall structure.

Edit: Also added a note that fields are computed in alphabetical order along with an example showing the behaviour.