### PR TITLE
Give unique titles to pages for PHP and Rust SDKs

### DIFF
--- a/src/content/doc-sdk-php/core/authentication.mdx
+++ b/src/content/doc-sdk-php/core/authentication.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 2
 sidebar_label: Authentication
-title: PHP | SDKs | Integration
+title: Authentication | PHP SDK | Integration | SurrealDB
 description: The SurrealDB SDK for PHP enables simple and advanced querying of a remote or embedded database.
 ---
 

--- a/src/content/doc-sdk-php/core/data-querying.mdx
+++ b/src/content/doc-sdk-php/core/data-querying.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 5
 sidebar_label: Data Querying
-title: PHP | SDKs | Integration
+title: Data Querying | PHP SDK | Integration | SurrealDB
 description: The SurrealDB SDK for PHP enables simple and advanced querying of a remote or embedded database.
 ---
 

--- a/src/content/doc-sdk-php/core/initialization.mdx
+++ b/src/content/doc-sdk-php/core/initialization.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 1
 sidebar_label: Initialization
-title: PHP | SDKs | Integration
+title: Initialization | PHP SDK | Integration | SurrealDB
 description: The SurrealDB SDK for PHP enables simple and advanced querying of a remote or embedded database.
 ---
 

--- a/src/content/doc-sdk-php/data-types.mdx
+++ b/src/content/doc-sdk-php/data-types.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 2
 sidebar_label: Data Types
-title: PHP | SDKs | Integration
+title: PHP Data Types | PHP SDK | Integration | SurrealDB
 description: The SurrealDB SDK for PHP enables simple and advanced querying of a remote database.
 ---
 

--- a/src/content/doc-sdk-php/index.mdx
+++ b/src/content/doc-sdk-php/index.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 1
 sidebar_label: Overview
-title: PHP | SDKs | Integration
+title: PHP SDK | Integration | SurrealDB
 description: The SurrealDB SDK for PHP enables simple and advanced querying of a remote database.
 ---
 

--- a/src/content/doc-sdk-php/methods/authenticate.mdx
+++ b/src/content/doc-sdk-php/methods/authenticate.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 1
 sidebar_label: authenticate
-title: PHP | SDKs | Integration
+title: Authenticate Method in PHP | PHP SDK | Integration | SurrealDB
 description: The SurrealDB SDK for PHP enables simple and advanced querying of a remote or embedded database.
 ---
 

--- a/src/content/doc-sdk-php/methods/connect.mdx
+++ b/src/content/doc-sdk-php/methods/connect.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 1
 sidebar_label: connect
-title: PHP | SDKs | Integration
+title: Connect Method in PHP | PHP SDK | Integration | SurrealDB
 description: The SurrealDB SDK for PHP enables simple and advanced querying of a remote or embedded database.
 ---
 

--- a/src/content/doc-sdk-php/methods/create.mdx
+++ b/src/content/doc-sdk-php/methods/create.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 1
 sidebar_label: create
-title: PHP | SDKs | Integration
+title: Create Method in PHP | PHP SDK | Integration | SurrealDB
 description: The SurrealDB SDK for PHP enables simple and advanced querying of a remote or embedded database.
 ---
 

--- a/src/content/doc-sdk-php/methods/delete.mdx
+++ b/src/content/doc-sdk-php/methods/delete.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 1
 sidebar_label: delete 
-title: PHP | SDKs | Integration
+title: Delete Method in PHP | PHP SDK | Integration | SurrealDB
 description: The SurrealDB SDK for PHP enables simple and advanced querying of a remote or embedded database.
 ---
 

--- a/src/content/doc-sdk-php/methods/disconnect.mdx
+++ b/src/content/doc-sdk-php/methods/disconnect.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 1
 sidebar_label: disconnect
-title: PHP | SDKs | Integration
+title: Disconnect Method in PHP | PHP SDK | Integration | SurrealDB
 description: The SurrealDB SDK for PHP enables simple and advanced querying of a remote or embedded database.
 ---
 

--- a/src/content/doc-sdk-php/methods/index.mdx
+++ b/src/content/doc-sdk-php/methods/index.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 1
 sidebar_label: SDK methods
