### PR TITLE
Change to new db and ns headers while preserving original examples for 1.x

### DIFF
--- a/doc-surrealdb_versioned_docs/version-latest/integration/http.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/integration/http.mdx
@@ -324,7 +324,12 @@ The following headers can be used to customise the query and the response.
 </table>
 
 ### Example with a Record user
-```bash title="Request"
+
+```bash title="Request (version 2.x)"
+curl -X POST -H "Accept: application/json" -d '{"surreal-ns":"test","surreal-db":"test","ac":"users","user":"john.doe","pass":"123456"}' http://localhost:8000/signin
+```
+
+```bash title="Request (version 1.x)"
 curl -X POST -H "Accept: application/json" -d '{"ns":"test","db":"test","ac":"users","user":"john.doe","pass":"123456"}' http://localhost:8000/signin
 ```
 
@@ -367,7 +372,18 @@ curl -X POST -H "Accept: application/json" -d '{"user":"john.doe","pass":"123456
 After you have defined the users permissions, you can use the `POST /signin` endpoint to sign in as a user.
 
 Using the [user credentials](/docs/surrealdb/security/authentication#record-users) created add the following to the request body:
-```json
+
+```json title="Version 2.x"
+{
+    "surreal-ns": "test",
+    "surreal-db": "test",
+    "ac": "account",
+    "email": "",
+    "pass": "123456"
+}
+```
+
+```json title="Version 1.x"
 {
     "ns": "test",
     "db": "test",
@@ -438,7 +454,12 @@ This HTTP RESTful endpoint is used to create an account inside the SurrealDB dat
 </table>
 
 ### Example usage
-```bash title="Request"
+
+```bash title="Request (version 2.x)"
+curl -X POST -H "Accept: application/json" -d '{"surreal-ns":"test","surreal-db":"test","ac":"users","user":"john.doe","pass":"123456"}' http://localhost:8000/signup
+```
+
+```bash title="Request (version 1.x)"
 curl -X POST -H "Accept: application/json" -d '{"ns":"test","db":"test","ac":"users","user":"john.doe","pass":"123456"}' http://localhost:8000/signup
 ```
 
@@ -472,7 +493,18 @@ The above query defines a record access method called `account` that allows user
 3. Click `Send` to send the request to the SurrealDB database server.
 4. Navigate to the `POST /signup` endpoint in Postman.
 5. Enter the following query in the body of the request:
-```json
+
+```json title="Version 2.x"
+{
+    "surreal-ns": "test",
+    "surreal-db": "test",
+    "ac": "account",
+    "email": "",
+    "pass": "123456"
+}
+```
+
+```json title="Version 1.x"
 {
     "ns": "test",
     "db": "test",
@@ -481,6 +513,7 @@ The above query defines a record access method called `account` that allows user
     "pass": "123456"
 }
 ```
+
 6. In the header of the request, set the following key-value pairs:
     - `Accept: application/json`
     - namespace: `test`

--- a/doc-surrealdb_versioned_docs/version-latest/integration/rpc.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/integration/rpc.mdx
@@ -264,15 +264,33 @@ signup [ NS, DB, AC, ... ]
 </table>
 
 ### Example usage
-```json title="Request"
+
+```json title="Request (version 2.x)"
 {
     "id": 1,
     "method": "signup",
     "params": [
         {
-            "NS": "surrealdb",
-            "DB": "docs",
-            "AC": "commenter",
+            "surreal-ns": "surrealdb",
+            "surreal-db": "docs",
+            "ac": "commenter",
+
+            "username": "johndoe",
+            "password": "SuperStrongPassword!"
+        }
+    ]
+}
+```
+
+```json title="Request (version 1.x)"
+{
+    "id": 1,
+    "method": "signup",
+    "params": [
+        {
+            "ns": "surrealdb",
+            "db": "docs",
+            "ac": "commenter",
 
             "username": "johndoe",
             "password": "SuperStrongPassword!"
@@ -383,17 +401,34 @@ signin [ NS, DB, AC, ... ]
 }
 ```
 
-### Example with Scope user
+### Example with Record user
 
