### PR TITLE
Update select.mdx

### DIFF
--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/select.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/select.mdx
@@ -21,7 +21,7 @@ SELECT [ VALUE ] @fields [ AS @alias ]
 	FROM [ ONLY ] @targets
 	[ WITH [ NOINDEX | INDEX @indexes ... ]]
 	[ WHERE @conditions ]
-	[ SPLIT [ AT ] @field ... ]
+	[ SPLIT [ ON ] @field ... ]
 	[ GROUP [ BY ] @fields ... ]
 	[ ORDER [ BY ]
 		@fields [


### PR DESCRIPTION
corrected split key word in the select statement.

AT is an invalid keyword to follow the split keyword the  correct keyword is ON.
AT will cause the query statement to be invalid.