### PR TITLE
docs-On Database Functions table, add column with descriptions of SurrealQL function modules

### DIFF
--- a/doc-surrealql_versioned_docs/version-latest/functions/database/count.mdx
+++ b/doc-surrealql_versioned_docs/version-latest/functions/database/count.mdx
@@ -2,12 +2,12 @@
 sidebar_position: 4
 sidebar_label: Count function
 title: Count function | SurrealQL
-description: These functions can be used when counting field values and expressions.
+description: This function can be used when counting field values and expressions.
 ---
 
 # Count function
 
-These functions can be used when counting field values and expressions.
+This function can be used when counting field values and expressions.
 
 <table>
   <thead>

--- a/doc-surrealql_versioned_docs/version-latest/functions/database/index.mdx
+++ b/doc-surrealql_versioned_docs/version-latest/functions/database/index.mdx
@@ -14,97 +14,97 @@ SurrealDB has many built-in functions designed to handle many common database ta
 <table>
   <thead>
     <tr>
-      <th scope="col">Module</th>
+      <th scope="col">Function Module</th>
       <th scope="col">Example / Notes</th>
     </tr>
   </thead>
   <tbody>
     <tr>
-      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/array"><code>Array Functions</code></a></td>
+      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/array"><code>Array</code></a></td>
       <td scope="row" data-label="Example"><code>array::len([1,2,3])</code></td>
     </tr>
     <tr>
-      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/bytes"><code>Bytes functions</code></a></td>
+      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/bytes"><code>Bytes</code></a></td>
       <td scope="row" data-label="Example"><code>bytes::len("SurrealDB".to_bytes());</code></td>
     </tr>
     <tr>
-      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/count"><code>Count function</code></a></td>
+      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/count"><code>Count</code></a></td>
       <td scope="row" data-label="Example"><code>count([1,2,3])</code></td>
     </tr>
     <tr>
-      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/crypto"><code>Crypto functions</code></a></td>
+      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/crypto"><code>Crypto</code></a></td>
       <td scope="row" data-label="Example"><code>crypto::argon2::generate("MyPaSSw0RD")</code></td>
     </tr>
     <tr>
-      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/duration"><code>Duration functions</code></a></td>
+      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/duration"><code>Duration</code></a></td>
       <td scope="row" data-label="Example"><code>duration::days(90h30m)</code></td>
     </tr>
     <tr>
-      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/encoding"><code>Encoding functions</code></a></td>
+      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/encoding"><code>Encoding</code></a></td>
       <td scope="row" data-label="Example"><code>encoding::base64::decode("aGVsbG8")</code></td>
     </tr>
     <tr>
-      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/geo"><code>Geo functions</code></a></td>
+      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/geo"><code>Geo</code></a></td>
       <td scope="row" data-label="Example"><code>geo::distance((-0.04, 51.55), (30.46, -17.86))</code></td>
     </tr>
     <tr>
-      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/http"><code>HTTP functions</code></a></td>
+      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/http"><code>HTTP</code></a></td>
       <td scope="row" data-label="Example"><code>http::get('https://surrealdb.com')</code></td>
     </tr>
     <tr>
-      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/math"><code>Math functions</code></a></td>
+      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/math"><code>Math</code></a></td>
       <td scope="row" data-label="Example"><code>math::max([ 26.164, 13.746189, 23, 16.4, 41.42 ])</code></td>
     </tr>
     <tr>
-      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/meta"><code>Meta functions</code></a></td>
-      <td scope="row" data-label="Example">Deprecated, moved to Record functions</td>
+      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/meta"><code>Meta</code></a></td>
+      <td scope="row" data-label="Example">Deprecated, moved to Record</td>
     </tr>
     <tr>
-      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/object"><code>Object functions</code></a></td>
+      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/object"><code>Object</code></a></td>
       <td scope="row" data-label="Example"><code>object::from_entries([[ "a", 1 ],[ "b", true ]])</code></td>
     </tr>
     <tr>
