### PR TITLE
Note that events are run within the current transaction

### DIFF
--- a/src/content/doc-surrealql/statements/define/event.mdx
+++ b/src/content/doc-surrealql/statements/define/event.mdx
@@ -9,7 +9,7 @@ import Since from '@components/shared/Since.astro'
 
 # `DEFINE EVENT` statement
 
-Events allow you to define custom logic that is executed when a record is created, updated, or deleted. These events are triggered automatically after data modifications in the record, giving you access to the state of the record [before `$before` and after `$after`](/docs/surrealql/parameters#before-after) the change.
+Events allow you to define custom logic that is executed when a record is created, updated, or deleted. These events are triggered automatically within the current transaction after data modifications in the record, giving you access to the state of the record [before `$before` and after `$after`](/docs/surrealql/parameters#before-after) the change.
 
 > [!NOTE]
 > Events are a side effect of other operations and thus are not triggered when data is [imported](/docs/surrealdb/cli/import).


### PR DESCRIPTION
Some users have asked about this before, and [the source code](https://github.com/surrealdb/surrealdb/blob/a5c3637957e91afe267ac41f2cd50bde35363cf8/core/src/doc/event.rs#L10) has the answer:

```
	/// Processes any DEFINE EVENT clauses which
	/// have been defined for the table which this
	/// record belongs to. This functions loops
	/// through the events and processes them all
	/// within the currently running transaction.
```

A few words inside the top-level note seem to be enough to make it clear.