### PR TITLE
Tweak formatting on SurrealQL ranges documentation

### DIFF
--- a/src/content/doc-surrealql/datamodel/ranges.mdx
+++ b/src/content/doc-surrealql/datamodel/ranges.mdx
@@ -18,26 +18,26 @@ A range is composed of `..` and possible delimiters to set the maximum and minim
 -- From 0 up to 9
 0..10;
 -- From 0 up to 10
-0..=10
+0..=10;
 -- From 1 to 9
 0>..10;
 -- From 1 to 10
-0>..=10
+0>..=10;
 ```
 
 A range becomes open ended if a delimiter is not specified.
 
 ```surql
 -- Anything from 0 and up
-0..
+0..;
 -- Anything from 1 and up
-0>..
+0>..;
 -- Anything up to 99
-..100
+..100;
 -- Anything up to 100
-..=100
+..=100;
 -- An infinite range
-..
+..;
 ```
 
 A range can be constructed from any type of value. This is most useful when comparing one value to another.
@@ -71,7 +71,7 @@ FOR $year IN 0..=2024 {
 A range can be cast into an array.
 
 ```surql
-<array>1..3;
+<array> 1..3;
 ```
 
 ```surql title="Output"
@@ -85,7 +85,7 @@ This opens up a range of functional programming patterns that are made possible 
 
 ```surql
 -- Construct an array
-(<array>1..=100)
+(<array> 1..=100)
 -- Turn it into an array that increments by 10
     .map(|$v| $v * 10)
 -- Turn each number into a object with original and square root value


### PR DESCRIPTION
This commit updates the documentation page for the SurrealQL range type to add semicolons to the end of all statements for consistency, and so that the examples will be valid if pasted into Surrealist and run.

This commit also changes the formatting of the examples of type casting a range into an array to add a space in between the type and the value being cast, to be consistent with the formatting of type casting in the rest of the documentation.