### PR TITLE
docs-Fixes to the Parse functions documentation page

### DIFF
--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/parse.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/parse.mdx
@@ -78,7 +78,7 @@ RETURN parse::email::host("info@surrealdb.com");
 The `parse::email::user` function parses and returns an email username from a valid email address.
 
 ```surql title="API DEFINITION"
-parse::email::user(string) -> bool
+parse::email::user(string) -> string
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:
 
@@ -96,7 +96,7 @@ The `parse::url::domain` function parses and returns domain from a valid URL.
 This function is similar to `parse::url::host` only that it will return `null` if the URL is an IP address.
 
 ```surql title="API DEFINITION"
-parse::url::domain(string) -> bool
+parse::url::domain(string) -> string
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:
 
@@ -118,7 +118,7 @@ null
 The `parse::url::fragment` function parses and returns the fragment from a valid URL.
 
 ```surql title="API DEFINITION"
-parse::url::fragment(string) -> bool
+parse::url::fragment(string) -> string
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:
 
@@ -135,7 +135,7 @@ RETURN parse::url::fragment("https://surrealdb.com:80/features?some=option#fragm
 The `parse::url::host` function parses and returns the hostname from a valid URL.
 
 ```surql title="API DEFINITION"
-parse::url::host(string) -> bool
+parse::url::host(string) -> string
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:
 
@@ -157,7 +157,7 @@ RETURN parse::url::host("http://127.0.0.1/index.html");
 The `parse::url::path`  function parses and returns the path from a valid URL.
 
 ```surql title="API DEFINITION"
-parse::url::path(string) -> bool
+parse::url::path(string) -> string
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:
 
@@ -174,7 +174,7 @@ RETURN parse::url::path("https://surrealdb.com:80/features?some=option#fragment"
 The `parse::url::port` function parses and returns the port from a valid URL.
 
 ```surql title="API DEFINITION"
-parse::url::port(string) -> bool
+parse::url::port(string) -> number
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:
 
@@ -191,7 +191,7 @@ RETURN parse::url::port("https://surrealdb.com:80/features?some=option#fragment"
 The `parse::url::scheme` function parses and returns the scheme from a valid URL, in lowercase, as an ASCII string without the ':' delimiter.
 
 ```surql title="API DEFINITION"
-parse::url::scheme(string) -> bool
+parse::url::scheme(string) -> string
 ```
 
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:
@@ -209,7 +209,7 @@ RETURN parse::url::scheme("https://surrealdb.com:80/features?some=option#fragmen
 The `parse::url::query` function parses and returns the query from a valid URL.
 
 ```surql title="API DEFINITION"
-parse::url::query(string) -> bool
+parse::url::query(string) -> string
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:
 

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/parse.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/parse.mdx
@@ -46,7 +46,7 @@ These functions can be used when parsing email addresses and URL web addresses.
       <td scope="row" data-label="Description">Parses and returns the port number from a URL</td>
     </tr>
     <tr>
-      <td scope="row" data-label="Function"><a href="#parseurlscheme"><code>parse::url::port()</code></a></td>
+      <td scope="row" data-label="Function"><a href="#parseurlscheme"><code>parse::url::scheme()</code></a></td>
       <td scope="row" data-label="Description">Parses and returns the scheme from a URL</td>
     </tr>
     <tr>


### PR DESCRIPTION
# Commit 1:

##  docs-Fix typo on Parse functions page duplicalting the `parse::url::port()` function

On the documentation page for the Parse functions, the list of functions includes the `parse::url::port()` function twice, The second appearance was intended to be the `parse::url::scheme()` function.

This commit changes the second appearance to `parse::url::scheme()`.

# Commit 2:

## docs-Fix function return types on Parse functions documentation page

On the documentation page for the Parse functions, many of the functions currently show a return type of `bool` in the API definitions, instead of their correct return types.

This commit changes the return type shown in the API definitions of the following functions  to `string`:
`parse::email::user`
`parse::url::domain`
`parse::url::fragment`
`parse::url::host`
`parse::url::path`
`parse::url::scheme`
`parse::url::query`

This commit changes the return type shown in the API definitions of the following functions  to `number`:
`parse::url::port`