### PR TITLE
docs-Changes to `array` function module documentation

### DIFF
--- a/doc-surrealql_versioned_docs/version-latest/functions/database/array.mdx
+++ b/doc-surrealql_versioned_docs/version-latest/functions/database/array.mdx
@@ -947,7 +947,12 @@ RETURN array::len([ 1, 2, 1, null, "something", 3, 3, 4, 0 ]);
 
 ## `array::logical_and`
 
-The `array::logical_and` function performs the [`AND` logical operations](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_AND) local but they return the element that represents the resulting truthiness similar to the above. Note that the functions prioritize the elements on the left hand. Also, in the event that neither element can represent the truthiness of the output, the resulting element is a boolean value of the truthiness.
+The `array::logical_and` function performs the [`AND` logical operation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_AND) element-wise between two arrays.
+The resulting array will have a length of the longer of the two input arrays, where each element is the result of the logical `AND` operation performed between an element from the left hand side array and an element from the right hand side array.
+
+When both of the compared elements are truthy, the resulting element will have the type and value of one of the two truthy values, prioritizing the value and type of the element from the left hand side (the first array).
+
+When one or both of the compared elements are not truthy, the resulting element will have the type and value of one of the non-truthy value(s), prioritizing the value and type of the element from the left hand side (the first array).
 
 ```surql title="API DEFINITION"
 array::logical_and(lh: array, rh: array)
@@ -971,8 +976,13 @@ RETURN array::logical_and([0, 1], [])
 
 ## `array::logical_or`
 
-The `array::logical_or` function performs the [`OR` logical operations](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_OR). Note that the functions prioritize the elements on the left hand.
+The `array::logical_or` function performs the [`OR` logical operations](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_OR) element-wise between two arrays.
 
+The resulting array will have a length of the longer of the two input arrays, where each element is the result of the logical `OR` operation performed between an element from the left hand side array and an element from the right hand side array.
+
+When one or both of the compared elements are truthy, the resulting element will have the type and value of one of the two truthy value(s), prioritizing the value and type of the element from the left hand side (the first array).
+
+When both of the compared elements are not truthy, the resulting element will have the type and value of one of the non-truthy values, prioritizing the value and type of the element from the left hand side (the first array).
 
 ```surql title="API DEFINITION"
 array::logical_or(lh: array, rh: array)
@@ -996,8 +1006,15 @@ RETURN array::logical_or([0, 1], []);
 
 ## `array::logical_xor`
 
-The `array::logical_or` function performs the [`XOR` logical operations](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_OR).
+The `array::logical_xor` function performs the [`XOR` logical operations](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_OR) element-wise between two arrays.
 
+The resulting array will have a length of the longer of the two input arrays, where each element is the result of the logical `XOR` operation performed between an element from the left hand side array and an element from the right hand side array.
+
+When exactly one of the compared elements is truthy, the resulting element will have the type and value of the truthy value.
+
+When both of the compared elements are truthy, the resulting element will be the `bool` value `false`.
+
+When neither of the compared elements are truthy, the resulting element will have the type and value of one of the non-truthy values, prioritizing the value and type of the element from the left hand side (the first array).
 
 ```surql title="API DEFINITION"
 array::logical_xor(lh: array, rh: array)

--- a/doc-surrealql_versioned_docs/version-latest/functions/database/array.mdx
+++ b/doc-surrealql_versioned_docs/version-latest/functions/database/array.mdx
@@ -274,10 +274,10 @@ RETURN ["same", "same", "same"].all("same");
 -- true
 
 [
-  "What's", 
-  "it", 
-  "got", 
-  "in", 
+  "What's",
+  "it",
+  "got",
+  "in",
   "its",
   "pocketses??"
 ].all(|$s| $s.len() > 1);
@@ -290,7 +290,7 @@ RETURN ["same", "same", "same"].all("same");
 The `array::all` function can also be called using its alias `array::every`.
 
 ```surql
-[1,2,3].every(|$num| $num > 0);
+[1, 2, 3].every(|$num| $num > 0);
 -- true
 ```
 
@@ -324,9 +324,9 @@ RETURN ["same", "same?", "Dude, same!"].any("same");
 
 [
   "What's", 
-  "it", 
-  "got", 
-  "in", 
+  "it",
+  "got",
+  "in",
   "its",
   "pocketses??"
 ].any(|$s| $s.len() > 15);
@@ -339,7 +339,7 @@ RETURN ["same", "same?", "Dude, same!"].any("same");
 The `array::any` function can also be called using the aliases `array::some` and `array::includes`.
 
 ```surql
-[1,2,3].some(|$num| $num > 2);
+[1, 2, 3].some(|$num| $num > 2);
 -- true
 
 [1999, 2001, 2002].includes(2000);
