### PR TITLE
fix: rename listenLive to subscribeLive

### DIFF
--- a/src/content/doc-sdk-javascript/core/index.mdx
+++ b/src/content/doc-sdk-javascript/core/index.mdx
@@ -66,7 +66,7 @@ The JavaScript SDK comes with a number of built-in functions.
             <td scope="row" data-label="Description">Initiate a live query</td>
         </tr>
         <tr>
-            <td scope="row" data-label="Function"><a href="/docs/sdk/javascript/core/streaming#listenLive"> <code>async db.listenLive&lt;T&gt;(queryUuid,callback)</code></a></td>
+            <td scope="row" data-label="Function"><a href="/docs/sdk/javascript/core/streaming#subscribeLive"> <code>async db.subscribeLive&lt;T&gt;(queryUuid,callback)</code></a></td>
             <td scope="row" data-label="Description">Register a callback for a running live query</td>
         </tr>
         <tr>

--- a/src/content/doc-sdk-javascript/core/streaming.mdx
+++ b/src/content/doc-sdk-javascript/core/streaming.mdx
@@ -77,12 +77,12 @@ const queryUuid = await db.live(
 
 <br />
 
-## `.listenLive()` {#listenLive}
+## `.subscribeLive()` {#subscribeLive}
 
 Registers a callback function for a running live query.
 
 ```ts title="Method Syntax"
-async db.listenLive<T>(queryUuid, callback)
+async db.subscribeLive<T>(queryUuid, callback)
 ```
 
 ### Arguments
@@ -117,7 +117,7 @@ async db.listenLive<T>(queryUuid, callback)
 
 ### Example usage
 ```ts
-await db.listenLive(
+await db.subscribeLive(
 	queryUuid,
 	// The callback function takes an object with the "action" and "result" properties
 	( action, result ) => {
@@ -170,7 +170,7 @@ await db.kill(queryUuid)
 
 ## Live Actions
 
-For `CREATE`, `UPDATE` and `DELETE`, the type `Result` is the generic argument passed to [`.live()`](#live) or [`.listenLive()`](#listenLive). <br />
+For `CREATE`, `UPDATE` and `DELETE`, the type `Result` is the generic argument passed to [`.live()`](#live) or [`.subscribeLive()`](#subscribeLive). <br />
 It extends either `Record<string, unknown>` or `Patch`.
 
 It's generally recommended to handle the `CLOSE` action first, as that clears out the type for the result parameter.


### PR DESCRIPTION
Javascript 1.0 package does not have a listenLive function. Instead, there exists a new version using subscribeLive