### PR TITLE
Add info on default permissions

### DIFF
--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/define/field.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/define/field.mdx
@@ -219,8 +219,26 @@ The `OVERWRITE` clause can be used to create a field and overwrite an existing o
 DEFINE FIELD OVERWRITE example ON TABLE user TYPE string;
 ```
 
-
 ### Setting permissions on fields
+
+By default, the permissions on a field will be set to FULL unless otherwise specified.
+
+```surql
+DEFINE FIELD info ON TABLE some_table TYPE string;
+INFO FOR TABLE some_table;
+```
+
+```bash title="Response"
+{
+	events: {},
+	fields: {
+		info: 'DEFINE FIELD info ON some_table TYPE string PERMISSIONS FULL'
+	},
+	indexes: {},
+	lives: {},
+	tables: {}
+}
+```
 
 You can set permissions on fields to control who can perform operations on them using the `PERMISSIONS` clause. The `PERMISSIONS` clause can be used to set permissions for `SELECT`, `CREATE`, `UPDATE`, and `DELETE` operations.
 

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/define/field.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/define/field.mdx
@@ -251,8 +251,6 @@ DEFINE FIELD email ON TABLE user
     FOR delete WHERE user=$auth.id OR $auth.role="admin";
 ```
 
-The `PERMISSIONS` clause can also be used to set permissions for all operations using the `FULL` keyword.
-
 ## Array with allowed values
 By using an Access Control List as an example we can show how we can restrict what values can be stored in an array. In this example we are using an array to store the permissions for a user on a resource. The permissions are restricted to a specific set of values.
 

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/define/table.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/define/table.mdx
@@ -287,6 +287,31 @@ As mentioned though, there are a few limitations to keep in mind.
 
 ### Defining permissions
 
+By default, the permissions on a table will be set to NONE unless otherwise specified.
+
+```surql
+CREATE some_table;
+DEFINE TABLE some_other_table;
+
+INFO FOR DB;
+```
+
+```bash title="Response"
+{
+	analyzers: {},
+	functions: {},
+	models: {},
+	params: {},
+	scopes: {},
+	tables: {
+		some_other_table: 'DEFINE TABLE some_other_table TYPE ANY SCHEMALESS PERMISSIONS NONE',
+		some_table: 'DEFINE TABLE some_table TYPE ANY SCHEMALESS PERMISSIONS NONE'
+	},
+	tokens: {},
+	users: {}
+}
+```
+
 The following shows how to set table level `PERMISSIONS` using the `DEFINE TABLE` statement. This allows you to set independent permissions for selecting, creating, updating, and deleting data.
 
 ```surql


### PR DESCRIPTION
Adds a quick note that the default permissions for table are NONE, but for field they are FULL.

Thanks @Xkonti for noticing!