-```json title="Request"
+```json title="Request (version 2.x)"
 {
     "id": 1,
     "method": "signin",
     "params": [
         {
-            "NS": "surrealdb",
-            "DB": "docs",
-            "AC": "commenter",
+            "surreal-ns": "surrealdb",
+            "surreal-db": "docs",
+            "ac": "commenter",
+
+            "username": "johndoe",
+            "password": "SuperStrongPassword!"
+        }
+    ]
+}
+```
+
+```json title="Request (version 1.x)"
+{
+    "id": 1,
+    "method": "signin",
+    "params": [
+        {
+            "ns": "surrealdb",
+            "db": "docs",
+            "ac": "commenter",
 
             "username": "johndoe",
             "password": "SuperStrongPassword!"

--- a/doc-surrealdb_versioned_docs/version-latest/security/authentication.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/security/authentication.mdx
@@ -99,10 +99,17 @@ db.signin({
 
 #### HTTP Request
 
-```bash
+```bash title="Version 2.x"
 curl -X POST \
 	-H "Accept: application/json" \
-	-d '{"NS":"test", "DB":"test", "user":"mary", "pass":"VerySecurePassword!"}' \
+	-d '{"surreal-ns":"test", "surreal-db":"test", "user":"mary", "pass":"VerySecurePassword!"}' \
+	http://localhost:8000/signin
+```
+
+```bash title="Version 1.x"
+curl -X POST \
+	-H "Accept: application/json" \
+	-d '{"ns":"test", "db":"test", "user":"mary", "pass":"VerySecurePassword!"}' \
 	http://localhost:8000/signin
 ```
 
@@ -204,10 +211,17 @@ db.signup({
 ```
 #### HTTP Request
 
-```bash
+```bash title="Version 2.x"
 curl -X POST \
 	-H "Accept: application/json" \
-	-d '{"NS":"test", "DB":"test", "AC":"user", "name":"John Doe", "email":"john@doe.org", "password":"VerySecurePassword!"}' \
+	-d '{"surreal-ns":"test", "surreal-db":"test", ac":"user", "name":"John Doe", "email":"john@doe.org", "password":"VerySecurePassword!"}' \
+	http://localhost:8000/signup
+```
+
+```bash title="Version 1.x"
+curl -X POST \
+	-H "Accept: application/json" \
+	-d '{"ns":"test", "db":"test", "ac":"user", "name":"John Doe", "email":"john@doe.org", "password":"VerySecurePassword!"}' \
 	http://localhost:8000/signup
 ```
 
@@ -241,10 +255,17 @@ db.signin({
 
 #### HTTP Request 
 
-```bash
+```bash	title="Version 2.x"
 curl -X POST \
 	-H "Accept: application/json" \
-	-d '{"NS":"test", "DB":"test", "AC":"user", "email":"john@doe.org", "password":"VerySecurePassword!"}' \
+	-d '{"surreal-ns":"test", "surreal-db":"test", "ac":"user", "email":"john@doe.org", "password":"VerySecurePassword!"}' \
+	http://localhost:8000/signin
+```
+
+```bash title="Version 1.x"
+curl -X POST \
+	-H "Accept: application/json" \
+	-d '{"ns":"test", "db":"test", "ac":"user", "email":"john@doe.org", "password":"VerySecurePassword!"}' \
 	http://localhost:8000/signin
 ```
 

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/datamodel/arrays.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/datamodel/arrays.mdx
@@ -36,3 +36,12 @@ CREATE team SET employees = [
 ```bash title="Response"
 'Expected a array<record<employee>, 5> but the array had 6 items'
 ```
+
+## Working with arrays
+
+An array can be followed 
+
+```surql
+[1,2,3][2];
+```
+

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/type.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/functions/database/type.mdx
@@ -866,6 +866,7 @@ The `type::is::uuid` function checks if the passed value is of type `uuid`.
 ```surql title="API DEFINITION"
 type::is::uuid(any) -> bool
 ```
+
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:
 
 ```surql

--- a/doc-surrealdb_versioned_docs/version-latest/tutorials/working-with-surrealdb-over-http-via-postman.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/tutorials/working-with-surrealdb-over-http-via-postman.mdx
@@ -137,7 +137,17 @@ access:human
 
 In the body of the request add the following information:
 
-```json
+```json title="Version 2.x"
+{
+    "surreal-ns": "test",
+    "surreal-db": "test",
+    "ac": "human",
+    "email": "test@surreal.com",
+    "pass":"1234567886"
+}
+```
+
+```json title="Version 1.x"
 {
     "ns": "test",
     "db": "test",
@@ -161,7 +171,17 @@ The result will be a  JSON object:
 
 Now that we have defined a User we can now log in. To do so, head to the `POST /signin` and using the same credentials. In the body of the request, add the same information you used to sign up:
 
-```json
+```json title="Version 2.x"
+{
+    "surreal-ns": "test",
+    "surreal-db": "test",
+    "ac": "human",
+    "email": "test3@surreal.com",
+    "pass":"1234567886"
+} 
+```
+
+```json title="Version 1.x"
 {
     "ns": "test",
     "db": "test",


### PR DESCRIPTION
The "ns" and "db" headers are now "surreal-ns" and "surreal-db" in version 2.x for HTTP (and RPC too, I think). This changes the examples that include these headers to put a 2.x version first, followed by the original example.