### PR TITLE
docs-Fix typos on Type functions documentation page 

### DIFF
--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/type.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/type.mdx
@@ -223,7 +223,7 @@ RETURN type::decimal("12345");
 12345.00
 ```
 
-This is the equivalent of using [`<decimal>`](/docs/surrealdb/surrealql/datamodel/casting#decimal) to cast a value to a datetime.
+This is the equivalent of using [`<decimal>`](/docs/surrealdb/surrealql/datamodel/casting#decimal) to cast a value to a decimal.
 
 <br />
 
@@ -242,7 +242,7 @@ RETURN type::duration("4h");
 4h
 ```
 
-This is the equivalent of using [`<duration>`](/docs/surrealdb/surrealql/datamodel/casting#duration) to cast a value to a datetime.
+This is the equivalent of using [`<duration>`](/docs/surrealdb/surrealql/datamodel/casting#duration) to cast a value to a duration.
 
 <br />
 
@@ -330,7 +330,7 @@ RETURN type::float("12345");
 
 12345.0
 ```
-This is the equivalent of using [`<float>`](/docs/surrealdb/surrealql/datamodel/casting#float) to cast a value to a datetime.
+This is the equivalent of using [`<float>`](/docs/surrealdb/surrealql/datamodel/casting#float) to cast a value to a float.
 
 <br />
 
@@ -348,7 +348,7 @@ RETURN type::int("12345");
 
 12345
 ```
-This is the equivalent of using [`<int>`](/docs/surrealdb/surrealql/datamodel/casting#int) to cast a value to a datetime.
+This is the equivalent of using [`<int>`](/docs/surrealdb/surrealql/datamodel/casting#int) to cast a value to a int.
 
 <br />
 
@@ -366,7 +366,7 @@ RETURN type::number("12345");
 
 12345
 ```
-This is the equivalent of using [`<number>`](/docs/surrealdb/surrealql/datamodel/casting#number) to cast a value to a datetime.
+This is the equivalent of using [`<number>`](/docs/surrealdb/surrealql/datamodel/casting#number) to cast a value to a number.
 
 <br />
 
@@ -407,7 +407,7 @@ RETURN type::string(12345);
 
 "12345"
 ```
-This is the equivalent of using [`<string>`](/docs/surrealdb/surrealql/datamodel/casting#string) to cast a value to a datetime.
+This is the equivalent of using [`<string>`](/docs/surrealdb/surrealql/datamodel/casting#string) to cast a value to a string.
 
 <br />
 

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/type.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/type.mdx
@@ -816,7 +816,7 @@ false
 
 ## `type::is::record` 
 
-The `type::is::record` function checks if the passed value is of type `record`
+The `type::is::record` function checks if the passed value is of type `record`.
 
 ```surql title="API DEFINITION"
 type::is::record(any, any) -> bool


### PR DESCRIPTION
# Commit 1:

## docs-Fix return type typos on Type functions documentation page

In the documentation page for the Type functions, the following functions' descriptions mention the wrong type which they covert values into:
`type::decimal`
`type::duration`
`type::float`
`type::int`
`type::number`
`type::string`

This commit corrects these return types.


# Commit 2:

## docs-Fix typo, add missing period on Type functions documentation page

In the documentation page for the Type functions, the description of the `type::is::record` function is missing a period at the end of the sentence.

This commit adds the missing period.