### PR TITLE
Clarify PARALLEL keyword

### DIFF
--- a/src/content/doc-surrealql/statements/create.mdx
+++ b/src/content/doc-surrealql/statements/create.mdx
@@ -356,7 +356,7 @@ CREATE |person:500000| SET age = 46, username = "john-smith" TIMEOUT 500ms;
 
 ### Parallel
 
-The `PARALLEL` keyword can be used to specify that the statement should be executed in parallel. Similar to the `TIMEOUT` clause this is useful for more control over how your queries should behave, if that is needed.
+The `PARALLEL` keyword can be used to specify that the statement should be processed concurrently, rather than sequentially. Similar to the `TIMEOUT` clause this is useful for more control over how your queries should behave, if that is needed.
 
 ```surql
 CREATE person:26, CREATE person:27 PARALLEL;

--- a/src/content/doc-surrealql/statements/relate.mdx
+++ b/src/content/doc-surrealql/statements/relate.mdx
@@ -622,7 +622,7 @@ SELECT * FROM person WHERE ->knows->person->(knows WHERE influencer = true) TIME
 
 ## Using `PARALLEL` clause
 
-When processing a large result set with many interconnected records, it is possible to use the `PARALLEL` keyword to signify that edges and remote records should be fetched and processed in parallel. This can be useful when you want to process a large result set in a short amount of time.
+When processing a large result set with many interconnected records, it is possible to use the `PARALLEL` keyword to signify that edges and remote records should be fetched and processed concurrently, rather than sequentially. This can be useful when you want to process a large result set in a short amount of time.
 
 ```surql
 -- Fetch and process the person, purchased and product targets in parallel

--- a/src/content/doc-surrealql/statements/select.mdx
+++ b/src/content/doc-surrealql/statements/select.mdx
@@ -527,7 +527,7 @@ SELECT * FROM person WHERE ->knows->person->(knows WHERE influencer = true) TIME
 
 ## The `PARALLEL` clause
 
-When processing a large result set with many interconnected records, it is possible to use the `PARALLEL` keyword to specify that the statement should be processed in parallel. This can significantly improve the performance of the statement, but it is important to note that the statement will not be processed in a transactional manner, and so the results may not be consistent.
+When processing a large result set with many interconnected records, it is possible to use the `PARALLEL` keyword to specify that the statement should be processed concurrently, rather than sequentially.
 
 ```surql
 -- Fetch and process the person, purchased and product targets in parallel


### PR DESCRIPTION
This clarifies that PARALLEL still carries the same transaction guarantees as any other statement, along with "concurrently, rather than sequentially" and similar phrasings to explain what "parallel" refers to.