-      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/parse"><code>Parse function</code></a></td>
+      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/parse"><code>Parse</code></a></td>
       <td scope="row" data-label="Example"><code>parse::url::domain("http://127.0.0.1/index.html")</code></td>
     </tr>
     <tr>
-      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/rand"><code>Rand functions</code></a></td>
+      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/rand"><code>Rand</code></a></td>
       <td scope="row" data-label="Example"><code>rand::enum('one', 'two', 3, 4.15385, 'five', true)</code></td>
     </tr>
     <tr>
-      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/record"><code>Record functions</code></a></td>
+      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/record"><code>Record</code></a></td>
       <td scope="row" data-label="Example"><code>record::id(person:tobie)</code></td>
     </tr>
     <tr>
-      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/search"><code>Search functions</code></a></td>
+      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/search"><code>Search</code></a></td>
       <td scope="row" data-label="Example"><code>SELECT search::score(1) AS score FROM book WHERE title @1@ 'rust web'</code></td>
     </tr>
     <tr>
-      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/session"><code>Session functions</code></a></td>
+      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/session"><code>Session</code></a></td>
       <td scope="row" data-label="Example"><code>session::db()</code></td>
     </tr>
     <tr>
-      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/sleep"><code>Sleep function</code></a></td>
+      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/sleep"><code>Sleep</code></a></td>
       <td scope="row" data-label="Example"><code>sleep(900ms)</code></td>
     </tr>
     <tr>
-      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/string"><code>String functions</code></a></td>
+      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/string"><code>String</code></a></td>
       <td scope="row" data-label="Example"><code>string::reverse('emosewa si 0.2 BDlaerruS')</code></td>
     </tr>
     <tr>
-      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/time"><code>Time functions</code></a></td>
+      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/time"><code>Time</code></a></td>
       <td scope="row" data-label="Example"><code>time::timezone()</code></td>
     </tr>
     <tr>
-      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/type"><code>Type functions</code></a></td>
+      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/type"><code>Type</code></a></td>
       <td scope="row" data-label="Example"><code>type::is::number(500)</code></td>
     </tr>
     <tr>
-      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/value"><code>Value functions</code></a></td>
+      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/value"><code>Value</code></a></td>
       <td scope="row" data-label="Example"><code>value::diff([true, false], [true, true])</code></td>
     </tr>
     <tr>
-      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/vector"><code>Vector functions</code></a></td>
+      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/vector"><code>Vector</code></a></td>
       <td scope="row" data-label="Example"><code>vector::add([1, 2, 3], [1, 2, 3])</code></td>
     </tr>
   </tbody>

--- a/doc-surrealql_versioned_docs/version-latest/functions/database/index.mdx
+++ b/doc-surrealql_versioned_docs/version-latest/functions/database/index.mdx
@@ -148,29 +148,13 @@ true
 cat:mr_meow
 ```
 
-### Mathematical constants
-
-The page on mathematical functions also contains a number of mathematical constants. They are used in a similar way to functions except that their paths point to hard-coded values instead of a function pointer and thus do not need parentheses.
-
-```surql
-RETURN [math::pi, math::tau, math::e];
-```
-
-```bash title="Response"
-[
-	3.141592653589793f,
-	6.283185307179586f,
-	2.718281828459045f
-]
-```
-
 ### Method syntax
 
 <Since v="v2.0.0" />
 
 Functions that are called on an existing value can be called using method syntax, using the `.` (dot) operator. When using method syntax, be sure to convert `::` in the regular function signature to `_` (an underscore).
 
-The following three functions will produce the same output as above - except `type::thing()`, which is used to outright create a record ID from nothing.
+The following three functions will produce the same output as the classic syntax above, with the exception of `type::thing()`, which is used to outright create a record ID from nothing.
 
 ```surql
 "SurrealDB 2.0 is on its way!".split(" ");
