### PR TITLE
Add page on env vars

### DIFF
--- a/doc-surrealdb_versioned_docs/version-latest/installation/running/env_vars.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/installation/running/env_vars.mdx
@@ -21,79 +21,79 @@ Environment variables can be used to tailor the behaviour of a running SurrealDB
   </thead>
   <tbody>
     <tr>
-      <td scope="row" data-label="Env var"><code>SURREAL_BUILD_METADATA</code></a></td>
+      <td scope="row" data-label="Env var"><code>SURREAL_BUILD_METADATA</code></td>
       <td scope="row" data-label="Default">false</td>
       <td scope="row" data-label="Notes">The version identifier of this build. Defaults to the CARGO_PKG_VERSION environment variable if not specified.</td>
     </tr>
     <tr>
-      <td scope="row" data-label="Env var"><code>SURREAL_EXPERIMENTAL_BEARER_ACCESS</code></a></td>
+      <td scope="row" data-label="Env var"><code>SURREAL_EXPERIMENTAL_BEARER_ACCESS</code></td>
       <td scope="row" data-label="Default">false</td>
       <td scope="row" data-label="Notes">Enable experimental bearer access and stateful access grant management. Still under active development. Using this experimental feature may introduce risks related to breaking changes and security issues.</td>
     </tr>
     <tr>
-      <td scope="row" data-label="Env var"><code>SURREAL_EXPORT_BATCH_SIZE</code></a></td>
+      <td scope="row" data-label="Env var"><code>SURREAL_EXPORT_BATCH_SIZE</code></td>
       <td scope="row" data-label="Default">1000</td>
       <td scope="row" data-label="Notes">The maximum number of keys that should be scanned at once for export queries.</td>
     </tr>
     <tr>
     <tr>
-      <td scope="row" data-label="Env var"><code>SURREAL_EXTERNAL_SORTING_BUFFER_LIMIT</code></a></td>
+      <td scope="row" data-label="Env var"><code>SURREAL_EXTERNAL_SORTING_BUFFER_LIMIT</code></td>
       <td scope="row" data-label="Default">50000</td>
       <td scope="row" data-label="Notes">Specifies the buffer limit for external sorting.</td>
     </tr>
     <tr>
-      <td scope="row" data-label="Env var"><code>SURREAL_FUNCTION_ALLOCATION_LIMIT</code></a></td>
+      <td scope="row" data-label="Env var"><code>SURREAL_FUNCTION_ALLOCATION_LIMIT</code></td>
       <td scope="row" data-label="Default">20</td>
       <td scope="row" data-label="Notes">Used to limit allocation for builtin functions.</td>
     </tr>
     <tr>
-      <td scope="row" data-label="Env var"><code> SURREAL_INSECURE_FORWARD_ACCESS_ERRORS </code></a></td>
+      <td scope="row" data-label="Env var"><code> SURREAL_INSECURE_FORWARD_ACCESS_ERRORS </code></td>
       <td scope="row" data-label="Default">false</td>
       <td scope="row" data-label="Notes">Forward all signup/signin/authenticate query errors to a client performing authentication. Do not use in production.</td>
     </tr>
     <tr>
-      <td scope="row" data-label="Env var"><code>SURREAL_MAX_CONCURRENT_TASKS</code></a></td>
+      <td scope="row" data-label="Env var"><code>SURREAL_MAX_CONCURRENT_TASKS</code></td>
       <td scope="row" data-label="Default">64</td>
       <td scope="row" data-label="Notes">Specifies how many concurrent jobs can be buffered in the worker channel.</td>
     </tr>
     <tr>
     <tr>
-      <td scope="row" data-label="Env var"><code>SURREAL_MAX_STREAM_BATCH_SIZE</code></a></td>
+      <td scope="row" data-label="Env var"><code>SURREAL_MAX_STREAM_BATCH_SIZE</code></td>
       <td scope="row" data-label="Default">1000</td>
       <td scope="row" data-label="Notes">The maximum number of keys that should be fetched when streaming range scans in a Scanner.</td>
     </tr>
     <tr>
-      <td scope="row" data-label="Env var"><code>SURREAL_NORMAL_FETCH_SIZE</code></a></td>
+      <td scope="row" data-label="Env var"><code>SURREAL_NORMAL_FETCH_SIZE</code></td>
       <td scope="row" data-label="Default">50</td>
       <td scope="row" data-label="Notes">The maximum number of keys that should be scanned at once in general queries.</td>
     </tr>
     <tr>