-title: PHP | SDKs | Integration
+title: PHP Methods | PHP SDK | Integration | SurrealDB
 description: The SurrealDB SDK for PHP enables simple and advanced querying of a remote or embedded database.
 ---
 

--- a/src/content/doc-sdk-php/methods/info.mdx
+++ b/src/content/doc-sdk-php/methods/info.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 1
 sidebar_label: info
-title: PHP | SDKs | Integration
+title: Info Method in PHP | PHP SDK | Integration | SurrealDB
 description: The SurrealDB SDK for PHP enables simple and advanced querying of a remote or embedded database.
 ---
 

--- a/src/content/doc-sdk-php/methods/insert.mdx
+++ b/src/content/doc-sdk-php/methods/insert.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 1
 sidebar_label: insert
-title: PHP | SDKs | Integration
+title: Insert Method in PHP | PHP SDK | Integration | SurrealDB
 description: The SurrealDB SDK for PHP enables simple and advanced querying of a remote or embedded database.
 ---
 

--- a/src/content/doc-sdk-php/methods/invalidate.mdx
+++ b/src/content/doc-sdk-php/methods/invalidate.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 1
 sidebar_label: invalidate
-title: PHP | SDKs | Integration
+title: Invalidate Method in PHP | PHP SDK | Integration | SurrealDB
 description: The SurrealDB SDK for PHP enables simple and advanced querying of a remote or embedded database.
 ---
 

--- a/src/content/doc-sdk-php/methods/let.mdx
+++ b/src/content/doc-sdk-php/methods/let.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 1
 sidebar_label: let
-title: PHP | SDKs | Integration
+title: Let Method in PHP | PHP SDK | Integration | SurrealDB
 description: The SurrealDB SDK for PHP enables simple and advanced querying of a remote or embedded database.
 ---
 

--- a/src/content/doc-sdk-php/methods/merge.mdx
+++ b/src/content/doc-sdk-php/methods/merge.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 1
 sidebar_label: merge
-title: PHP | SDKs | Integration
+title: Merge Method in PHP | PHP SDK | Integration | SurrealDB
 description: The SurrealDB SDK for PHP enables simple and advanced querying of a remote or embedded database.
 ---
 

--- a/src/content/doc-sdk-php/methods/patch.mdx
+++ b/src/content/doc-sdk-php/methods/patch.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 1
 sidebar_label: patch
-title: PHP | SDKs | Integration
+title: Patch Method in PHP | PHP SDK | Integration | SurrealDB
 description: The SurrealDB SDK for PHP enables simple and advanced querying of a remote or embedded database.
 ---
 

--- a/src/content/doc-sdk-php/methods/query.mdx
+++ b/src/content/doc-sdk-php/methods/query.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 1
 sidebar_label: query
-title: PHP | SDKs | Integration
+title: Query Method in PHP | PHP SDK | Integration | SurrealDB
 description: The SurrealDB SDK for PHP enables simple and advanced querying of a remote or embedded database.
 ---
 

--- a/src/content/doc-sdk-php/methods/select.mdx
+++ b/src/content/doc-sdk-php/methods/select.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 1
 sidebar_label: select
-title: PHP | SDKs | Integration
+title: Select Method in PHP | PHP SDK | Integration | SurrealDB
 description: The SurrealDB SDK for PHP enables simple and advanced querying of a remote or embedded database.
 ---
 

--- a/src/content/doc-sdk-php/methods/signin.mdx
+++ b/src/content/doc-sdk-php/methods/signin.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 1
 sidebar_label: signin
-title: PHP | SDKs | Integration
+title: Signin Method in PHP | PHP SDK | Integration | SurrealDB
 description: The SurrealDB SDK for PHP enables simple and advanced querying of a remote or embedded database.
 ---
 

--- a/src/content/doc-sdk-php/methods/signup.mdx
+++ b/src/content/doc-sdk-php/methods/signup.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 1
 sidebar_label: signup
-title: PHP | SDKs | Integration
+title: Signup Method in PHP | PHP SDK | Integration | SurrealDB
 description: The SurrealDB SDK for PHP enables simple and advanced querying of a remote or embedded database.
 ---
 

--- a/src/content/doc-sdk-php/methods/unset.mdx
+++ b/src/content/doc-sdk-php/methods/unset.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 1
 sidebar_label: unset