@@ -210,6 +194,22 @@ This can be made even more readable by splitting over multiple lines.
     .distinct()
     .windows(2)
     .len();
+```
+
+### Mathematical constants
+
+The page on mathematical functions also contains a number of mathematical constants. They are used in a similar way to functions except that their paths point to hard-coded values instead of a function pointer and thus do not need parentheses.
+
+```surql
+RETURN [math::pi, math::tau, math::e];
+```
+
+```bash title="Response"
+[
+	3.141592653589793f,
+	6.283185307179586f,
+	2.718281828459045f
+]
 ```
 
 ## Anonymous functions

--- a/doc-surrealql_versioned_docs/version-latest/functions/database/index.mdx
+++ b/doc-surrealql_versioned_docs/version-latest/functions/database/index.mdx
@@ -154,7 +154,7 @@ cat:mr_meow
 
 Functions that are called on an existing value can be called using method syntax, using the `.` (dot) operator. When using method syntax, be sure to convert `::` in the regular function signature to `_` (an underscore).
 
-The following three functions will produce the same output as the classic syntax above, with the exception of `type::thing()`, which is used to outright create a record ID from nothing.
+The following functions will produce the same output as the classic syntax above. `type::thing()` cannot be called with method syntax because it is used to outright create a record ID from nothing, rather than being called on an existing value.
 
 ```surql
 "SurrealDB 2.0 is on its way!".split(" ");

--- a/doc-surrealql_versioned_docs/version-latest/functions/database/index.mdx
+++ b/doc-surrealql_versioned_docs/version-latest/functions/database/index.mdx
@@ -14,97 +14,97 @@ SurrealDB has many built-in functions designed to handle many common database ta
 <table>
   <thead>
     <tr>
-      <th scope="col" style="width:15%">Function Module</th>
-      <th scope="col" style="width:85%">Description and Example</th>
+      <th scope="col" style={{width: '20%'}}>Function</th>
+      <th scope="col" style={{width: '80%'}}>Description and Example</th>
     </tr>
   </thead>
   <tbody>
     <tr>
-      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/array"><code>Array</code></a></td>
+      <td scope="row" data-label="Function"><a href="/docs/surrealql/functions/database/array"><code>Array</code></a></td>
       <td scope="row" data-label="Description and Example">These functions can be used when working with, and manipulating arrays of data.<br/>Example: <code>array::len([1,2,3])</code></td>
     </tr>
     <tr>
-      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/bytes"><code>Bytes</code></a></td>
+      <td scope="row" data-label="Function"><a href="/docs/surrealql/functions/database/bytes"><code>Bytes</code></a></td>
       <td scope="row" data-label="Description and Example">These functions can be used when working with bytes in SurrealQL.<br/>Example: <code>bytes::len("SurrealDB".to_bytes());</code></td>
     </tr>
     <tr>
-      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/count"><code>Count</code></a></td>
+      <td scope="row" data-label="Function"><a href="/docs/surrealql/functions/database/count"><code>Count</code></a></td>
       <td scope="row" data-label="Description and Example">This function can be used when counting field values and expressions.<br/>Example: <code>count([1,2,3])</code></td>
     </tr>
     <tr>
-      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/crypto"><code>Crypto</code></a></td>
+      <td scope="row" data-label="Function"><a href="/docs/surrealql/functions/database/crypto"><code>Crypto</code></a></td>
       <td scope="row" data-label="Description and Example">These functions can be used when hashing data, encrypting data, and for securely authenticating users into the database.<br/>Example: <code>crypto::argon2::generate("MyPaSSw0RD")</code></td>
     </tr>
     <tr>
-      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/duration"><code>Duration</code></a></td>
+      <td scope="row" data-label="Function"><a href="/docs/surrealql/functions/database/duration"><code>Duration</code></a></td>
       <td scope="row" data-label="Description and Example">These functions can be used when converting between numeric and duration data.<br/>Example: <code>duration::days(90h30m)</code></td>
     </tr>
     <tr>
