### PR TITLE
Fix comment describing Record ID creation

### DIFF
--- a/src/content/doc-surrealql/statements/create.mdx
+++ b/src/content/doc-surrealql/statements/create.mdx
@@ -74,7 +74,7 @@ CREATE type::thing("person", "one");
 When creating a record, you can specify the record data using the `SET` clause, or the `CONTENT` clause. The `SET` clause is used to specify record data one field at a time, while the `CONTENT` clause is used to specify record data using a SurrealQL object. The `CONTENT` clause is useful when the record data is already in the form of a SurrealQL or JSON object.
 
 ```surql
--- Create a new record with a numeric id
+-- Create a new record with a text id
 CREATE person:tobie SET
     name = 'Tobie',
     company = 'SurrealDB',


### PR DESCRIPTION
Comment described creation of `numeric` ID, but it is a `text` ID.

[Reported via Discord](https://discord.com/channels/902568124350599239/1181598754122518642/1306114646498869289)