### PR TITLE
Change API for many time functions which are optional

### DIFF
--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/time.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/time.mdx
@@ -8,7 +8,20 @@ import Since from '@site/src/components/Since'
 
 # Time Functions
 
-These functions can be used when working with and manipulating datetime values.
+These functions can be used when working with and manipulating [datetime](/docs/surrealdb/surrealql/datamodel/datetimes) values.
+
+Many time functions take an `option<datetime>` in order to return certain values from a datetime such as its hours, minutes, day of the year, and so in. If no argument is present, the current datetime will be extracted and used. As such, all of the following function calls are valid and will not return an error.
+
+```surql
+time::hour(d'2024-09-04T00:32:44.107Z');
+time::hour();
+
+time::minute(d'2024-09-04T00:32:44.107Z');
+time::minute();
+
+time::yday(d'2024-09-04T00:32:44.107Z');
+time::yday();
+```
 
 <table>
   <thead>
@@ -229,7 +242,7 @@ d"2021-01-01T00:00:00Z"
 
 ## `time::hour`
 
-The `time::hour` function extracts the hour as a number from a datetime or from the current date if no datetime argument is present.
+The `time::hour` function extracts the hour as a number from a datetime, or from the current date if no datetime argument is present.
 
 ```surql title="API DEFINITION"
 time::hour(option<datetime>) -> number

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/time.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/time.mdx
@@ -24,7 +24,7 @@ These functions can be used when working with and manipulating datetime values.
     </tr>
     <tr>
       <td scope="row" data-label="Function"><a href="#timeday"><code>time::day()</code></a></td>
-      <td scope="row" data-label="Description">Extracts the day as a number from a datetime</td>
+      <td scope="row" data-label="Description">Extracts the day as a number from a datetime or current datetime</td>
     </tr>
     <tr>
       <td scope="row" data-label="Function"><a href="#timefloor"><code>time::floor()</code></a></td>
@@ -40,7 +40,7 @@ These functions can be used when working with and manipulating datetime values.
     </tr>
     <tr>
       <td scope="row" data-label="Function"><a href="#timehour"><code>time::hour()</code></a></td>
-      <td scope="row" data-label="Description">Extracts the hour as a number from a datetime</td>
+      <td scope="row" data-label="Description">Extracts the hour as a number from a datetime or current datetime</td>
     </tr>
     <tr>
       <td scope="row" data-label="Function"><a href="#timemax"><code>time::max()</code></a></td>
@@ -48,11 +48,11 @@ These functions can be used when working with and manipulating datetime values.
     </tr>
     <tr>
       <td scope="row" data-label="Function"><a href="#timemicros"><code>time::micros()</code></a></td>
-      <td scope="row" data-label="Description">Extracts the microseconds as a number from a datatime</td>
+      <td scope="row" data-label="Description">Extracts the microseconds as a number from a datatime or current datetime</td>
     </tr>
     <tr>
       <td scope="row" data-label="Function"><a href="#timemillis"><code>time::millis()</code></a></td>
-      <td scope="row" data-label="Description">Extracts the milliseconds as a number from a datatime</td>
+      <td scope="row" data-label="Description">Extracts the milliseconds as a number from a datatime or current datetime</td>
     </tr>
     <tr>
       <td scope="row" data-label="Function"><a href="#timemin"><code>time::min()</code></a></td>
@@ -60,15 +60,15 @@ These functions can be used when working with and manipulating datetime values.
     </tr>
     <tr>
       <td scope="row" data-label="Function"><a href="#timeminute"><code>time::minute()</code></a></td>
-      <td scope="row" data-label="Description">Extracts the minutes as a number from a datetime</td>
+      <td scope="row" data-label="Description">Extracts the minutes as a number from a datetime or current datetime</td>
     </tr>
     <tr>
       <td scope="row" data-label="Function"><a href="#timemonth"><code>time::month()</code></a></td>
-      <td scope="row" data-label="Description">Extracts the month as a number from a datetime</td>
+      <td scope="row" data-label="Description">Extracts the month as a number from a datetime or current datetime</td>
     </tr>
     <tr>
       <td scope="row" data-label="Function"><a href="#timenano"><code>time::nano()</code></a></td>
-      <td scope="row" data-label="Description">Returns the number of nanoseconds since the UNIX epoch</td>
+      <td scope="row" data-label="Description">Returns the number of nanoseconds since the UNIX epoch until a datetime or current datetime</td>
     </tr>
     <tr>
       <td scope="row" data-label="Function"><a href="#timenow"><code>time::now()</code></a></td>
@@ -80,7 +80,7 @@ These functions can be used when working with and manipulating datetime values.
     </tr>
     <tr>
       <td scope="row" data-label="Function"><a href="#timesecond"><code>time::second()</code></a></td>
-      <td scope="row" data-label="Description">Extracts the second as a number from a datetime</td>
+      <td scope="row" data-label="Description">Extracts the second as a number from a datetime or current datetime</td>
     </tr>
     <tr>
       <td scope="row" data-label="Function"><a href="#timetimezone"><code>time::timezone()</code></a></td>
@@ -92,19 +92,19 @@ These functions can be used when working with and manipulating datetime values.
     </tr>
     <tr>
       <td scope="row" data-label="Function"><a href="#timewday"><code>time::wday()</code></a></td>
-      <td scope="row" data-label="Description">Extracts the week day as a number from a datetime</td>
+      <td scope="row" data-label="Description">Extracts the week day as a number from a datetime or current datetime</td>
     </tr>
     <tr>
       <td scope="row" data-label="Function"><a href="#timeweek"><code>time::week()</code></a></td>
-      <td scope="row" data-label="Description">Extracts the week as a number from a datetime</td>
+      <td scope="row" data-label="Description">Extracts the week as a number from a datetime or current datetime</td>
     </tr>
     <tr>
       <td scope="row" data-label="Function"><a href="#timeyday"><code>time::yday()</code></a></td>
-      <td scope="row" data-label="Description">Extracts the yday as a number from a datetime</td>
+      <td scope="row" data-label="Description">Extracts the yday as a number from a datetime or current datetime</td>
     </tr>
     <tr>
       <td scope="row" data-label="Function"><a href="#timeyear"><code>time::year()</code></a></td>
-      <td scope="row" data-label="Description">Extracts the year as a number from a datetime</td>
+      <td scope="row" data-label="Description">Extracts the year as a number from a datetime or current datetime</td>
     </tr>
     <tr>
       <td scope="row" data-label="Function"><a href="#timefrommicros"><code>time::from::micros()</code></a></td>
@@ -157,10 +157,10 @@ RETURN [
 
 ## `time::day`
 
-The `time::day` function extracts the day as a number from a datetime.
+The `time::day` function extracts the day as a number from a datetime, or from the current date if no datetime argument is present.
 
 ```surql title="API DEFINITION"
