### PR TITLE
docs(random): add doc for `rand::guid` with 2 args

### DIFF
--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/rand.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/rand.mdx
@@ -172,9 +172,7 @@ RETURN rand::float(10, 15);
 
 ## `rand::guid`
 
-The `rand::guid` function generates a 20-character random guid.
-
-
+The `rand::guid` function generates a 20-characters random guid.
 
 ```surql title="API DEFINITION"
 rand::guid() -> string
@@ -185,17 +183,28 @@ If a number is provided, then the function generates a random guid, with a speci
 rand::guid(number) -> string
 ```
 
+If a second number is provided, then the function will generate a random guid, with a length between the two numbers.
+
+```surql title="API DEFINITION"
+rand::guid(min, max) -> string
+```
+
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:
 
-```surql
+```surql title="A 20-chars random guid"
 RETURN rand::guid();
 
 "4uqmrmtjhtjeg77et0dl"
 ```
-```surql
+```surql title="A 10-chars random guid"
 RETURN rand::guid(10);
 
 "f3b6cjh0nt"
+```
+```surql title="A random guid with a length between 5 and 15 chars"
+RETURN rand::guid(5, 15);
+
+"894bqt4lp"
 ```
 
 <br />
@@ -488,3 +497,4 @@ SELECT VALUE num FROM test:[rand::ulid($rec.created - 100ms)]..;
 
 
 <br /><br />
+


### PR DESCRIPTION
From the code here: https://github.com/surrealdb/surrealdb/blob/3f5ef432481f4506feb5dc818281fce6c0f1e400/core/src/fnc/rand.rs#L45