### PR TITLE
DOC-246: Update `type::range` function example

### DIFF
--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/type.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/type.mdx
@@ -448,28 +448,26 @@ RETURN type::thing($tb, $id);
 
 <Since v="v2.0.0" />
 
-The `type::range` function converts a value into a record range.
+The `type::range` function converts a value into a record range. It accepts a single argument either a range or an array with two values will be converted into a range similar to [casting](/docs/surrealdb/surrealql/datamodel/casting).
 
 ```surql title="API DEFINITION"
-type::range(any, any, any, object) -> range<record>
+type::range(range | array) -> range<record>
 ```
-This function takes up to four arguments.
-
-The first is the table name for the range. The second and third are the beginning and end of the range. If either is NULL or not specified, the range will be unbounded in the direction that is not specified.
-
-The fourth is an object which can be used to define how the range is bounded. If it contains the properties `begin` or `end` (containing the value `"included"` or `"excluded"`) the ranges bound will be updated accordingly.
-
-If no bounds are specified, the function will default to including the begin bound and excluding the end bound.
-
 
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:
 
 ```surql
-LET $tb = "product_price";
-LET $begin = "10";
-LET $end = "100";
-// create the range `product_price:10>..=100`
-RETURN type::range($tb, $begin, $end, { begin: "excluded", end: "included" });
+RETURN type::range([1, 2]);
+
+[1..2]
+
+RETURN type::range(1..10)
+  
+[1..10]
+
+RETURN type::range([1,9,4]);
+
+['Expected a range but cannot convert [1, 9, 4] into a range']
 ```
 
 <br />

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/type.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/type.mdx
@@ -448,7 +448,7 @@ RETURN type::thing($tb, $id);
 
 <Since v="v2.0.0" />
 
-The `type::range` function converts a value into a record range. It accepts a single argument either a range or an array with two values will be converted into a range similar to [casting](/docs/surrealdb/surrealql/datamodel/casting).
+The `type::range` function converts a value into a record range. It accepts a single argument, either a range or an array with two values. If the argument is an array, it will be converted into a range,  similar to [casting](/docs/surrealdb/surrealql/datamodel/casting).
 
 ```surql title="API DEFINITION"
 type::range(range | array) -> range<record>


### PR DESCRIPTION
The `type::range` function now accepts a single argument, either a range or an array, to be converted into a record range. Closes https://github.com/surrealdb/surrealdb/issues/4639