### PR TITLE
Add rocksdb example to embed doc

### DIFF
--- a/src/content/doc-surrealdb/embedding/rust.mdx
+++ b/src/content/doc-surrealdb/embedding/rust.mdx
@@ -57,9 +57,14 @@ Open `src/main.rs` and replace everything in there with the following code to tr
 
 ```rust
 use serde::{Deserialize, Serialize};
-use surrealdb::engine::local::Mem;
 use surrealdb::sql::Thing;
 use surrealdb::Surreal;
+
+// For an in memory database
+use surrealdb::engine::local::Mem;
+
+// For a RocksDB file
+// use surrealdb::engine::local::RocksDb;
 
 #[derive(Debug, Serialize)]
 struct Name<'a> {
@@ -87,8 +92,11 @@ struct Record {
 
 #[tokio::main]
 async fn main() -> surrealdb::Result<()> {
-    // Create database connection
+    // Create database connection in memory
     let db = Surreal::new::<Mem>(()).await?;
+    
+    // Create database connection using RocksDB
+    // let db = Surreal::new::<RocksDb>("path/to/database-folder").await?;
 
     // Select a specific namespace / database
     db.use_ns("test").use_db("test").await?;


### PR DESCRIPTION
Added an example of how to use RocksDB embedded.
Example was added in comments to make sure the code snippet would still run if just copy and pasted.