### PR TITLE
Fix: url segments matching

### DIFF
--- a/src/components/Sidebar/RenderSidebarLink.astro
+++ b/src/components/Sidebar/RenderSidebarLink.astro
@@ -1,5 +1,6 @@
 ---
 import { cn } from '@src/util/tailwind';
+import { isActiveLink } from "@src/util/doc";
 
 export type SidebarLink = {
     title: string;
@@ -13,7 +14,8 @@ const doc = Astro.params.sdk ? `sdk/${Astro.params.sdk}` : Astro.params.doc;
 const matchLiteral = doc && href === `/docs/${doc}`;
 const active = matchLiteral
     ? Astro.url.pathname === href
-    : Astro.url.pathname.startsWith(href);
+    : isActiveLink(Astro.url.pathname, href);
+    
 ---
 
 <a href={href} class={cn("text-sm text-text/60 px-4 py-1.5 w-full block cursor-pointer", active && "text-surreal-pink")}>

--- a/src/components/Sidebar/RenderSidebarLink.astro
+++ b/src/components/Sidebar/RenderSidebarLink.astro
@@ -1,6 +1,5 @@
 ---
 import { cn } from '@src/util/tailwind';
-import { isActiveLink } from "@src/util/doc";
 
 export type SidebarLink = {
     title: string;
@@ -10,11 +9,7 @@ export type SidebarLink = {
 };
 
 const { title, href } = Astro.props;
-const doc = Astro.params.sdk ? `sdk/${Astro.params.sdk}` : Astro.params.doc;
-const matchLiteral = doc && href === `/docs/${doc}`;
-const active = matchLiteral
-    ? Astro.url.pathname === href
-    : isActiveLink(Astro.url.pathname, href);
+const active = Astro.url.pathname === href;
     
 ---
 

--- a/src/util/doc.ts
+++ b/src/util/doc.ts
@@ -190,23 +190,3 @@ export function getTitle(
 ): string {
     return meta.sidebar_label ?? meta.title ?? titleFromSlug(slug);
 }
-
-export function isActiveLink(
-    url: string,
-    href: string
-) {
-    const urlParts = url.split('/').filter((a) => a !== '');
-    const hrefParts = href.split('/').filter((a) => a !== '');
-
-    if (urlParts.length !== hrefParts.length) {
-        return false;
-    }
-
-    for(let i = 0; i < urlParts.length; i++) {
-        if (urlParts[i] !== hrefParts[i]) {
-            return false;
-        }
-    }
-
-    return true;
-}

--- a/src/util/doc.ts
+++ b/src/util/doc.ts
@@ -190,3 +190,23 @@ export function getTitle(
 ): string {
     return meta.sidebar_label ?? meta.title ?? titleFromSlug(slug);
 }
+
+export function isActiveLink(
+    url: string,
+    href: string
+) {
+    const urlParts = url.split('/').filter((a) => a !== '');
+    const hrefParts = href.split('/').filter((a) => a !== '');
+
+    if (urlParts.length !== hrefParts.length) {
+        return false;
+    }
+
+    for(let i = 0; i < urlParts.length; i++) {
+        if (urlParts[i] !== hrefParts[i]) {
+            return false;
+        }
+    }
+
+    return true;
+}


### PR DESCRIPTION
There was an issue where the segments of an url were inproperly matched. So for example you selected a link that leads you to `insert` and there was another entry called `insert-relation`. both the links were highlighted instead of `insert`. This pull request resolves that issue.