### PR TITLE
Auxiliary statements review

### DIFF
--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/sleep.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/sleep.mdx
@@ -7,7 +7,7 @@ description: These functions can be used to introduce a delay or pause in the ex
 
 # Sleep function
 
-These functions can be used to introduce a delay or pause in the execution of a query or a batch of queries for a specific amount of time.
+This function can be used to introduce a delay or pause in the execution of a query or a batch of queries for a specific amount of time.
 
 <table>
   <thead>
@@ -28,8 +28,6 @@ These functions can be used to introduce a delay or pause in the execution of a 
 
 The `sleep` function delays or pauses the execution of a query or a set of statements.
 
-
-
 ```surql title="API DEFINITION"
 sleep(duration) -> none
 ```
@@ -40,7 +38,44 @@ RETURN sleep(1s);
 RETURN sleep(500ms);
 ```
 
-<br />
+SurrealDB also has a [SLEEP statement](/docs/surrealdb/surrealql/statements/sleep) statement that accepts a datetime; however, the `sleep` function can be used in more dynamic ways such as the following example that simulates a 100ms delay between each record in a query.
 
-## See also
-Alternatively you may want to use the [SLEEP statement](/docs/surrealdb/surrealql/statements/sleep).
+```surql
+-- Create 3 `person` records
+CREATE |person:3|;
+
+LET $now = time::now();
+
+SELECT *, 
+  sleep(100ms) AS _, 
+  time::now() - $now AS elapsed
+FROM person;
+```
+
+```bash title="Response"
+[
+	{
+		_: NONE,
+		elapsed: 101ms457µs,
+		id: person:fkgvriz1kl2tcgv6yqfq
+	},
+	{
+		_: NONE,
+		elapsed: 203ms599µs,
+		id: person:lgibwdgtvx4v8ck60guk
+	},
+	{
+		_: NONE,
+		elapsed: 305ms728µs,
+		id: person:pr0uby896y1az2p44wtw
+	}
+]
+```
+
+## Use cases
+
+Putting a database to sleep can be useful in a small number of situations, such as:
+
+* Testing and debugging: can be used to understand how concurrent transactions interact, test how systems handle timeouts and delays, simulate behaviour in more distant regions with longer latency
+* Throttling: can be used to throttle the execution of operations to prevent the database from being overwhelmed by too many requests at once
+* Security measures: can be used to slow down the response rate of login attempts to mitigate the risk of brute force attacks

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/break.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/break.mdx
@@ -2,13 +2,12 @@
 sidebar_position: 3
 sidebar_label: BREAK
 title: BREAK statement | SurrealQL
-description: The BREAK statement can be used to break out of a loop, like within the FOR statement.
+description: The BREAK statement can be used to break out of a loop.
 ---
 
 # `BREAK` statement
 
-The BREAK statement can be used to break out of a loop, like within the [FOR statement](/docs/surrealdb/surrealql/statements/for).
-
+The BREAK statement can be used to break out of a loop, such as inside one created by the [FOR statement](/docs/surrealdb/surrealql/statements/for).
 
 ### Statement syntax
 
@@ -18,24 +17,64 @@ BREAK
 
 ## Example usage
 
-The following query shows example usage of this statement.
+The following queries shows example usage of this statement.
+
+Creating a person for everyone in the array where the number is less than or equal to 5:
 
 ```surql
--- Create a person for everyone in the array where the number is lower than or equal to 5
-LET $num = [1,2,3,4,5,6,7,8,9];
+LET $numbers = [1,2,3,4,5,6,7,8,9];
 
