### PR TITLE
Typo in login credentials in memory server docs

### DIFF
--- a/doc-surrealdb_versioned_docs/version-latest/installation/running/memory.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/installation/running/memory.mdx
@@ -22,13 +22,13 @@ surreal start --log trace memory
 In order to keep SurrealDB secure, configure your initial root-level user by setting the *`--user`* and *`--pass`* command-line arguments. The following command starts the database with a top-level user named `root` with a password also set to `root`.
 
 ```bash
-surreal start --log trace memory
+surreal start --log trace --user root --pass root memory
 ```
 
 The previous command will bootstrap the server with the provided initial credentials, you can now remove those args and rely on [DEFINE USER](/docs/surrealdb/surrealql/statements/define/user) to change the password or create more users.
 
 ```bash
-surreal start --log trace memory
+surreal start --log trace --user username --pass 123456 memory
 ```
 In order to change the default port that SurrealDB uses for web connections and from database clients you can use the *`--bind`* argument. The following command starts the database on port `8080`.
 


### PR DESCRIPTION
Fixed a typo in the login credentials of  the `Run a single-node, in-memory server` docs.