### PR TITLE
Add missing functions

### DIFF
--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/array.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/array.mdx
@@ -879,7 +879,7 @@ false
 ```
 
 ```surql title="An empty array"
-RETURN array::is_empty([1,2,3,4]);
+RETURN array::is_empty([]);
 
 true
 ```

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/array.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/array.mdx
@@ -176,7 +176,7 @@ These functions can be used when working with, and manipulating arrays of data.
     </tr>
     <tr>
       <td scope="row" data-label="Function"><a href="#arrayrange"><code>array::range()</code></a></td>
-      <td scope="row" data-label="Description">Creates a number array from a range (start to begin)</td>
+      <td scope="row" data-label="Description">Creates a number array from a range (start to end)</td>
     </tr>
     <tr>
       <td scope="row" data-label="Function"><a href="#arrayremove"><code>array::remove()</code></a></td>
@@ -191,7 +191,7 @@ These functions can be used when working with, and manipulating arrays of data.
       <td scope="row" data-label="Description">Reverses the sorting order of an array</td>
     </tr>
     <tr>
-      <td scope="row" data-label="Function"><a href="#arrayfill"><code>array::shuffle()</code></a></td>
+      <td scope="row" data-label="Function"><a href="#arrayshuffle"><code>array::shuffle()</code></a></td>
       <td scope="row" data-label="Description">Randomly shuffles the contents of an array</td>
     </tr>
     <tr>
@@ -573,6 +573,8 @@ RETURN array::distinct([ 1, 2, 1, 3, 3, 4 ]);
 
 ## `array::fill`
 
+<Since v="v2.0.0" />
+
 The `array::fill` function replaces all values of an array with a new value.
 
 ```surql title="API DEFINITION"
@@ -860,6 +862,8 @@ RETURN array::intersect([1,2,3,4], [3,4,5,6]);
 <br />
 
 ## `array::is_empty`
+
+<Since v="v2.0.0" />
 
 The `array::is_empty` checks whether the array contains values.
 
@@ -1215,10 +1219,12 @@ RETURN array::push([1,2,3,4], 5);
 
 ## `array::range`
 
+<Since v="v2.0.0" />
+
 The `array::range` function creates an array of numbers from a given range.
 
 ```surql title="API DEFINITION"
-array::range(start, count) -> array
+array::range(start, end) -> array
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:
 
@@ -1263,6 +1269,8 @@ RETURN array::remove([1,2,3,4,5], -2);
 
 ## `array::repeat`
 
+<Since v="v2.0.0" />
+
 The `array::repeat` function creates an array of a given size that will contain the same value.
 
 ```surql title="API DEFINITION"
@@ -1303,6 +1311,8 @@ RETURN array::reverse([ 1, 2, 3, 4, 5 ]);
 <br />
 
 ## `array::shuffle`
+
+<Since v="v2.0.0" />
 
 The `array::shuffle` function randomly shuffles the items of an array.
 
@@ -1451,18 +1461,29 @@ RETURN array::sort::desc([ 1, 2, 1, null, "something", 3, 3, 4, 0 ]);
 
 ## `array::swap`
 
+<Since v="v2.0.0" />
+
 The `array::swap` swaps two values of an array based on indexes.
 
 
 ```surql title="API DEFINITION"
-array::swap(array, from, to) -> array
+array::swap(array, from: int, to: int) -> array
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:
 
 ```surql
-RETURN array::swap([ 1, 2, 3, 4, 5 ], 1, 3);
+RETURN array::swap(["What's", "its", "got", "in", "it", "pocketses?"], 1, 4);
+```
 
-[ 1, 4, 3, 2, 5 ]
+```bash title="Output"
+[
+	"What's",
+	'it',
+	'got',
+	'in',
+	'its',
+	'pocketses?'
+]
 ```
 
 The following example shows how you can use this function with a positive index, and a negative index, which will swap the first and last element from the array:
@@ -1471,6 +1492,16 @@ The following example shows how you can use this function with a positive index,
 RETURN array::swap([ 1, 2, 3, 4, 5 ], 0, -1);
 
 [ 5, 2, 3, 4, 1 ]
+```
+
+An error will be returned if any of the indexes are invalid that informs of range of possible indexes that can be used.
+
+```surql
+RETURN array::swap([0,1], 100, 1000000);
+```
+
+```bash title="Output"
+'Incorrect arguments for function array::swap(). Argument 1 is out of range. Expected a number between -2 and 2'
 ```
 
 <br />

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/array.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/array.mdx
@@ -79,6 +79,10 @@ These functions can be used when working with, and manipulating arrays of data.
       <td scope="row" data-label="Description">Returns the unique items in an array</td>
     </tr>
     <tr>
