### PR TITLE
Add info on ranges in WHERE clause

### DIFF
--- a/src/content/doc-surrealql/datamodel/ranges.mdx
+++ b/src/content/doc-surrealql/datamodel/ranges.mdx
@@ -66,6 +66,26 @@ FOR $year IN 0..=2024 {
 }
 ```
 
+## Ranges in WHERE clauses
+
+A range can be used in a `WHERE` clause in place of operators like `<` and `>`. This is especially useful when checking for a number that must be within a certain range. Using a range carries two main benefits. One is that it produces shorter code that is easier to read and maintain.
+
+```surql
+SELECT * FROM person WHERE age >= 18 AND age <= 65;
+SELECT * FROM person WHERE age IN 18..=65;
+```
+
+Another benefit is performance. The following code should show a modest but measurable improvement in performance between the first and second `SELECT` statement, as only one condition needs to be checked instead of two.
+
+```surql
+DELETE person;
+CREATE |person:20000| SET age = (rand::float() * 120).round() RETURN NONE;
+
+-- Assign output to a parameter so the SELECT output is not displayed
+LET $_ = SELECT * FROM person WHERE age > 18 AND age < 65;
+LET $_ = SELECT * FROM person WHERE age in 18..=65;
+```
+
 ## Casting and functional usage
 
 A range can be cast into an array.

--- a/src/content/doc-surrealql/statements/select.mdx
+++ b/src/content/doc-surrealql/statements/select.mdx
@@ -209,6 +209,8 @@ SELECT *, (SELECT * FROM events WHERE host == $parent.id) AS hosted_events FROM 
 
 ## Numeric ranges in a `WHERE` clause
 
+<Since v="v2.0.0" />
+
 A numeric range inside a `WHERE` clause can improve performance if the range is able to replace multiple checks on a certain condition. The following code should show a modest but measurable improvement in performance between the first and second `SELECT` statement, as only one condition needs to be checked instead of two.
 
 ```surql
@@ -228,8 +230,6 @@ SELECT * FROM person WHERE age IN 18..=65;
 ```
 
 ## Record ranges
-
-<Since v="v2.0.0" />
 
 SurrealDB supports the ability to query a range of records, using the record ID. The record ID ranges, retrieve records using the natural sorting order of the record IDs. These range queries can be used to query a range of records in a timeseries context. You can see more here about [array-based Record IDs](/docs/surrealql/datamodel/ids#array-based-record-ids).
 

--- a/src/content/doc-surrealql/statements/select.mdx
+++ b/src/content/doc-surrealql/statements/select.mdx
@@ -207,6 +207,26 @@ SELECT * from $history;
 SELECT *, (SELECT * FROM events WHERE host == $parent.id) AS hosted_events FROM user;
 ```
 
+## Numeric ranges in a `WHERE` clause
+
+A numeric range inside a `WHERE` clause can improve performance if the range is able to replace multiple checks on a certain condition. The following code should show a modest but measurable improvement in performance between the first and second `SELECT` statement, as only one condition needs to be checked instead of two.
+
+```surql
+DELETE person;
+CREATE |person:20000| SET age = (rand::float() * 120).round() RETURN NONE;
+
+-- Assign output to a parameter so the SELECT output is not displayed
+LET $_ = SELECT * FROM person WHERE age > 18 AND age < 65;
+LET $_ = SELECT * FROM person WHERE age in 18..=65;
+```
+
+A numeric range inside a `WHERE` also tends to produce shorter code that is easier to read and maintain.
+
+```surql
+SELECT * FROM person WHERE age >= 18 AND age <= 65;
+SELECT * FROM person WHERE age IN 18..=65;
+```
+
 ## Record ranges
 
 SurrealDB supports the ability to query a range of records, using the record ID. The record ID ranges, retrieve records using the natural sorting order of the record IDs. These range queries can be used to query a range of records in a timeseries context. You can see more here about [array-based Record IDs](/docs/surrealql/datamodel/ids#array-based-record-ids).

--- a/src/content/doc-surrealql/statements/select.mdx
+++ b/src/content/doc-surrealql/statements/select.mdx
@@ -229,6 +229,8 @@ SELECT * FROM person WHERE age IN 18..=65;
 
 ## Record ranges
 
+<Since v="v2.0.0" />
+
 SurrealDB supports the ability to query a range of records, using the record ID. The record ID ranges, retrieve records using the natural sorting order of the record IDs. These range queries can be used to query a range of records in a timeseries context. You can see more here about [array-based Record IDs](/docs/surrealql/datamodel/ids#array-based-record-ids).
 
 ```surql


### PR DESCRIPTION
Closes https://github.com/surrealdb/docs.surrealdb.com/issues/949

Also notes that there is an improvement to both readability and performance if a range is used to replace a wordy check like `WHERE age >= 18 AND age <= 65`.

For the `SELECT` page, the numeric example is a nice way to get the reader into range-reading mode before the more complex record range examples start.