### PR TITLE
array::pop() returns a value, not an array

### DIFF
--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/array.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/array.mdx
@@ -764,11 +764,11 @@ RETURN array::min([0, 1, 2]);
 
 ## `array::pop`
 
-The `array::pop` function removes a value from the end of an array and returns it.
+The `array::pop` function removes a value from the end of an array and returns it. If the array is empty, NONE is returned.
 
 
 ```surql title="API DEFINITION"
-array::pop(array) -> array
+array::pop(array) -> value
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:
 


### PR DESCRIPTION
Small fix: array::pop() returns a value, not an array. (Looking at the discussion in Discord it looks like it (maybe) used to return an array until the behaviour was improved)