+      <td scope="row" data-label="Function"><a href="#arrayfill"><code>array::fill()</code></a></td>
+      <td scope="row" data-label="Description">Fills an existing array of the same value</td>
+    </tr>
+    <tr>
       <td scope="row" data-label="Function"><a href="#arrayfilter"><code>array::filter()</code></a></td>
       <td scope="row" data-label="Description">Filters out values that do not match a pattern</td>
     </tr>
@@ -113,6 +117,10 @@ These functions can be used when working with, and manipulating arrays of data.
     <tr>
       <td scope="row" data-label="Function"><a href="#arrayintersect"><code>array::intersect()</code></a></td>
       <td scope="row" data-label="Description">Returns the values which intersect two arrays</td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Function"><a href="#arrayis_empty"><code>array::is_empty()</code></a></td>
+      <td scope="row" data-label="Description">Checks if an array is empty</td>
     </tr>
     <tr>
       <td scope="row" data-label="Function"><a href="#arrayjoin"><code>array::join()</code></a></td>
@@ -167,12 +175,24 @@ These functions can be used when working with, and manipulating arrays of data.
       <td scope="row" data-label="Description">Appends an item to the end of an array</td>
     </tr>
     <tr>
+      <td scope="row" data-label="Function"><a href="#arrayrange"><code>array::range()</code></a></td>
+      <td scope="row" data-label="Description">Creates a number array from a range (start to begin)</td>
+    </tr>
+    <tr>
       <td scope="row" data-label="Function"><a href="#arrayremove"><code>array::remove()</code></a></td>
       <td scope="row" data-label="Description">Removes an item at a specific position from an array, supports negative index</td>
     </tr>
     <tr>
+      <td scope="row" data-label="Function"><a href="#arrayrepeat"><code>array::repeat()</code></a></td>
+      <td scope="row" data-label="Description">Creates an array of the same value of a given size</td>
+    </tr>
+    <tr>
       <td scope="row" data-label="Function"><a href="#arrayreverse"><code>array::reverse()</code></a></td>
       <td scope="row" data-label="Description">Reverses the sorting order of an array</td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Function"><a href="#arrayfill"><code>array::shuffle()</code></a></td>
+      <td scope="row" data-label="Description">Randomly shuffles the contents of an array</td>
     </tr>
     <tr>
       <td scope="row" data-label="Function"><a href="#arraysort"><code>array::sort()</code></a></td>
@@ -189,6 +209,10 @@ These functions can be used when working with, and manipulating arrays of data.
     <tr>
       <td scope="row" data-label="Function"><a href="#arraysortdesc"><code>array::sort::desc()</code></a></td>
       <td scope="row" data-label="Description">Sorts the values in an array in descending order</td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Function"><a href="#arrayswap"><code>array::swap()</code></a></td>
+      <td scope="row" data-label="Description">Swaps two items in an array</td>
     </tr>
     <tr>
       <td scope="row" data-label="Function"><a href="#arraytranspose"><code>array::transpose()</code></a></td>
@@ -547,6 +571,46 @@ RETURN array::distinct([ 1, 2, 1, 3, 3, 4 ]);
 
 <br />
 
+## `array::fill`
+
+The `array::fill` function replaces all values of an array with a new value.
+
+```surql title="API DEFINITION"
+array::fill(array, any) -> array
+```
+
+The function also accepts a third and a fourth parameter which allows you to replace only a portion of the source array.
+
+```surql title="API DEFINITION"
+array::fill(array, any, start: int, end: int) -> array
+```
+
+The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:
+
+```surql
+RETURN array::fill([ 1, 2, 3, 4, 5 ], 10);
+
+[ 10, 10, 10, 10, 10 ]
+```
+
+The following example shows how you can use this function with a starting position, and an ending position, which in this example will replace one item from the array:
+
+```surql
+RETURN array::fill([ 1, NONE, 3, 4, 5 ], 10, 1, 2);
+
+[ 1, 10, 3, 4, 5 ]
+```
+
+The following example shows how you can use this function with starting and ending negative positions, which in this example will replace one item from the array:
+
+```surql
+RETURN array::fill([ 1, 2, NONE, 4, 5 ], 10, -3, -2);
+
+[ 1, 2, 10, 4, 5 ]
+```
+
+<br />
+
 ## `array::filter`
 
 The `array::filter` function filters out values in an array that do not match a pattern, returning only the ones that do match.