-time::day(datetime) -> number
+time::day(option<datetime>) -> number
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:
 
@@ -229,10 +229,10 @@ d"2021-01-01T00:00:00Z"
 
 ## `time::hour`
 
-The `time::hour` function extracts the hour as a number from a datetime.
+The `time::hour` function extracts the hour as a number from a datetime or from the current date if no datetime argument is present.
 
 ```surql title="API DEFINITION"
-time::hour(datetime) -> number
+time::hour(option<datetime>) -> number
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:
 
@@ -265,10 +265,10 @@ d"1988-06-22T08:30:45Z"
 
 <Since v="v1.1.0" />
 
-The `time::micros` function extracts the microseconds as a number from a datetime.
+The `time::micros` function extracts the microseconds as a number from a datetime, or from the current date if no datetime argument is present.
 
 ```surql title="API DEFINITION"
-time::micros(datetime) -> number
+time::micros(option<datetime>) -> number
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:
 
@@ -284,10 +284,10 @@ RETURN time::micros(d"1987-06-22T08:30:45Z");
 
 <Since v="v1.1.0" />
 
-The `time::millis` function extracts the milliseconds as a number from a datetime.
+The `time::millis` function extracts the milliseconds as a number from a datetime, or from the current date if no datetime argument is present.
 
 ```surql title="API DEFINITION"
-time::millis(datetime) -> number
+time::millis(option<datetime>) -> number
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:
 
@@ -318,10 +318,10 @@ d"1987-06-22T08:30:45Z"
 
 ## `time::minute`
 
-The `time::minute` function extracts the minutes as a number from a datetime.
+The `time::minute` function extracts the minutes as a number from a datetime, or from the current date if no datetime argument is present.
 
 ```surql title="API DEFINITION"
