### PR TITLE
docs-Add missing `math` constants to documentation pages of numeric data types and `math` function module

### DIFF
--- a/src/content/doc-surrealql/datamodel/numbers.mdx
+++ b/src/content/doc-surrealql/datamodel/numbers.mdx
@@ -204,6 +204,17 @@ CREATE circle SET radius = circumference / ( 2 * MATH::PI );
         </tr>
         <tr>
             <td colspan="2" scope="row" data-label="Constant">
+                <code>MATH::INF</code>
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+                Positive infinity
+            </td>
+            <td colspan="2" scope="row" data-label="Value">
+                inf
+            </td>
+        </tr>
+        <tr>
+            <td colspan="2" scope="row" data-label="Constant">
                 <code>MATH::LN_10</code>
             </td>
             <td colspan="2" scope="row" data-label="Description">
@@ -266,6 +277,17 @@ CREATE circle SET radius = circumference / ( 2 * MATH::PI );
             </td>
             <td colspan="2" scope="row" data-label="Value">
                 1.4426950408889634
+            </td>
+        </tr>
+        <tr>
+            <td colspan="2" scope="row" data-label="Constant">
+                <code>MATH::NEG_INF</code>
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+                Negative infinity
+            </td>
+            <td colspan="2" scope="row" data-label="Value">
+                -inf
             </td>
         </tr>
         <tr>

--- a/src/content/doc-surrealql/functions/database/math.mdx
+++ b/src/content/doc-surrealql/functions/database/math.mdx
@@ -64,7 +64,7 @@ These functions can be used when analysing numeric data and numeric collections.
     </tr>
     <tr>
       <td scope="row" data-label="Constant"><a href="#mathe"><code>math::e</code></a></td>
