### PR TITLE
docs-Changes to the CLI `surreal start` command documentation

### DIFF
--- a/doc-surrealdb_versioned_docs/version-latest/cli/start.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/cli/start.mdx
@@ -148,7 +148,7 @@ Ensure that the hosting location indicated by the output of the `surreal start` 
 This example also selects a namespace and database so that you can immediately start entering queries if you wish.
 
 ```bash
-surreal sql --endpoint http://127.0.0.1:8000 --namespace my_namespace --database my_database
+surreal sql --endpoint http://127.0.0.1:8000 --namespace my_namespace --database my_database --auth-level root --username my_username --password my_password
 ```
 
 See the documentation of the [`surreal sql` command](/docs/surrealdb/cli/sql) for more information.

--- a/doc-surrealdb_versioned_docs/version-latest/cli/start.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/cli/start.mdx
@@ -153,7 +153,6 @@ surreal sql --endpoint http://127.0.0.1:8000 --namespace my_namespace --database
 
 Note that the `username` and `password` in the `surreal sql` command must be the same as the `start` command. See the documentation of the [`surreal sql` command](/docs/surrealdb/cli/sql) for more information.
 
-
 ## Strict mode
 
 SurrealDB supports the ability to startup in strict mode. When running in strict mode, all `NAMESPACE`, `DATABASE`, and `TABLE` definitions will not be created automatically when data is inserted. Instead, if the selected namespace, database, or table has not been specifically defined, then the query will return an error.

