### PR TITLE
docs-Add title to Record functions documentation page

### DIFF
--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/record.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/record.mdx
@@ -7,6 +7,8 @@ description: These functions can be used to retrieve specific metadata from a Su
 
 import Since from '@site/src/components/Since'
 
+# Record functions
+
 :::note
 Record functions before SurrealDB 2.0 were located inside the module [meta](/docs/surrealdb/surrealql/functions/database/meta).
 :::


### PR DESCRIPTION
On the documentation page for the Record functions, the title is omitted from the page's source code, causing the page's title to default to the title from the page's header metadata ("Record functions | SurrealQL")

This commit adds the explicit page tile of "Record functions" to make the page's title format consistent with the rest of the function documentation pages ("Record functions").