### PR TITLE
docs-Small fixes to `string` data type documentation

### DIFF
--- a/doc-surrealql_versioned_docs/version-latest/datamodel/strings.mdx
+++ b/doc-surrealql_versioned_docs/version-latest/datamodel/strings.mdx
@@ -82,7 +82,7 @@ The `r` prefix tells the parser that the contents of the string represent a [`re
 __Note:__ As of SurrealDB 2.0, without the `r` prefix the type of the value will be `string`.
 :::
 
-Here is an example of record ID literal value, specified using a string with the `r` prefix.
+Here is an example of a record ID literal value, specified using a string with the `r` prefix.
 
 ```surql
 RETURN r"person:john";

--- a/doc-surrealql_versioned_docs/version-latest/datamodel/strings.mdx
+++ b/doc-surrealql_versioned_docs/version-latest/datamodel/strings.mdx
@@ -96,11 +96,10 @@ person:john
 In the example below, using the [`type::is::string()`](/docs/surrealql/functions/database/type#typeisstring) and [`type::is::record()`](/docs/surrealql/functions/database/type#typeisrecord) functions respectively, you can check the type of the string.
 
 ```surql
-type::is::string("person:john");
-type::is::record("person:john");
-type::is::record(r"person:john");
+RETURN type::is::string("person:john");
+RETURN type::is::record("person:john");
+RETURN type::is::record(r"person:john");
 ```
-
 ```bash title="Response"
 -------- Query 1 --------
 
@@ -127,6 +126,27 @@ RETURN d"2023-11-28T11:41:20.262-04:00";  --- Sub-second precision included, tim
 RETURN d"2023-11-28T11:41:20Z";           --- Sub-second precision excluded, timezone defaulted to UTC
 RETURN d"2023-11-28T11:41:20+04:00";      --- Sub-second precision excluded, timezone specified as UTC + 4:00
 ```
+```bash title="Response"
+-------- Query 1 --------
+
+d'2023-11-28T11:41:20.262Z'
+
+-------- Query 2 --------
+
+d'2023-11-28T07:41:20.262Z'
+
+-------- Query 3 --------
+
+d'2023-11-28T15:41:20.262Z'
+
+-------- Query 4 --------
+
+d'2023-11-28T11:41:20Z'
+
+-------- Query 5 --------
+
+d'2023-11-28T07:41:20Z'
+```
 
 ### UUID literal values with the `u` prefix {#uuid}
 
@@ -152,7 +172,6 @@ As a result, incorrect input with a cast will generate an error:
 RETURN <uuid>"018f0e6a_9b95-7ecc-8a38-aea7bf3627dd";
 RETURN <datetime>"2024_06-06T12:00:00Z";
 ```
-
 ```bash title="Response"
 -------- Query 1 --------
 


### PR DESCRIPTION
# Commit 1:
## docs-Fix typo in `string` data type documentation

On the documentation page for the `string` data type, the following sentence is missing the word "a":
"Here is an example of record ID literal value"

This commit adds the missing word "a":
"Here is an example of a record ID literal value"

# Commit 2:
##  docs-Add missing example query response in `string` data type documentation

On the documentation page for the `string` data type, the example query demonstrating datetime literal values with the `d` prefix is missing the query response.

This commit adds the missing query response.