-      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/encoding"><code>Encoding</code></a></td>
+      <td scope="row" data-label="Function"><a href="/docs/surrealql/functions/database/encoding"><code>Encoding</code></a></td>
       <td scope="row" data-label="Description and Example">These functions can be used to encode and decode data in <code>base64</code>.<br/>Example: <code>encoding::base64::decode("aGVsbG8")</code></td>
     </tr>
     <tr>
-      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/geo"><code>Geo</code></a></td>
+      <td scope="row" data-label="Function"><a href="/docs/surrealql/functions/database/geo"><code>Geo</code></a></td>
       <td scope="row" data-label="Description and Example">These functions can be used when working with and analysing geospatial data.<br/>Example: <code>geo::distance((-0.04, 51.55), (30.46, -17.86))</code></td>
     </tr>
     <tr>
-      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/http"><code>HTTP</code></a></td>
+      <td scope="row" data-label="Function"><a href="/docs/surrealql/functions/database/http"><code>HTTP</code></a></td>
       <td scope="row" data-label="Description and Example">These functions can be used when opening and submitting remote web requests, and webhooks.<br/>Example: <code>http::get('https://surrealdb.com')</code></td>
     </tr>
     <tr>
-      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/math"><code>Math</code></a></td>
+      <td scope="row" data-label="Function"><a href="/docs/surrealql/functions/database/math"><code>Math</code></a></td>
       <td scope="row" data-label="Description and Example">These functions can be used when analysing numeric data and numeric collections.<br/>Example: <code>math::max([ 26.164, 13.746189, 23, 16.4, 41.42 ])</code></td>
     </tr>
     <tr>
-      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/meta"><code>Meta</code></a></td>
+      <td scope="row" data-label="Function"><a href="/docs/surrealql/functions/database/meta"><code>Meta</code></a></td>
       <td scope="row" data-label="Description and Example">These functions can be used to retrieve specific metadata from a SurrealDB Record ID. As of version 2.0, these functions are deprecated and replaced with SurrealDB's <code>record</code> functions.</td>
     </tr>
     <tr>
-      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/object"><code>Object</code></a></td>
+      <td scope="row" data-label="Function"><a href="/docs/surrealql/functions/database/object"><code>Object</code></a></td>
       <td scope="row" data-label="Description and Example">These functions can be used when working with, and manipulating data objects.<br/>Example: <code>object::from_entries([[ "a", 1 ],[ "b", true ]])</code></td>
     </tr>
     <tr>
-      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/parse"><code>Parse</code></a></td>
+      <td scope="row" data-label="Function"><a href="/docs/surrealql/functions/database/parse"><code>Parse</code></a></td>
       <td scope="row" data-label="Description and Example">These functions can be used when parsing email addresses and URL web addresses.<br/>Example: <code>parse::url::domain("http://127.0.0.1/index.html")</code></td>
     </tr>
     <tr>
-      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/rand"><code>Rand</code></a></td>
+      <td scope="row" data-label="Function"><a href="/docs/surrealql/functions/database/rand"><code>Rand</code></a></td>
       <td scope="row" data-label="Description and Example">These functions can be used when generating random data values.<br/>Example: <code>rand::enum('one', 'two', 3, 4.15385, 'five', true)</code></td>
     </tr>
     <tr>
-      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/record"><code>Record</code></a></td>
+      <td scope="row" data-label="Function"><a href="/docs/surrealql/functions/database/record"><code>Record</code></a></td>
       <td scope="row" data-label="Description and Example">These functions can be used to retrieve specific metadata from a SurrealDB Record ID.<br/>Example: <code>record::id(person:tobie)</code></td>
     </tr>
     <tr>
