### PR TITLE
docs-Changes to Number data types documentation

### DIFF
--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/datamodel/numbers.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/datamodel/numbers.mdx
@@ -10,7 +10,7 @@ description: In SurrealDB, numbers can be one of three types - 64-bit integers, 
 
 In SurrealDB, numbers can be one of three types: 64-bit integers, 64-bit floating point numbers, or 128-bit decimal numbers.
 
-Integer numbers
+## Integer numbers
 If a numeric value is specified without a decimal point and is within the range `-9223372036854775808` to `9223372036854775807` then the value will be parsed, stored, and treated as a 64-bit integer.
 
 ```surql

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/datamodel/numbers.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/datamodel/numbers.mdx
@@ -87,6 +87,7 @@ CREATE circle SET radius = circumference / ( 2 * MATH::PI );
     <thead>
         <tr>
             <th colspan="2" scope="col">Constant</th>
+            <th colspan="2" scope="col">Description</th>
             <th colspan="2" scope="col">Value</th>
         </tr>
     </thead>  
@@ -94,6 +95,9 @@ CREATE circle SET radius = circumference / ( 2 * MATH::PI );
         <tr>
             <td colspan="2" scope="row" data-label="Constant">
                 <code>MATH::E</code>
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+                Euler’s number (e)
             </td>
             <td colspan="2" scope="row" data-label="Value">
                 2.718281828459045
@@ -103,6 +107,9 @@ CREATE circle SET radius = circumference / ( 2 * MATH::PI );
             <td colspan="2" scope="row" data-label="Constant">
                 <code>MATH::FRAC_1_PI</code>
             </td>
+            <td colspan="2" scope="row" data-label="Description">
+                1/π
+            </td>
             <td colspan="2" scope="row" data-label="Value">
                 0.3183098861837907
             </td>
@@ -110,6 +117,9 @@ CREATE circle SET radius = circumference / ( 2 * MATH::PI );
         <tr>
             <td colspan="2" scope="row" data-label="Constant">
                 <code>MATH::FRAC_1_SQRT_2</code>
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+                1/sqrt(2)
             </td>
             <td colspan="2" scope="row" data-label="Value">
                 0.7071067811865476
@@ -119,6 +129,9 @@ CREATE circle SET radius = circumference / ( 2 * MATH::PI );
             <td colspan="2" scope="row" data-label="Constant">
                 <code>MATH::FRAC_2_PI</code>
             </td>
+            <td colspan="2" scope="row" data-label="Description">
+                2/π
+            </td>
             <td colspan="2" scope="row" data-label="Value">
                 0.6366197723675814
             </td>
@@ -126,6 +139,9 @@ CREATE circle SET radius = circumference / ( 2 * MATH::PI );
         <tr>
             <td colspan="2" scope="row" data-label="Constant">
                 <code>MATH::FRAC_2_SQRT_PI</code>
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+                2/sqrt(π)
             </td>
             <td colspan="2" scope="row" data-label="Value">
                 1.1283791670955126
@@ -135,6 +151,9 @@ CREATE circle SET radius = circumference / ( 2 * MATH::PI );
             <td colspan="2" scope="row" data-label="Constant">
                 <code>MATH::FRAC_PI_2</code>
             </td>
+            <td colspan="2" scope="row" data-label="Description">
+                π/2
+            </td>
             <td colspan="2" scope="row" data-label="Value">
             1.5707963267948966
             </td>
@@ -142,6 +161,9 @@ CREATE circle SET radius = circumference / ( 2 * MATH::PI );
         <tr>
             <td colspan="2" scope="row" data-label="Constant">
                 <code>MATH::FRAC_PI_3</code>
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+                π/3
             </td>
             <td colspan="2" scope="row" data-label="Value">
                 1.0471975511965979
@@ -151,6 +173,9 @@ CREATE circle SET radius = circumference / ( 2 * MATH::PI );
             <td colspan="2" scope="row" data-label="Constant">
                 <code>MATH::FRAC_PI_4</code>
             </td>
+            <td colspan="2" scope="row" data-label="Description">
+                π/4
+            </td>
             <td colspan="2" scope="row" data-label="Value">
                 0.7853981633974483
             </td>
@@ -158,6 +183,9 @@ CREATE circle SET radius = circumference / ( 2 * MATH::PI );
         <tr>
             <td colspan="2" scope="row" data-label="Constant">
                 <code>MATH::FRAC_PI_6</code>
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+                π/6
             </td>
             <td colspan="2" scope="row" data-label="Value">
                 0.5235987755982989
@@ -167,6 +195,9 @@ CREATE circle SET radius = circumference / ( 2 * MATH::PI );
             <td colspan="2" scope="row" data-label="Constant">
                 <code>MATH::FRAC_PI_8</code>
             </td>
+            <td colspan="2" scope="row" data-label="Description">
+                π/8
+            </td>
             <td colspan="2" scope="row" data-label="Value">
                 0.39269908169872414
             </td>
@@ -174,6 +205,9 @@ CREATE circle SET radius = circumference / ( 2 * MATH::PI );
         <tr>
             <td colspan="2" scope="row" data-label="Constant">
                 <code>MATH::LN_10</code>
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+                ln(10)
             </td>
             <td colspan="2" scope="row" data-label="Value">
                 2.302585092994046
@@ -183,6 +217,9 @@ CREATE circle SET radius = circumference / ( 2 * MATH::PI );
             <td colspan="2" scope="row" data-label="Constant">
                 <code>MATH::LN_2</code>
             </td>
+            <td colspan="2" scope="row" data-label="Description">
+                ln(2)
+            </td>
             <td colspan="2" scope="row" data-label="Value">
                 0.6931471805599453
             </td>
@@ -190,6 +227,9 @@ CREATE circle SET radius = circumference / ( 2 * MATH::PI );
         <tr>
             <td colspan="2" scope="row" data-label="Constant">
                 <code>MATH::LOG10_2</code>
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+                log2(10)
             </td>
             <td colspan="2" scope="row" data-label="Value">
                 0.3010299956639812
@@ -199,6 +239,9 @@ CREATE circle SET radius = circumference / ( 2 * MATH::PI );
             <td colspan="2" scope="row" data-label="Constant">
                 <code>MATH::LOG10_E</code>
             </td>
+            <td colspan="2" scope="row" data-label="Description">
+                log10(e)
+            </td>
             <td colspan="2" scope="row" data-label="Value">
                 0.4342944819032518
             </td>
@@ -206,6 +249,9 @@ CREATE circle SET radius = circumference / ( 2 * MATH::PI );
         <tr>
             <td colspan="2" scope="row" data-label="Constant">
                 <code>MATH::LOG2_10</code>
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+                log2(10)
             </td>
             <td colspan="2" scope="row" data-label="Value">
             3.321928094887362
@@ -215,6 +261,9 @@ CREATE circle SET radius = circumference / ( 2 * MATH::PI );
             <td colspan="2" scope="row" data-label="Constant">
                 <code>MATH::LOG2_E</code>
             </td>
+            <td colspan="2" scope="row" data-label="Description">
+                log2(e)
+            </td>
             <td colspan="2" scope="row" data-label="Value">
                 1.4426950408889634
             </td>
@@ -222,6 +271,9 @@ CREATE circle SET radius = circumference / ( 2 * MATH::PI );
         <tr>
             <td colspan="2" scope="row" data-label="Constant">
                 <code>MATH::PI</code>
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+                Archimedes’ constant (π)
             </td>
             <td colspan="2" scope="row" data-label="Value">
                 3.141592653589793
@@ -231,6 +283,9 @@ CREATE circle SET radius = circumference / ( 2 * MATH::PI );
             <td colspan="2" scope="row" data-label="Constant">
                 <code>MATH::SQRT_2</code>
             </td>
+            <td colspan="2" scope="row" data-label="Description">
+                sqrt(2)
+            </td>
             <td colspan="2" scope="row" data-label="Value">
             1.4142135623730951
             </td>
@@ -238,6 +293,9 @@ CREATE circle SET radius = circumference / ( 2 * MATH::PI );
         <tr>
             <td colspan="2" scope="row" data-label="Constant">
                 <code>MATH::TAU</code>
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+                The full circle constant (τ)
             </td>
             <td colspan="2" scope="row" data-label="Value">
                 6.283185307179586

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/datamodel/numbers.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/datamodel/numbers.mdx
@@ -229,7 +229,7 @@ CREATE circle SET radius = circumference / ( 2 * MATH::PI );
                 <code>MATH::LOG10_2</code>
             </td>
             <td colspan="2" scope="row" data-label="Description">
-                log2(10)
+                log<sub>10</sub>(2)
             </td>
             <td colspan="2" scope="row" data-label="Value">
                 0.3010299956639812
@@ -240,7 +240,7 @@ CREATE circle SET radius = circumference / ( 2 * MATH::PI );
                 <code>MATH::LOG10_E</code>
             </td>
             <td colspan="2" scope="row" data-label="Description">
-                log10(e)
+                log<sub>10</sub>(e)
             </td>
             <td colspan="2" scope="row" data-label="Value">
                 0.4342944819032518
@@ -251,7 +251,7 @@ CREATE circle SET radius = circumference / ( 2 * MATH::PI );
                 <code>MATH::LOG2_10</code>
             </td>
             <td colspan="2" scope="row" data-label="Description">
-                log2(10)
+                log<sub>2</sub>(10)
             </td>
             <td colspan="2" scope="row" data-label="Value">
             3.321928094887362
@@ -262,7 +262,7 @@ CREATE circle SET radius = circumference / ( 2 * MATH::PI );
                 <code>MATH::LOG2_E</code>
             </td>
             <td colspan="2" scope="row" data-label="Description">
-                log2(e)
+                log<sub>2</sub>(e)
             </td>
             <td colspan="2" scope="row" data-label="Value">
                 1.4426950408889634


### PR DESCRIPTION
# Commit 1:
## docs-Add descriptions of mathematical constants

This commit adds a column to the table of mathematical constants with a description of what each constant is. These descriptions were taken from the documentation of the Rust module from which SurrealDB gets these constants (https://doc.rust-lang.org/std/f64/consts/index.html).

# Commit 2:
## docs-Fix header formatting for integer numbers documentation

In the Numbers data type documentation page, the "Integer numbers" section's header is missing the header formatting ("##").

This commit adds the header formatting ("##").

# Commit 3:
## docs-Add subscript formatting to mathematical constants' descriptions

This commit adds subscript formatting to the descriptions of the mathematical constants.
