### PR TITLE
migration to 2.0: use new helm chart template value to allow unauthorised access

### DIFF
--- a/src/content/doc-surrealdb/deployment/kubernetes.mdx
+++ b/src/content/doc-surrealdb/deployment/kubernetes.mdx
@@ -179,7 +179,7 @@ export TIKV_URL=tikv://basic-pd.tikv:2379
 ### 3. Install the SurrealDB Helm chart with the TIKV_URL defined above and with auth disabled so we can create the initial credentials:
 
 ```bash title="Install SurrealDB HELM chart"
-helm install --set surrealdb.path=$TIKV_URL --set surrealdb.auth=false --set image.tag=latest surrealdb-tikv surrealdb/surrealdb
+helm install --set surrealdb.path=$TIKV_URL --set surrealdb.unauthenticated=true --set image.tag=latest surrealdb-tikv surrealdb/surrealdb
 ```
 
 ### 4. Connect to the cluster and define the initial credentials (see in the section below how to connect):


### PR DESCRIPTION
migration to 2.0: use new helm chart template value to allow unauthorised access because of change in env vars.

This change depends on: https://github.com/surrealdb/helm-charts/pull/9  -- where new template value surrealdb.unauthorised is introduced.