### PR TITLE
Change beta guide, add fix command to CLI

### DIFF
--- a/doc-surrealdb_versioned_docs/version-latest/cli/export.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/cli/export.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 5
 sidebar_label: Export command
 title: Export command | CLI tool
 description: The export command exports a SurrealQL script file from a local or remote SurrealDB database server.

--- a/doc-surrealdb_versioned_docs/version-latest/cli/fix.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/cli/fix.mdx
@@ -1,0 +1,92 @@
+---
+sidebar_position: 6
+sidebar_label: Fix command
+title: Fix command | CLI tool
+description: The fix command converts SurrealDB version 1.x data into a format that can be used in SurrealDB 2.0
+---
+
+# Fix command
+
+The fix command converts SurrealDB version 1.x data into a format that can be used in SurrealDB 2.0
+
+:::note
+__BEFORE YOU START :__ Make sure you’ve [installed SurrealDB](/docs/surrealdb/installation) — it should only take a second!
+:::
+
+## Command options 
+
+<table>
+    <thead>
+        <tr>
+            <th>Arguments</th>
+            <th>Description</th>
+        </tr>
+    </thead>  
+    <tbody>
+        <tr>
+            <td>
+                <code>-e</code> / <code>--log</code>
+                <l className='grey'>OPTIONAL</l>
+            </td>
+            <td>
+            Sets the logging level during the command
+            </td>
+        </tr>
+    </tbody>
+</table>
+
+## Positional argument
+
+<table>
+    <thead>
+        <tr>
+            <th>Arguments</th>
+            <th>Description</th>
+        </tr>
+    </thead>  
+    <tbody>
+        <tr>
+            <td>
+                <code>file</code>
+            </td>
+            <td>
+                Sets the the path to the existing data to convert to 2.x storage format
+            </td>
+        </tr>
+    </tbody>
+</table>
+
+## Example usage
+
+To perform a fix from SurrealDB 1.x to 2.0 storage, run the `surreal fix` command in a terminal with the path to the stored data.
+
+```bash
+surreal fix surrealkv://mydatabase.db
+
+surreal fix rocksdb:somedatabase
+```
+
+
+## Command help
+
+To see the help information and usage instructions, in a terminal run the `surreal fix --help` command without any further arguments. This command gives general information on the arguments, inputs, and additional options for the export command.
+
+```bash
+surreal fix --help
+```
+
+The output of the above command :
+
+```
+Fix database storage issues
+
+Usage: surreal fix [OPTIONS] [PATH]
+
+Arguments:
+  [PATH]  Database path used for storing data [env: SURREAL_PATH=] [default: memory]
+
+Options:
+  -l, --log <LOG>  The logging level for the database server [env: SURREAL_LOG=] [default: info] [possible values: none, full, error, warn, info, debug, trace]
+  -h, --help       Print help
+
+```

--- a/doc-surrealdb_versioned_docs/version-latest/cli/help.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/cli/help.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 12
+sidebar_position: 4
 sidebar_label: Help command
 title: Help command | CLI tool
 description: The help command displays help information and instructions on the command-line tool and its arguments.

--- a/doc-surrealdb_versioned_docs/version-latest/cli/import.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/cli/import.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 7
 sidebar_label: Import command
 title: Import command | CLI tool
 description: The import command imports a SurrealQL script file into a local or remote SurrealDB database server.

--- a/doc-surrealdb_versioned_docs/version-latest/cli/isready.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/cli/isready.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 8
 sidebar_label: Isready command
 title: Isready command | CLI tool
 description: The isready command attempts to connect to a remote SurrealDB server to detect if it has successfully started.

--- a/doc-surrealdb_versioned_docs/version-latest/cli/ml/_category_.json
+++ b/doc-surrealdb_versioned_docs/version-latest/cli/ml/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "ML commands",
-  "position": 10
+  "position": 9
 }

--- a/doc-surrealdb_versioned_docs/version-latest/cli/sql.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/cli/sql.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 9
+sidebar_position: 3
 sidebar_label: SQL command
 title: SQL command | CLI tool
 description: The SQL command starts a REPL for running or piping SurrealQL queries to a local or remote SurrealDB database server.

--- a/doc-surrealdb_versioned_docs/version-latest/cli/upgrade.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/cli/upgrade.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 9
+sidebar_position: 10
 sidebar_label: Upgrade command
 title: Upgrade command | CLI tool
 description: The upgrade command upgrades SurrealDB to the latest version, nightly or a specified version.

--- a/doc-surrealdb_versioned_docs/version-latest/cli/upgrade.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/cli/upgrade.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 11
+sidebar_position: 9
 sidebar_label: Upgrade command
 title: Upgrade command | CLI tool
 description: The upgrade command upgrades SurrealDB to the latest version, nightly or a specified version.

