### PR TITLE
Add some explanation for positional argument in surreal start command

### DIFF
--- a/doc-surrealdb_versioned_docs/version-latest/cli/start.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/cli/start.mdx
@@ -101,11 +101,11 @@ __BEFORE YOU START :__ Make sure you’ve [installed SurrealDB](/docs/surrealdb/
                 
                 Examples: `surrealkv://mydb` or `rocksdb:database`.
                 <ul>
-                    <li><code>rocksdb</code> for RocksDB</li>
+                    <li><code>rocksdb://</code> for RocksDB</li>
                     <li><code>fdb</code> for FoundationDB</li>
                     <li><code>indxdb</code> for IndxDB</li>
                     <li><code>memory</code> (or no argument) for in-memory storage</li>
-                    <li><code>surrealkv</code> for SurrealKV</li>
+                    <li><code>surrealkv://</code> for SurrealKV</li>
                     <li><code>tikv</code> for TiKV</li>
                 </ul>
             </td>

--- a/doc-surrealdb_versioned_docs/version-latest/cli/start.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/cli/start.mdx
@@ -97,7 +97,9 @@ __BEFORE YOU START :__ Make sure you’ve [installed SurrealDB](/docs/surrealdb/
                 <l className='grey'>OPTIONAL</l>
             </td>
             <td>
-                Sets the the database path used for storing data. If no argument is given, the default `memory` argument for non-persistent storage in memory is assumed. Arguments for persistent backends are a combination of the backend name, a `:` or `://`, and the address or filename. Examples: `surrealkv://mydatabase.db` or `rocksdb://myrocksdatabase.db`.
+                Sets the the path for storing data. If no argument is given, the default of `memory` for non-persistent storage in memory is assumed. Arguments for persistent backends are a combination of the backend name, a `:` or `://`, and an address or filename.
+                
+                Examples: `surrealkv://mydatabase.db` or `rocksdb://database.db`.
                 <ul>
                     <li><code>file</code> or <code>rocksdb</code> for RocksDB</li>
                     <li><code>fdb</code> for FoundationDB</li>

--- a/doc-surrealdb_versioned_docs/version-latest/cli/start.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/cli/start.mdx
@@ -97,13 +97,14 @@ __BEFORE YOU START :__ Make sure you’ve [installed SurrealDB](/docs/surrealdb/
                 <l className='grey'>OPTIONAL</l>
             </td>
             <td>
-                Sets the the database path used for storing data, can be one of:
+                Sets the the database path used for storing data. If no argument is given, the default `memory` argument for non-persistent storage in memory is assumed. Arguments for persistent backends are a combination of the backend name, a `:` or `://`, and the address or filename. Examples: `surrealkv://mydatabase.db` or `rocksdb://myrocksdatabase.db`.
                 <ul>
-                    <li><code>memory</code></li>
-                    <li><code>file:&lt;path&gt;</code></li>
-                    <li><code>tikv:&lt;addr&gt;</code></li>
-                    <li><code>file://&lt;path&gt;</code></li>
-                    <li><code>tikv://&lt;addr&gt;</code></li>
+                    <li><code>file</code> or <code>rocksdb</code> for RocksDB</li>
+                    <li><code>fdb</code> for FoundationDB</li>
+                    <li><code>indxdb</code> for IndxDB</li>
+                    <li><code>memory</code> (or no argument) for in-memory storage</li>
+                    <li><code>surrealkv</code> for SurrealKV</li>
+                    <li><code>tikv</code> for TiKV</li>
                 </ul>
             </td>
         </tr>

--- a/doc-surrealdb_versioned_docs/version-latest/cli/start.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/cli/start.mdx
@@ -101,7 +101,7 @@ __BEFORE YOU START :__ Make sure you’ve [installed SurrealDB](/docs/surrealdb/
                 
                 Examples: `surrealkv://mydb` or `rocksdb:database`.
                 <ul>
-                    <li><code>file</code> or <code>rocksdb</code> for RocksDB</li>
+                    <li><code>rocksdb</code> for RocksDB</li>
                     <li><code>fdb</code> for FoundationDB</li>
                     <li><code>indxdb</code> for IndxDB</li>
                     <li><code>memory</code> (or no argument) for in-memory storage</li>

--- a/doc-surrealdb_versioned_docs/version-latest/cli/start.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/cli/start.mdx
@@ -101,11 +101,11 @@ __BEFORE YOU START :__ Make sure you’ve [installed SurrealDB](/docs/surrealdb/
                 
                 Examples: `surrealkv://mydb` or `rocksdb:database`.
                 <ul>
-                    <li><code>rocksdb://</code> for RocksDB</li>
+                    <li><code>rocksdb</code> for RocksDB</li>
                     <li><code>fdb</code> for FoundationDB</li>
                     <li><code>indxdb</code> for IndxDB</li>
                     <li><code>memory</code> (or no argument) for in-memory storage</li>
-                    <li><code>surrealkv://</code> for SurrealKV</li>
+                    <li><code>surrealkv</code> for SurrealKV</li>
                     <li><code>tikv</code> for TiKV</li>
                 </ul>
             </td>

--- a/doc-surrealdb_versioned_docs/version-latest/cli/start.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/cli/start.mdx
@@ -99,7 +99,7 @@ __BEFORE YOU START :__ Make sure you’ve [installed SurrealDB](/docs/surrealdb/
             <td>
                 Sets the the path for storing data. If no argument is given, the default of `memory` for non-persistent storage in memory is assumed. Arguments for persistent backends are a combination of the backend name, a `:` or `://`, and an address or filename.
                 
-                Examples: `surrealkv://mydatabase.db` or `rocksdb://database.db`.
+                Examples: `surrealkv://mydb` or `rocksdb:database`.
                 <ul>
                     <li><code>file</code> or <code>rocksdb</code> for RocksDB</li>
                     <li><code>fdb</code> for FoundationDB</li>


### PR DESCRIPTION
Adds the SurrealKV backend (plus rocksdb) as well as an explanation of how to form the argument for the backend.

As an aside, what's the best way to make the part of the table with the new explanation a little prettier?