### PR TITLE
📝 Update invalid fields in Surrealist demo

### DIFF
--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/demo.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/demo.mdx
@@ -50,7 +50,7 @@ surreal start --user root --pass root --allow-all
 
 Lastly, use the [import command](/docs/surrealdb/cli/import) to add the dataset.
 
-Use the command below to import the [surreal deal store dataset](https://datasets.surrealdb.com/surreal-deal-store.surql): 
+Use the command below to import the [surreal deal store dataset](https://datasets.surrealdb.com/surreal-deal-store.surql):
 
 ```bash
 surreal import --conn http://localhost:8000 --user root --pass root --ns test --db test surreal-deal-store.surql
@@ -103,7 +103,7 @@ __Note__: The query results below have been limited to 4 rows for brevity. If yo
 :::
 
 
-<SurrealistMini url='https://dev.surrealist.app/mini?query=--+Query+1%3A+Using+record+links+to+select+from+the+seller+table+%0ASELECT%0A++name%2C%0A++seller.name%0AFROM+product+LIMIT+4%3B%0A%0A%0A--+Query+2%3A+Using+graph+relations+to+select+from+the+person+and+product+table%0ASELECT%0A++++order_date%2C%0A++++product_name%2C%0A++++%3C-person.name+as+person_name%2C%0A++++-%3Eproduct.description%0AFROM+order+LIMIT+4%3B%0A%0A%0A--+Query+3%3A+Conditional+filtering+based+on+an+embedded+object+property.%0ASELECT+%0A++name%2C%0A++email+%0AFROM+person+%0AWHERE+address.country+%3F%3D+%22England%22+LIMIT+4%3B%09%0A%0A%0A--+Query+4%3A+Conditional+filtering+using+record+links.%0ASELECT+*+FROM+review%0AWHERE+-%3Eproduct.sub_category+%3F%3D+%22Activewear%22+LIMIT+4%3B%0A%0A%0A--+Query+5%3A+Count+orders+based+on+order+status%0ASELECT+count%28%29+FROM+order%0AWHERE+order_status+IN+%5B+%22processed%22%2C+%22shipped%22%5D%0AGROUP+ALL+LIMIT+4%3B%0A%0A%0A--+Query+6%3A+Get+a+deduplicated+list+of+products+that+were+ordered%0ASELECT+%0A++++array%3A%3Adistinct%28product_name%29+as+ordered_products%0AFROM+order%0AGROUP+ALL+LIMIT+4%3B%0A%0A%0A--+Query+7%3A+Get+the+average+price+per+product+category%0ASELECT+%0A++++-%3Eproduct.category+AS+product_category%2C%0A++++math%3A%3Amean%28price%29+AS+avg_price%0AFROM+order%0AGROUP+BY+product_category%0AORDER+BY+avg_price+DESC+LIMIT+4%3B%0A%0A%0A--+Query+8%3A+encapsulating+logic+in+a+function%0ARETURN+fn%3A%3Anumber_of_unfulfilled_orders%28%29%3B%0A%0A%0A--+Query+9%3A+using+a+custom+fuction+for+currency+conversion%0ASELECT+%0A++++product_name%2C%0A++++fn%3A%3Apound_to_usd%28price%29+AS+price_usd%0AFROM+order+LIMIT+4%3B&dataset=surreal-deal-store&orientation=horizontal'/>
+<SurrealistMini url='https://dev.surrealist.app/mini?query=--+Query+1%3A+Using+record+links+to+select+from+the+seller+table+%0ASELECT%0A++name%2C%0A++seller.name%0AFROM+product+LIMIT+4%3B%0A%0A%0A--+Query+2%3A+Using+graph+relations+to+select+from+the+person+and+product+table%0ASELECT%0A++++time.created_at as order_date%2C%0A++++product_name%2C%0A++++%3C-person.name+as+person_name%2C%0A++++-%3Eproduct.details%0AFROM+order+LIMIT+4%3B%0A%0A%0A--+Query+3%3A+Conditional+filtering+based+on+an+embedded+object+property.%0ASELECT+%0A++name%2C%0A++email+%0AFROM+person+%0AWHERE+address.country+%3F%3D+%22England%22+LIMIT+4%3B%09%0A%0A%0A--+Query+4%3A+Conditional+filtering+using+record+links.%0ASELECT+*+FROM+review%0AWHERE+-%3Eproduct.sub_category+%3F%3D+%22Activewear%22+LIMIT+4%3B%0A%0A%0A--+Query+5%3A+Count+orders+based+on+order+status%0ASELECT+count%28%29+FROM+order%0AWHERE+order_status+IN+%5B+%22processed%22%2C+%22shipped%22%5D%0AGROUP+ALL+LIMIT+4%3B%0A%0A%0A--+Query+6%3A+Get+a+deduplicated+list+of+products+that+were+ordered%0ASELECT+%0A++++array%3A%3Adistinct%28product_name%29+as+ordered_products%0AFROM+order%0AGROUP+ALL+LIMIT+4%3B%0A%0A%0A--+Query+7%3A+Get+the+average+price+per+product+category%0ASELECT+%0A++++-%3Eproduct.category+AS+product_category%2C%0A++++math%3A%3Amean%28price%29+AS+avg_price%0AFROM+order%0AGROUP+BY+product_category%0AORDER+BY+avg_price+DESC+LIMIT+4%3B%0A%0A%0A--+Query+8%3A+encapsulating+logic+in+a+function%0ARETURN+fn%3A%3Anumber_of_unfulfilled_orders%28%29%3B%0A%0A%0A--+Query+9%3A+using+a+custom+fuction+for+currency+conversion%0ASELECT+%0A++++product_name%2C%0A++++fn%3A%3Apound_to_usd%28price%29+AS+price_usd%0AFROM+order+LIMIT+4%3B&dataset=surreal-deal-store&orientation=horizontal'/>
 
 
 ## Surreal Deal - deals so good it's surreal!
@@ -143,7 +143,7 @@ surreal start --user root --pass root --allow-all
 
 Lastly, use the [import command](/docs/surrealdb/cli/import) to add the dataset.
 
-Use the command below to import the [surreal deal dataset](https://datasets.surrealdb.com/surreal-deal-store.surql): 
+Use the command below to import the [surreal deal dataset](https://datasets.surrealdb.com/surreal-deal-store.surql):
 
 ```bash
 surreal import --conn http://localhost:8000 --user root --pass root --ns test --db test surreal-deal-store.surql


### PR DESCRIPTION
It seems like the fields of the `order` table in the [Surreal Deal Store demo](https://surrealdb.com/docs/surrealdb/surrealql/demo) have changed compared to the "mini" counterpart.

Running the query as is on the demo led to some empty fields (see screenshot below):
![image](https://github.com/user-attachments/assets/c4df5b29-fac6-42f3-96a2-ead9234fc622)

I cross-referenced the actual field names via the Surrealist Explorer (beautiful feature btw — is there a way to show this as a tab in the Query page?), and updated the field names:
![image](https://github.com/user-attachments/assets/eeec26ee-88f1-4ade-bfd4-fe8183ed9260)

Here's a PR with the updated query.