### PR TITLE
Syntax fix: SHOW can take a versionstamp

### DIFF
--- a/src/content/doc-surrealql/statements/show.mdx
+++ b/src/content/doc-surrealql/statements/show.mdx
@@ -15,7 +15,9 @@ The `SHOW` statement can be used to replay changes made to a table.
 ### Statement syntax
 
 ```syntax title="SurrealQL Syntax"
-SHOW CHANGES FOR TABLE @tableName [ SINCE "@timestamp" ] [ LIMIT @number ]
+SHOW CHANGES FOR TABLE @tablename
+	SINCE @timestamp | @versionstamp
+	[ LIMIT @number ]
 ```
 
 ## Example usage


### PR DESCRIPTION
The SHOW page demonstrates that it can take a versionstamp in addition to a timestamp, but the syntax doesn't show this yet.