### PR TITLE
Update vector.mdx

### DIFF
--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/vector.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/vector.mdx
@@ -243,7 +243,7 @@ The `vector::project` function computes the projection of one vector onto anothe
 
 
 ```surql title="API DEFINITION"
-vector::project(array) -> array
+vector::project(array, array) -> array
 
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:


### PR DESCRIPTION
corrected vector::project definition, current definition says that it only accepts a single array, but it accepts two arrays as arguments

originally 
```
vector::project(array) -> array
```

corrected
```
vector::project(array, array) -> array
```
