### PR TITLE
Add search::analyze output to DEFINE ANALYZER

### DIFF
--- a/src/content/doc-surrealql/statements/define/analyzer.mdx
+++ b/src/content/doc-surrealql/statements/define/analyzer.mdx
@@ -8,7 +8,9 @@ import Since from '@components/Since.astro'
 
 # `DEFINE ANALYZER` statement
 
-In the context of a database, an analyzer plays a crucial role in text processing and searching. It is defined by its name, a set of tokenizers, and a collection of filters. The output of an analyzer can be experimented with by using the [`search::analyze()`](/docs/surrealql/functions/database/search#searchhighlight) function.
+In the context of a database, an analyzer plays a crucial role in text processing and searching. It is defined by its name, a set of tokenizers, and a collection of filters. 
+
+The output of an analyzer can be experimented with by using the [`search::analyze()`](/docs/surrealql/functions/database/search#searchhighlight) function.
 
 ## Requirements
 - You must be authenticated as a root, namespace, or database user before you can use the `DEFINE ANALYZER` statement.

--- a/src/content/doc-surrealql/statements/define/analyzer.mdx
+++ b/src/content/doc-surrealql/statements/define/analyzer.mdx
@@ -8,7 +8,7 @@ import Since from '@components/Since.astro'
 
 # `DEFINE ANALYZER` statement
 
-In the context of a database, an analyzer plays a crucial role in text processing and searching. It is defined by its name, a set of tokenizers, and a collection of filters.
+In the context of a database, an analyzer plays a crucial role in text processing and searching. It is defined by its name, a set of tokenizers, and a collection of filters. The output of an analyzer can be experimented with by using the [`search::analyze()`](/docs/surrealql/functions/database/search#searchhighlight) function.
 
 ## Requirements
 - You must be authenticated as a root, namespace, or database user before you can use the `DEFINE ANALYZER` statement.
@@ -20,49 +20,76 @@ In the context of a database, an analyzer plays a crucial role in text processin
 DEFINE ANALYZER [ OVERWRITE | IF NOT EXISTS ] @name [ TOKENIZERS @tokenizers ] [ FILTERS @filters ] [ COMMENT @string ]
 ```
 
-
 ## Tokenizers
+
 Tokenizers are responsible for breaking down a given text into individual tokens based on a set of instructions. There are a couple of tokenizers that can be used while defining an analyzer as seen below:
 
 ### `blank`
 
 The blank tokenizer breaks down a text into tokens by creating a new token each time it encounters a space, tab, or newline character. It's a straightforward way to split text into words or chunks based on whitespace.
 
-For example, if you had the text **"hello world"**, the blank tokenizer would create two tokens, **["hello" and "world"]**. Below is an example of how to use the blank tokenizer:
-
 ```surql
 DEFINE ANALYZER example_blank TOKENIZERS blank;
+search::analyze("example_blank", "hello world");
+```
+
+```bash title="Output"
+[
+	'hello',
+	'world'
+]
 ```
 
 ### `camel`
 
 The camel tokenizer is used for identifying and creating tokens when the next character in the text is uppercase. This is particularly useful for processing camelCase or PascalCase text, common in programming, to split them into meaningful words.
 
-For example, if you had the text **"helloWorld"**, the camel tokenizer would create two tokens, **["hello", "World"]**. Below is an example of how to use the camel tokenizer:
-
 ```surql
 DEFINE ANALYZER example_camel TOKENIZERS camel;
+search::analyze("example_camel", "helloWorld");
+```
+
+```bash title="Output"
+[
+	'hello',
+	'World'
+]
 ```
 
 ### `class`
 
 The class tokenizer segments text into tokens by detecting changes (digit, letter, punctuation, blank) in the Unicode class of characters. It creates a new token when the character class changes, distinguishing between digits, letters, punctuation, and blanks. This allows for flexible tokenization based on character types.
 
-For example, if you had the text **"123abc!XYZ"**, the class tokenizer would create four tokens, **["123", "abc", "!", "XYZ"]**. Below is an example of how to use the class tokenizer:
-
-
 ```surql
 DEFINE ANALYZER example_class TOKENIZERS class;
+search::analyze("example_class", "123abc!XYZ");
+```
+
+```bash title="Output"
+[
+	'123',
+	'abc',
+	'!',
+	'XYZ'
+]
 ```
 
 ### `punct`
 
 The punct tokenizer generates tokens by breaking the text whenever a punctuation character is encountered. It's suitable for tokenizing sentences or breaking text into smaller units based on punctuation marks.
 
-For example, if you had the text **"Hello, World!"**, the punct tokenizer would create four tokens, **["Hello", ",", "World", "!"]**. Below is an example of how to use the punct tokenizer:
-
 ```surql
 DEFINE ANALYZER example_punct TOKENIZERS punct;
+search::analyze("example_punct", "Hello, World!");
+```
+
+```bash title="Output"
+[
+	'Hello',
+	',',
+	'World',
+	'!'
+]
 ```
 
 ## Filters
@@ -73,50 +100,32 @@ Filters take on the task of transforming these tokens for further processing and
 
 The ascii filter is responsible for processing tokens by replacing or removing diacritical marks (accents and special characters) from the text. It helps standardize text by converting accented characters to their basic ASCII equivalents, making it more suitable for various text analysis tasks.
 
-For example, if you had the text **"résumé café"**, the ascii filter would create two tokens, **["resume", "cafe"]**. Below is an example of how to use the ascii filter:
-
 ```surql
 DEFINE ANALYZER example_ascii TOKENIZERS class FILTERS ascii;
+search::analyze("example_ascii", "résumé café");
 ```
 
-### `ngram(min,max)`
-
-The ngram filter is used to create a sequence of 'n' tokens from a given sample of text or speech. These items can be syllables, letters, words or base pairs according to the application. It accepts two parameters `min` and `max` which indicates that you want to create n-grams starting from min to size of max.
-
-For example, if you had the text **"apple banana"**, the ngram filter would create these tokens: **["a", "p", "p", "l", "e", "ap", "pp", "pl", "le", "app", "ppl", "ple", "b", "a", "n", "a", "n", "a", "ba", "an", "na", "an", "na", "ban", "ana", "nan", "ana"]**. Below is an example of how to use the ngram filter:
-
-```surql
-DEFINE ANALYZER example_ngram TOKENIZERS class FILTERS ngram(1,3);
-```
-
-### `edgengram(min,max)`
-
-The edgengram filter is used to create tokens that represent prefixes of terms. It generates a sequence of tokens that gradually build up a term, which can be useful for autocomplete or searching based on partial words. It accepts two parameters `min` and `max` which define the minimum and maximum amount of characters in the prefix.
-
-For example, if you had the text **"apple banana"**, the edgengram filter would create six tokens, **["a", "ap", "app", "b", "ba", "ban"]**. Below is an example of how to use the edgengram filter:
-
-```surql
-DEFINE ANALYZER example_edgengram TOKENIZERS class FILTERS edgengram(1,3);
+```bash title="Output"
+[
+	'resume',
+	'cafe'
+]
 ```
 
 ### `lowercase`
 
 The lowercase filter converts tokens to lowercase, ensuring that text is consistently in lowercase format. This is often used to make text case-insensitive for search and analysis purposes.
 
-For example, if you had the text **"Hello World"**, the lowercase filter would create two tokens, **["hello", "world"]**. Below is an example of how to use the lowercase filter:
-
 ```surql
 DEFINE ANALYZER example_lowercase TOKENIZERS class FILTERS lowercase;
+search::analyze("example_lowercase", "Hello World");
 ```
 
-### `snowball(language)`
-
-The snowball filter applies Snowball stemming to tokens, reducing them to their root form and converts the case to lowercase. The following supported languages can be passed as a parameter in snowball: Arabic, Danish, Dutch, English, French, German, Greek, Hungarian, Italian, Norwegian, Portuguese, Romanian, Russian, Spanish, Swedish, Tamil, Turkish.
-
-For example, if you had the text **"running cats"**, the snowball filter would create two tokens, **["run", "cat"]**. Below is an example of how to use the snowball filter with the English language:
-
-```surql
-DEFINE ANALYZER example_snowball TOKENIZERS class FILTERS snowball(english);
+```bash title="Output"
+[
+	'hello',
+	'world'
+]
 ```
 
 ### `uppercase`
@@ -127,6 +136,111 @@ For example, if you had the text **"Hello World"**, the uppercase filter would c
 
 ```surql
 DEFINE ANALYZER example_uppercase TOKENIZERS class FILTERS uppercase;
+search::analyze("example_uppercase", "Hello World");
+```
+
+```bash title="Output"
+[
+	'HELLO',
+	'WORLD'
+]
+```
+
+### `edgengram(min,max)`
+
+The edgengram filter is used to create tokens that represent prefixes of terms. It generates a sequence of tokens that gradually build up a term, which can be useful for autocomplete or searching based on partial words. It accepts two parameters `min` and `max` which define the minimum and maximum amount of characters in the prefix.
+
+For example, if you had the text **"apple banana"**, the edgengram filter would create six tokens, **["a", "ap", "app", "b", "ba", "ban"]**. Below is an example of how to use the edgengram filter:
+
+```surql
+DEFINE ANALYZER example_edgengram TOKENIZERS class FILTERS edgengram(1,3);
+search::analyze("example_edgengram", "apple banana");
+```
+
+```
+[
+	'a',
+	'ap',
+	'app',
+	'b',
+	'ba',
+	'ban'
+]
+```
+
+### `ngram(min,max)`
+
+The ngram filter is used to create a sequence of 'n' tokens from a given sample of text or speech. These items can be syllables, letters, words or base pairs according to the application. It accepts two parameters `min` and `max` which indicates that you want to create n-grams starting from min to size of max.
+
+```surql
+DEFINE ANALYZER example_ngram TOKENIZERS class FILTERS ngram(1,3);
+search::analyze("example_ngram", "apple banana");
+```
+
+```bash title="Output"
+[
+	'a',
+	'ap',
+	'app',
+	'p',
+	'pp',
+	'ppl',
+	'p',
+	'pl',
+	'ple',
+	'l',
+	'le',
+	'e',
+	'b',
+	'ba',
+	'ban',
+	'a',
+	'an',
+	'ana',
+	'n',
+	'na',
+	'nan',
+	'a',
+	'an',
+	'ana',
+	'n',
+	'na',
+	'a'
+]
+```
+
+### `snowball(language)`
+
+The snowball filter applies Snowball stemming to tokens, reducing them to their root form and converts the case to lowercase. The following supported languages can be passed as a parameter in snowball: Arabic, Danish, Dutch, English, French, German, Greek, Hungarian, Italian, Norwegian, Portuguese, Romanian, Russian, Spanish, Swedish, Tamil, Turkish.
+
+```surql
+DEFINE ANALYZER english_snowball TOKENIZERS class FILTERS snowball(english);
+DEFINE ANALYZER german_snowball TOKENIZERS class FILTERS snowball(german);
+
+RETURN [
+    search::analyze("english_snowball", "Looking at some running cats"),
+    search::analyze("german_snowball", "Sollen wir was trinken gehen?")
+];
+```
+
+```bash title="Output"
+[
+	[
+		'look',
+		'at',
+		'some',
+		'run',
+		'cat'
+	],
+	[
+		'soll',
+		'wir',
+		'was',
+		'trink',
+		'geh',
+		'?'
+	]
+]
 ```
 
 ## Using `IF NOT EXISTS` clause
@@ -165,21 +279,22 @@ This example creates an analyzer that tokenizes text based on the class of chara
 -- Creates a simple analyzer removing diacritics marks
 DEFINE ANALYZER ascii TOKENIZERS class FILTERS lowercase,ascii;
 ```
-This command statement creates an analyzer specifically designed for processing English texts.
+
+This example creates an analyzer specifically designed for processing English texts.
 
 ```surql
 -- Creates an analyzer suitable for English text
 DEFINE ANALYZER english TOKENIZERS class FILTERS snowball(english);
 ```
 
-This statement creates an analyzer specifically designed for auto-completion tasks.
+This example creates an analyzer specifically designed for auto-completion tasks.
 
 ```surql
 -- Creates an analyzer suitable for auto-completion.
 DEFINE ANALYZER autocomplete FILTERS lowercase,edgengram(2,10);
 ```
 
-This command statement creates an analyzer specifically designed for source code analysis.
+This example creates an analyzer specifically designed for source code analysis.
 
 ```surql
 -- Creates an analyzer suitable for source code analysis.


### PR DESCRIPTION
This PR changes the DEFINE ANALYZER page to move from a preparatory "for example, the output will be..." to having each example use the `search::analyze()` function to show the output instead.

Also moves the filters around a bit so that they introduce similar filters next to each other:

* Simple ones: ascii, lowercase, uppercase
* -gram ones: ngram, edgengram
* Snowball