--- a/doc-surrealdb_versioned_docs/version-latest/cli/validate.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/cli/validate.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 10
+sidebar_position: 11
 sidebar_label: Validate command
 title: Validate command | CLI tool
 description: The validate command validates one or many SurrealQL language files.

--- a/doc-surrealdb_versioned_docs/version-latest/cli/validate.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/cli/validate.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8
+sidebar_position: 10
 sidebar_label: Validate command
 title: Validate command | CLI tool
 description: The validate command validates one or many SurrealQL language files.

--- a/doc-surrealdb_versioned_docs/version-latest/cli/version.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/cli/version.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 11
+sidebar_position: 12
 sidebar_label: Version command
 title: Version command | CLI tool
 description: The version command outputs the current version of the installed command-line tool, and the machine architecture.

--- a/doc-surrealdb_versioned_docs/version-latest/cli/version.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/cli/version.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 11
 sidebar_label: Version command
 title: Version command | CLI tool
 description: The version command outputs the current version of the installed command-line tool, and the machine architecture.

--- a/doc-surrealdb_versioned_docs/version-latest/installation/upgrading/beta.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/installation/upgrading/beta.mdx
@@ -15,8 +15,6 @@ The `2.0.0-beta` release of SurrealDB includes many new features, improvements, 
     -  [Record IDs now support storing UUIDs instead of strings](https://github.com/surrealdb/surrealdb/pull/4491). 
     -  [`Value::Range` stored as just a range instead of a string](https://github.com/surrealdb/surrealdb/pull/4506).
 
-Because of this, data will need to be exported as SQL and imported into `2.0.0-beta`.
-
 ### Do I have this issue?
 
 If you are experiencing this issue, an error similar to the following will be thrown when connecting to the database or when selecting specific data.
@@ -25,7 +23,17 @@ If you are experiencing this issue, an error similar to the following will be th
 error: Storage version is out-of-date.
 ```
 
-## Handling current data. 
+## Moving from 1.x to 2.0.0-beta
+
+A new [`surreal fix`](/docs/surrealdb/cli/start) command has been implemented to automatically change the format of your stored data. The command is followed by a path to the data. Two examples:
+
+```bash
+surreal fix surrealkv://mydata
+
+surreal fix rocksdb:somedatabase
+```
+
+## Moving from 2.0.0-alpha to 2.0.0-beta
 
 1. Export your current data as SQL. You can do this using the [`surreal export`](/docs/surrealdb/cli/export) command in the terminal:
 

--- a/doc-surrealdb_versioned_docs/version-latest/installation/upgrading/beta.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/installation/upgrading/beta.mdx
@@ -7,7 +7,7 @@ description: This guide will help you upgrade your current SurrealDB installatio
 
 # Upgrading to `2.0.0-beta` 
 
-The `2.0.0-beta` release of SurrealDB includes many new features, improvements, and bug fixes. However, because of changes in the underlying way that SurrealDB stores data, three steps are required to migrate to 2.0.0-beta. We've listed them below, and we advise following this migration guide whether or not you encounter this issue!
+The `2.0.0-beta` release of SurrealDB includes many new features, improvements, and bug fixes. However, because of changes in the underlying way that SurrealDB stores data, three steps are required to migrate to `2.0.0-beta`. We've listed them below, and we advise following this migration guide whether or not you encounter this issue!
 
 ## Issues
 
@@ -25,7 +25,7 @@ error: Storage version is out-of-date.
 
 ## Moving from 1.x to 2.0.0-beta
 
-A new [`surreal fix`](/docs/surrealdb/cli/start) command has been implemented to automatically change the format of your stored data. The command is followed by a path to the data. Two examples:
+A new [`surreal fix`](/docs/surrealdb/cli/fix) command has been implemented to automatically change the format of your stored data. The command is followed by a path to the data. Two examples:
 
 ```bash
 surreal fix surrealkv://mydata
@@ -34,6 +34,8 @@ surreal fix rocksdb:somedatabase
 ```
 
 ## Moving from 2.0.0-alpha to 2.0.0-beta
+
+The `surreal fix` command above has been created specifically for 1.x instances. However, data currently on a `2.0.0-alpha` instance can still be manually exported and then reimported into a project running on `2.0.0-beta` via the following steps.
 
 1. Export your current data as SQL. You can do this using the [`surreal export`](/docs/surrealdb/cli/export) command in the terminal:
 

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/commit.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/commit.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 4
 sidebar_label: COMMIT
 title: COMMIT statement | SurrealQL
 description: The COMMIT statement is used to commit a set of statements within a transaction, ensuring that all data modifications become a permanent part of the database.


### PR DESCRIPTION
This changes the beta guide to note the following:

* Manual export and import is only required when moving from 2.0.0-alpha to 2.0.0-beta
* Otherwise, use the surreal fix command.

Also adds a page to the CLI commands for the surreal fix command.

In addition, the order has been changed a little which I think makes sense:

* surreal start
* surreal sql
* surreal help
* All the rest in alphabetical order