### PR TITLE
Add examples of bilateral (equal?) relation querying

### DIFF
--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/relate.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/relate.mdx
@@ -321,6 +321,99 @@ For example, suppose we want to limit the query to only take recent purchases in
 SELECT ->purchased->product<-purchased<-person->(purchased WHERE created_at > time::now() - 3w)->product FROM person:tobie;
 ```
 
+## Bidirectional relation querying
+
+Sometimes a relation is such that it is impossible to determine which record is located at the `in` part of a graph table, and which is located at the `out` part. This is the case when a relationship is truly bidirectional and equal, such as a friendship, marriage, or sister cities:
+
+```surql
+CREATE city:calgary, city:daejeon;
+RELATE city:calgary->sister_of->city:daejeon;
+
+SELECT id, ->sister_of->city AS sister_cities FROM city;
+```
+
+In such a case, a query on the relationship makes it appear as if one city has a twin city but the other does not.
+
+```bash
+[
+	{
+		id: city:calgary,
+		sister_cities: [
+			city:daejeon
+		]
+	},
+	{
+		id: city:daejeon,
+		sister_cities: []
+	}
+]
+```
+
+To solve this, we can use the `<->` operator instead of `->`. Using `<->` will access both the `in` and `out` fields, instead of just one.
+
+```surql
+SELECT id, <->sister_of<->city AS sister_cities FROM city;
+```
+
+This brings up another issue in which a city now appears to be a sister city of itself.
+
+```bash
+[
+	{
+		id: city:calgary,
+		sister_cities: [
+			city:calgary,
+			city:daejeon
+		]
+	},
+	{
+		id: city:daejeon,
+		sister_cities: [
+			city:calgary,
+			city:daejeon
+		]
+	}
+]
+```
+
+Here we can use the `array::complement` function to return only items from one array that are not present in another array.
+
+```surql
+SELECT id, array::complement(<->sister_of<->city, [id]) AS sister_cities FROM city;
+```
+
+```bash title="Response"
+[
+	{
+		id: city:calgary,
+		sister_cities: [
+			city:daejeon
+		]
+	},
+	{
+		id: city:daejeon,
+		sister_cities: [
+			city:calgary
+		]
+	}
+]
+```
+
+When using `RELATE` for this sort of relationship, you may want to define a unique key based on the ordered record IDs involved.
+
+```surql
+DEFINE FIELD key ON TABLE sister_of VALUE <string>array::sort([$this.in, $this.out]);
+DEFINE INDEX only_one_sister_city ON TABLE sister_of FIELDS key UNIQUE;
+```
+
+With the index in place, a relation set from one record to the other now cannot be created a second time.
+
+```surql
+RELATE city:calgary->sister_of->city:daejeon; -- OK
+RELATE city:daejeon->sister_of->city:calgary;
+-- "Database index `only_one_sister_city` already contains '[city:calgary, city:daejeon]', with record `sister_of:npab0uoxogmrvpwsvfoa`"
+```
+
 ## Structure of queries on relations
 
 Using an alias is a common practice in both regular and relation queries in SurrealDB to make output more readable and collapse nested structures. You can create an alias using the `AS` clause. 

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/relate.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/relate.mdx
@@ -376,7 +376,7 @@ This brings up another issue in which a city now appears to be a sister city of 
 ]
 ```
 
-Here we can use the `array::complement` function to return only items from one array that are not present in another array.
+Here we can use the [`array::complement`](/docs/surrealdb/surrealql/functions/database/array#arraycomplement) function to return only items from one array that are not present in another array.
 
 ```surql
 SELECT id, array::complement(<->sister_of<->city, [id]) AS sister_cities FROM city;


### PR DESCRIPTION
This PR adds examples of the `<->` operator to query, which at the moment isn't in the documentation.

Also includes some advice on using an index to ensure that these relations can't be doubled by relating from one record to a second one, and then from the second one back to the first one again.

I wonder if bilateral is the right word here? The subject is a relation that exists between two equals, and thus could have been set as much from the first record as from the second.