### PR TITLE
Add example of graph query structure without aliases

### DIFF
--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/relate.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/relate.mdx
@@ -312,7 +312,7 @@ based on all the products Tobie purchased, which person also purchased those pro
 
 ## Structure of queries on relations
 
-Using an alias is a common practice in both regular and relation queries in SurrealDB to make output more readable and collapse nested structures.
+Using an alias is a common practice in both regular and relation queries in SurrealDB to make output more readable and collapse nested structures. You can create an alias using the `AS` clause. 
 
 ```surql
 CREATE cat:one, cat:two, cat:three;
@@ -321,6 +321,7 @@ RELATE cat:one->friends_with->cat:two;
 RELATE cat:two->friends_with->cat:three;
 
 SELECT ->friends_with->cat->friends_with->cat FROM cat:one;
+-- create an alias for the result using the `AS` clause. 
 SELECT ->friends_with->cat->friends_with->cat AS friends_of_friends FROM cat:one;
 ```
 

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/relate.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/relate.mdx
@@ -245,6 +245,7 @@ Using the ONLY keyword, just an object for the relation in question will be retu
 ```surql
 RELATE ONLY person:l19zjikkw1p1h9o6ixrg->wrote->article:8nkk6uj4yprt49z7y3zm;
 ```
+
 ## Basics of querying graphs
 Let's look at how the above gets queried, for more examples see the [SELECT docs](/docs/surrealdb/surrealql/statements/select).
 
@@ -308,6 +309,126 @@ person:tobie
 
 Putting it all together it would be:
 based on all the products Tobie purchased, which person also purchased those products and what did they purchase?
+
+## Structure of queries on relations
+
+Using an alias is a common practice in both regular and relation queries in SurrealDB to make output more readable and collapse nested structures.
+
+```surql
+CREATE cat:one, cat:two, cat:three;
+
+RELATE cat:one->friends_with->cat:two;
+RELATE cat:two->friends_with->cat:three;
+
+SELECT ->friends_with->cat->friends_with->cat FROM cat:one;
+SELECT ->friends_with->cat->friends_with->cat AS friends_of_friends FROM cat:one;
+```
+
+```bash
+// Output without alias
+{
+	"->friends_with": {
+		"->cat": {
+			"->friends_with": {
+				"->cat": [
+					cat:three
+				]
+			}
+		}
+	}
+}
+
+// Output with alias
+{
+	friends_of_friends: [
+		cat:three
+	]
+}
+```
+
+However, an alias might not be preferred in a case where you have multiple graph queries that resolve to the fields of a large nested structure. Take the following data for example:
+
+```surql
+CREATE country:usa SET name = "USA";
+CREATE state:pennsylvania SET population = 12970000;
+CREATE state:michigan SET population = 10030000;
+CREATE city:philadelphia, city:pittsburgh, city:detroit, city:grand_rapids;
+
+RELATE country:usa->contains->[state:pennsylvania, state:michigan];
+RELATE state:pennsylvania->contains->[city:philadelphia, city:pittsburgh];
+RELATE state:michigan->contains->[city:detroit, city:grand_rapids];
+```
+
+A query on the states and cities of these records using aliases would return the data in a structure remade to fit the aliases declared in the query.
+
+```surql
+SELECT 
+    name, 
+    ->contains->state AS states,
+    ->contains->state->contains->city AS cities
+FROM country:usa;
+```
+
+```bash title="Output"
+[
+	{
+		cities: [
+			city:philadelphia,
+			city:pittsburgh,
+			city:grand_rapids,
+			city:detroit
+		],
+		name: 'USA',
+		states: [
+			state:pennsylvania,
+			state:michigan
+		]
+	}
+]
+```
+
+However, opting to not use an alias will return the original graph structure which makes the levels of depth of the query clearer. In addition, the `population` field is clearly the population for the states.
+
+```surql
+SELECT 
+    id,
+    ->contains->state.id,
+    ->contains->state.population,
+    ->contains->state->contains->city.id
+FROM country:usa;
+```
+
+```bash title="Output"
+[
+	{
+		"->contains": {
+			"->state": {
+				"->contains": {
+					"->city": {
+						id: [
+							city:philadelphia,
+							city:pittsburgh,
+							city:grand_rapids,
+							city:detroit
+						]
+					}
+				},
+				id: [
+					state:pennsylvania,
+					state:michigan
+				],
+				population: [
+					12970000,
+					10030000
+				]
+			}
+		},
+		id: country:usa
+	}
+]
+```
+
+As the query that uses aliases does not maintain the original graph structure, adding `population` would require clever renaming such as `->contains->state.population AS state_populations` to make it clear that the numbers represent state and not city populations.
 
 ## Using [`LET`](/docs/surrealdb/surrealql/statements/let) parameters in RELATE statements
 


### PR DESCRIPTION
Adds an example or two of how a graph query that includes multiple fields automatically gets returned in the same structure and might be preferable to using aliases.