-      <td scope="row" data-label="Env var"><code>SURREAL_RUNTIME_MAX_BLOCKING_THREADS</code></a></td>
+      <td scope="row" data-label="Env var"><code>SURREAL_RUNTIME_MAX_BLOCKING_THREADS</code></td>
       <td scope="row" data-label="Default">512</td>
       <td scope="row" data-label="Notes">Number of threads which can be started for blocking operations.</td>
     </tr>
     <tr>
-      <td scope="row" data-label="Env var"><code>SURREAL_RUNTIME_STACK_SIZE</code></a></td>
+      <td scope="row" data-label="Env var"><code>SURREAL_RUNTIME_STACK_SIZE</code></td>
       <td scope="row" data-label="Default">10485760 (10 MiB)</td>
       <td scope="row" data-label="Notes">Runtime thread memory stack size. Stack size is doubled if compiled from source in Debug mode.</td>
     </tr>
     <tr>
-      <td scope="row" data-label="Env var"><code>SURREAL_TRANSACTION_CACHE_SIZE</code></a></td>
+      <td scope="row" data-label="Env var"><code>SURREAL_TRANSACTION_CACHE_SIZE</code></td>
       <td scope="row" data-label="Default">10000</td>
       <td scope="row" data-label="Notes">Specifies the number of items which can be cached within a single transaction.</td>
     </tr>
     <tr>
-      <td scope="row" data-label="Env var"><code>SURREAL_WEBSOCKET_MAX_CONCURRENT_REQUESTS</code></a></td>
+      <td scope="row" data-label="Env var"><code>SURREAL_WEBSOCKET_MAX_CONCURRENT_REQUESTS</code></td>
       <td scope="row" data-label="Default">24</td>
       <td scope="row" data-label="Notes">Maximum concurrent tasks that can be handled on each WebSocket.</td>
     </tr>
     <tr>
-      <td scope="row" data-label="Env var"><code>SURREAL_WEBSOCKET_MAX_FRAME_SIZE</code></a></td>
+      <td scope="row" data-label="Env var"><code>SURREAL_WEBSOCKET_MAX_FRAME_SIZE</code></td>
       <td scope="row" data-label="Default">16777216 (16 MiB)</td>
       <td scope="row" data-label="Notes">Maximum WebSocket frame size.</td>
     </tr>
     <tr>
-      <td scope="row" data-label="Env var"><code>SURREAL_WEBSOCKET_MAX_MESSAGE_SIZE</code></a></td>
+      <td scope="row" data-label="Env var"><code>SURREAL_WEBSOCKET_MAX_MESSAGE_SIZE</code></td>
       <td scope="row" data-label="Default">134217728 (128 MiB)</td>
       <td scope="row" data-label="Notes">Maximum WebSocket message size.</td>
     </tr>
@@ -115,17 +115,17 @@ Environment variables can be used to tailor the behaviour of a running SurrealDB
   </thead>
   <tbody>
     <tr>
-      <td scope="row" data-label="Env var"><code>SURREAL_FOUNDATIONDB_TRANSACTION_MAX_RETRY_DELAY</code></a></td>
+      <td scope="row" data-label="Env var"><code>SURREAL_FOUNDATIONDB_TRANSACTION_MAX_RETRY_DELAY</code></td>
       <td scope="row" data-label="Default">500</td>
       <td scope="row" data-label="Notes"></td>
     </tr>
     <tr>
-      <td scope="row" data-label="Env var"><code>SURREAL_FOUNDATIONDB_TRANSACTION_TIMEOUT</code></a></td>
+      <td scope="row" data-label="Env var"><code>SURREAL_FOUNDATIONDB_TRANSACTION_TIMEOUT</code></td>
       <td scope="row" data-label="Default">5000</td>
       <td scope="row" data-label="Notes"></td>
     </tr>
     <tr>
-      <td scope="row" data-label="Env var"><code>SURREAL_FOUNDATIONDB_TRANSACTION_RETRY_LIMIT</code></a></td>
+      <td scope="row" data-label="Env var"><code>SURREAL_FOUNDATIONDB_TRANSACTION_RETRY_LIMIT</code></td>
       <td scope="row" data-label="Default">5</td>
       <td scope="row" data-label="Notes"></td>
     </tr>
@@ -145,48 +145,48 @@ Environment variables can be used to tailor the behaviour of a running SurrealDB
   </thead>
   <tbody>
     <tr>
