### PR TITLE
docs-Fix typo in Database functions overview page (index.html)

### DIFF
--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/index.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/index.mdx
@@ -72,7 +72,7 @@ SurrealDB comes with a large number of in-built functions for checking, manipula
       <td scope="row" data-label="Example"><code>rand::enum('one', 'two', 3, 4.15385, 'five', true)</code></td>
     </tr>
     <tr>
-      <td scope="row" data-label="Module"><a href="/docs/surrealdb/surrealql/functions/database/record"><code>Meta functions</code></a></td>
+      <td scope="row" data-label="Module"><a href="/docs/surrealdb/surrealql/functions/database/record"><code>Record functions</code></a></td>
       <td scope="row" data-label="Example"><code>record::id(person:tobie)</code></td>
     </tr>
     <tr>


### PR DESCRIPTION
On the documentation overview page for Database functions (`index.html`), the "Meta functions"  module is currently listed twice. The second appearance was intended to be the "Record functions" module.

This commit changes the second appearance of "Meta functions" to "Record functions".