-      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/search"><code>Search</code></a></td>
+      <td scope="row" data-label="Function"><a href="/docs/surrealql/functions/database/search"><code>Search</code></a></td>
       <td scope="row" data-label="Description and Example">These functions are used in conjunction with the <code>@@</code> operator (the 'matches' operator) to either collect the relevance score or highlight the searched keywords within the content.<br/>Example: <code>SELECT search::score(1) AS score FROM book WHERE title @1@ 'rust web'</code></td>
     </tr>
     <tr>
-      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/session"><code>Session</code></a></td>
+      <td scope="row" data-label="Function"><a href="/docs/surrealql/functions/database/session"><code>Session</code></a></td>
       <td scope="row" data-label="Description and Example">These functions return information about the current SurrealDB session.<br/>Example: <code>session::db()</code></td>
     </tr>
     <tr>
-      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/sleep"><code>Sleep</code></a></td>
+      <td scope="row" data-label="Function"><a href="/docs/surrealql/functions/database/sleep"><code>Sleep</code></a></td>
       <td scope="row" data-label="Description and Example">This function can be used to introduce a delay or pause in the execution of a query or a batch of queries for a specific amount of time.<br/>Example: <code>sleep(900ms)</code></td>
     </tr>
     <tr>
-      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/string"><code>String</code></a></td>
+      <td scope="row" data-label="Function"><a href="/docs/surrealql/functions/database/string"><code>String</code></a></td>
       <td scope="row" data-label="Description and Example">These functions can be used when working with and manipulating text and string values.<br/>Example: <code>string::reverse('emosewa si 0.2 BDlaerruS')</code></td>
     </tr>
     <tr>
-      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/time"><code>Time</code></a></td>
+      <td scope="row" data-label="Function"><a href="/docs/surrealql/functions/database/time"><code>Time</code></a></td>
       <td scope="row" data-label="Description and Example">These functions can be used when working with and manipulating datetime values.<br/>Example: <code>time::timezone()</code></td>
     </tr>
     <tr>
-      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/type"><code>Type</code></a></td>
+      <td scope="row" data-label="Function"><a href="/docs/surrealql/functions/database/type"><code>Type</code></a></td>
       <td scope="row" data-label="Description and Example">These functions can be used for generating and coercing data to specific data types.<br/>Example: <code>type::is::number(500)</code></td>
     </tr>
     <tr>
-      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/value"><code>Value</code></a></td>
+      <td scope="row" data-label="Function"><a href="/docs/surrealql/functions/database/value"><code>Value</code></a></td>
       <td scope="row" data-label="Description and Example">This module contains several miscellaneous functions that can be used with values of any type.<br/>Example: <code>value::diff([true, false], [true, true])</code></td>
     </tr>
     <tr>
-      <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/vector"><code>Vector</code></a></td>
+      <td scope="row" data-label="Function"><a href="/docs/surrealql/functions/database/vector"><code>Vector</code></a></td>
       <td scope="row" data-label="Description and Example">A collection of essential vector operations that provide foundational functionality for numerical computation, machine learning, and data analysis.<br/>Example: <code>vector::add([1, 2, 3], [1, 2, 3])</code></td>
     </tr>
   </tbody>

--- a/doc-surrealql_versioned_docs/version-latest/functions/database/index.mdx
+++ b/doc-surrealql_versioned_docs/version-latest/functions/database/index.mdx
@@ -14,98 +14,98 @@ SurrealDB has many built-in functions designed to handle many common database ta
 <table>
   <thead>
     <tr>
-      <th scope="col">Function Module</th>
-      <th scope="col">Example / Notes</th>
+      <th scope="col" style="width:15%">Function Module</th>
+      <th scope="col" style="width:85%">Description and Example</th>
     </tr>
   </thead>
   <tbody>
     <tr>
       <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/array"><code>Array</code></a></td>