-title: PHP | SDKs | Integration
+title: Unset Method in PHP | PHP SDK | Integration | SurrealDB
 description: The SurrealDB SDK for PHP enables simple and advanced querying of a remote or embedded database.
 ---
 

--- a/src/content/doc-sdk-php/methods/update.mdx
+++ b/src/content/doc-sdk-php/methods/update.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 1
 sidebar_label: update
-title: PHP | SDKs | Integration
+title: Update Method in PHP | PHP SDK | Integration | SurrealDB
 description: The SurrealDB SDK for PHP enables simple and advanced querying of a remote or embedded database.
 ---
 

--- a/src/content/doc-sdk-php/methods/use.mdx
+++ b/src/content/doc-sdk-php/methods/use.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 1
 sidebar_label: use
-title: PHP | SDKs | Integration
+title: Use Method in PHP | PHP SDK | Integration | SurrealDB
 description: The SurrealDB SDK for PHP enables simple and advanced querying of a remote or embedded database.
 ---
 

--- a/src/content/doc-sdk-rust/concepts/authenticating-users.mdx
+++ b/src/content/doc-sdk-rust/concepts/authenticating-users.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 6
 sidebar_label: Authenticating users
-title: Rust | SDKs | Integration
+title: Authenticating Users in Rust | Rust SDK | SurrealDB
 description: The Rust SDK for SurrealDB supports a number of methods for authenticating users and securing the database.
 ---
 

--- a/src/content/doc-sdk-rust/concepts/concurrency.mdx
+++ b/src/content/doc-sdk-rust/concepts/concurrency.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 7
 sidebar_label: Concurrency
-title: Rust | SDKs | Integration
+title: Concurrency in Rust | Rust SDK | SurrealDB
 description: Multiple threads or asynchronous tasks can be used to speed up queries to a SurrealDB database
 ---
 

--- a/src/content/doc-sdk-rust/concepts/fetch.mdx
+++ b/src/content/doc-sdk-rust/concepts/fetch.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 2
 sidebar_label: Fetching linked records
-title: Rust | SDKs | Integration
+title: Fetching Records in Rust | Rust SDK | SurrealDB
 description: All the fields of a SurrealDB linked record can be fetched and deserialized into a Rust type
 ---
 

--- a/src/content/doc-sdk-rust/concepts/flexible_typing.mdx
+++ b/src/content/doc-sdk-rust/concepts/flexible_typing.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 4
 sidebar_label: Flexible typing
-title: Rust | SDKs | Integration
+title: Flexible Typing in Rust | Rust SDK | SurrealDB
 description: The Rust SDK for SurrealDB offers methods for working with types without deserialization
 ---
 

--- a/src/content/doc-sdk-rust/concepts/live.mdx
+++ b/src/content/doc-sdk-rust/concepts/live.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 5
 sidebar_label: Live queries
-title: Rust | SDKs | Integration
+title: Live Queries in Rust | Rust SDK | SurrealDB
 description: The Rust SDK for SurrealDB allows changes to tables in real time to be observed
 ---
 

--- a/src/content/doc-sdk-rust/concepts/transaction.mdx
+++ b/src/content/doc-sdk-rust/concepts/transaction.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 3
 sidebar_label: Manual transactions
-title: Rust | SDKs | Integration
+title: Manual Transactions in Rust | Rust SDK | SurrealDB
 description: Manual transactions can be used via the Rust SDK in the same manner as regular SurrealQL queries
 ---
 

--- a/src/content/doc-sdk-rust/methods/authenticate.mdx
+++ b/src/content/doc-sdk-rust/methods/authenticate.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 2
 sidebar_label: authenticate
-title: Rust | SDKs | Integration
+title: Authenticate Method in Rust | Rust SDK | Integration | SurrealDB
 description: The .authenticate() method authenticates the current connection with a JWT token.
 ---
 

--- a/src/content/doc-sdk-rust/methods/connect.mdx
+++ b/src/content/doc-sdk-rust/methods/connect.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 3
 sidebar_label: connect
-title: Rust | SDKs | Integration
+title: Connect Method in Rust | Rust SDK | Integration | SurrealDB
 description: The .connect() method connects to a local or remote database endpoint.
 ---
 

