### PR TITLE
Add CONTENT/PATCH headers to upsert and update

### DIFF
--- a/src/content/doc-surrealql/statements/update.mdx
+++ b/src/content/doc-surrealql/statements/update.mdx
@@ -241,6 +241,8 @@ UPDATE person SET skills += "System design" WHERE company != "SurrealDB";
 ]
 ```
 
+## CONTENT clause
+
 Instead of specifying record data using the `SET` clause, it is also possible to use the `CONTENT` keyword to specify the record data using a SurrealQL object.
 
 ```surql
@@ -310,6 +312,8 @@ UPDATE person:tobie MERGE {
 	}
 ]
 ```
+
+## PATCH clause
 
 You can also specify changes to be applied to your query response, using the PATCH command which works similar to the [JSON Patch specification](https://jsonpatch.com/)
 

--- a/src/content/doc-surrealql/statements/upsert.mdx
+++ b/src/content/doc-surrealql/statements/upsert.mdx
@@ -166,6 +166,8 @@ UPSERT person:tobie MERGE {
 };
 ```
 
+## PATCH clause
+
 You can also specify changes to be applied to your query response, using the `PATCH` clause which works similar to the [JSON Patch specification](https://jsonpatch.com/)
 
 ```surql


### PR DESCRIPTION
Small PR: our SDK update and upsert functions are often (always?) divided into three depending on which clause to use and users will benefit from seeing them in the menu on the right.