-FOR $thing IN $num {
-    IF $thing > 5 {
+FOR $num IN $numbers {
+    IF $num > 5 {
         BREAK;
  
-    } ELSE IF $thing < 5 {
+    } ELSE IF $num < 5 {
         CREATE type::thing(
-            'person', $thing
+            'person', $num
         ) CONTENT {
-            name: $thing 
+            name: "Person number " + <string>$num 
         };
- 
     };
- 
+};
+```
+
+Breaking out of a loop once unwanted data is encountered:
+
+```surql
+-- Data retrieved from somewhere which contains many NONE values
+LET $weather = [
+	{
+		city: 'London',
+		temperature: 22.2,
+		timestamp: 1722565566389
+	},
+	NONE,
+	{
+		city: 'London',
+		temperature: 20.1,
+		timestamp: 1722652002699
+	},
+    {
+        city: 'Phoenix',
+        temperature: 45.1,
+        timestamp: 1722565642160
+    },
+    NONE,
+    NONE,
+    {
+        city: 'Phoenix',
+        temperature: 45.1,
+        timestamp: 1722652070372
+    },
+];
+
+-- Sort the data to move the NONE values to the end
+-- and break once the first NONE is reached
+FOR $data IN array::sort::desc($weather) {
+    IF $data IS NONE {
+        BREAK;
+    } ELSE {
+        CREATE weather CONTENT $data;
+    };
 };
 ```

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/continue.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/continue.mdx
@@ -17,7 +17,9 @@ CONTINUE
 
 ## Example usage
 
-The following query shows example usage of this statement.
+The following queries shows example usage of this statement.
+
+Skipping an iteration of a loop unless a certain condition is met:
 
 ```surql
 -- Set can_vote to true for every person over 18 years old.
@@ -27,5 +29,44 @@ FOR $person IN (SELECT id, age FROM person) {
 	};
 
 	UPDATE $person.id SET can_vote = true;
+};
+```
+
+Skipping an iteration of a loop when bad data is encountered:
+
+```surql
+-- Data retrieved from somewhere which contains many NONE values
+LET $weather = [
+	{
+		city: 'London',
+		temperature: 22.2,
+		timestamp: 1722565566389
+	},
+	NONE,
+	{
+		city: 'London',
+		temperature: 20.1,
+		timestamp: 1722652002699
+	},
+    {
+        city: 'Phoenix',
+        temperature: 45.1,
+        timestamp: 1722565642160
+    },
+    NONE,
+    NONE,
+    {
+        city: 'Phoenix',
+        temperature: 45.1,
+        timestamp: 1722652070372
+    },
+];
+
+FOR $data IN $weather {
+    IF $data IS NONE {
+        CONTINUE;
+    };
+    
+	CREATE weather CONTENT $data;
 };
 ```

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/for.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/for.mdx
@@ -15,7 +15,7 @@ ___NOTE:___ A `FOR` loop currently cannot access items outside its own scope, su
 
 ```surql title="SurrealQL Syntax"
 FOR @item IN @iterable {
-
+@block
 };
 ```
 

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/for.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/for.mdx
@@ -2,15 +2,21 @@
 sidebar_position: 9
 sidebar_label: FOR
 title: FOR statement | SurrealQL
-description: The FOR statement can be used to iterate over the values of an array, and to perform certain actions with those values.
+description: The FOR statement creates a loop that iterates over the values of an array.
 ---
 
 # `FOR` statement
 
 The `FOR` statement can be used to iterate over the values of an array, and to perform certain actions with those values.
 
+:::note
+___NOTE:___ A `FOR` loop currently cannot access items outside its own scope, such as variables declared before the loop.
+:::
+
 ```surql title="SurrealQL Syntax"
-FOR @item IN @iterable @block
+FOR @item IN @iterable {
+
+};
 ```
 
 ## Example usage

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/ifelse.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/ifelse.mdx
@@ -47,6 +47,22 @@ IF 9 = 9 THEN RETURN "Nine is indeed nine" END;
 IF 9 = 9 { RETURN 'Nine is indeed nine' };
 ```
 
+As the last line of a scope is its return value, the `RETURN` keyword can also be placed before the entire `IF THEN` statement. This is particularly convenient in long `IF ELSE` chains to avoid using the `RETURN` keyword at the end of every check for a condition.
+
+```surql
+LET $num = 100;
+
+RETURN IF $num < 0 {
+    "Negative"
+} ELSE IF $num = 0 {
+    "Zero"
+} ELSE IF $num = 13 {
+    "Thirteen"
+} ELSE {
+    "Positive uninteresting number"
+};
+````
+
 The `THROW` keyword inside `{}` braces can be used to break out of an `IF LET` statement early.
 
 ```surql

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/let.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/let.mdx
@@ -7,7 +7,7 @@ description: The LET statement sets and stores a value which can then be used in
 
 # `LET` statement
 
-A parameter can store any value, including the result of a query.
+A `LET` statement creates a parameter that can store any value, including the result of a query.
 
 ### Statement syntax
 
@@ -33,4 +33,47 @@ The following query shows the `LET` statement being used to store the result of 
 LET $adults = (SELECT * FROM person WHERE age > 18);
 -- Use the parameter
 UPDATE $adults SET adult = true;
+```
+
+`LET` can also set variables determined by the output of an `IF ELSE` statement.
+
+```surql
+LET $num = 10;
+
+LET $num_type = 
+         IF type::is::int($num)     { "integer" }
+    ELSE IF type::is::decimal($num) { "decimal" }
+    ELSE IF type::is::float($num)   { "float"   };
+```
+
+SurrealDB uses [pre-defined parameters](/docs/surrealdb/surrealql/parameters) in its statements. Any parameters created with `LET` will be unaccessible during such statements.
+
+```surql
+LET $before = "Before!";
+
+-- Returns ["Before!"];
+RETURN $before;
+
+-- Returns the `person` records before deletion
+DELETE person RETURN $before;
+
+-- Returns "Before!" again
+RETURN $before;
+```
+
+Some pre-defined parameters are accessible in any and all contexts, and thus cannot be used.
+
+```surql
+LET $auth = 1;
+LET $session = 10;
+```
+
+```bash title="Output"
+-------- Query 1 (0ns) --------
+
+"'auth' is a protected variable and cannot be set"
+
+-------- Query 2 (0ns) --------
+
+"'session' is a protected variable and cannot be set"
 ```

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/return.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/return.mdx
@@ -2,14 +2,14 @@
 sidebar_position: 19
 sidebar_label: RETURN
 title: RETURN statement | SurrealQL
-description: The RETURN statement can be used to return a value or the result of a query, and to set the return value for a transaction, block or function.
+description: The RETURN statement can be used to return an implicit value or the result of a query, and to set the return value for a transaction, block or function.
 ---
 
 import Since from '@site/src/components/Since'
 
 # `RETURN` statement
 
-The `RETURN` statement can be used to return a value or the result of a query, and to set the return value for a transaction or function.
+The `RETURN` statement can be used to return an implicit value or the result of a query, and to set the return value for a transaction, block, or function.
 
 ### Statement syntax
 
@@ -20,7 +20,7 @@ RETURN @value
 ## Example usage
 ### Basic usage
 
-The `RETURN` statement can return anything from simple values to the result of queries.
+`RETURN` is always followed by a value. As every data type in SurrealDB is a type of [value](/docs/surrealdb/surrealql/datamodel/values), the `RETURN` statement can return anything from simple values to the result of queries.
 
 ```surql
 -- Return a simple value
@@ -33,6 +33,18 @@ RETURN {
 -- Return the result of a query
 RETURN SELECT * FROM person;
 RETURN (CREATE person).id;
+```
+
+Values on their own are treated as if they have an implicit `RETURN` in front. As such, the following queries return the same output as in the previous example.
+
+```surql
+123;
+"I am a string!";
+{
+	prop: "value"
+};
+SELECT * FROM person;
+(CREATE person).id;
 ```
 
 ## Transaction return value
@@ -49,7 +61,7 @@ LET $lastname = "Doe";
 LET $person = CREATE person CONTENT {
 	firstname: $firstname,
 	lastname: $lastname,
-}
+};
 
 -- But because we end with a RETURN query, only the person's ID will be returned
 -- The results of the other queries will be omitted.
@@ -61,21 +73,27 @@ RETURN $person.id;
 COMMIT TRANSACTION;
 ```
 
+## Return breaks execution
+<Since v="v2.0.0" />
+Opposite to `RETURN` in SurrealDB `1.x`, `RETURN` now breaks execution of statements, functions and transactions.
+
 ```surql title="Function return value"
 DEFINE FUNCTION fn::person::create($firstname: string, $lastname: string) {
 	LET $person = CREATE person CONTENT {
 		firstname: $firstname,
 		lastname: $lastname,
-	}
+	};
 
 	-- The RETURN statement will set the return value of the custom function, and further queries will not be executed.
 	RETURN $person.id;
-};
-```
 
-## Return breaks execution
-<Since v="v2.0.0" />
-Opposite to `RETURN` in SurrealDB `1.x`, `RETURN` now breaks execution of statements, functions and transactions.
+    -- This query will never be executed
+    CREATE person SET firstname = "Stephen", lastname = "Strange";
+};
+
+fn::person::create("Thanos", "Johnson");
+SELECT * FROM person;
+```
 
 ```surql title="Functions"
 DEFINE FUNCTION fn::round::up($num: number) {
@@ -97,6 +115,7 @@ COMMIT;
 ```
 
 Lastly, if not executed inside a transaction or function, `RETURN` will break execution until the most top-level statement it is executed in. RETURN will **not** prevent top level statements from being executed, nor will it adjust their output.
+
 ```surql title="Statements"
 LET $id = 123;
 LET $id = {

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/sleep.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/sleep.mdx
@@ -26,7 +26,7 @@ SLEEP 1s;
 SLEEP 100ms;
 ```
 
-For more dynamic usage of sleep, see SurrealDB's [sleep](docs/surrealdb/surrealql/functions/database/sleep) function.
+For more dynamic usage of sleep, see SurrealDB's [sleep](/docs/surrealdb/surrealql/functions/database/sleep) function.
 
 ## Use cases
 

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/sleep.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/sleep.mdx
@@ -26,7 +26,7 @@ SLEEP 1s;
 SLEEP 100ms;
 ```
 
-For more dynamic usage of sleep, see SurrealDB's `sleep`(docs/surrealdb/surrealql/functions/database/sleep) function.
+For more dynamic usage of sleep, see SurrealDB's [sleep](docs/surrealdb/surrealql/functions/database/sleep) function.
 
 ## Use cases
 

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/sleep.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/sleep.mdx
@@ -26,6 +26,8 @@ SLEEP 1s;
 SLEEP 100ms;
 ```
 
+For more dynamic usage of sleep, see SurrealDB's `sleep`(docs/surrealdb/surrealql/functions/database/sleep) function.
+
 ## Use cases
 
 `SLEEP` can be useful in a small number of situations, such as:

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/throw.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/throw.mdx
@@ -2,12 +2,12 @@
 sidebar_position: 23
 sidebar_label: THROW
 title: THROW statement | SurrealQL
-description: The THROW statement can be used to throw an error in a place where something unexpected is happening
+description: The THROW statement can be used to stop execution of a query and return information on the underlying problem
 ---
 
 # `THROW` statement
 
-The `THROW` statement can be used to throw an error in a place where something unexpected is happening. Execution of the query will be aborted and the error will be returned to the client. Any value can be used as an error.
+The `THROW` statement can be used to throw an error in a place where something unexpected is happening. Execution of the query will be aborted and the error will be returned to the client. While a string is most commonly seen after a `THROW` statement, any [value](/docs/surrealdb/surrealql/datamodel/values) at all can be used as error output.
 
 ### Statement syntax
 


### PR DESCRIPTION
PR to review and improve statements for the ones I can only think of the word 'auxiliary' to describe them: they function in the context of a query but don't make queries themselves: BREAK, CONTINUE, FOR, IF ELSE, LET, RETURN, SLEEP, THROW.

Mostly these sorts of changes:

* More examples
* Try to avoid duplicate content in the header + intro
* Some rephrasing
* More links between pages
* Also added an example to the sleep function which can be used in a more dynamic way than the SLEEP statement.

Also note the syntax change in FOR, might be a better way to do it