### PR TITLE
docs-Changes to the Session functions documentation page

### DIFF
--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/session.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/session.mdx
@@ -57,7 +57,11 @@ These functions return information about the current SurrealDB session.
 
 <Since v="v2.0.0" />
 
-The `session::ac` function replaces the `session::sc` function and returns the current user's access method.
+:::note
+___NOTE:___ This function was known as `session::sc` in versions of SurrrealDB before 2.0. The behaviour has not changed.
+:::
+
+The `session::ac` function returns the current user's access method.
 
 ```surql title="API DEFINITION"
 session::ac() -> string

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/session.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/session.mdx
@@ -2,13 +2,13 @@
 sidebar_position: 17
 sidebar_label: Session functions
 title: Session functions | SurrealQL
-description: These functions can be used when working with and manipulating text and string values.
+description: These functions return information about the current SurrealDB session.
 ---
 import Since from '@site/src/components/Since'
 
 # Session functions
 
-These functions can be used when working with and manipulating text and string values.
+These functions return information about the current SurrealDB session.
 
 <table>
   <thead>


### PR DESCRIPTION
# Commit 1:

The documentation page for the Session functions currently has the description from the documentation page for the String functions:

"These functions can be used when working with and manipulating text and string values."

This commit replaces this with the following description:

"These functions return information about the current SurrealDB session."


# Commit 2:

The documentation page for the Session functions include:

"The `session::ac` function replaces the `session::sc` function and returns the current user's access method."

This commit changes this to keep the description of the function in its own sentence, and mention the change in a separate note. This is consistent with how other parts of the documentation flag when a new version of SuurealDB has changed a function name, such as `string::endsWith`.