-      <td scope="row" data-label="Env var"><code>SURREAL_ROCKSDB_THREAD_COUNT</code></a></td>
+      <td scope="row" data-label="Env var"><code>SURREAL_ROCKSDB_THREAD_COUNT</code></td>
       <td scope="row" data-label="Default">Number of CPUs on machine</td>
       <td scope="row" data-label="Notes"></td>
     </tr>
     <tr>
-      <td scope="row" data-label="Env var"><code>SURREAL_ROCKSDB_WRITE_BUFFER_SIZE</code></a></td>
+      <td scope="row" data-label="Env var"><code>SURREAL_ROCKSDB_WRITE_BUFFER_SIZE</code></td>
       <td scope="row" data-label="Default">268435456 (256 MiB)</td>
       <td scope="row" data-label="Notes"></td>
     </tr>
     <tr>
-      <td scope="row" data-label="Env var"><code>SURREAL_ROCKSDB_TARGET_FILE_SIZE_BASE</code></a></td>
+      <td scope="row" data-label="Env var"><code>SURREAL_ROCKSDB_TARGET_FILE_SIZE_BASE</code></td>
       <td scope="row" data-label="Default">536870912 (512 MiB)</td>
       <td scope="row" data-label="Notes"></td>
     </tr>
 
     <tr>
-      <td scope="row" data-label="Env var"><code>SURREAL_ROCKSDB_MAX_WRITE_BUFFER_NUMBER</code></a></td>
+      <td scope="row" data-label="Env var"><code>SURREAL_ROCKSDB_MAX_WRITE_BUFFER_NUMBER</code></td>
       <td scope="row" data-label="Default">32</td>
       <td scope="row" data-label="Notes"></td>
     </tr>
     <tr>
-      <td scope="row" data-label="Env var"><code>SURREAL_ROCKSDB_MIN_WRITE_BUFFER_NUMBER_TO_MERGE</code></a></td>
+      <td scope="row" data-label="Env var"><code>SURREAL_ROCKSDB_MIN_WRITE_BUFFER_NUMBER_TO_MERGE</code></td>
       <td scope="row" data-label="Default">4</td>
       <td scope="row" data-label="Notes"></td>
     </tr>
     <tr>
-      <td scope="row" data-label="Env var"><code>SURREAL_ROCKSDB_ENABLE_PIPELINED_WRITES</code></a></td>
+      <td scope="row" data-label="Env var"><code>SURREAL_ROCKSDB_ENABLE_PIPELINED_WRITES</code></td>
       <td scope="row" data-label="Default">true</td>
       <td scope="row" data-label="Notes"></td>
     </tr>
     <tr>
-      <td scope="row" data-label="Env var"><code>SURREAL_ROCKSDB_ENABLE_BLOB_FILES</code></a></td>
+      <td scope="row" data-label="Env var"><code>SURREAL_ROCKSDB_ENABLE_BLOB_FILES</code></td>
       <td scope="row" data-label="Default">true</td>
       <td scope="row" data-label="Notes"></td>
     </tr>
     <tr>
-      <td scope="row" data-label="Env var"><code>SURREAL_ROCKSDB_MIN_BLOB_SIZE</code></a></td>
+      <td scope="row" data-label="Env var"><code>SURREAL_ROCKSDB_MIN_BLOB_SIZE</code></td>
       <td scope="row" data-label="Default">4096</td>
       <td scope="row" data-label="Notes"></td>
     </tr>
     <tr>
-      <td scope="row" data-label="Env var"><code>SURREAL_ROCKSDB_KEEP_LOG_FILE_NUM</code></a></td>
+      <td scope="row" data-label="Env var"><code>SURREAL_ROCKSDB_KEEP_LOG_FILE_NUM</code></td>
       <td scope="row" data-label="Default">20</td>
       <td scope="row" data-label="Notes"></td>
     </tr>

