### PR TITLE
DEFINE PARAM can take a PERMISSIONS clause

### DIFF
--- a/src/content/doc-surrealql/statements/define/param.mdx
+++ b/src/content/doc-surrealql/statements/define/param.mdx
@@ -19,7 +19,10 @@ The `DEFINE PARAM` statement allows you to define global (database-wide) paramet
 ## Statement syntax
 
 ```syntax title="SurrealQL Syntax"
-DEFINE PARAM [ OVERWRITE | IF NOT EXISTS ] $@name VALUE @value [ COMMENT @string ]
+DEFINE PARAM [ OVERWRITE | IF NOT EXISTS ] $@name 
+    VALUE @value
+    [ COMMENT @string ]
+    [ PERMISSIONS [ NONE | FULL | WHERE @condition ] ]
 ```
 
 ## Example usage


### PR DESCRIPTION
Closes https://github.com/surrealdb/docs.surrealdb.com/issues/971 by noting that DEFINE PARAM can take a PERMISSIONS clause.