--- a/doc-surrealdb_versioned_docs/version-latest/cli/start.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/cli/start.mdx
@@ -126,7 +126,7 @@ __BEFORE YOU START :__ Make sure you’ve [installed SurrealDB](/docs/surrealdb/
 
 This example will show how to host a SurrealDB server with the `surreal start` command, and then access the Surreal DB server using the [`surreal sql` command](/docs/surrealdb/cli/sql).
 
-To start a SurrealDB server, run the `surreal start` command, using the options below. This example stores the database in memory, with a username and password, hosted at 127.0.0.1:8000 (the default location).
+To start a SurrealDB server, run the `surreal start` command, using the options below. This example stores the database in memory, with a username and password, hosted at `127.0.0.1:8000` (the default location).
 
 ```bash
 surreal start memory --user my_username --pass my_password
@@ -134,25 +134,8 @@ surreal start memory --user my_username --pass my_password
 
 The following should appear in your console window, with potential slight differences depending on your operating system and version of SurrealDB. The server is actively running, and should be left alone until you want to stop hosting the SurrealDB server.
 
-Note the message "Started web server on 127.0.0.1:8000", which indicates where the server is being hosted and must be accessed by clients. The location 127.0.0.1:8000 is the default, and can be manually changed by specifing the `--bind` option of the `surreal start` command.
+Note the message "Started web server on 127.0.0.1:8000", which indicates where the server is being hosted and must be accessed by clients. The location `127.0.0.1:8000` is the default, and can be manually changed by specifing the `--bind` option of the `surreal start` command.
 
-```text
- .d8888b.                                             888 8888888b.  888888b.
-d88P  Y88b                                            888 888  'Y88b 888  '88b
-Y88b.                                                 888 888    888 888  .88P
- 'Y888b.   888  888 888d888 888d888  .d88b.   8888b.  888 888    888 8888888K.
-    'Y88b. 888  888 888P'   888P'   d8P  Y8b     '88b 888 888    888 888  'Y88b
-      '888 888  888 888     888     88888888 .d888888 888 888    888 888    888
-Y88b  d88P Y88b 888 888     888     Y8b.     888  888 888 888  .d88P 888   d88P
- 'Y8888P'   'Y88888 888     888      'Y8888  'Y888888 888 8888888P'  8888888P'
-
-
-2024-09-04T08:54:48.898733Z  INFO surreal::env: Running 2.0.0-beta.1 for windows on x86_64
-2024-09-04T08:54:48.899231Z  INFO surrealdb::core::kvs::tr: Starting kvs store in memory
-2024-09-04T08:54:48.899652Z  INFO surrealdb::core::kvs::tr: Started kvs store in memory
-2024-09-04T08:54:48.900734Z  INFO surrealdb::core::kvs::tr: Credentials were provided, and no root users were found. The root user 'my_username' will be created
-2024-09-04T08:54:48.928488Z  INFO surrealdb::net: Started web server on 127.0.0.1:8000
-```
 
 To access the SurrealDB server that you have started hosting, open a separate terminal which will act as the client, while the previous terminal is still running the `surreal start` command described above. In the new terminal, run the [`surreal sql` command](/docs/surrealdb/cli/sql) using the options shown below.
 
@@ -164,20 +147,6 @@ surreal sql --endpoint http://127.0.0.1:8000 --user my_username --pass my_passwo
 
 The following should appear in your console window, with potential slight differences depending on your operating system and version of SurrealDB. This is a Surreal SQL REPL in which you can enter SurrealQL statements and queries. See the documentation of the [`surreal sql` command](/docs/surrealdb/cli/sql) for more information.
 
-```text
-#
-#  Welcome to the SurrealDB SQL shell
-#
-#  How to use this shell:
-#    - Different statements within a query should be separated by a (;) semicolon.
-#    - To create a multi-line query, end your lines with a (\) backslash, and press enter.
-#    - To exit, send a SIGTERM or press CTRL+C
-#
-#  Consult https://surrealdb.com/docs/cli/sql for further instructions
-#
-#  SurrealDB version: 2.0.0-beta.1
-#
-```
 
 ## Strict mode
 

--- a/doc-surrealdb_versioned_docs/version-latest/cli/start.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/cli/start.mdx
@@ -143,15 +143,14 @@ To access the SurrealDB server that you have started hosting, open a separate te
 
 In the new terminal, run the [`surreal sql` command](/docs/surrealdb/cli/sql) using the options shown below.
 
-Ensure that the hosting location indicated by the output of the `surreal start` command is passed to the `--endpoint` argument, and that you specify the same username and password as in the `surreal start` command.
-
-This example also selects a namespace and database so that you can immediately start entering queries if you wish.
-
 ```bash
 surreal sql --endpoint http://127.0.0.1:8000 --namespace my_namespace --database my_database --auth-level root --username my_username --password my_password
 ```
 
-Note that the `username` and `password` in the `surreal sql` command must be the same as the `start` command. See the documentation of the [`surreal sql` command](/docs/surrealdb/cli/sql) for more information.
+Ensure that the hosting location indicated by the output of the `surreal start` command is passed to the `--endpoint` argument, and that you specify the same `--username` and `--password` as in the `surreal start` command.
+
+The above example also selects a namespace and database so that you can immediately start entering queries if you wish. See the documentation of the [`surreal sql` command](/docs/surrealdb/cli/sql) for more information.
+
 
 ## Strict mode
 

--- a/doc-surrealdb_versioned_docs/version-latest/cli/start.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/cli/start.mdx
@@ -148,7 +148,7 @@ Ensure that the hosting location indicated by the output of the `surreal start` 
 This example also selects a namespace and database so that you can immediately start entering queries if you wish.
 
 ```bash
-surreal sql --endpoint http://127.0.0.1:8000 --user my_username --pass my_password --namespace my_namespace --database my_database
+surreal sql --endpoint http://127.0.0.1:8000 --namespace my_namespace --database my_database
 ```
 
 See the documentation of the [`surreal sql` command](/docs/surrealdb/cli/sql) for more information.

--- a/doc-surrealdb_versioned_docs/version-latest/cli/start.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/cli/start.mdx
@@ -132,20 +132,26 @@ To start a SurrealDB server, run the `surreal start` command, using the options 
 surreal start memory --user my_username --pass my_password
 ```
 
-The following should appear in your console window, with potential slight differences depending on your operating system and version of SurrealDB. The server is actively running, and should be left alone until you want to stop hosting the SurrealDB server.
+The server is actively running, and should be left alone until you want to stop hosting the SurrealDB server.
 
-Note the message "Started web server on 127.0.0.1:8000", which indicates where the server is being hosted and must be accessed by clients. The location `127.0.0.1:8000` is the default, and can be manually changed by specifing the `--bind` option of the `surreal start` command.
+:::note
+__Note:__ The message "Started web server on 127.0.0.1:8000", indicates where the server is being hosted and must be accessed by clients. The location `127.0.0.1:8000` is the default, and can be manually changed by specifying the `--bind` option of the `surreal start` command.
+:::
 
 
-To access the SurrealDB server that you have started hosting, open a separate terminal which will act as the client, while the previous terminal is still running the `surreal start` command described above. In the new terminal, run the [`surreal sql` command](/docs/surrealdb/cli/sql) using the options shown below.
+To access the SurrealDB server that you have started hosting, open a separate terminal which will act as the "client", while the previous terminal is still running the `surreal start` command described above. 
 
-Make sure that the hosting location indicated by the output of the `surreal start` command is passed to the `--endpoint` argument, and that you specify the same username and password as in the `surreal start` command. This example also selects a namespace and database so that you can immediately start entering queries if you wish.
+In the new terminal, run the [`surreal sql` command](/docs/surrealdb/cli/sql) using the options shown below.
+
+Ensure that the hosting location indicated by the output of the `surreal start` command is passed to the `--endpoint` argument, and that you specify the same username and password as in the `surreal start` command.
+
+This example also selects a namespace and database so that you can immediately start entering queries if you wish.
 
 ```bash
 surreal sql --endpoint http://127.0.0.1:8000 --user my_username --pass my_password --namespace my_namespace --database my_database
 ```
 
-The following should appear in your console window, with potential slight differences depending on your operating system and version of SurrealDB. This is a Surreal SQL REPL in which you can enter SurrealQL statements and queries. See the documentation of the [`surreal sql` command](/docs/surrealdb/cli/sql) for more information.
+See the documentation of the [`surreal sql` command](/docs/surrealdb/cli/sql) for more information.
 
 
 ## Strict mode

--- a/doc-surrealdb_versioned_docs/version-latest/cli/start.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/cli/start.mdx
@@ -151,7 +151,7 @@ This example also selects a namespace and database so that you can immediately s
 surreal sql --endpoint http://127.0.0.1:8000 --namespace my_namespace --database my_database --auth-level root --username my_username --password my_password
 ```
 
-See the documentation of the [`surreal sql` command](/docs/surrealdb/cli/sql) for more information.
+Note that the `username` and `password` in the `surreal sql` command must be the same as the `start` command. See the documentation of the [`surreal sql` command](/docs/surrealdb/cli/sql) for more information.
 
 
 ## Strict mode

--- a/doc-surrealdb_versioned_docs/version-latest/cli/start.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/cli/start.mdx
@@ -112,7 +112,7 @@ __BEFORE YOU START :__ Make sure you’ve [installed SurrealDB](/docs/surrealdb/
                 <ul>
                     <li><code>rocksdb</code> for RocksDB</li>
                     <li><code>fdb</code> for FoundationDB</li>
-                    <li><code>indxdb</code> for IndxDB</li>
+                    <li><code>indxdb</code> for IndexedDB</li>
                     <li><code>memory</code> (or no argument) for in-memory storage</li>
                     <li><code>surrealkv</code> for SurrealKV</li>
                     <li><code>tikv</code> for TiKV</li>

--- a/doc-surrealdb_versioned_docs/version-latest/cli/start.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/cli/start.mdx
@@ -124,10 +124,59 @@ __BEFORE YOU START :__ Make sure you’ve [installed SurrealDB](/docs/surrealdb/
 
 ## Example usage
 
-To display the current command-line tool version, along with the platform and architecture, in a terminal run the surreal version.
+This example will show how to host a SurrealDB server with the `surreal start` command, and then access the Surreal DB server using the [`surreal sql` command](/docs/surrealdb/cli/sql).
+
+To start a SurrealDB server, run the `surreal start` command, using the options below. This example stores the database in memory, with a username and password, hosted at 127.0.0.1:8000 (the default location).
 
 ```bash
-surreal version
+surreal start memory --user my_username --pass my_password
+```
+
+The following should appear in your console window, with potential slight differences depending on your operating system and version of SurrealDB. The server is actively running, and should be left alone until you want to stop hosting the SurrealDB server.
+
+Note the message "Started web server on 127.0.0.1:8000", which indicates where the server is being hosted and must be accessed by clients. The location 127.0.0.1:8000 is the default, and can be manually changed by specifing the `--bind` option of the `surreal start` command.
+
+```text
+ .d8888b.                                             888 8888888b.  888888b.
+d88P  Y88b                                            888 888  'Y88b 888  '88b
+Y88b.                                                 888 888    888 888  .88P
+ 'Y888b.   888  888 888d888 888d888  .d88b.   8888b.  888 888    888 8888888K.
+    'Y88b. 888  888 888P'   888P'   d8P  Y8b     '88b 888 888    888 888  'Y88b
+      '888 888  888 888     888     88888888 .d888888 888 888    888 888    888
+Y88b  d88P Y88b 888 888     888     Y8b.     888  888 888 888  .d88P 888   d88P
+ 'Y8888P'   'Y88888 888     888      'Y8888  'Y888888 888 8888888P'  8888888P'
+
+
+2024-09-04T08:54:48.898733Z  INFO surreal::env: Running 2.0.0-beta.1 for windows on x86_64
+2024-09-04T08:54:48.899231Z  INFO surrealdb::core::kvs::tr: Starting kvs store in memory
+2024-09-04T08:54:48.899652Z  INFO surrealdb::core::kvs::tr: Started kvs store in memory
+2024-09-04T08:54:48.900734Z  INFO surrealdb::core::kvs::tr: Credentials were provided, and no root users were found. The root user 'my_username' will be created
+2024-09-04T08:54:48.928488Z  INFO surrealdb::net: Started web server on 127.0.0.1:8000
+```
+
+To access the SurrealDB server that you have started hosting, open a separate terminal which will act as the client, while the previous terminal is still running the `surreal start` command described above. In the new terminal, run the [`surreal sql` command](/docs/surrealdb/cli/sql) using the options shown below.
+
+Make sure that the hosting location indicated by the output of the `surreal start` command is passed to the `--endpoint` argument, and that you specify the same username and password as in the `surreal start` command. This example also selects a namespace and database so that you can immediately start entering queries if you wish.
+
+```bash
+surreal sql --endpoint http://127.0.0.1:8000 --user my_username --pass my_password --namespace my_namespace --database my_database
+```
+
+The following should appear in your console window, with potential slight differences depending on your operating system and version of SurrealDB. This is a Surreal SQL REPL in which you can enter SurrealQL statements and queries. See the documentation of the [`surreal sql` command](/docs/surrealdb/cli/sql) for more information.
+
+```text
+#
+#  Welcome to the SurrealDB SQL shell
+#
+#  How to use this shell:
+#    - Different statements within a query should be separated by a (;) semicolon.
+#    - To create a multi-line query, end your lines with a (\) backslash, and press enter.
+#    - To exit, send a SIGTERM or press CTRL+C
+#
+#  Consult https://surrealdb.com/docs/cli/sql for further instructions
+#
+#  SurrealDB version: 2.0.0-beta.1
+#
 ```
 
 ## Strict mode


### PR DESCRIPTION
# Commit 1:
##  docs-Fix misspelling of IndexedDB on documentation page of CLI tool's `surreal start` command

On the documentation page for the SurrealDB CLI tool's `start` command, the description of the `path` argument says that `indxdb` can be specified to use "IndxDB" as the storage backend. The argument value is correct, but the name of the storage backend is misspelling of "IndexedDB".

This commit changes this misspelling to "IndexedDB".


# Commit 2:
## docs-Add example usage for the CLI surreal start command

In the documentation page for the CLI `surreal start` command, the usage example is the one from the `surreal version` command.

This commit replaces this with an example of how to use the `surreal start` command.