### PR TITLE
fly deployment - Add warning for file:// 

### DIFF
--- a/src/content/doc-surrealdb/deployment/fly.mdx
+++ b/src/content/doc-surrealdb/deployment/fly.mdx
@@ -42,8 +42,11 @@ In the `Dockerfile` we specify which base image we want to use, and to which add
 ```bash title="Docker file"
 FROM surrealdb/surrealdb:latest
 EXPOSE 8080
-CMD ["start", "--bind", "0.0.0.0:8080", "surrealkv://data/srdb.db"]
+CMD ["start", "--bind", "0.0.0.0:8080", "file://data/srdb.db"]
 ```
+
+>[!IMPORTANT]
+> The file:// prefix for starting SurrealDB is deprecated, please use surrealkv:// or rocksdb:// as a storage engine
 
 ## Generate fly.toml
 We will generate most of the content for the `fly.toml` configuration file using the `fly launch` utility. Please answer the questions with the guidelines given below.

--- a/src/content/doc-surrealdb/deployment/fly.mdx
+++ b/src/content/doc-surrealdb/deployment/fly.mdx
@@ -46,7 +46,7 @@ CMD ["start", "--bind", "0.0.0.0:8080", "file://data/srdb.db"]
 ```
 
 >[!IMPORTANT]
-> The file:// prefix for starting SurrealDB is deprecated, please use surrealkv:// or rocksdb:// as a storage engine
+> The `file://` prefix for starting SurrealDB is deprecated, please use `surrealkv://` or `rocksdb://` as a storage engine
 
 ## Generate fly.toml
 We will generate most of the content for the `fly.toml` configuration file using the `fly launch` utility. Please answer the questions with the guidelines given below.

--- a/src/content/doc-surrealdb/deployment/fly.mdx
+++ b/src/content/doc-surrealdb/deployment/fly.mdx
@@ -42,7 +42,7 @@ In the `Dockerfile` we specify which base image we want to use, and to which add
 ```bash title="Docker file"
 FROM surrealdb/surrealdb:latest
 EXPOSE 8080
-CMD ["start", "--bind", "0.0.0.0:8080", "file://data/srdb.db"]
+CMD ["start", "--bind", "0.0.0.0:8080", "surrealkv://data/srdb.db"]
 ```
 
 ## Generate fly.toml


### PR DESCRIPTION
as [PATH] argument prefix"file://" of the command 'surreal start' is deprecated, CMD property of the fly.io deployment Dockerfile should have "surrealkv://" or "rocksdb://" as [PATH] prefix for the start command. source : https://surrealdb.com/docs/surrealdb/cli/start