### PR TITLE
Document algorithm for `record:rand()` generations

### DIFF
--- a/src/content/doc-surrealql/datamodel/ids.mdx
+++ b/src/content/doc-surrealql/datamodel/ids.mdx
@@ -90,6 +90,8 @@ Record IDs can be generated with a number of built-in ID generation functions. T
 
 ```surql
 // Generate a random record ID
+// Charset: `abcdefghijklmnopqrstuvwxyz0123456789`
+// ID Length: 20 characters long
 CREATE temperature:rand() SET time = time::now(), celsius = 37.5;
 // Generate a ULID-based record ID
 CREATE temperature:ulid() SET time = time::now(), celsius = 37.5;


### PR DESCRIPTION
Not sure why the `# Learn More` section was added with the blog post, I guess I had an older fork, but I think it's worthwhile keeping that link there