@@ -791,6 +855,29 @@ The following example shows this function, and its output, when used in a [`RETU
 RETURN array::intersect([1,2,3,4], [3,4,5,6]);
 
 [ 3, 4 ]
+```
+
+<br />
+
+## `array::is_empty`
+
+The `array::is_empty` checks whether the array contains values.
+
+```surql title="API DEFINITION"
+array::is_empty(array) -> bool
+```
+The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:
+
+```surql title="An array that contain values"
+RETURN array::is_empty([1,2,3,4]);
+
+false
+```
+
+```surql title="An empty array"
+RETURN array::is_empty([1,2,3,4]);
+
+true
 ```
 
 <br />
@@ -1126,6 +1213,29 @@ RETURN array::push([1,2,3,4], 5);
 
 <br />
 
+## `array::range`
+
+The `array::range` function creates an array of numbers from a given range.
+
+```surql title="API DEFINITION"
+array::range(start, count) -> array
+```
+The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:
+
+```surql
+RETURN array::range(1, 10);
+
+[ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ]
+```
+
+```surql
+RETURN array::range(3, 2);
+
+[ 3, 4 ]
+```
+
+<br />
+
 ## `array::remove`
 
 The `array::remove` function removes an item from a specific position in an array, supports negative index.
@@ -1151,6 +1261,29 @@ RETURN array::remove([1,2,3,4,5], -2);
 
 <br />
 
+## `array::repeat`
+
+The `array::repeat` function creates an array of a given size that will contain the same value.
+
+```surql title="API DEFINITION"
+array::repeat(any, count) -> array
+```
+The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:
+
+```surql
+RETURN array::repeat(1, 10);
+
+[ 10, 10, 10, 10, 10, 10, 10, 10, 10, 10 ]
+```
+
+```surql
+RETURN array::repeat("hello", 2);
+
+[ "hello", "hello" ]
+```
+
+<br />
+
 ## `array::reverse`
 
 The `array::reverse` function reverses the sorting order of an array.
@@ -1165,6 +1298,24 @@ The following example shows this function, and its output, when used in a [`RETU
 RETURN array::reverse([ 1, 2, 3, 4, 5 ]);
 
 [ 5, 4, 3, 2, 1 ]
+```
+
+<br />
+
+## `array::shuffle`
+
+The `array::shuffle` function randomly shuffles the items of an array.
+
+```surql title="API DEFINITION"
+array::shuffle(array) -> array
+```
+
+The following example shows this function, and its possible output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:
+
+```surql
+RETURN array::shuffle([ 1, 2, 3, 4, 5 ]);
+
+[ 2, 1, 4, 3, 5 ]
 ```
 
 <br />
@@ -1294,6 +1445,32 @@ The following example shows this function, and its output, when used in a [`RETU
 RETURN array::sort::desc([ 1, 2, 1, null, "something", 3, 3, 4, 0 ]);
 
 [ "something", 4, 3, 3, 2, 1, 1, 9, null ]
+```
+
+<br />
+
+## `array::swap`
+
+The `array::swap` swaps two values of an array based on indexes.
+
+
+```surql title="API DEFINITION"
+array::swap(array, from, to) -> array
+```
+The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:
+
+```surql
+RETURN array::swap([ 1, 2, 3, 4, 5 ], 1, 3);
+
+[ 1, 4, 3, 2, 5 ]
+```
+
+The following example shows how you can use this function with a positive index, and a negative index, which will swap the first and last element from the array:
+
+```surql 
+RETURN array::swap([ 1, 2, 3, 4, 5 ], 0, -1);
+
+[ 5, 2, 3, 4, 1 ]
 ```
 
 <br />

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/bytes.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/bytes.mdx
@@ -1,0 +1,50 @@
+
+---
+sidebar_position: 3
+sidebar_label: Bytes functions
+title: Bytes functions | SurrealQL
+description: These functions can be used when working with bytes.
+---
+
+# Bytes functions
+
+These functions can be used when working with bytes in SurrealQL.
+
+<table>
+  <thead>
+    <tr>
+      <th scope="col">Function</th>
+      <th scope="col">Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td scope="row" data-label="Function"><a href="#byteslen"><code>bytes::len()</code></a></td>
+      <td scope="row" data-label="Description">Gives the length in bytes</td>
+    </tr>
+  </tbody>
+</table>
+
+## `bytes::len`
+
+The `bytes::len` function returns the length in bytes of a `bytes` value.
+
+
+```surql title="API DEFINITION"
+bytes::len(bytes) -> int
+```
+
+```
+The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:
+
+```surql 
+RETURN [
+    bytes::len(<bytes>"Simple ASCII string"),
+    bytes::len(<bytes>"οὐ γὰρ δυνατόν ἐστιν ἔτι καθεύδειν"),
+    bytes::len(<bytes>"청춘예찬 靑春禮讚")
+];
+```
+
+```bash title="Output"
+[ 19, 67, 25 ]
+```

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/bytes.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/bytes.mdx
@@ -1,4 +1,3 @@
-
 ---
 sidebar_position: 3
 sidebar_label: Bytes functions

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/bytes.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/bytes.mdx
@@ -34,7 +34,6 @@ The `bytes::len` function returns the length in bytes of a `bytes` value.
 bytes::len(bytes) -> int
 ```
 
-```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:
 
 ```surql 

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/count.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/count.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 4
 sidebar_label: Count function
 title: Count function | SurrealQL
 description: These functions can be used when counting field values and expressions.

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/crypto.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/crypto.mdx
@@ -5,6 +5,8 @@ title: Crypto functions | SurrealQL
 description: These functions can be used when hashing data, encrypting data, and for securely authenticating users into the database.
 ---
 
+import Since from '@site/src/components/Since'
+
 # Crypto functions
 
 These functions can be used when hashing data, encrypting data, and for securely authenticating users into the database.
@@ -73,6 +75,8 @@ These functions can be used when hashing data, encrypting data, and for securely
 </table>
 
 ## `crypto::blake3`
+
+<Since v="v2.0.0" />
 
 The `crypto::blake3` function returns the blake3 hash of the input value.
 

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/crypto.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/crypto.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 5
 sidebar_label: Crypto functions
 title: Crypto functions | SurrealQL
 description: These functions can be used when hashing data, encrypting data, and for securely authenticating users into the database.
@@ -17,6 +17,10 @@ These functions can be used when hashing data, encrypting data, and for securely
     </tr>
   </thead>
   <tbody>
+    <tr>
+      <td scope="row" data-label="Function"><a href="#cryptoblake3"><code>crypto::md5()</code></a></td>
+      <td scope="row" data-label="Description">Returns the blake3 hash of a value</td>
+    </tr>
     <tr>
       <td scope="row" data-label="Function"><a href="#cryptomd5"><code>crypto::md5()</code></a></td>
       <td scope="row" data-label="Description">Returns the md5 hash of a value</td>
@@ -67,6 +71,23 @@ These functions can be used when hashing data, encrypting data, and for securely
     </tr>
   </tbody>
 </table>
+
+## `crypto::blake3`
+
+The `crypto::blake3` function returns the blake3 hash of the input value.
+
+```surql title="API DEFINITION"
+crypto::blake3(string) -> string
+```
+The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:
+
+```surql
+RETURN crypto::blake3("tobie");
+
+'85052e9aab1b67b6622d94a08441b09fd5b7aca61ee360416d70de5da67d86ca'
+```
+
+<br />
 
 ## `crypto::md5`
 

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/duration.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/duration.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 6
 sidebar_label: Duration functions
 title: Duration functions | SurrealQL
 description: These functions can be used when converting between numeric and duration data.

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/encoding.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/encoding.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 7
 sidebar_label: Encoding functions
 title: Encoding functions | SurrealQL
 description: These functions can be used to encode and decode data in base64. It is particularly used when that data needs to be stored and transferred over media that are designed to deal with text. This encoding and decoding helps to ensure that the data remains intact without modification during transport.

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/geo.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/geo.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 8
 sidebar_label: Geo functions
 title: Geo functions | SurrealQL
 description: These functions can be used when working with and analysing geospatial data.

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/http.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/http.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 9
 sidebar_label: HTTP functions
 title: HTTP functions | SurrealQL
 description: These functions can be used when opening and submitting remote web requests, and webhooks.

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/index.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/index.mdx
@@ -24,6 +24,10 @@ SurrealDB comes with a large number of in-built functions for checking, manipula
       <td scope="row" data-label="Example"><code>array::len([1,2,3])</code></td>
     </tr>
     <tr>
+      <td scope="row" data-label="Module"><a href="/docs/surrealdb/surrealql/functions/database/bytes"><code>Bytes functions</code></a></td>
+      <td scope="row" data-label="Example"><code>bytes::len("SurrealDB".to_bytes());</code></td>
+    </tr>
+    <tr>
       <td scope="row" data-label="Module"><a href="/docs/surrealdb/surrealql/functions/database/count"><code>Count function</code></a></td>
       <td scope="row" data-label="Example"><code>count([1,2,3])</code></td>
     </tr>

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/math.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/math.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8
+sidebar_position: 10
 sidebar_label: Math functions
 title: Math functions | SurrealQL
 description: These functions can be used when analysing numeric data and numeric collections.
@@ -145,6 +145,10 @@ These functions can be used when analysing numeric data and numeric collections.
     <tr>
       <td scope="row" data-label="Constant"><a href="#mathpi"><code>math::pi</code></a></td>
       <td scope="row" data-label="Description">Represents the mathematical constant π.</td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Constant"><a href="#mathpow"><code>math::pi</code></a></td>
+      <td scope="row" data-label="Description">Returns a number raised to a power</td>
     </tr>
     <tr>
       <td scope="row" data-label="Function"><a href="#mathproduct"><code>math::product()</code></a></td>
@@ -765,6 +769,24 @@ The following example shows this function, and its output, when used in a [`RETU
 RETURN math::pi;
 
 3.141592653589793f
+```
+
+<br />
+
+## `math::pow`
+
+The `math::pow` function returns a number raised to the power of a second number.
+
+```surql title="API DEFINITION"
+math::pow(number, number) -> number
+```
+
+The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:
+
+```surql
+RETURN math::pow(1.07, 10);
+
+1.9671513572895665f
 ```
 
 <br />

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/meta.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/meta.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 9
+sidebar_position: 11
 sidebar_label: Meta functions
 title: Meta functions | SurrealQL
 description: These functions can be used to retrieve specific metadata from a SurrealDB Record ID.

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/object.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/object.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 11
+sidebar_position: 12
 sidebar_label: Object functions
 title: Object functions | SurrealQL 
 description: These functions can be used when working with, and manipulating data objects.

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/parse.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/parse.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 12
+sidebar_position: 13
 sidebar_label: Parse functions
 title: Parse functions | SurrealQL
 description: These functions can be used when parsing email addresses and URL web addresses.
@@ -44,6 +44,10 @@ These functions can be used when parsing email addresses and URL web addresses.
     <tr>
       <td scope="row" data-label="Function"><a href="#parseurlport"><code>parse::url::port()</code></a></td>
       <td scope="row" data-label="Description">Parses and returns the port number from a URL</td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Function"><a href="#parseurlscheme"><code>parse::url::port()</code></a></td>
+      <td scope="row" data-label="Description">Parses and returns the scheme from a URL</td>
     </tr>
     <tr>
       <td scope="row" data-label="Function"><a href="#parseurlquery"><code>parse::url::query()</code></a></td>
@@ -167,7 +171,7 @@ RETURN parse::url::path("https://surrealdb.com:80/features?some=option#fragment"
 
 ## `parse::url::port`
 
-The `parse::url::port` function parses and returns the port from a valid URL..
+The `parse::url::port` function parses and returns the port from a valid URL.
 
 ```surql title="API DEFINITION"
 parse::url::port(string) -> bool
@@ -178,6 +182,24 @@ The following example shows this function, and its output, when used in a [`RETU
 RETURN parse::url::port("https://surrealdb.com:80/features?some=option#fragment");
 
 80
+```
+
+<br />
+
+## `parse::url::scheme`
+
+The `parse::url::scheme` function parses and returns the scheme from a valid URL, in lowercase, as an ASCII string without the ':' delimiter.
+
+```surql title="API DEFINITION"
+parse::url::scheme(string) -> bool
+```
+
+The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:
+
+```surql
+RETURN parse::url::scheme("https://surrealdb.com:80/features?some=option#fragment");
+
+'https'
 ```
 
 <br />

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/rand.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/rand.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 13
+sidebar_position: 14
 sidebar_label: Rand functions
 title: Rand functions | SurrealQL
 description: These functions can be used when generating random data values.
@@ -242,8 +242,6 @@ RETURN rand::int(10, 15);
 ## `rand::string`
 
 The `rand::string` function generates a random string, with 32 characters.
-
-
 
 ```surql title="API DEFINITION"
 rand::string() -> string

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/record.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/record.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 14
+sidebar_position: 15
 sidebar_label: Record functions
 title: Record functions | SurrealQL
 description: These functions can be used to retrieve specific metadata from a SurrealDB Record ID.

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/search.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/search.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 15
+sidebar_position: 16
 sidebar_label: Search functions
 title: Search functions | SurrealQL
 description: These functions are used in conjunction with the 'matches' operator to either collect the relevance score or highlight the searched keywords within the content.

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/session.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/session.mdx
@@ -4,6 +4,7 @@ sidebar_label: Session functions
 title: Session functions | SurrealQL
 description: These functions can be used when working with and manipulating text and string values.
 ---
+import Since from '@site/src/components/Since'
 
 # Session functions
 
@@ -18,7 +19,7 @@ These functions can be used when working with and manipulating text and string v
   </thead>
   <tbody>
     <tr>
-      <td scope="row" data-label="Function"><a href="#sessionsc"><code>session::ac()</code></a></td>
+      <td scope="row" data-label="Function"><a href="#sessionac"><code>session::ac()</code></a></td>
       <td scope="row" data-label="Description">Returns the current user's access method</td>
     </tr>
     <tr>
@@ -53,6 +54,8 @@ These functions can be used when working with and manipulating text and string v
 </table>
 
 ## `session::ac`
+
+<Since v="v2.0.0" />
 
 The `session::ac` function replaces the `session::sc` function and returns the current user's access method.
 
@@ -156,6 +159,8 @@ RETURN session::origin();
 <br />
 
 ## `session::rd`
+
+<Since v="v2.0.0" />
 
 The `session::rd` function returns the current user's record authentication.
 

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/session.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/session.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 16
+sidebar_position: 17
 sidebar_label: Session functions
 title: Session functions | SurrealQL
 description: These functions can be used when working with and manipulating text and string values.
@@ -17,6 +17,10 @@ These functions can be used when working with and manipulating text and string v
     </tr>
   </thead>
   <tbody>
+    <tr>
+      <td scope="row" data-label="Function"><a href="#sessionsc"><code>session::ac()</code></a></td>
+      <td scope="row" data-label="Description">Returns the current user's access method</td>
+    </tr>
     <tr>
       <td scope="row" data-label="Function"><a href="#sessiondb"><code>session::db()</code></a></td>
       <td scope="row" data-label="Description">Returns the currently selected database</td>
@@ -38,11 +42,33 @@ These functions can be used when working with and manipulating text and string v
       <td scope="row" data-label="Description">Returns the current user's HTTP origin</td>
     </tr>
     <tr>
-      <td scope="row" data-label="Function"><a href="#sessionsc"><code>session::ac()</code></a></td>
-      <td scope="row" data-label="Description">Returns the current user's access method</td>
+      <td scope="row" data-label="Function"><a href="#sessionrd"><code>session::rd()</code></a></td>
+      <td scope="row" data-label="Description">Returns the current user's record authentication data</td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Function"><a href="#sessiontoken"><code>session::token()</code></a></td>
+      <td scope="row" data-label="Description">Returns the current user's authentication token</td>
     </tr>
   </tbody>
 </table>
+
+## `session::ac`
+
+The `session::ac` function replaces the `session::sc` function and returns the current user's access method.
+
+```surql title="API DEFINITION"
+session::ac() -> string
+```
+
+The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:
+
+```surql
+RETURN session::ac();
+
+"user"
+```
+
+<br /><br />
 
 ## `session::db`
 
@@ -129,19 +155,20 @@ RETURN session::origin();
 
 <br />
 
-## `session::ac`
+## `session::rd`
 
-The `session::ac` function replaces the `session::sc` function and returns the current user's access method.
+The `session::rd` function returns the current user's record authentication.
 
 ```surql title="API DEFINITION"
-session::ac() -> string
-```
-The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:
-
-```surql
-RETURN session::ac();
-
-"user"
+session::rd() -> string
 ```
 
-<br /><br />
+## `session::token`
+
+The `session::token` function returns the current authentication token.
+
+```surql title="API DEFINITION"
+session::token() -> string
+```
+
+<br />

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/sleep.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/sleep.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 17
+sidebar_position: 18
 sidebar_label: Sleep function
 title: Sleep function | SurrealQL
 description: These functions can be used to introduce a delay or pause in the execution of a query or a batch of queries for a specific amount of time.

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/string.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/string.mdx
@@ -318,6 +318,27 @@ RETURN string::lowercase('THIS IS A TEST');
 
 <br />
 
+## `string::matches`
+
+The `string::matches` function performs a regex match on a string.
+
+```surql title="API DEFINITION"
+string::matches(string, string) -> bool
+```
+
+The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:
+
+```surql
+RETURN [
+  string::matches("grey", "gr(a|e)y"),
+  string::matches("gray", "gr(a|e)y")
+];
+
+[ true, true ]
+```
+
+<br />
+
 ## `string::repeat`
 
 The `string::repeat`  function repeats a string a number of times.
@@ -848,27 +869,6 @@ The following example shows this function, and its output, when used in a [`RETU
 RETURN string::is::uuid("018a6680-bef9-701b-9025-e1754f296a0f");
 
 true
-```
-
-<br />
-
-## `string::matches`
-
-The `string::matches` function performs a regex match on a string.
-
-```surql title="API DEFINITION"
-string::matches(string, string) -> bool
-```
-
-The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:
-
-```surql
-RETURN [
-  string::matches("grey", "gr(a|e)y"),
-  string::matches("gray", "gr(a|e)y")
-];
-
-[ true, true ]
 ```
 
 <br />

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/string.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/string.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 18
+sidebar_position: 19
 sidebar_label: String functions
 title: String functions | SurrealQL
 description: These functions can be used when working with and manipulating text and string values.
@@ -42,6 +42,10 @@ These functions can be used when working with and manipulating text and string v
     <tr>
       <td scope="row" data-label="Function"><a href="#stringlowercase"><code>string::lowercase()</code></a></td>
       <td scope="row" data-label="Description">Converts a string to lowercase</td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Function"><a href="#stringmatches"><code>string::matches()</code></a></td>
+      <td scope="row" data-label="Description">Performs a regex match on a string</td>
     </tr>
     <tr>
       <td scope="row" data-label="Function"><a href="#stringrepeat"><code>string::repeat()</code></a></td>
@@ -844,6 +848,27 @@ The following example shows this function, and its output, when used in a [`RETU
 RETURN string::is::uuid("018a6680-bef9-701b-9025-e1754f296a0f");
 
 true
+```
+
+<br />
+
+## `string::matches`
+
+The `string::matches` function performs a regex match on a string.
+
+```surql title="API DEFINITION"
+string::matches(string, string) -> bool
+```
+
+The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:
+
+```surql
+RETURN [
+  string::matches("grey", "gr(a|e)y"),
+  string::matches("gray", "gr(a|e)y")
+];
+
+[ true, true ]
 ```
 
 <br />

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/time.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/time.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 19
+sidebar_position: 20
 sidebar_label: Time functions
 title: Time functions | SurrealQL
 description: These functions can be used when working with and manipulating datetime values.
@@ -18,6 +18,10 @@ These functions can be used when working with and manipulating datetime values.
     </tr>
   </thead>
   <tbody>
+    <tr>
+      <td scope="row" data-label="Function"><a href="#timeceil"><code>time::ceil()</code></a></td>
+      <td scope="row" data-label="Description">Rounds a datetime up to the next largest duration</td>
+    </tr>
     <tr>
       <td scope="row" data-label="Function"><a href="#timeday"><code>time::day()</code></a></td>
       <td scope="row" data-label="Description">Extracts the day as a number from a datetime</td>
@@ -125,6 +129,31 @@ These functions can be used when working with and manipulating datetime values.
   </tbody>
 </table>
 
+## `time::ceil`
+
+The `time::ceil` function rounds a datetime up to the next largest duration.
+
+```surql title="API DEFINITION"
+time::day(datetime, duration) -> datetime
+```
+
+The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:
+
+```surql
+LET $now = d'2024-08-30T02:22:50.231631Z';
+
+RETURN [
+  time::ceil($now, 1h),
+  time::ceil($now, 1w)
+];
+```
+
+```bash title="Output"
+[
+	d'2024-08-30T03:00:00Z',
+	d'2024-09-05T00:00:00Z'
+]
+```
 
 ## `time::day`
 

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/time.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/time.mdx
@@ -134,7 +134,7 @@ These functions can be used when working with and manipulating datetime values.
 The `time::ceil` function rounds a datetime up to the next largest duration.
 
 ```surql title="API DEFINITION"
-time::day(datetime, duration) -> datetime
+time::ceil(datetime, duration) -> datetime
 ```
 
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/type.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/type.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 20
+sidebar_position: 21
 sidebar_label: Type functions
 title: Type functions | SurrealQL
 description: These functions can be used for generating and coercing data to specific data types.

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/value.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/value.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 21
+sidebar_position: 22
 sidebar_label: Value functions
 title: Value functions | SurrealQL
 description: Functions that can be called on more than one type of SurrealQL value.

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/vector.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/vector.mdx
@@ -269,9 +269,9 @@ The `vector::scale` function multiplies each item in a vector by a number.
 
 
 ```surql title="API DEFINITION"
-vector::similarity::scale(array, number) -> array
-
+vector::scale(array, number) -> array
 ```
+
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:
 
 ```surql

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/vector.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/vector.mdx
@@ -4,6 +4,7 @@ sidebar_label: Vector functions
 title: Vector functions | SurrealQL
 description: A collection of essential vector operations that provide foundational functionality for numerical computation, machine learning, and data analysis.
 ---
+import Since from '@site/src/components/Since'
 
 # Vector functions
 
@@ -457,6 +458,8 @@ RETURN vector::similarity::pearson([1,2,3], [1,5,7]);
 <br />
 
 ## `vector::scale`
+
+<Since v="v2.0.0" />
 
 The `vector::scale` function multiplies each item in a vector by a number.
 

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/vector.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/vector.mdx
@@ -277,7 +277,7 @@ The following example shows this function, and its output, when used in a [`RETU
 ```surql
 RETURN vector::scale([3, 1, 5, -3, 7, 2], 5);
 
-[	15,	5,	25, -15, 35, 10 ]
+[	15,	5, 25, -15, 35, 10 ]
 ```
 
 <br />

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/vector.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/vector.mdx
@@ -55,6 +55,10 @@ A collection of essential vector operations that provide foundational functional
       <td scope="row" data-label="Description">Computes the projection of one vector onto another</td>
     </tr>
     <tr>
+      <td scope="row" data-label="Function"><a href="vectorscale"><code>vector::scale</code></a></td>
+      <td scope="row" data-label="Description">Multiplies each item in a vector</td>
+    </tr>
+    <tr>
       <td scope="row" data-label="Function"><a href="#vectorsubtract"><code>vector::subtract()</code></a></td>
       <td scope="row" data-label="Description">Performs element-wise subtraction between two vectors</td>
     </tr>
@@ -81,10 +85,6 @@ A collection of essential vector operations that provide foundational functional
     <tr>
       <td scope="row" data-label="Function"><a href="#vectordistanceminkowski"><code>vector::distance::minkowski()</code></a></td>
       <td scope="row" data-label="Description">Computes the Minkowski distance between two vectors</td>
-    </tr>
-    <tr>
-      <td scope="row" data-label="Function"><a href="vectorscale"><code>vector::scale</code></a></td>
-      <td scope="row" data-label="Description">Multiplies each item in a vector</td>
     </tr>
     <tr>
       <td scope="row" data-label="Function"><a href="vectorsimilaritycosine"><code>vector::similarity::cosine()</code></a></td>

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/vector.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/vector.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 22
+sidebar_position: 23
 sidebar_label: Vector functions
 title: Vector functions | SurrealQL
 description: A collection of essential vector operations that provide foundational functionality for numerical computation, machine learning, and data analysis.
@@ -82,7 +82,11 @@ A collection of essential vector operations that provide foundational functional
       <td scope="row" data-label="Description">Computes the Minkowski distance between two vectors</td>
     </tr>
     <tr>
-      <td scope="row" data-label="Function"><a href="vector#vectorsimilaritycosine"><code>vector::similarity::cosine()</code></a></td>
+      <td scope="row" data-label="Function"><a href="vectorscale"><code>vector::scale</code></a></td>
+      <td scope="row" data-label="Description">Multiplies each item in a vector</td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Function"><a href="vectorsimilaritycosine"><code>vector::similarity::cosine()</code></a></td>
       <td scope="row" data-label="Description">Computes the Cosine similarity between two vectors</td>
     </tr>
     <tr>
@@ -448,6 +452,25 @@ The following example shows this function, and its output, when used in a [`RETU
 RETURN vector::similarity::pearson([1,2,3], [1,5,7]);
 
 0.9819805060619659f
+```
+
+<br />
+
+## `vector::scale`
+
+The `vector::scale` function multiplies each item in a vector by a number.
+
+
+```surql title="API DEFINITION"
+vector::similarity::pearson(array, number) -> array
+
+```
+The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:
+
+```surql
+RETURN vector::scale([3, 1, 5, -3, 7, 2], 5);
+
+[	15,	5,	25, -15, 35, 10 ]
 ```
 
 <br /><br />

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/vector.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/vector.mdx
@@ -261,6 +261,27 @@ RETURN vector::project([1, 2, 3], [4, 5, 6]);
 
 <br />
 
+## `vector::scale`
+
+<Since v="v2.0.0" />
+
+The `vector::scale` function multiplies each item in a vector by a number.
+
+
+```surql title="API DEFINITION"
+vector::similarity::scale(array, number) -> array
+
+```
+The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:
+
+```surql
+RETURN vector::scale([3, 1, 5, -3, 7, 2], 5);
+
+[	15,	5,	25, -15, 35, 10 ]
+```
+
+<br />
+
 ## `vector::subtract`
 
 The `vector::subtract` function performs element-wise subtraction between two vectors, where each element in the second vector is subtracted from the corresponding element in the first vector.
@@ -456,24 +477,5 @@ RETURN vector::similarity::pearson([1,2,3], [1,5,7]);
 ```
 
 <br />
-
-## `vector::scale`
-
-<Since v="v2.0.0" />
-
-The `vector::scale` function multiplies each item in a vector by a number.
-
-
-```surql title="API DEFINITION"
-vector::similarity::pearson(array, number) -> array
-
-```
-The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:
-
-```surql
-RETURN vector::scale([3, 1, 5, -3, 7, 2], 5);
-
-[	15,	5,	25, -15, 35, 10 ]
-```
 
 <br /><br />


### PR DESCRIPTION
This PR adds all the functions missing in the documentation, with the exception of those that have a path but haven't been implemented yet (e.g. vector::distance::mahalanobis)

Some of these are new to 2.0. Big thanks to @Odonno who has a separate PR for many new array functions that I used for this

* array::fill
* array::is_empty
* array::range
* array::repeat
* array::shuffle
* array::swap
* crypto::blake3
* session::ac
* session::rd
* vector::scale

Others are not new and were just missed:

* bytes::len
* math::pow
* parse::url::scheme
* string::matches
* time::ceil