-      <td scope="row" data-label="Example"><code>array::len([1,2,3])</code></td>
+      <td scope="row" data-label="Description and Example">These functions can be used when working with, and manipulating arrays of data.<br/>Example: <code>array::len([1,2,3])</code></td>
     </tr>
     <tr>
       <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/bytes"><code>Bytes</code></a></td>
-      <td scope="row" data-label="Example"><code>bytes::len("SurrealDB".to_bytes());</code></td>
+      <td scope="row" data-label="Description and Example">These functions can be used when working with bytes in SurrealQL.<br/>Example: <code>bytes::len("SurrealDB".to_bytes());</code></td>
     </tr>
     <tr>
       <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/count"><code>Count</code></a></td>
-      <td scope="row" data-label="Example"><code>count([1,2,3])</code></td>
+      <td scope="row" data-label="Description and Example">This function can be used when counting field values and expressions.<br/>Example: <code>count([1,2,3])</code></td>
     </tr>
     <tr>
       <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/crypto"><code>Crypto</code></a></td>
-      <td scope="row" data-label="Example"><code>crypto::argon2::generate("MyPaSSw0RD")</code></td>
+      <td scope="row" data-label="Description and Example">These functions can be used when hashing data, encrypting data, and for securely authenticating users into the database.<br/>Example: <code>crypto::argon2::generate("MyPaSSw0RD")</code></td>
     </tr>
     <tr>
       <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/duration"><code>Duration</code></a></td>
-      <td scope="row" data-label="Example"><code>duration::days(90h30m)</code></td>
+      <td scope="row" data-label="Description and Example">These functions can be used when converting between numeric and duration data.<br/>Example: <code>duration::days(90h30m)</code></td>
     </tr>
     <tr>
       <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/encoding"><code>Encoding</code></a></td>
-      <td scope="row" data-label="Example"><code>encoding::base64::decode("aGVsbG8")</code></td>
+      <td scope="row" data-label="Description and Example">These functions can be used to encode and decode data in <code>base64</code>.<br/>Example: <code>encoding::base64::decode("aGVsbG8")</code></td>
     </tr>
     <tr>
       <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/geo"><code>Geo</code></a></td>
-      <td scope="row" data-label="Example"><code>geo::distance((-0.04, 51.55), (30.46, -17.86))</code></td>
+      <td scope="row" data-label="Description and Example">These functions can be used when working with and analysing geospatial data.<br/>Example: <code>geo::distance((-0.04, 51.55), (30.46, -17.86))</code></td>
     </tr>
     <tr>
       <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/http"><code>HTTP</code></a></td>
-      <td scope="row" data-label="Example"><code>http::get('https://surrealdb.com')</code></td>
+      <td scope="row" data-label="Description and Example">These functions can be used when opening and submitting remote web requests, and webhooks.<br/>Example: <code>http::get('https://surrealdb.com')</code></td>
     </tr>
     <tr>
       <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/math"><code>Math</code></a></td>
-      <td scope="row" data-label="Example"><code>math::max([ 26.164, 13.746189, 23, 16.4, 41.42 ])</code></td>
+      <td scope="row" data-label="Description and Example">These functions can be used when analysing numeric data and numeric collections.<br/>Example: <code>math::max([ 26.164, 13.746189, 23, 16.4, 41.42 ])</code></td>
     </tr>
     <tr>
       <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/meta"><code>Meta</code></a></td>
-      <td scope="row" data-label="Example">Deprecated, moved to Record</td>
+      <td scope="row" data-label="Description and Example">These functions can be used to retrieve specific metadata from a SurrealDB Record ID. As of version 2.0, these functions are deprecated and replaced with SurrealDB's <code>record</code> functions.</td>
     </tr>
     <tr>
       <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/object"><code>Object</code></a></td>
-      <td scope="row" data-label="Example"><code>object::from_entries([[ "a", 1 ],[ "b", true ]])</code></td>
+      <td scope="row" data-label="Description and Example">These functions can be used when working with, and manipulating data objects.<br/>Example: <code>object::from_entries([[ "a", 1 ],[ "b", true ]])</code></td>
     </tr>
     <tr>
       <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/parse"><code>Parse</code></a></td>
