### PR TITLE
Remove duplicate sentence from records page

### DIFF
--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/datamodel/records.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/datamodel/records.mdx
@@ -40,7 +40,7 @@ CREATE person:marcus SET name = 'Marcus', friends = [person:tobie];
 
 ## Fetching remote records from within records
 
-Records ids can be stored directly within other records, either as top-level properties, or nested within objects or arrays. Nested field traversal can be used to fetch the properties from the remote records, as if the record was embedded within the record being queried.
+Nested field traversal can be used to fetch the properties from the remote records, as if the record was embedded within the record being queried.
 
 ```surql
 SELECT friends.name FROM person:tobie;


### PR DESCRIPTION
Page [Record links](https://surrealdb.com/docs/surrealdb/surrealql/datamodel/records).

Currently the sentence:
- "_Records ids can be stored directly within other records, either as top-level properties, or nested within objects or arrays._"

is included at the beginning of both sections:
- [Storing record links within records](https://surrealdb.com/docs/surrealdb/surrealql/datamodel/records#storing-record-links-within-records), and 
- [Fetching remote records from within records](https://surrealdb.com/docs/surrealdb/surrealql/datamodel/records#fetching-remote-records-from-within-records)

The first one appears as the correct one, as the example on how to store record links within records is discussed in this section. The one in the other section seems duplicate/redundant. This section can in fact start directly with the explanations on how to fetch the properties of remote records.

Thanks!