### PR TITLE
Typo: ~ is the 'match' operator

### DIFF
--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/string.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/string.mdx
@@ -1028,7 +1028,7 @@ RETURN string::semver::set::patch("1.2.3", 9);
 
 ## `string::similarity::fuzzy` 
 
-While [the ~ operator](/docs/surrealdb/surrealql/operators#matches) is a quick go-to to see if two strings are a fuzzy match, it returns a boolean that does not indicate relative similarity.
+While [the ~ operator](/docs/surrealdb/surrealql/operators#match) is a quick go-to to see if two strings are a fuzzy match, it returns a boolean that does not indicate relative similarity.
 
 ```surql
 RETURN "SurrealDB" ~ "db";

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/string.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/string.mdx
@@ -200,7 +200,7 @@ These functions can be used when working with and manipulating text and string v
       <td scope="row" data-label="Description">Set the patch version of a semver string</td>
     </tr>
     <tr>
-      <td scope="row" data-label="Function"><a href="#stringsemversetpatch"><code>string::similarity::fuzzy()</code></a></td>
+      <td scope="row" data-label="Function"><a href="#stringsimilarityfuzzy"><code>string::similarity::fuzzy()</code></a></td>
       <td scope="row" data-label="Description">Return the similarity score of fuzzy matching strings</td>
     </tr>
   </tbody>


### PR DESCRIPTION
Small typo: should be match, not matches