### PR TITLE
Fix small errors from the documentation

### DIFF
--- a/doc-surrealdb_versioned_docs/version-latest/integration/rpc.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/integration/rpc.mdx
@@ -356,7 +356,7 @@ signin [ NS, DB, AC, ... ]
                 <code>...</code>
             </td>
             <td colspan="2" scope="row" data-label="Description">
-                Specifies any variables used by the record's SIGNUP method
+                Specifies any variables used by the record's SIGNIN method
             </td>
         </tr>
     </tbody>

--- a/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/define/access/record.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/surrealql/statements/define/access/record.mdx
@@ -188,6 +188,7 @@ In the below example, we check if the session may already be tied to an existing
 
 ```surql
 DEFINE ACCESS user ON DATABASE TYPE RECORD
+    WITH JWT ALGORITHM HS512 KEY 'secret'
     AUTHENTICATE {
         IF $auth.id {
             RETURN $auth.id;
@@ -195,7 +196,6 @@ DEFINE ACCESS user ON DATABASE TYPE RECORD
             RETURN SELECT * FROM user WHERE email = $token.email;
         };
     }
-    WITH JWT ALGORITHM HS512 KEY 'secret'
 ;
 ```
 


### PR DESCRIPTION
- The clause ordering in one of the `AUTHENTICATE` examples was incorrect.
- The `SIGNIN` clause is incorrectly referred to as `SIGNUP`.