--- a/src/content/doc-sdk-rust/methods/create.mdx
+++ b/src/content/doc-sdk-rust/methods/create.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 4
 sidebar_label: create
-title: Rust | SDKs | Integration
+title: Create Method in Rust | Rust SDK | Integration | SurrealDB
 description: The .create() method creates one or more records in the database.
 ---
 

--- a/src/content/doc-sdk-rust/methods/delete.mdx
+++ b/src/content/doc-sdk-rust/methods/delete.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 5
 sidebar_label: delete
-title: Rust | SDKs | Integration
+title: Delete Method in Rust | Rust SDK | Integration | SurrealDB
 description: The .delete() method deletes all or specific records from the database.
 ---
 

--- a/src/content/doc-sdk-rust/methods/export.mdx
+++ b/src/content/doc-sdk-rust/methods/export.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 6
 sidebar_label: export
-title: Rust | SDKs | Integration
+title: Export Method in Rust | Rust SDK | Integration | SurrealDB
 description: The .export() method dumps the database contents to a file.
 ---
 

--- a/src/content/doc-sdk-rust/methods/import.mdx
+++ b/src/content/doc-sdk-rust/methods/import.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 7
 sidebar_label: import
-title: Rust | SDKs | Integration
+title: Import Method in Rust | Rust SDK | Integration | SurrealDB
 description: The .import() method restores the database from a file.
 ---
 

--- a/src/content/doc-sdk-rust/methods/index.mdx
+++ b/src/content/doc-sdk-rust/methods/index.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 1
 sidebar_label: SDK methods
-title: Rust | SDKs | Integration
+title: Rust Methods | Rust SDK | Integration | SurrealDB
 description: The SurrealDB SDK for Rust enables simple and advanced querying of a remote or embedded database.
 ---
 

--- a/src/content/doc-sdk-rust/methods/init.mdx
+++ b/src/content/doc-sdk-rust/methods/init.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 8
 sidebar_label: init
-title: Rust | SDKs | Integration
+title: Init Method in Rust | Rust SDK | Integration | SurrealDB
 description: The .init() method initializes a new unconnected instance.
 ---
 

--- a/src/content/doc-sdk-rust/methods/insert.mdx
+++ b/src/content/doc-sdk-rust/methods/insert.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 9
 sidebar_label: insert
-title: Rust | SDKs | Integration
+title: Insert Method in Rust | Rust SDK | Integration | SurrealDB
 description: The .insert() method inserts a record or records into a tablre.
 ---
 

--- a/src/content/doc-sdk-rust/methods/invalidate.mdx
+++ b/src/content/doc-sdk-rust/methods/invalidate.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 10
 sidebar_label: invalidate
-title: Rust | SDKs | Integration
+title: Invalidate Method in Rust | Rust SDK | Integration | SurrealDB
 description: The .invalidate() method invalidates the authentication for the current connection.
 ---
 

--- a/src/content/doc-sdk-rust/methods/new.mdx
+++ b/src/content/doc-sdk-rust/methods/new.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 11
 sidebar_label: new
-title: Rust | SDKs | Integration
+title: New Method in Rust | Rust SDK | Integration | SurrealDB
 description: The .new() method connects to a local or remote database endpoint.
 ---
 

--- a/src/content/doc-sdk-rust/methods/query.mdx
+++ b/src/content/doc-sdk-rust/methods/query.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 12
 sidebar_label: query
-title: Rust | SDKs | Integration
+title: Query Method in Rust | Rust SDK | Integration | SurrealDB
 description: The .query() method runs one or more SurrealQL statements against the database.
 ---
 

--- a/src/content/doc-sdk-rust/methods/run.mdx
+++ b/src/content/doc-sdk-rust/methods/run.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 13
 sidebar_label: run
-title: Rust | SDKs | Integration
+title: Run Method in Rust | Rust SDK | Integration | SurrealDB
 description: The .run() method runs a SurrealQL function.
 ---
 

--- a/src/content/doc-sdk-rust/methods/select.mdx
+++ b/src/content/doc-sdk-rust/methods/select.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 15
 sidebar_label: select
-title: Rust | SDKs | Integration
+title: Select Method in Rust | Rust SDK | Integration | SurrealDB
 description: The .select() method selects all or specific records from the database.
 ---
 

