### PR TITLE
docs: correction to installation with Composer

### DIFF
--- a/src/content/doc-sdk-php/setup.mdx
+++ b/src/content/doc-sdk-php/setup.mdx
@@ -15,7 +15,7 @@ This guide will walk you through the process of installing the SDK into your pro
 Within your Compose project, run the following command to install the SDK:
 
 ```bash
-composer add surrealdb.php [version]
+composer require surrealdb/surrealdb.php
 ```
 
 ### Using the SDK


### PR DESCRIPTION
This PR fixes the installation command in the PHP docs, as `composer add` doesn't exist.

The command in the PHP package README is correct, so that one is used for consistency.
