### PR TITLE
docs-Changes to Math functions documentation

### DIFF
--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/math.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/math.mdx
@@ -887,40 +887,6 @@ RETURN math::sin(1);
 
 <br />
 
-## `math::tan`
-
-<Since v="v2.0.0" />
-
-The `math::tan` function returns the tangent of a number, which is assumed to be in radians.
-
-```surql title="API DEFINITION"
-math::tan(number) -> number
-```
-The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:
-
-```surql
-RETURN math::tan(1);
-
-1.5574077246549023
-```
-
-<br />
-
-## `math::tau`
-
-The `math::tau` constant represents the mathematical constant τ, which is equal to 2π.
-
-```surql title="API DEFINITION"
-math::tau -> number
-```
-The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:
-
-```surql
-RETURN math::tau;
-
-6.283185307179586f
-```
-
 ## `math::spread`
 
 The `math::spread` function returns the spread of an array of numbers.
@@ -985,6 +951,42 @@ The following example shows this function, and its output, when used in a [`RETU
 RETURN math::sum([ 26.164, 13.746189, 23, 16.4, 41.42 ]);
 
 120.730189
+```
+
+<br />
+
+## `math::tan`
+
+<Since v="v2.0.0" />
+
+The `math::tan` function returns the tangent of a number, which is assumed to be in radians.
+
+```surql title="API DEFINITION"
+math::tan(number) -> number
+```
+The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:
+
+```surql
+RETURN math::tan(1);
+
+1.5574077246549023
+```
+
+<br />
+
+## `math::tau`
+
+The `math::tau` constant represents the mathematical constant τ, which is equal to 2π.
+
+```surql title="API DEFINITION"
+math::tau -> number
+```
+The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:
+
+```surql
+RETURN math::tau;
+
+6.283185307179586f
 ```
 
 <br />

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/math.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/math.mdx
@@ -187,6 +187,10 @@ These functions can be used when analysing numeric data and numeric collections.
       <td scope="row" data-label="Description">Returns the total sum of a set of numbers</td>
     </tr>
     <tr>
+      <td scope="row" data-label="Function"><a href="#mathtan"><code>math::tan</code></a></td>
+      <td scope="row" data-label="Description">Computes the tangent of an angle given in radians.</td>
+    </tr>
+    <tr>
       <td scope="row" data-label="Constant"><a href="#mathtau"><code>math::tau</code></a></td>
       <td scope="row" data-label="Description">Represents the mathematical constant τ.</td>
     </tr>

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/math.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/math.mdx
@@ -187,11 +187,11 @@ These functions can be used when analysing numeric data and numeric collections.
       <td scope="row" data-label="Description">Returns the total sum of a set of numbers</td>
     </tr>
     <tr>
-      <td scope="row" data-label="Function"><a href="#mathtan"><code>math::tan</code></a></td>
+      <td scope="row" data-label="Function"><a href="#mathtan"><code>math::tan()</code></a></td>
       <td scope="row" data-label="Description">Computes the tangent of an angle given in radians.</td>
     </tr>
     <tr>
-      <td scope="row" data-label="Constant"><a href="#mathtau"><code>math::tau</code></a></td>
+      <td scope="row" data-label="Constant"><a href="#mathtau"><code>math::tau()</code></a></td>
       <td scope="row" data-label="Description">Represents the mathematical constant τ.</td>
     </tr>
     <tr>

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/math.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/math.mdx
@@ -28,7 +28,7 @@ These functions can be used when analysing numeric data and numeric collections.
     </tr>
     <tr>
       <td scope="row" data-label="Function"><a href="#mathacot"><code>math::acot()</code></a></td>
-      <td scope="row" data-label="Description">Computes the cotangent of an angle given in radians</td>
+      <td scope="row" data-label="Description">Computes the arccotangent (inverse cotangent) of an angle given in radians</td>
     </tr>
     <tr>
       <td scope="row" data-label="Function"><a href="#mathasin"><code>math::asin()</code></a></td>


### PR DESCRIPTION
# Commit 1:
## docs-Add missing `math::tan` function to table in Math functions documentation

On the documentation page for the Math functions, the table of functions is missing the `math::tan` function.

This commit adds the missing `math::tan` function to the table.


# Commit 2:
## docs-Fix description of `math::acot` function in Math functions documentation

In the Math functions documentation page, the `math::acot` function has the description of the `math::cot` function:
"Computes the cotangent of an angle given in radians"

This commit changes the description of `Math::acot` to:
"Computes the arccotangent (inverse cotangent) of an angle given in radians"


# Commit 3:
## docs-Move `math::tan` and `math::tau` in Math functions documentation

In the documentation page for the Math functions, the `math::tan` and `math::tau` appear in a different position than in the page's function table (alphabetical order).

This commit moves the `math::tan` and `math::tau` functions to the positions shown in the page's function table (alphabetical order).


# Commit 4:
## docs-Add missing parenthesis to SurrealQL functions math::tan and `math::tau`

In the SurrealQL math functions documentation, the `math::tan` and `math::tau` functions are missing parentheses.

This commit adds the missing parentheses.