-      <td scope="row" data-label="Description">Represents the base of the natural logarithm</td>
+      <td scope="row" data-label="Description">Constant representing the base of the natural logarithm (Euler's number)</td>
     </tr>
     <tr>
       <td scope="row" data-label="Function"><a href="#mathfixed"><code>math::fixed()</code></a></td>
@@ -75,8 +75,44 @@ These functions can be used when analysing numeric data and numeric collections.
       <td scope="row" data-label="Description">Rounds a number down to the nearest integer</td>
     </tr>
     <tr>
+      <td scope="row" data-label="Function"><a href="#mathfrac_1_pi"><code>math::frac_1_pi</code></a></td>
+      <td scope="row" data-label="Description">Constant representing the fraction 1/π</td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Function"><a href="#mathfrac_1_sqrt_2"><code>math::frac_1_sqrt_2</code></a></td>
+      <td scope="row" data-label="Description">Constant representing the fraction 1/sqrt(2)</td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Function"><a href="#mathfrac_2_pi"><code>math::frac_2_pi</code></a></td>
+      <td scope="row" data-label="Description">Constant representing the fraction 2/π</td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Function"><a href="#mathfrac_2_sqrt_pi"><code>math::frac_2_sqrt_pi</code></a></td>
+      <td scope="row" data-label="Description">Constant representing the fraction 2/sqrt(π)</td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Function"><a href="#mathfrac_pi_2"><code>math::frac_pi_2</code></a></td>
+      <td scope="row" data-label="Description">Constant representing the fraction π/2</td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Function"><a href="#mathfrac_pi_3"><code>math::frac_pi_3</code></a></td>
+      <td scope="row" data-label="Description">Constant representing the fraction π/3</td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Function"><a href="#mathfrac_pi_4"><code>math::frac_pi_4</code></a></td>
+      <td scope="row" data-label="Description">Constant representing the fraction π/4</td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Function"><a href="#mathfrac_pi_6"><code>math::frac_pi_6</code></a></td>
+      <td scope="row" data-label="Description">Constant representing the fraction π/6</td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Function"><a href="#mathfrac_pi_8"><code>math::frac_pi_8</code></a></td>
+      <td scope="row" data-label="Description">Constant representing the fraction π/8</td>
+    </tr>
+    <tr>
       <td scope="row" data-label="Constant"><a href="#mathinf"><code>math::inf</code></a></td>
-      <td scope="row" data-label="Description">Represents positive infinity</td>
+      <td scope="row" data-label="Description">Constant representing positive infinity</td>
     </tr>
     <tr>
       <td scope="row" data-label="Function"><a href="#mathinterquartile"><code>math::interquartile()</code></a></td>
@@ -95,6 +131,14 @@ These functions can be used when analysing numeric data and numeric collections.
       <td scope="row" data-label="Description">Computes the natural logarithm (base e) of a value</td>
     </tr>
     <tr>
+      <td scope="row" data-label="Function"><a href="#mathln_10"><code>math::ln_10</code></a></td>
+      <td scope="row" data-label="Description">Constant representing the natural logarithm (base e) of 10</td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Function"><a href="#mathln_2"><code>math::ln_2</code></a></td>
+      <td scope="row" data-label="Description">Constant representing the natural logarithm (base e) of 2</td>
+    </tr>
+    <tr>
       <td scope="row" data-label="Function"><a href="#mathlog"><code>math::log()</code></a></td>
       <td scope="row" data-label="Description">Computes the logarithm of a value with the specified base</td>
     </tr>
@@ -103,8 +147,24 @@ These functions can be used when analysing numeric data and numeric collections.
       <td scope="row" data-label="Description">Computes the base-10 logarithm of a value</td>
     </tr>
     <tr>
+      <td scope="row" data-label="Function"><a href="#mathlog10_2"><code>math::log10_2</code></a></td>
+      <td scope="row" data-label="Description">Constant representing the base-10 logarithm of 2</td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Function"><a href="#mathlog10_e"><code>math::log10_e</code></a></td>
+      <td scope="row" data-label="Description">Constant representing the base-10 logarithm of e, the base of the natural logarithm (Euler’s number)</td>
+    </tr>
+    <tr>
       <td scope="row" data-label="Function"><a href="#mathlog2"><code>math::log2()</code></a></td>
       <td scope="row" data-label="Description">Computes the base-2 logarithm of a value</td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Function"><a href="#mathlog2_10"><code>math::log2_10</code></a></td>
+      <td scope="row" data-label="Description">Constant representing the base-2 logarithm of 10</td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Function"><a href="#mathlog2_e"><code>math::log2_e</code></a></td>
+      <td scope="row" data-label="Description">Constant representing the base-2 logarithm of e, the base of the natural logarithm (Euler’s number)</td>
     </tr>
     <tr>
       <td scope="row" data-label="Function"><a href="#mathmax"><code>math::max()</code></a></td>
@@ -136,7 +196,7 @@ These functions can be used when analysing numeric data and numeric collections.
     </tr>
     <tr>
       <td scope="row" data-label="Constant"><a href="#mathneg_inf"><code>math::neg_inf</code></a></td>
-      <td scope="row" data-label="Description">Represents negative infinity</td>
+      <td scope="row" data-label="Description">Constant representing negative infinity</td>
     </tr>
     <tr>
       <td scope="row" data-label="Function"><a href="#mathpercentile"><code>math::percentile()</code></a></td>
@@ -144,7 +204,7 @@ These functions can be used when analysing numeric data and numeric collections.
     </tr>
     <tr>
       <td scope="row" data-label="Constant"><a href="#mathpi"><code>math::pi</code></a></td>
-      <td scope="row" data-label="Description">Represents the mathematical constant π.</td>
+      <td scope="row" data-label="Description">Constant representing the mathematical constant π.</td>
     </tr>
     <tr>
       <td scope="row" data-label="Constant"><a href="#mathpow"><code>math::pow()</code></a></td>
@@ -179,6 +239,10 @@ These functions can be used when analysing numeric data and numeric collections.
       <td scope="row" data-label="Description">Returns the square root of a number</td>
     </tr>
     <tr>
+      <td scope="row" data-label="Function"><a href="#mathsqrt_2"><code>math::sqrt_2</code></a></td>
+      <td scope="row" data-label="Description">Constant representing the square root of 2</td>
+    </tr>
+    <tr>
       <td scope="row" data-label="Function"><a href="#mathstddev"><code>math::stddev()</code></a></td>
       <td scope="row" data-label="Description">Calculates how far a set of numbers are away from the mean</td>
     </tr>
@@ -192,7 +256,7 @@ These functions can be used when analysing numeric data and numeric collections.
     </tr>
     <tr>
       <td scope="row" data-label="Constant"><a href="#mathtau"><code>math::tau()</code></a></td>
-      <td scope="row" data-label="Description">Represents the mathematical constant τ.</td>
+      <td scope="row" data-label="Description">Represents the mathematical constant τ, which is equal to 2π</td>
     </tr>
     <tr>
       <td scope="row" data-label="Function"><a href="#mathtop"><code>math::top()</code></a></td>
@@ -412,7 +476,7 @@ RETURN math::deg2rad(180);
 
 ## `math::e`
 
-The `math::e` constant represents the base of the natural logarithm.
+The `math::e` constant represents the base of the natural logarithm (Euler’s number).
 
 ```surql title="API DEFINITION"
 math::e -> number
@@ -460,6 +524,160 @@ RETURN math::floor(13.746189);
 ```
 
 <br />
+
+## `math::frac_1_pi`
+
+The `math::frac_1_pi` constant represents the fraction 1/π.
+
+```surql title="API DEFINITION"
+math::frac_1_pi -> number
+```
+The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
+
+```surql
+RETURN math::frac_1_pi;
+
+0.3183098861837907f
+```
+
+<br />
+
+## `math::frac_1_sqrt_2`
+
+The `math::frac_1_sqrt_2` constant represents the fraction 1/sqrt(2).
+
+```surql title="API DEFINITION"
+math::frac_1_sqrt_2 -> number
+```
+The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
+
+```surql
+RETURN math::frac_1_sqrt_2;
+
+0.7071067811865476f
+```
+
+<br />
+
+## `math::frac_2_pi`
+
+The `math::frac_2_pi` constant represents the fraction 2/π.
+
+```surql title="API DEFINITION"
+math::frac_2_pi -> number
+```
+The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
+
+```surql
+RETURN math::frac_2_pi;
+
+0.6366197723675814f
+```
+
+<br />
+
+## `math::frac_2_sqrt_pi`
+
+The `math::frac_2_sqrt_pi` constant represents the fraction 2/sqrt(π).
+
+```surql title="API DEFINITION"
+math::frac_2_sqrt_pi -> number
+```
+The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
+
+```surql
+RETURN math::frac_2_sqrt_pi;
+
+1.1283791670955126f
+```
+
+<br />
+
+## `math::frac_pi_2`
+
+The `math::frac_pi_2` constant represents the fraction π/2.
+
+```surql title="API DEFINITION"
+math::frac_pi_2 -> number
+```
+The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
+
+```surql
+RETURN math::frac_pi_2;
+
+1.5707963267948966f
+```
+
+<br />
+
+## `math::frac_pi_3`
+
+The `math::frac_pi_3` constant represents the fraction π/3.
+
+```surql title="API DEFINITION"
+math::frac_pi_3 -> number
+```
+The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
+
+```surql
+RETURN math::frac_pi_3;
+
+1.0471975511965979f
+```
+
+<br />
+
+## `math::frac_pi_4`
+
+The `math::frac_pi_4` constant represents the fraction π/4.
+
+```surql title="API DEFINITION"
+math::frac_pi_4 -> number
+```
+The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
+
+```surql
+RETURN math::frac_pi_4;
+
+0.7853981633974483f
+```
+
+<br />
+
+## `math::frac_pi_6`
+
+The `math::frac_pi_6` constant represents the fraction π/6.
+
+```surql title="API DEFINITION"
+math::frac_pi_6 -> number
+```
+The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
+
+```surql
+RETURN math::frac_pi_6;
+
+0.5235987755982989f
+```
+
+<br />
+
+## `math::frac_pi_8`
+
+The `math::frac_pi_8` constant represents the fraction π/8.
+
+```surql title="API DEFINITION"
+math::frac_pi_8 -> number
+```
+The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
+
+```surql
+RETURN math::frac_pi_8;
+
+0.39269908169872414f
+```
+
+<br />
+
 
 ## `math::inf`
 
@@ -552,6 +770,40 @@ RETURN math::ln(10);
 
 <br />
 
+## `math::ln_10`
+
+The `math::ln_10` constant represents the natural logarithm (base e) of 10.
+
+```surql title="API DEFINITION"
+math::ln_10 -> number
+```
+The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
+
+```surql
+RETURN math::ln_10;
+
+2.302585092994046f
+```
+
+<br />
+
+## `math::ln_2`
+
+The `math::ln_2` constant represents the natural logarithm (base e) of 2.
+
+```surql title="API DEFINITION"
+math::ln_2 -> number
+```
+The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
+
+```surql
+RETURN math::ln_2;
+
+0.6931471805599453f
+```
+
+<br />
+
 ## `math::log`
 
 <Since v="v2.0.0" />
@@ -589,6 +841,40 @@ RETURN math::log10(1000);
 
 <br />
 
+## `math::log10_2`
+
+The `math::log10_2` constant represents the base-10 logarithm of 2.
+
+```surql title="API DEFINITION"
+math::log10_2 -> number
+```
+The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
+
+```surql
+RETURN math::log10_2;
+
+0.3010299956639812f
+```
+
+<br />
+
+## `math::log10_e`
+
+The `math::log10_e` constant represents the base-10 logarithm of e, the base of the natural logarithm (Euler’s number).
+
+```surql title="API DEFINITION"
+math::log10_e -> number
+```
+The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
+
+```surql
+RETURN math::log10_e;
+
+0.4342944819032518f
+```
+
+<br />
+
 ## `math::log2`
 <Since v="v2.0.0" />
 
@@ -603,6 +889,40 @@ The following example shows this function, and its output, when used in a [`RETU
 RETURN math::log2(8);
 
 3
+```
+
+<br />
+
+## `math::log2_10`
+
+The `math::log2_10` constant represents the base-2 logarithm of 10.
+
+```surql title="API DEFINITION"
+math::log2_10 -> number
+```
+The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
+
+```surql
+RETURN math::log2_10;
+
+3.321928094887362f
+```
+
+<br />
+
+## `math::log2_e`
+
+The `math::log2_e` constant represents the base-2 logarithm of e, the base of the natural logarithm (Euler’s number).
+
+```surql title="API DEFINITION"
+math::log2_e -> number
+```
+The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
+
+```surql
+RETURN math::log2_e;
+
+1.4426950408889634f
 ```
 
 <br />
@@ -917,6 +1237,23 @@ The following example shows this function, and its output, when used in a [`RETU
 RETURN math::sqrt(15);
 
 3.872983346207417
+```
+
+<br />
+
+## `math::sqrt_2`
+
+The `math::sqrt_2` constant represents the square root of 2.
+
+```surql title="API DEFINITION"
+math::sqrt_2 -> number
+```
+The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
+
+```surql
+RETURN math::sqrt_2;
+
+1.4142135623730951f
 ```
 
 <br />


### PR DESCRIPTION
Closes #832.

# Commit 1:
##  docs-Add missing `math` constants to numeric data types documentation page
The documentation page for the numeric data types is missing the following two constants:
`math::inf`
`math::neg_inf`

This commit adds the two missing constants.

# Commit 2:
##  docs-Add missing `math` constants to `math` function module documentation page

The documentation page for the math` function module is missing the following constants:
`math::frac_1_pi`
`math::frac_1_sqrt_2`
`math::frac_2_pi`
`math::frac_2_sqrt_pi`
`math::frac_pi_2`
`math::frac_pi_3`
`math::frac_pi_4`
`math::frac_pi_6`
`math::frac_pi_8`
`math::ln_10`
`math::ln_2`
`math::log10_2`
`math::log10_e`
`math::log2_10`
`math::log2_e`
`math::sqrt_2`

This commit adds the missing constants.