--- a/doc-surrealdb_versioned_docs/version-latest/installation/running/env_vars.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/installation/running/env_vars.mdx
@@ -1,0 +1,194 @@
+---
+sidebar_position: 5
+sidebar_label: Environment variables
+title: Environment variables used for SurrealDB
+description: A list of the available environment variables used when running SurrealDB.
+---
+
+# Environment variables
+
+Environment variables can be used to tailor the behaviour of a running SurrealDB instance.
+
+## SurrealDB environment variables
+
+<table>
+  <thead>
+    <tr>
+      <th scope="col">Environment variable</th>
+      <th scope="col">Default value</th>
+      <th scope="col">Notes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td scope="row" data-label="Env var"><code>SURREAL_BUILD_METADATA</code></a></td>
+      <td scope="row" data-label="Default">false</td>
+      <td scope="row" data-label="Notes">The version identifier of this build. Defaults to the CARGO_PKG_VERSION environment variable if not specified.</td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Env var"><code>SURREAL_EXPERIMENTAL_BEARER_ACCESS</code></a></td>
+      <td scope="row" data-label="Default">false</td>
+      <td scope="row" data-label="Notes">Enable experimental bearer access and stateful access grant management. Still under active development. Using this experimental feature may introduce risks related to breaking changes and security issues.</td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Env var"><code>SURREAL_EXPORT_BATCH_SIZE</code></a></td>
+      <td scope="row" data-label="Default">1000</td>
+      <td scope="row" data-label="Notes">The maximum number of keys that should be scanned at once for export queries.</td>
+    </tr>
+    <tr>
+    <tr>
+      <td scope="row" data-label="Env var"><code>SURREAL_EXTERNAL_SORTING_BUFFER_LIMIT</code></a></td>
+      <td scope="row" data-label="Default">50000</td>
+      <td scope="row" data-label="Notes">Specifies the buffer limit for external sorting.</td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Env var"><code>SURREAL_FUNCTION_ALLOCATION_LIMIT</code></a></td>
+      <td scope="row" data-label="Default">20</td>
+      <td scope="row" data-label="Notes">Used to limit allocation for builtin functions.</td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Env var"><code> SURREAL_INSECURE_FORWARD_ACCESS_ERRORS </code></a></td>
+      <td scope="row" data-label="Default">false</td>
+      <td scope="row" data-label="Notes">Forward all signup/signin/authenticate query errors to a client performing authentication. Do not use in production.</td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Env var"><code>SURREAL_MAX_CONCURRENT_TASKS</code></a></td>
+      <td scope="row" data-label="Default">64</td>
+      <td scope="row" data-label="Notes">Specifies how many concurrent jobs can be buffered in the worker channel.</td>
+    </tr>
+    <tr>
+    <tr>
+      <td scope="row" data-label="Env var"><code>SURREAL_MAX_STREAM_BATCH_SIZE</code></a></td>
+      <td scope="row" data-label="Default">1000</td>
+      <td scope="row" data-label="Notes">The maximum number of keys that should be fetched when streaming range scans in a Scanner.</td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Env var"><code>SURREAL_NORMAL_FETCH_SIZE</code></a></td>
+      <td scope="row" data-label="Default">50</td>
+      <td scope="row" data-label="Notes">The maximum number of keys that should be scanned at once in general queries.</td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Env var"><code>SURREAL_RUNTIME_MAX_BLOCKING_THREADS</code></a></td>
+      <td scope="row" data-label="Default">512</td>
+      <td scope="row" data-label="Notes">Number of threads which can be started for blocking operations.</td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Env var"><code>SURREAL_RUNTIME_STACK_SIZE</code></a></td>
+      <td scope="row" data-label="Default">10485760 (10 MiB)</td>
+      <td scope="row" data-label="Notes">Runtime thread memory stack size. Stack size is doubled if compiled from source in Debug mode.</td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Env var"><code>SURREAL_TRANSACTION_CACHE_SIZE</code></a></td>
+      <td scope="row" data-label="Default">10000</td>
+      <td scope="row" data-label="Notes">Specifies the number of items which can be cached within a single transaction.</td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Env var"><code>SURREAL_WEBSOCKET_MAX_CONCURRENT_REQUESTS</code></a></td>
+      <td scope="row" data-label="Default">24</td>
+      <td scope="row" data-label="Notes">Maximum concurrent tasks that can be handled on each WebSocket.</td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Env var"><code>SURREAL_WEBSOCKET_MAX_FRAME_SIZE</code></a></td>
+      <td scope="row" data-label="Default">16777216 (16 MiB)</td>
+      <td scope="row" data-label="Notes">Maximum WebSocket frame size.</td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Env var"><code>SURREAL_WEBSOCKET_MAX_MESSAGE_SIZE</code></a></td>
+      <td scope="row" data-label="Default">134217728 (128 MiB)</td>
+      <td scope="row" data-label="Notes">Maximum WebSocket message size.</td>
+    </tr>
+  </tbody>
+</table>
+
+
+## Storage backend environment variables
+
+### FoundationDB
+
+<table>
+  <thead>
+    <tr>
+      <th scope="col">Environment variable</th>
+      <th scope="col">Default value</th>
+      <th scope="col">Notes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td scope="row" data-label="Env var"><code>SURREAL_FOUNDATIONDB_TRANSACTION_MAX_RETRY_DELAY</code></a></td>
+      <td scope="row" data-label="Default">500</td>
+      <td scope="row" data-label="Notes"></td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Env var"><code>SURREAL_FOUNDATIONDB_TRANSACTION_TIMEOUT</code></a></td>
+      <td scope="row" data-label="Default">5000</td>
+      <td scope="row" data-label="Notes"></td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Env var"><code>SURREAL_FOUNDATIONDB_TRANSACTION_RETRY_LIMIT</code></a></td>
+      <td scope="row" data-label="Default">5</td>
+      <td scope="row" data-label="Notes"></td>
+    </tr>
+  </tbody>
+</table>
+
+
+### RocksDB
+
+<table>
+  <thead>
+    <tr>
+      <th scope="col">Environment variable</th>
+      <th scope="col">Default value</th>
+      <th scope="col">Notes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td scope="row" data-label="Env var"><code>SURREAL_ROCKSDB_THREAD_COUNT</code></a></td>
+      <td scope="row" data-label="Default">Number of CPUs on machine</td>
+      <td scope="row" data-label="Notes"></td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Env var"><code>SURREAL_ROCKSDB_WRITE_BUFFER_SIZE</code></a></td>
+      <td scope="row" data-label="Default">268435456 (256 MiB)</td>
+      <td scope="row" data-label="Notes"></td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Env var"><code>SURREAL_ROCKSDB_TARGET_FILE_SIZE_BASE</code></a></td>
+      <td scope="row" data-label="Default">536870912 (512 MiB)</td>
+      <td scope="row" data-label="Notes"></td>
+    </tr>
+
+    <tr>
+      <td scope="row" data-label="Env var"><code>SURREAL_ROCKSDB_MAX_WRITE_BUFFER_NUMBER</code></a></td>
+      <td scope="row" data-label="Default">32</td>
+      <td scope="row" data-label="Notes"></td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Env var"><code>SURREAL_ROCKSDB_MIN_WRITE_BUFFER_NUMBER_TO_MERGE</code></a></td>
+      <td scope="row" data-label="Default">4</td>
+      <td scope="row" data-label="Notes"></td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Env var"><code>SURREAL_ROCKSDB_ENABLE_PIPELINED_WRITES</code></a></td>
+      <td scope="row" data-label="Default">true</td>
+      <td scope="row" data-label="Notes"></td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Env var"><code>SURREAL_ROCKSDB_ENABLE_BLOB_FILES</code></a></td>
+      <td scope="row" data-label="Default">true</td>
+      <td scope="row" data-label="Notes"></td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Env var"><code>SURREAL_ROCKSDB_MIN_BLOB_SIZE</code></a></td>
+      <td scope="row" data-label="Default">4096</td>
+      <td scope="row" data-label="Notes"></td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Env var"><code>SURREAL_ROCKSDB_KEEP_LOG_FILE_NUM</code></a></td>
+      <td scope="row" data-label="Default">20</td>
+      <td scope="row" data-label="Notes"></td>
+    </tr>
+  </tbody>
+</table>

--- a/doc-surrealdb_versioned_docs/version-latest/installation/running/env_vars.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/installation/running/env_vars.mdx
@@ -36,7 +36,6 @@ Environment variables can be used to tailor the behaviour of a running SurrealDB
       <td scope="row" data-label="Notes">The maximum number of keys that should be scanned at once for export queries.</td>
     </tr>
     <tr>
-    <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_EXTERNAL_SORTING_BUFFER_LIMIT</code></td>
       <td scope="row" data-label="Default">50000</td>
       <td scope="row" data-label="Notes">Specifies the buffer limit for external sorting.</td>
@@ -56,7 +55,6 @@ Environment variables can be used to tailor the behaviour of a running SurrealDB
       <td scope="row" data-label="Default">64</td>
       <td scope="row" data-label="Notes">Specifies how many concurrent jobs can be buffered in the worker channel.</td>
     </tr>
-    <tr>
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_MAX_STREAM_BATCH_SIZE</code></td>
       <td scope="row" data-label="Default">1000</td>


### PR DESCRIPTION
Just a bland page with all the env vars I could find, as they are currently only found in the source code and users sometimes ask about them. This section looks like the best place to put it, but could easily go somewhere else.