--- a/src/content/doc-sdk-rust/methods/select_live.mdx
+++ b/src/content/doc-sdk-rust/methods/select_live.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 14
 sidebar_label: select_live
-title: Rust | SDKs | Integration
+title: Live Select Method in Rust | Rust SDK | Integration | SurrealDB
 description: The .select().live() method initiates live queries for a live stream of notifications.
 ---
 

--- a/src/content/doc-sdk-rust/methods/set.mdx
+++ b/src/content/doc-sdk-rust/methods/set.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 16
 sidebar_label: set
-title: Rust | SDKs | Integration
+title: Set Method in Rust | Rust SDK | Integration | SurrealDB
 description: The .set() method assigns a value as a parameter for this connection.
 ---
 

--- a/src/content/doc-sdk-rust/methods/signin.mdx
+++ b/src/content/doc-sdk-rust/methods/signin.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 17
 sidebar_label: signin
-title: Rust | SDKs | Integration
+title: Signin Method in Rust | Rust SDK | Integration | SurrealDB
 description: The .signin() method signs in to a specific access method.
 ---
 

--- a/src/content/doc-sdk-rust/methods/signup.mdx
+++ b/src/content/doc-sdk-rust/methods/signup.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 18
 sidebar_label: signup
-title: Rust | SDKs | Integration
+title: Signup Method in Rust | Rust SDK | Integration | SurrealDB
 description: The .signup() method signs up to a specific access method.
 ---
 

--- a/src/content/doc-sdk-rust/methods/unset.mdx
+++ b/src/content/doc-sdk-rust/methods/unset.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 19
 sidebar_label: unset
-title: Rust | SDKs | Integration
+title: Unset Method in Rust | Rust SDK | Integration | SurrealDB
 description: The .unset() method removes a parameter from the connection.
 ---
 

--- a/src/content/doc-sdk-rust/methods/update.mdx
+++ b/src/content/doc-sdk-rust/methods/update.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 20
 sidebar_label: update
-title: Rust | SDKs | Integration
+title: Update Method in Rust | Rust SDK | Integration | SurrealDB
 description: The .update() method updates all or specific records in the database.
 ---
 

--- a/src/content/doc-sdk-rust/methods/upsert.mdx
+++ b/src/content/doc-sdk-rust/methods/upsert.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 21
 sidebar_label: upsert
-title: Rust | SDKs | Integration
+title: Upsert Method in Rust | Rust SDK | Integration | SurrealDB
 description: The .upsert() method upserts all or specific records in a table.
 ---
 

--- a/src/content/doc-sdk-rust/methods/use.mdx
+++ b/src/content/doc-sdk-rust/methods/use.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 22
 sidebar_label: db.use_ns().use_db()
-title: Rust | SDKs | Integration
+title: Use Method in Rust | Rust SDK | Integration | SurrealDB
 description: The .use_ns() and .use_db() methods switch to a specific namespace and database.
 ---
 

--- a/src/content/doc-sdk-rust/methods/version.mdx
+++ b/src/content/doc-sdk-rust/methods/version.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 23
 sidebar_label: version
-title: Rust | SDKs | Integration
+title: Version Method in Rust | Rust SDK | Integration | SurrealDB
 description: The .version() method returns the version of the server.
 ---
 

--- a/src/content/doc-sdk-rust/methods/wait_for.mdx
+++ b/src/content/doc-sdk-rust/methods/wait_for.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 24
 sidebar_label: wait_for
-title: Rust | SDKs | Integration
+title: Wait for Method in Rust | Rust SDK | Integration | SurrealDB
 description: The .wait_for() method waits for the selected event to happen before proceeding.
 ---
 

--- a/src/content/doc-sdk-rust/setup.mdx
+++ b/src/content/doc-sdk-rust/setup.mdx
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 2
 sidebar_label: Quick start
-title: Rust | SDKs | Integration
+title: Quick Start | Rust SDK | Integration | SurrealDB
 description: The SurrealDB SDK for Rust enables simple and advanced querying of a remote or embedded database.
 ---
 


### PR DESCRIPTION
Gives unique titles to each of the PHP and Rust SDK pages that all have the same title currently.