### PR TITLE
array::windows() documentation

### DIFF
--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/array.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/array.mdx
@@ -1023,3 +1023,5 @@ RETURN array::union([1,2,1,6], [1,3,4,5,6]);
 ```
 
 <br /><br />
+
+## `array::windows`

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/array.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/array.mdx
@@ -1031,6 +1031,8 @@ RETURN array::union([1,2,1,6], [1,3,4,5,6]);
 
 ## `array::windows`
 
+<Since v="v2.0.0" />
+
 The `array::windows` function returns a number of arrays of length `size` created by moving one index at a time down the original array. The arrays returned are guaranteed to be of length `size`. As a result, the function will return `NONE` if the length of the original array is not large enough to create a single output array.
 
 The following examples show this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/array.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/array.mdx
@@ -410,17 +410,22 @@ RETURN array::concat([1,2,3,4], [3,4,5,6]);
 
 ## `array::clump`
 
-The `array::clump` function returns the original array split into sub-arrays of `size`.
+The `array::clump` function returns the original array split into sub-arrays of `size`. The last sub-array may have a length less than the length of `size` if `size` does not divide equally into the original array.
 
 ```surql title="API DEFINITION"
 array::clump(array, value) -> array
 ```
-The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:
+The following examples show this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:
 
 ```surql
-RETURN array::clump([1, 2, 3, 4, 5], 2);
+LET $array = [1, 2, 3, 4];
+RETURN array::clump($array, 2);
+RETURN array::clump($array, 3);
+```
 
-[ [1, 2], [3, 4], [5] ]
+```bash title="Response"
+[ [ 1, 2], [3, 4] ];
+[ [1, 2, 3], [4] ]
 ```
 
 <br />
@@ -1025,3 +1030,18 @@ RETURN array::union([1,2,1,6], [1,3,4,5,6]);
 <br /><br />
 
 ## `array::windows`
+
+The `array::windows` function returns a number of arrays of length `size` created by moving one index at a time down the original array. The arrays returned are guaranteed to be of length `size`. As a result, the function will return `NONE` if the length of the original array is not large enough to create a single output array.
+
+The following examples show this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:
+
+```surql
+LET $array = [1,2,3,4];
+RETURN array::windows($array, 2);
+RETURN array::windows($array, 5);
+```
+
+```bash title="Response"
+[ [1, 2], [2, 3], [3, 4] ];
+NONE
+```

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/array.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/array.mdx
@@ -4,6 +4,7 @@ sidebar_label: Array functions
 title: Array functions | SurrealQL
 description: These functions can be used when working with, and manipulating arrays of data.
 ---
+import Since from '@site/src/components/Since'
 
 # Array functions
 

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/array.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/array.mdx
@@ -1045,3 +1045,17 @@ RETURN array::windows($array, 5);
 [ [1, 2], [2, 3], [3, 4] ];
 NONE
 ```
+
+An example of the same function used in a `RELATE` statement:
+
+```surql
+CREATE person:grandfather, person:father, person:son;
+
+FOR $pair IN array::windows(["grandfather", "father", "son"], 2) {
+    LET $first = type::thing("person", $pair[0]);
+    LET $second = type::thing("person", $pair[1]);
+    RELATE $first->father_of->$second;
+};
+
+SELECT id, ->father_of->person, ->father_of->father_of->person FROM person;
+```


### PR DESCRIPTION
Adds documentation for the array::windows function, which was added in https://github.com/surrealdb/surrealdb/pull/4445.