### PR TITLE
Correct the syntax

### DIFF
--- a/src/content/doc-surrealql/statements/insert.mdx
+++ b/src/content/doc-surrealql/statements/insert.mdx
@@ -13,7 +13,7 @@ The `INSERT` statement can be used to insert or update data into the database, u
 ### Statement syntax
 
 ```syntax title="SurrealQL Syntax"
-INSERT [ IGNORE ] INTO [ RELATION ] @what
+INSERT [ IGNORE | RELATION ] INTO @what
 	[ @value
 	  | (@fields) VALUES (@values)
 		[ ON DUPLICATE KEY UPDATE @field = @value ... ]


### PR DESCRIPTION
Saw that we say in the syntax that `relation` comes after `into` but it actually comes before, like the examples below show.