@@ -394,7 +394,7 @@ The `array::boolean_and` function performs the [`AND` `bitwise operations`](http
 If one array is shorter than the other it is considered null and thus false.
 
 ```surql title="API DEFINITION"
-array::boolean_and(lh: Array, rh: Array)
+array::boolean_and(lh: array, rh: array)
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
@@ -419,7 +419,7 @@ The `array::boolean_or` function performs the [OR bitwise operations](https://de
 It takes two arrays and if one array is shorter than the other or missing, the output is considered null and thus false.
 
 ```surql title="API DEFINITION"
-array::boolean_or(lh: Array, rh: Array)
+array::boolean_or(lh: array, rh: array)
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
@@ -436,7 +436,7 @@ RETURN array::boolean_or([false, true, false, true], [false, false, true, true])
 The `array::boolean_xor` function performs the [XOR bitwise operations](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_OR).
 
 ```surql title="API DEFINITION"
-array::boolean_xor(lh: Array, rh: Array)
+array::boolean_xor(lh: array, rh: array)
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
@@ -454,7 +454,7 @@ The `array::boolean_not` function performs the [`NOT bitwise operations`](https:
 It takes in one array and it returns false if its single operand can be converted to true.
 
 ```surql title="API DEFINITION"
-array::boolean_not(Array)
+array::boolean_not(array)
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
@@ -476,9 +476,9 @@ array::combine(array, array) -> array
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
 ```surql
-RETURN array::combine([1,2], [2,3]);
+RETURN array::combine([1, 2], [2, 3]);
 
-[ [1,2], [1,3], [2,2], [2,3] ]
+[ [1, 2], [1, 3], [2, 2], [2, 3] ]
 ```
 
 <br />
@@ -493,7 +493,7 @@ array::complement(array, array) -> array
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
 ```surql
-RETURN array::complement([1,2,3,4], [3,4,5,6]);
+RETURN array::complement([1, 2, 3, 4], [3, 4, 5, 6]);
 
 [ 1, 2 ]
 ```
@@ -510,7 +510,7 @@ array::concat(array, array) -> array
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
 ```surql
-RETURN array::concat([1,2,3,4], [3,4,5,6]);
+RETURN array::concat([1, 2, 3, 4], [3, 4, 5, 6]);
 
 [ 1, 2, 3, 4, 3, 4, 5, 6 ]
 ```
@@ -533,7 +533,7 @@ RETURN array::clump($array, 3);
 ```
 
 ```bash title="Response"
-[ [ 1, 2], [3, 4] ];
+[ [ 1, 2], [3, 4] ]
 [ [1, 2, 3], [4] ]
 ```
 
@@ -549,7 +549,7 @@ array::difference(array, array) -> array
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
 ```surql
-RETURN array::difference([1,2,3,4], [3,4,5,6]);
+RETURN array::difference([1, 2, 3, 4], [3, 4, 5, 6]);
 
 [ 1, 2, 5, 6 ]
 ```
@@ -809,7 +809,7 @@ array::flatten(array) -> array
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
 ```surql
-RETURN array::flatten([ [1,2], [3, 4], 'SurrealDB', [5, 6, [7, 8]] ]);
+RETURN array::flatten([ [1, 2], [3, 4], 'SurrealDB', [5, 6, [7, 8]] ]);
 ```
 
 ```bash title="Response"
@@ -828,7 +828,7 @@ array::group(array) -> array
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
 ```surql
-RETURN array::group([1, 2, 3, 4, [3,5,6], [2,4,5,6], 7, 8, 8, 9]);
+RETURN array::group([1, 2, 3, 4, [3, 5, 6], [2, 4, 5, 6], 7, 8, 8, 9]);
 
 [ 1, 2, 3, 4, 5, 6, 7, 8, 9 ]
 ```
@@ -845,7 +845,7 @@ array::insert(array, value, number) -> array
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
 ```surql
-RETURN array::insert([1,2,3,4], 5, 2);
+RETURN array::insert([1, 2, 3, 4], 5, 2);
 
 [ 1, 2, 5, 3, 4 ]
 ```
@@ -862,7 +862,7 @@ array::intersect(array, array) -> array
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
 ```surql
-RETURN array::intersect([1,2,3,4], [3,4,5,6]);
+RETURN array::intersect([1, 2, 3, 4], [3, 4, 5, 6]);
 
 [ 3, 4 ]
 ```
@@ -881,7 +881,7 @@ array::is_empty(array) -> bool
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
 ```surql title="An array that contain values"
-RETURN array::is_empty([1,2,3,4]);
+RETURN array::is_empty([1, 2, 3, 4]);
 
 false
 ```
@@ -950,7 +950,7 @@ RETURN array::len([ 1, 2, 1, null, "something", 3, 3, 4, 0 ]);
 The `array::logical_and` function performs the [`AND` logical operations](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_AND) local but they return the element that represents the resulting truthiness similar to the above. Note that the functions prioritize the elements on the left hand. Also, in the event that neither element can represent the truthiness of the output, the resulting element is a boolean value of the truthiness.
 
 ```surql title="API DEFINITION"
-array::logical_and(lh: Array, rh: Array)
+array::logical_and(lh: array, rh: array)
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
@@ -975,7 +975,7 @@ The `array::logical_or` function performs the [`OR` logical operations](https://
 
 
 ```surql title="API DEFINITION"
-array::logical_or(lh: Array, rh: Array)
+array::logical_or(lh: array, rh: array)
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
@@ -1000,7 +1000,7 @@ The `array::logical_or` function performs the [`XOR` logical operations](https:/
 
 
 ```surql title="API DEFINITION"
-array::logical_xor(lh: Array, rh: Array)
+array::logical_xor(lh: array, rh: array)
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
@@ -1029,7 +1029,7 @@ array::map(array, @closure) -> array;
 The most basic use of `array::map` involves choosing a parameter name for each item in the array and a desired output. The following example gives each item the parameter name `$v`, which can then be used to double the value.
 
 ```surql
-[1,2,3].map(|$v| $v * 2);
+[1, 2, 3].map(|$v| $v * 2);
 ```
 
 ```bash title="Response"
@@ -1074,7 +1074,7 @@ An example of a longer operation that uses `{}` to allow the closure to take mul
 The types for the closure arguments and output can be annotated for extra type safety. Take the following simple closure:
 
 ```surql
-[1,2,3].map(|$num| $num + 1.1);
+[1, 2, 3].map(|$num| $num + 1.1);
 ```
 
 The output is `[2.1f, 3.1f, 4.1f]`.
@@ -1082,7 +1082,7 @@ The output is `[2.1f, 3.1f, 4.1f]`.
 However, if the `1.1` inside the function was actually a typo and should have been the integer 11, the following would have prevented it from running.
 
 ```surql
-[1,2,3].map(|$num: int| -> int { $num + 1.1 });
+[1, 2, 3].map(|$num: int| -> int { $num + 1.1 });
 ```
 
 ```bash title="Response"
@@ -1116,7 +1116,7 @@ The `array::max` function returns the maximum item in an array
 
 
 ```surql title="API DEFINITION"
-array::max(Array) -> any
+array::max(array) -> any
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
@@ -1134,7 +1134,7 @@ The `array::matches` function returns an array of booleans indicating which elem
 
 
 ```surql title="API DEFINITION"
-array::matches(Array, value) -> Array<bool>
+array::matches(array, value) -> array<bool>
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
@@ -1159,7 +1159,7 @@ The `array::min` function returns the minimum item in an array
 
 
 ```surql title="API DEFINITION"
-array::min(Array) -> any
+array::min(array) -> any
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
@@ -1200,7 +1200,7 @@ array::prepend(array, value) -> array
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
 ```surql
-RETURN array::prepend([1,2,3,4], 5);
+RETURN array::prepend([1, 2, 3, 4], 5);
 
 [ 5, 1, 2, 3, 4 ]
 ```
@@ -1218,7 +1218,7 @@ array::push(array, value) -> array
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
 ```surql
-RETURN array::push([1,2,3,4], 5);
+RETURN array::push([1, 2, 3, 4], 5);
 
 [ 1, 2, 3, 4, 5 ]
 ```
@@ -1261,14 +1261,14 @@ array::remove(array, number) -> array
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
 ```surql
-RETURN array::remove([1,2,3,4,5], 2);
+RETURN array::remove([1, 2, 3, 4, 5], 2);
 
 [ 1, 2, 4, 5 ]
 ```
 
 The following examples shows this function using a negative index.
 ```surql
-RETURN array::remove([1,2,3,4,5], -2);
+RETURN array::remove([1, 2, 3, 4, 5], -2);
 
 [ 1, 2, 3, 5 ]
 ```
@@ -1351,7 +1351,7 @@ The following example shows this function, and its output, when used in a [`RETU
 ```surql
 RETURN array::slice([ 1, 2, 3, 4, 5 ], 1, 2);
 
-[2,3]
+[2, 3]
 ```
 
 The following example shows how you can use this function with a starting position, and a negative position, which will slice off the first and last element from the array:
@@ -1414,17 +1414,17 @@ RETURN array::sort([ 1, 2, 1, null, "something", 3, 3, 4, 0 ]);
 [ null, 0, 1, 1, 2, 3, 3, 4, "something" ]
 ```
 ```surql
-RETURN array::sort([1,2,1,null,"something",3,3,4,0], false);
+RETURN array::sort([1, 2, 1, null, "something", 3, 3, 4, 0], false);
 
 [ "something", 4, 3, 3, 2, 1, 1, 9, null ]
 ```
 ```surql
-RETURN array::sort([1,2,1,null,"something",3,3,4,0], "asc");
+RETURN array::sort([1, 2, 1, null, "something", 3, 3, 4, 0], "asc");
 
 [ null, 0, 1, 1, 2, 3, 3, 4, "something" ]
 ```
 ```surql
-RETURN array::sort([1,2,1,null,"something",3,3,4,0], "desc");
+RETURN array::sort([1, 2, 1, null, "something", 3, 3, 4, 0], "desc");
 
 [ "something", 4, 3, 3, 2, 1, 1, 9, null ]
 ```
@@ -1505,7 +1505,7 @@ RETURN array::swap([ 1, 2, 3, 4, 5 ], 0, -1);
 An error will be returned if any of the indexes are invalid that informs of range of possible indexes that can be used.
 
 ```surql
-RETURN array::swap([0,1], 100, 1000000);
+RETURN array::swap([0, 1], 100, 1000000);
 ```
 
 ```bash title="Output"
@@ -1543,7 +1543,7 @@ array::union(array, array) -> array
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
 ```surql
-RETURN array::union([1,2,1,6], [1,3,4,5,6]);
+RETURN array::union([1, 2, 1, 6], [1, 3, 4, 5, 6]);
 
 [ 1, 2, 6, 3, 4, 5 ]
 ```
@@ -1563,7 +1563,7 @@ The `array::windows` function returns a number of arrays of length `size` create
 The following examples show this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
 ```surql
-LET $array = [1,2,3,4];
+LET $array = [1, 2, 3, 4];
 RETURN array::windows($array, 2);
 RETURN array::windows($array, 5);
 ```

--- a/doc-surrealql_versioned_docs/version-latest/functions/database/array.mdx
+++ b/doc-surrealql_versioned_docs/version-latest/functions/database/array.mdx
@@ -691,7 +691,7 @@ The `array::filter_index` function can also take a [closure](/docs/surrealql/dat
 ```
 
 ```bash title="Response"
-[	0, 3 ]
+[0, 3 ]
 ```
 
 <br />

--- a/doc-surrealql_versioned_docs/version-latest/functions/database/array.mdx
+++ b/doc-surrealql_versioned_docs/version-latest/functions/database/array.mdx
@@ -184,7 +184,7 @@ These functions can be used when working with, and manipulating arrays of data.
     </tr>
     <tr>
       <td scope="row" data-label="Function"><a href="#arrayrepeat"><code>array::repeat()</code></a></td>
-      <td scope="row" data-label="Description">Creates an array of the same value of a given size</td>
+      <td scope="row" data-label="Description">Creates an array a given size with a specified value used for each element.</td>
     </tr>
     <tr>
       <td scope="row" data-label="Function"><a href="#arrayreverse"><code>array::reverse()</code></a></td>
@@ -1279,7 +1279,7 @@ RETURN array::remove([1,2,3,4,5], -2);
 
 <Since v="v2.0.0" />
 
-The `array::repeat` function creates an array of a given size that will contain the same value.
+The `array::repeat` function creates an array of a given size contain the specified value for each element.
 
 ```surql title="API DEFINITION"
 array::repeat(any, count) -> array

--- a/doc-surrealql_versioned_docs/version-latest/functions/database/array.mdx
+++ b/doc-surrealql_versioned_docs/version-latest/functions/database/array.mdx
@@ -112,7 +112,7 @@ These functions can be used when working with, and manipulating arrays of data.
     </tr>
     <tr>
       <td scope="row" data-label="Function"><a href="#arrayinsert"><code>array::insert()</code></a></td>
-      <td scope="row" data-label="Description">Inserts an item at the end of an array, or in a specific position, supports negative index</td>
+      <td scope="row" data-label="Description">Inserts an item at the end of an array, or in a specific position</td>
     </tr>
     <tr>
       <td scope="row" data-label="Function"><a href="#arrayintersect"><code>array::intersect()</code></a></td>
@@ -180,7 +180,7 @@ These functions can be used when working with, and manipulating arrays of data.
     </tr>
     <tr>
       <td scope="row" data-label="Function"><a href="#arrayremove"><code>array::remove()</code></a></td>
-      <td scope="row" data-label="Description">Removes an item at a specific position from an array, supports negative index</td>
+      <td scope="row" data-label="Description">Removes an item at a specific position from an array</td>
     </tr>
     <tr>
       <td scope="row" data-label="Function"><a href="#arrayrepeat"><code>array::repeat()</code></a></td>
@@ -837,7 +837,7 @@ RETURN array::group([1, 2, 3, 4, [3, 5, 6], [2, 4, 5, 6], 7, 8, 8, 9]);
 
 ## `array::insert`
 
-The `array::insert`  function inserts a value into an array at a specific position, supports negative index.
+The `array::insert` function inserts a value into an array at a specific position. A negative index can be provided to specify a position relative to the end of the array.
 
 ```surql title="API DEFINITION"
 array::insert(array, value, number) -> array
@@ -1252,7 +1252,7 @@ RETURN array::range(3, 2);
 
 ## `array::remove`
 
-The `array::remove` function removes an item from a specific position in an array, supports negative index.
+The `array::remove` function removes an item from a specific position in an array. A negative index can be provided to specify a position relative to the end of the array.
 
 
 ```surql title="API DEFINITION"

--- a/doc-surrealql_versioned_docs/version-latest/functions/database/array.mdx
+++ b/doc-surrealql_versioned_docs/version-latest/functions/database/array.mdx
@@ -1520,7 +1520,7 @@ The `array::transpose` function is used to perform 2d array transposition but it
 
 
 ```surql title="API DEFINITION"
-array::transpose(array, array) -> array array
+array::transpose(array, array) -> array<array>
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 

--- a/doc-surrealql_versioned_docs/version-latest/functions/database/array.mdx
+++ b/doc-surrealql_versioned_docs/version-latest/functions/database/array.mdx
@@ -156,7 +156,7 @@ These functions can be used when working with, and manipulating arrays of data.
     </tr>
     <tr>
       <td scope="row" data-label="Function"><a href="#arraymatches"><code>array::matches()</code></a></td>
-      <td scope="row" data-label="Description">Returns an array of booleans</td>
+      <td scope="row" data-label="Description">Returns an array of booleans indicating which elements of the input array contain a specified value.</td>
     </tr>
     <tr>
       <td scope="row" data-label="Function"><a href="#arraymin"><code>array::min()</code></a></td>
@@ -1130,11 +1130,11 @@ RETURN array::max([0, 1, 2]);
 
 ## `array::matches`
 
-The `array::matches` function returns an array of booleans
+The `array::matches` function returns an array of booleans indicating which elements of the input array contain a specified value.
 
 
 ```surql title="API DEFINITION"
-array::matches(Array,value) -> Array
+array::matches(Array, value) -> Array<bool>
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
@@ -1146,7 +1146,7 @@ RETURN array::matches([0, 1, 2], 1);
 The following example shows this function when the array contains objects.
 
 ```surql
-RETURN array::matches([{id: r"ohno:0"}, {id: r"ohno:1"}], {id: r"ohno:1"})
+RETURN array::matches([{id: r"ohno:0"}, {id: r"ohno:1"}], {id: r"ohno:1"});
 
 [ false, true ]
 ```

--- a/doc-surrealql_versioned_docs/version-latest/functions/database/array.mdx
+++ b/doc-surrealql_versioned_docs/version-latest/functions/database/array.mdx
@@ -502,7 +502,7 @@ RETURN array::complement([1, 2, 3, 4], [3, 4, 5, 6]);
 
 ## `array::concat`
 
-The `array::concat` function merges two arrays together, returning an array which may contain duplicate values. If you want to remove duplicate values from the resulting array, then use the [`array::union()`](/docs/surrealql/functions/database/array#arrayunion) function
+The `array::concat` function merges two arrays together, returning an array which may contain duplicate values. If you want to remove duplicate values from the resulting array, then use the [`array::union()`](/docs/surrealql/functions/database/array#arrayunion) function.
 
 ```surql title="API DEFINITION"
 array::concat(array, array) -> array
@@ -1112,7 +1112,7 @@ For a similar function that allows using a closure on entire values instead of e
 
 ## `array::max`
 
-The `array::max` function returns the maximum item in an array
+The `array::max` function returns the maximum item in an array.
 
 
 ```surql title="API DEFINITION"
@@ -1155,7 +1155,7 @@ RETURN array::matches([{id: r"ohno:0"}, {id: r"ohno:1"}], {id: r"ohno:1"});
 
 ## `array::min`
 
-The `array::min` function returns the minimum item in an array
+The `array::min` function returns the minimum item in an array.
 
 
 ```surql title="API DEFINITION"

--- a/doc-surrealql_versioned_docs/version-latest/functions/database/array.mdx
+++ b/doc-surrealql_versioned_docs/version-latest/functions/database/array.mdx
@@ -249,13 +249,15 @@ RETURN array::add(["one", "two"], "three");
 
 ## `array::all`
 
+When called on an array without any extra arguments, the `array::all` function checks whether all array values are [truthy](/docs/surrealql/datamodel/values#values-and-truthiness).
+
 ```surql title="API DEFINITION"
 array::all(array) -> bool
 array::all(array, value) -> bool
 array::all(array, @closure) -> bool
 ```
 
-When called on an array without any extra arguments, the `array::all` function checks whether all array values are [truthy](/docs/surrealql/datamodel/values#values-and-truthiness).
+The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:
 
 ```surql
 RETURN array::all([ 1, 2, 3, NONE, 'SurrealDB', 5 ]);
@@ -696,12 +698,14 @@ The `array::filter_index` function can also take a [closure](/docs/surrealql/dat
 
 ## `array::find`
 
+The `array::find` function returns the first occurrence of `value` in the array or `NONE` if `array` does not contain `value`.
+
 ```surql title="API DEFINITION"
 array::find(array, value) -> value | NONE
 array::find(array, @closure) -> value | NONE
 ```
 
-The `array::find` function returns the first occurrence of `value` in the array or `NONE` if `array` does not contain `value`.
+The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:
 
 ```surql
 RETURN array::find(['a', 'b', 'c', 'b', 'a'], 'b');
@@ -745,12 +749,14 @@ NONE
 
 ## `array::find_index`
 
+The `array::find_index` function returns the index of the first occurrence of `value` in the array or `NONE` if `array` does not contain `value`.
+
 ```surql title="API DEFINITION"
 array::find_index(array, value) -> number | NONE
 array::find_index(array, @closure) -> number | NONE
 ```
 
-The `array::find_index` function returns the index of the first occurrence of `value` in the array or `NONE` if `array` does not contain `value`.
+The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealdb/surrealql/statements/return) statement:
 
 ```surql
 RETURN array::find_index(['a', 'b', 'c', 'b', 'a'], 'b');

--- a/doc-surrealql_versioned_docs/version-latest/functions/database/array.mdx
+++ b/doc-surrealql_versioned_docs/version-latest/functions/database/array.mdx
@@ -298,7 +298,7 @@ The `array::all` function can also be called using its alias `array::every`.
 
 ## `array::any`
 
-The `array::any` function checks whether any array values are [truthy][truthy](/docs/surrealql/datamodel/values#values-and-truthiness).
+The `array::any` function checks whether any array values are [truthy](/docs/surrealql/datamodel/values#values-and-truthiness).
 
 ```surql title="API DEFINITION"
 array::any(array) -> bool

--- a/doc-surrealql_versioned_docs/version-latest/functions/database/array.mdx
+++ b/doc-surrealql_versioned_docs/version-latest/functions/database/array.mdx
@@ -353,7 +353,7 @@ The `array::any` function can also be called using the aliases `array::some` and
 The `array::at` function returns the value at the specified index, or in reverse for a negative index.
 
 ```surql title="API DEFINITION"
-array::at(array, index) -> any
+array::at(array, index: int) -> any
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
@@ -1249,7 +1249,7 @@ RETURN array::push([1, 2, 3, 4], 5);
 The `array::range` function creates an array of numbers from a given range.
 
 ```surql title="API DEFINITION"
-array::range(start, count) -> array
+array::range(start: int, count: int) -> array
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
@@ -1299,7 +1299,7 @@ RETURN array::remove([1, 2, 3, 4, 5], -2);
 The `array::repeat` function creates an array of a given size contain the specified value for each element.
 
 ```surql title="API DEFINITION"
-array::repeat(any, count) -> array
+array::repeat(any, count: int) -> array
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
@@ -1361,7 +1361,7 @@ The `array::slice` function returns a slice of an array, based on a starting pos
 
 
 ```surql title="API DEFINITION"
-array::slice(array, start, len) -> array
+array::slice(array, start: int, len: int) -> array
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 

--- a/doc-surrealql_versioned_docs/version-latest/functions/database/array.mdx
+++ b/doc-surrealql_versioned_docs/version-latest/functions/database/array.mdx
@@ -388,7 +388,7 @@ RETURN array::append([1, 2, 3, 4], 5);
 
 ## `array::boolean_and`
 
-The `array::boolean_and` Perform the [`AND` `bitwise operations`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_AND) on the input arrays per-element based on the element's truthiness.
+The `array::boolean_and` function performs the [`AND` `bitwise operations`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_AND) on the input arrays per-element based on the element's truthiness.
 If one array is shorter than the other it is considered null and thus false.
 
 ```surql title="API DEFINITION"
@@ -413,7 +413,7 @@ RETURN array::boolean_and([true, true], [false])
 
 ## `array::boolean_or`
 
-The `array::boolean_or` Perform the [OR bitwise operations](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Bitwise_OR) on the input arrays per-element based on the element's truthiness.
+The `array::boolean_or` function performs the [OR bitwise operations](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Bitwise_OR) on the input arrays per-element based on the element's truthiness.
 It takes two arrays and if one array is shorter than the other or missing, the output is considered null and thus false.
 
 ```surql title="API DEFINITION"
@@ -431,7 +431,7 @@ RETURN array::boolean_or([false, true, false, true], [false, false, true, true])
 
 ## `array::boolean_xor`
 
-The `array::boolean_xor` Performs the [XOR bitwise operations](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_OR).
+The `array::boolean_xor` function performs the [XOR bitwise operations](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_OR).
 
 ```surql title="API DEFINITION"
 array::boolean_xor(lh: Array, rh: Array)
@@ -448,7 +448,7 @@ RETURN array::boolean_xor([false, true, false, true], [false, false, true, true]
 
 ## `array::boolean_not`
 
-The `array::boolean_not` Perform the [`NOT bitwise operations`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Bitwise_NOT) on the input array(s) per-element based on the element's truthiness.
+The `array::boolean_not` function performs the [`NOT bitwise operations`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Bitwise_NOT) on the input array(s) per-element based on the element's truthiness.
 It takes in one array and it returns false if its single operand can be converted to true.
 
 ```surql title="API DEFINITION"
@@ -539,7 +539,7 @@ RETURN array::clump($array, 3);
 
 ## `array::difference`
 
-The `array::difference` determines the difference between two arrays, returning a single array containing items which are not in both arrays.
+The `array::difference` function determines the difference between two arrays, returning a single array containing items which are not in both arrays.
 
 ```surql title="API DEFINITION"
 array::difference(array, array) -> array
@@ -660,7 +660,7 @@ The `array::filter` function can also take a [closure](/docs/surrealql/datamodel
 
 ## `array::filter_index`
 
-The `array::filter_index` returns the indexes of all occurrences of all matching values.
+The `array::filter_index` function returns the indexes of all occurrences of all matching values.
 
 ```surql title="API DEFINITION"
 array::filter_index(array, value) -> array
@@ -701,7 +701,7 @@ array::find(array, value) -> value | NONE
 array::find(array, @closure) -> value | NONE
 ```
 
-The `array::find` Returns the first occurrence of `value` in the array or `NONE` if `array` does not contain `value`.
+The `array::find` function returns the first occurrence of `value` in the array or `NONE` if `array` does not contain `value`.
 
 ```surql
 RETURN array::find(['a', 'b', 'c', 'b', 'a'], 'b');
@@ -750,7 +750,7 @@ array::find_index(array, value) -> number | NONE
 array::find_index(array, @closure) -> number | NONE
 ```
 
-The `array::find_index` Returns the index of the first occurrence of `value` in the array or `NONE` if `array` does not contain `value`.
+The `array::find_index` function returns the index of the first occurrence of `value` in the array or `NONE` if `array` does not contain `value`.
 
 ```surql
 RETURN array::find_index(['a', 'b', 'c', 'b', 'a'], 'b');
@@ -795,7 +795,7 @@ RETURN array::first([ 's', 'u', 'r', 'r', 'e', 'a', 'l' ]);
 
 ## `array::flatten`
 
-The `array::flatten` flattens an array of arrays, returning a new array with all sub-array elements concatenated into it.
+The `array::flatten` function flattens an array of arrays, returning a new array with all sub-array elements concatenated into it.
 
 ```surql title="API DEFINITION"
 array::flatten(array) -> array
@@ -867,7 +867,7 @@ RETURN array::intersect([1,2,3,4], [3,4,5,6]);
 
 <Since v="v2.0.0" />
 
-The `array::is_empty` checks whether the array contains values.
+The `array::is_empty` function checks whether the array contains values.
 
 ```surql title="API DEFINITION"
 array::is_empty(array) -> bool
@@ -907,7 +907,7 @@ RETURN array::join(["again", "again", "again"], " and ");
 
 ## `array::last`
 
-The `array::last`function returns the last value from an array.
+The `array::last` function returns the last value from an array.
 
 ```surql title="API DEFINITION"
 array::last(array) -> any
@@ -941,7 +941,7 @@ RETURN array::len([ 1, 2, 1, null, "something", 3, 3, 4, 0 ]);
 
 ## `array::logical_and`
 
-The `array::logical_and` performs the [`AND` logical operations](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_AND) local but they return the element that represents the resulting truthiness similar to the above. Note that the functions prioritize the elements on the left hand. Also, in the event that neither element can represent the truthiness of the output, the resulting element is a boolean value of the truthiness.
+The `array::logical_and` function performs the [`AND` logical operations](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_AND) local but they return the element that represents the resulting truthiness similar to the above. Note that the functions prioritize the elements on the left hand. Also, in the event that neither element can represent the truthiness of the output, the resulting element is a boolean value of the truthiness.
 
 ```surql title="API DEFINITION"
 array::logical_and(lh: Array, rh: Array)
@@ -965,7 +965,7 @@ RETURN array::logical_and([0, 1], [])
 
 ## `array::logical_or`
 
-The `array::logical_or` Performs the [`OR` logical operations](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_OR). Note that the functions prioritize the elements on the left hand.
+The `array::logical_or` function performs the [`OR` logical operations](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_OR). Note that the functions prioritize the elements on the left hand.
 
 
 ```surql title="API DEFINITION"
@@ -990,7 +990,7 @@ RETURN array::logical_or([0, 1], []);
 
 ## `array::logical_xor`
 
-The `array::logical_or` performs the [`XOR` logical operations](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_OR).
+The `array::logical_or` function performs the [`XOR` logical operations](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_OR).
 
 
 ```surql title="API DEFINITION"
@@ -1106,7 +1106,7 @@ For a similar function that allows using a closure on entire values instead of e
 
 ## `array::max`
 
-The `array::max` returns the maximum item in an array
+The `array::max` function returns the maximum item in an array
 
 
 ```surql title="API DEFINITION"
@@ -1124,7 +1124,7 @@ RETURN array::max([0, 1, 2]);
 
 ## `array::matches`
 
-The `array::matches` returns an array of booleans
+The `array::matches` function returns an array of booleans
 
 
 ```surql title="API DEFINITION"
@@ -1149,7 +1149,7 @@ RETURN array::matches([{id: r"ohno:0"}, {id: r"ohno:1"}], {id: r"ohno:1"})
 
 ## `array::min`
 
-The `array::min` returns the minimum item in an array
+The `array::min` function returns the minimum item in an array
 
 
 ```surql title="API DEFINITION"
@@ -1334,7 +1334,7 @@ RETURN array::shuffle([ 1, 2, 3, 4, 5 ]);
 
 ## `array::slice`
 
-The `array::slice` returns a slice of an array, based on a starting position, and a length or negative position.
+The `array::slice` function returns a slice of an array, based on a starting position, and a length or negative position.
 
 
 ```surql title="API DEFINITION"
@@ -1465,7 +1465,7 @@ RETURN array::sort::desc([ 1, 2, 1, null, "something", 3, 3, 4, 0 ]);
 
 <Since v="v2.0.0" />
 
-The `array::swap` swaps two values of an array based on indexes.
+The `array::swap` function swaps two values of an array based on indexes.
 
 
 ```surql title="API DEFINITION"
@@ -1510,7 +1510,7 @@ RETURN array::swap([0,1], 100, 1000000);
 
 ## `array::transpose`
 
-The `array::transpose` is used to perform 2d array transposition but its behavior in cases of arrays of differing sizes can be best described as taking in multiple arrays and 'layering' them on top of each other.
+The `array::transpose` function is used to perform 2d array transposition but its behavior in cases of arrays of differing sizes can be best described as taking in multiple arrays and 'layering' them on top of each other.
 
 
 ```surql title="API DEFINITION"


### PR DESCRIPTION
# Commit 1:
## docs-Add missing word "function" to `array` function descriptions
In the documentation page for the `array` function module, the descriptions of the following functions are missing the word "function":

`array::boolean_and`
`array::boolean_or`
`array::boolean_xor`
`array::boolean_not`
`array::difference`
`array::find`
`array::filter_index`
`array::find_index`
`array::flatten`
`array::is_empty`
`array::logical_and`
`array::logical_or`
`array::logical_xor`
`array::max`
`array::matches`
`array::min`
`array::swap`
`array::transpose`

This commit adds the missing word "function" to the descriptions.


# Commit 2:
## docs-Move `array` functions' descriptions above API definitions
In the documentation page for the `array` function module, the API definition appears above the function description for the following functions:

`array::all`
`array::find`
`array::find_index`

This commit moves the API definitions of these functions below the descriptions, to be consistent with the rest of the functions on the page.


# Commit 3:
## docs-Clarify description of `array::repeat` function
This commit makes the description of the `array::repeat` function slightly more clear.


# Commit 4:
## docs-Fix return type in API definition of `array::transpose` function
On the documentation page of the `array` function module, the API definition of the `array::transpose` function is listed as "array array".

This commit changes the return type to "array<array>", specifying that the value returned will be an array containing arrays as elements.


# Commit 5:
## docs-Remove unnecessary tab character in documentation of `array::filter_index` function
In the documentation page of the `array` function module, the `array:filter_index` function's example query response contains an unnecessary tab character.

This commit removes the unnecessary tab character.


# Commit 6:
## docs-Fix documentation of `array:matches` function
In the documentation page of the `array` function module, the description of the `array::matches` function is incomplete.

This commit completes the description.


# Commit 7:
## docs-Standardize formatting in `array` function module documentation
This commit attempts to standardize the following in the `array` function module's documentation page, to keep the API definitions and examples queries consistent:

* use "array" as the type notation (replacing some instances of "Array")
* Adding spaces after commas separating array elements for the example queries that did not have them.


# Commit 8:
## docs-Add missing punctuation in `array` function module documentation
In the documentation page of the `array` function module, Several sentences are missing punctuation.

This commit adds the missing punctuation.


# Commit 9:
## docs-Clarify use of negative index with `array::insert` and `array::remove` functions
In the documentation page for the `array` module, the `array::insert` and `array::remove` functions mention that they "support negative index."

This commit clarifies what is meant by this, replacing it with "A negative index can be provided to specify a position relative to the end of the array."


# Commit 10:
## docs-Fix link in `array` function module documentation
In the documentation page for the `array` function module, a link to the "Values and truthiness" section of the `values` data type documentation pages is broken.

This commit fixes the link.


# Commit 11:
## docs-Expand documentation of functions `array::logical_and`, `array::logical_or`, and `array::logical_xor`
This commit expands the descriptions of the following functions in the documentation page of the `array` function module, further explaining the comparisons that they perform and the values that they return:

`array::logical_and`
`array::logical_or`
`array::logical_xor`


# Commit 12:
## docs-Add parameter type annotations for functions in the `array` module
In the documentation page of the `array` function module, several functions' API definitions have function parameters with specific names instead of types, without type annotations indicating the expected types of the parameters.

This commit adds type annotations to these named parameters.