-time::minute(datetime) -> number
+time::minute(option<datetime>) -> number
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:
 
@@ -335,10 +335,10 @@ RETURN time::minute(d"2021-11-01T08:30:17+00:00");
 
 ## `time::month`
 
-The `time::month` function extracts the month as a number from a datetime.
+The `time::month` function extracts the month as a number from a datetime, or from the current date if no datetime argument is present.
 
 ```surql title="API DEFINITION"
-time::month(datetime) -> number
+time::month(option<datetime>) -> number
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:
 
@@ -352,10 +352,10 @@ RETURN time::month(d"2021-11-01T08:30:17+00:00");
 
 ## `time::nano`
 
-The `time::nano`function returns a datetime as an integer representing the number of nanoseconds since the UNIX epoch.
+The `time::nano`function returns a datetime as an integer representing the number of nanoseconds since the UNIX epoch until a datetime, or the current date if no datetime argument is present.
 
 ```surql title="API DEFINITION"
-time::nano(datetime) -> number
+time::nano(option<datetime>) -> number
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:
 
@@ -396,10 +396,10 @@ d"2021-11-04T00:00:00Z"
 
 ## `time::second`
 
-The `time::second` function extracts the second as a number from a datetime.
+The `time::second` function extracts the second as a number from a datetime, or from the current date if no datetime argument is present.
 
 ```surql title="API DEFINITION"
-time::second(datetime) -> number
+time::second(option<datetime>) -> number
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:
 
@@ -423,10 +423,10 @@ time::timezone() -> string
 
 ## `time::unix`
 
-The `time::unix` function returns a datetime as an integer representing the number of seconds since the UNIX epoch.
+The `time::unix` function returns a datetime as an integer representing the number of seconds since the UNIX epoch until a certain datetime, or from the current date if no datetime argument is present.
 
 ```surql title="API DEFINITION"
-time::unix(datetime) -> number
+time::unix(option<datetime>) -> number
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:
 
@@ -440,10 +440,10 @@ RETURN time::unix(d"2021-11-01T08:30:17+00:00");
 
 ## `time::wday`
 
-The `time::wday` function extracts the week day as a number from a datetime.
+The `time::wday` function extracts the week day as a number from a datetime, or from the current date if no datetime argument is present.
 
 ```surql title="API DEFINITION"
-time::wday(datetime) -> number
+time::wday(option<datetime>) -> number
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:
 
@@ -457,10 +457,10 @@ RETURN time::wday(d"2021-11-01T08:30:17+00:00");
 
 ## `time::week`
 
-The `time::week` function extracts the week as a number from a datetime.
+The `time::week` function extracts the week as a number from a datetime, or from the current date if no datetime argument is present.
 
 ```surql title="API DEFINITION"
-time::week(datetime) -> number
+time::week(option<datetime>) -> number
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:
 
@@ -474,10 +474,10 @@ RETURN time::week(d"2021-11-01T08:30:17+00:00");
 
 ## `time::yday`
 
-The `time::yday` function extracts the yday as a number from a datetime.
+The `time::yday` function extracts the day of the year as a number from a datetime, or from the current date if no datetime argument is present.
 
 ```surql title="API DEFINITION"
-time::yday(datetime) -> number
+time::yday(option<datetime>) -> number
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:
 
@@ -491,10 +491,10 @@ RETURN time::yday(d"2021-11-01T08:30:17+00:00");
 
 ## `time::year`
 
-The `time::year` function extracts the year as a number from a datetime.
+The `time::year` function extracts the year as a number from a datetime, or from the current date if no datetime argument is present.
 
 ```surql title="API DEFINITION"
-time::year(datetime) -> number
+time::year(option<datetime>) -> number
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:
 


### PR DESCRIPTION
Noticed today that many of these time functions have the nice convenience of being optional, defaulting to the current datetime if no datetime argument is present.