-      <td scope="row" data-label="Example"><code>parse::url::domain("http://127.0.0.1/index.html")</code></td>
+      <td scope="row" data-label="Description and Example">These functions can be used when parsing email addresses and URL web addresses.<br/>Example: <code>parse::url::domain("http://127.0.0.1/index.html")</code></td>
     </tr>
     <tr>
       <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/rand"><code>Rand</code></a></td>
-      <td scope="row" data-label="Example"><code>rand::enum('one', 'two', 3, 4.15385, 'five', true)</code></td>
+      <td scope="row" data-label="Description and Example">These functions can be used when generating random data values.<br/>Example: <code>rand::enum('one', 'two', 3, 4.15385, 'five', true)</code></td>
     </tr>
     <tr>
       <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/record"><code>Record</code></a></td>
-      <td scope="row" data-label="Example"><code>record::id(person:tobie)</code></td>
+      <td scope="row" data-label="Description and Example">These functions can be used to retrieve specific metadata from a SurrealDB Record ID.<br/>Example: <code>record::id(person:tobie)</code></td>
     </tr>
     <tr>
       <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/search"><code>Search</code></a></td>
-      <td scope="row" data-label="Example"><code>SELECT search::score(1) AS score FROM book WHERE title @1@ 'rust web'</code></td>
+      <td scope="row" data-label="Description and Example">These functions are used in conjunction with the <code>@@</code> operator (the 'matches' operator) to either collect the relevance score or highlight the searched keywords within the content.<br/>Example: <code>SELECT search::score(1) AS score FROM book WHERE title @1@ 'rust web'</code></td>
     </tr>
     <tr>
       <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/session"><code>Session</code></a></td>
-      <td scope="row" data-label="Example"><code>session::db()</code></td>
+      <td scope="row" data-label="Description and Example">These functions return information about the current SurrealDB session.<br/>Example: <code>session::db()</code></td>
     </tr>
     <tr>
       <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/sleep"><code>Sleep</code></a></td>
-      <td scope="row" data-label="Example"><code>sleep(900ms)</code></td>
+      <td scope="row" data-label="Description and Example">This function can be used to introduce a delay or pause in the execution of a query or a batch of queries for a specific amount of time.<br/>Example: <code>sleep(900ms)</code></td>
     </tr>
     <tr>
       <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/string"><code>String</code></a></td>
-      <td scope="row" data-label="Example"><code>string::reverse('emosewa si 0.2 BDlaerruS')</code></td>
+      <td scope="row" data-label="Description and Example">These functions can be used when working with and manipulating text and string values.<br/>Example: <code>string::reverse('emosewa si 0.2 BDlaerruS')</code></td>
     </tr>
     <tr>
       <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/time"><code>Time</code></a></td>
-      <td scope="row" data-label="Example"><code>time::timezone()</code></td>
+      <td scope="row" data-label="Description and Example">These functions can be used when working with and manipulating datetime values.<br/>Example: <code>time::timezone()</code></td>
     </tr>
     <tr>
       <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/type"><code>Type</code></a></td>
-      <td scope="row" data-label="Example"><code>type::is::number(500)</code></td>
+      <td scope="row" data-label="Description and Example">These functions can be used for generating and coercing data to specific data types.<br/>Example: <code>type::is::number(500)</code></td>
     </tr>
     <tr>
       <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/value"><code>Value</code></a></td>
-      <td scope="row" data-label="Example"><code>value::diff([true, false], [true, true])</code></td>
+      <td scope="row" data-label="Description and Example">This module contains several miscellaneous functions that can be used with values of any type.<br/>Example: <code>value::diff([true, false], [true, true])</code></td>
     </tr>
     <tr>
       <td scope="row" data-label="Module"><a href="/docs/surrealql/functions/database/vector"><code>Vector</code></a></td>
