### PR TITLE
docs-Remove SpeeDB from Rust embedding documentation

### DIFF
--- a/doc-surrealdb_versioned_docs/version-latest/embedding/rust.mdx
+++ b/doc-surrealdb_versioned_docs/version-latest/embedding/rust.mdx
@@ -39,9 +39,6 @@ cargo add surrealdb --features kv-mem
 # For a RocksDB file
 cargo add surrealdb --features kv-rocksdb
 
-# For a SpeeDB file
-cargo add surrealdb --features kv-speedb
-
 # For FoundationDB cluster (FoundationDB must be installed and the appropriate version selected)
 cargo add surrealdb --features kv-fdb-7_1
 


### PR DESCRIPTION
The documentation page for embedding SurrealDB in Rust programs contains instructions for using SpeeDB as storage a backend. Support for SpeeDB has been removed from SurrealDB.

This commit removes the mention of SpeeDB.