### PR TITLE
Remove reference to legacy scopes from IFELSE docs

### DIFF
--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/ifelse.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/ifelse.mdx
@@ -86,20 +86,20 @@ IF !type::is::datetime($badly_formatted_datetime) {
 
 ```surql
 // Original syntax
-IF $scope = "admin" THEN
+IF $access = "admin" THEN
 	SELECT * FROM account
-ELSE IF $scope = "user" THEN
+ELSE IF $access = "user" THEN
 	SELECT * FROM $auth.account
 ELSE {
-    THROW "Scope hasn't been defined!"
+    THROW "Access method hasn't been defined!"
 }
 END;
 
 // New scope syntax
 RETURN
-    IF $scope = "admin" { (SELECT * FROM account) }
-    ELSE IF $scope = "user"  { (SELECT * FROM $auth.account) }
-    ELSE { THROW "Scope hasn't been defined!" };
+    IF $access = "admin" { (SELECT * FROM account) }
+    ELSE IF $access = "user"  { (SELECT * FROM $auth.account) }
+    ELSE { THROW "Access method hasn't been defined!" };
 ```
 
 ### Advanced usage
@@ -148,9 +148,9 @@ UPDATE person SET railcard =
 You can also have nested conditions:
 
 ```surql
-IF $scope = "admin" THEN
+IF $access = "admin" THEN
     SELECT * FROM admin_data WHERE access_level = 'full'
-ELSE IF $scope = "user" THEN
+ELSE IF $access = "user" THEN
     IF $auth.role = "premium" THEN
         IF $auth.subscription_status = "active" THEN
             SELECT * FROM premium_user_data WHERE active = 1
@@ -167,21 +167,21 @@ ELSE IF $scope = "user" THEN
         SELECT * FROM unauthorized_user_data
     END
 ELSE
-    SELECT * FROM unknown_scope_data
+    SELECT * FROM unknown_access_data
 END;
 ```
 
 The new scope syntax makes it easy to carry out multiple statements even inside nested conditions.
 
 ```surql
-IF $scope = 'admin'
+IF $access = 'admin'
 	{
         CREATE admin_user_event SET 
             time = time::now(),
             info = "Admin user activity registered";
 		SELECT * FROM admin_data WHERE access_level = 'full';
 	}
-ELSE IF $scope = 'user'
+ELSE IF $access = 'user'
 	{
 		IF $auth.role = 'premium'
 			{
@@ -204,5 +204,5 @@ ELSE IF $scope = 'user'
 			{ SELECT * FROM unauthorized_user_data }
 	}
 ELSE
-	{ SELECT * FROM unknown_scope_data }
+	{ SELECT * FROM unknown_access_data }
 ```


### PR DESCRIPTION
This reference to the `$scope` variable in the IFELSE statements documentation slipped by when we updated after the change. This specific example is now only applicable to SurrealDB 2.X users.