-      <td scope="row" data-label="Example"><code>vector::add([1, 2, 3], [1, 2, 3])</code></td>
+      <td scope="row" data-label="Description and Example">A collection of essential vector operations that provide foundational functionality for numerical computation, machine learning, and data analysis.<br/>Example: <code>vector::add([1, 2, 3], [1, 2, 3])</code></td>
     </tr>
   </tbody>
 </table>

--- a/doc-surrealql_versioned_docs/version-latest/functions/database/index.mdx
+++ b/doc-surrealql_versioned_docs/version-latest/functions/database/index.mdx
@@ -9,7 +9,7 @@ import Since from '@site/src/components/Since'
 
 # Database Functions
 
-SurrealDB comes with a large number of in-built functions for checking, manipulating, and working with many different types of data. These functions are grouped into a number of different packages, which can be seen below.
+SurrealDB has many built-in functions designed to handle many common database tasks and work with SurrealDB's various data types, grouped into modules based on their purpose and the data types they are designed to work with. The table below lists all of SurrealDB's function modules, with descriptions and links to their own detailed documentation.
 
 <table>
   <thead>

--- a/doc-surrealql_versioned_docs/version-latest/functions/database/record.mdx
+++ b/doc-surrealql_versioned_docs/version-latest/functions/database/record.mdx
@@ -13,6 +13,8 @@ import Since from '@site/src/components/Since'
 Record functions before SurrealDB 2.0 were located inside the module [meta](/docs/surrealql/functions/database/meta).
 :::
 
+These functions can be used to retrieve specific metadata from a SurrealDB Record ID.
+
 <table>
   <thead>
     <tr>

--- a/doc-surrealql_versioned_docs/version-latest/functions/database/sleep.mdx
+++ b/doc-surrealql_versioned_docs/version-latest/functions/database/sleep.mdx
@@ -2,7 +2,7 @@
 sidebar_position: 18
 sidebar_label: Sleep function
 title: Sleep function | SurrealQL
-description: These functions can be used to introduce a delay or pause in the execution of a query or a batch of queries for a specific amount of time.
+description: This function can be used to introduce a delay or pause in the execution of a query or a batch of queries for a specific amount of time.
 ---
 
 # Sleep function

--- a/doc-surrealql_versioned_docs/version-latest/functions/database/value.mdx
+++ b/doc-surrealql_versioned_docs/version-latest/functions/database/value.mdx
@@ -2,12 +2,14 @@
 sidebar_position: 22
 sidebar_label: Value functions
 title: Value functions | SurrealQL
-description: Functions that can be called on more than one type of SurrealQL value.
+description: This module contains several miscellaneous functions that can be used with values of any type.
 ---
 
 import Since from '@site/src/components/Since'
 
 # Value functions
+
+This module contains several miscellaneous functions that can be used with values of any type.
 
 <table>
   <thead>


### PR DESCRIPTION
This pull request adds description of each SurrealQL function module to the "Database Functions" page In the SurrealQL functions documentation.  (https://surrealdb.com/docs/surrealdb/surrealql/functions/database), as discussed in #819.

Notes for Review:

1. For each module, I used the description that is found on the dedicated page of the function module, with the following exceptions:

* For the `encoding`, `type`, and `vector` modules, the description on the dedicated page is multiple sentences, so I used only the first sentence for concision.
* The `value` module does not have a description on the dedicated page, and I am not sure what to add as one. Please advise.

2. Let me know if you think the table looks too cluttered with three columns and if it would be better to remove the Examples column to leave more width for the Module and Description columns. My opinion from #819 is the following:

"I think that the examples currently in the second column have value, but that readers who are interested in seeing examples for a given function module will navigate to the module's dedicated page, and see such examples for all functions there, where they will be even more informative with context, information about what the usage example actually does, and full descriptions of functions."

closes #819