### PR TITLE
docs-Fix typo in `time::month()` function documentation

### DIFF
--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/time.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/time.mdx
@@ -338,7 +338,7 @@ RETURN time::minute(d"2021-11-01T08:30:17+00:00");
 The `time::month` function extracts the month as a number from a datetime.
 
 ```surql title="API DEFINITION"
-time::minute(datetime) -> number
+time::month(datetime) -> number
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:
 


### PR DESCRIPTION
The documentation for the `time::month()` function uses the `time::minute()` function in the API definition. This commit corrects this to use the `time::month()` function.