### PR TITLE
Fix incorrect SQL syntax for multiple INSERT values

### DIFF
--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/relate.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/relate.mdx
@@ -104,7 +104,7 @@ DEFINE FIELD out ON TABLE wrote TYPE record<article>;
 A `RELATE` statement that involves an array instead of a single id will not fail. Instead, it will create a graph edge for each record in the array:
 
 ```surql
-INSERT INTO cat (id) VALUES ("mr_meow", "mrs_meow", "kitten");
+INSERT INTO cat (id) VALUES ("mr_meow"), ("mrs_meow"), ("kitten");
 RELATE [cat:mr_meow, cat:mrs_meow]->parent_of->cat:kitten;
 ```
 


### PR DESCRIPTION
Corrected the SQL syntax in the SurrealDB documentation for inserting multiple values into the `cat` table. The original syntax used a single `INSERT INTO` statement with all values in one set, which is invalid. Updated it to use separate sets for each value, as in:

```sql
INSERT INTO cat (id) VALUES ("mr_meow"), ("mrs_meow"), ("kitten");
```

This change ensures the example executes correctly and adheres to proper SQL syntax for inserting multiple rows.