### PR TITLE
Docs: SCHEMAFULL table should be TYPE NORMAL by default

### DIFF
--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/define/table.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/define/table.mdx
@@ -162,6 +162,10 @@ SHOW CHANGES FOR TABLE reading SINCE u"2023-09-07T01:23:52Z" LIMIT 10;
 
 The following example demonstrates the `SCHEMAFULL` portion of the `DEFINE TABLE` statement. When a table is defined as schemafull, the database strictly enforces any schema definitions that are specified using the `DEFINE TABLE` statement. New fields can not be added to a `SCHEMAFULL` table unless they are defined via the [`DEFINE FIELD`](/docs/surrealdb/surrealql/statements/define/field) statement.
 
+:::note
+__Note:__  Since `v2.0.0`, schemafull tables are implicitly type [`NORMAL`](/docs/surrealdb/surrealql/statements/define/table#table-with-specialized-type-clause) tables by default. 
+:::
+
 ```surql
 -- Create schemafull user table.
 DEFINE TABLE user SCHEMAFULL;
@@ -342,21 +346,28 @@ DEFINE TABLE OVERWRITE example;
 
 <Since v="v1.4.0" />
 
-With `TYPE ANY`, both relations and "normal" data can be stored on a table. Due to SurrealDB's schemaless nature, this is the default option if no `TYPE`-clause is specified.
+When defining a table in SurrealDB, you can specify the type of data that can be stored in the table. This can be done using the `TYPE` clause, followed by either `ANY`, `NORMAL`, or `RELATION`.
+
+With `TYPE ANY`, you can specify a table to store any type of data, whether it's a normal record or a relational record. 
+
+With `TYPE NORMAL`, you can specify a table to only store "normal" records, and not relations. When a table is defined as `TYPE NORMAL`, it will not be able to store relations this can be useful when you want to restrict the type of data that can be stored in a table in schemafull mode. 
+
+Finally, with `TYPE RELATION`, you can specify a table to only store relational type content. This can be useful when you want to restrict the type of data that can be stored in a table.
 
 ```surql
 DEFINE TABLE person TYPE ANY;
--- Since it's default, we can also omit it.
 DEFINE TABLE person;
 ```
 
-With `TYPE NORMAL`, you can specify a table to only store "normal" records, and not relations.
+With `TYPE NORMAL`, you can specify a table to only store "normal" records, and not relations. 
 
 ```surql
+-- Since it's default, we can also omit the TYPE clause
 DEFINE TABLE person TYPE NORMAL;
+
 ```
 
-With `TYPE RELATION`, you can specify a table to only store relation type content, and restrict what kind of relations can be stored.
+With `TYPE RELATION`, you can specify a table to only store relational type content, and restrict what kind of relations can be stored.
 
 ```surql
 -- Just a RELATION table, no constraints on the type of table
@@ -367,7 +378,7 @@ DEFINE TABLE likes TYPE RELATION FROM user TO post;
 ```
 
 ```surql
---
+-- Define a relation table, and constraint the type of relation which can be stored
 DEFINE TABLE assigned_to SCHEMAFULL TYPE RELATION IN tag OUT sticky
     PERMISSIONS
         FOR create, select, update, delete


### PR DESCRIPTION
Related to https://github.com/surrealdb/surrealdb/pull/4558