### PR TITLE
docs-Fix typos in Duration functions documentation page

### DIFF
--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/duration.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/duration.mdx
@@ -250,7 +250,7 @@ RETURN duration::years(300w);
 
 ## `duration::from::days`
 
-The `duration::years` function counts how many years fit into a duration.
+The `duration::from::days` function counts how many years fit into a duration.
 
 ```surql title="API DEFINITION"
 duration::from::days(number) -> duration
@@ -369,7 +369,7 @@ RETURN duration::from::secs(3);
 
 ## `duration::from::weeks`
 
-The `duration::from::days` function converts a numeric amount of weeks into a duration that represents weeks.
+The `duration::from::weeks` function converts a numeric amount of weeks into a duration that represents weeks.
 
 ```surql title="API DEFINITION"
 duration::from::weeks(number) -> duration


### PR DESCRIPTION
In the documentation pages for the Duration functions, the `duration::from::days` and `duration::from::weeks` functions include the wrong function name in their descriptions.

This commit corrects the function names in the descriptions.