### PR TITLE
Remove unneccessary AWS nodes

### DIFF
--- a/src/content/doc-surrealdb/deployment/amazon.mdx
+++ b/src/content/doc-surrealdb/deployment/amazon.mdx
@@ -76,42 +76,6 @@ managedNodeGroups:
     labels:
       dedicated: admin
 
-  - name: tidb-1a
-    desiredCapacity: 1
-    privateNetworking: true
-    availabilityZones: ["${AWS_REGION}a"]
-    instanceType: c5.2xlarge
-    labels:
-      dedicated: tidb
-    taints:
-    - key: "dedicated"
-      value: "tidb"
-      effect: NoSchedule
-
-  - name: tidb-1b
-    desiredCapacity: 0
-    privateNetworking: true
-    availabilityZones: ["${AWS_REGION}b"]
-    instanceType: c5.2xlarge
-    labels:
-      dedicated: tidb
-    taints:
-    - key: "dedicated"
-      value: "tidb"
-      effect: NoSchedule
-
-  - name: tidb-1c
-    desiredCapacity: 1
-    privateNetworking: true
-    availabilityZones: ["${AWS_REGION}c"]
-    instanceType: c5.2xlarge
-    labels:
-      dedicated: tidb
-    taints:
-    - key: "dedicated"
-      value: "tidb"
-      effect: NoSchedule
-
   - name: pd-1a
     desiredCapacity: 1
     privateNetworking: true
@@ -221,12 +185,9 @@ The following instructions will install `TiKV` operators in your EKS cluster.
 ```yaml title="CREATE TIKV CLUSTER"
 kubectl create namespace tidb-cluster
 
-curl -O https://raw.githubusercontent.com/pingcap/tidb-operator/v1.5.0/examples/aws/tidb-cluster.yaml && \
-curl -O https://raw.githubusercontent.com/pingcap/tidb-operator/v1.5.0/examples/aws/tidb-monitor.yaml && \
-curl -O https://raw.githubusercontent.com/pingcap/tidb-operator/v1.5.0/examples/aws/tidb-dashboard.yaml
+curl -O https://raw.githubusercontent.com/pingcap/tidb-operator/v1.5.0/examples/aws/tidb-cluster.yaml
 
-kubectl apply -f tidb-cluster.yaml -n tidb-cluster && \
-kubectl apply -f tidb-monitor.yaml -n tidb-cluster
+kubectl apply -f tidb-cluster.yaml -n tidb-cluster
 ```
 
 ## Install ALB Controller
@@ -306,7 +267,6 @@ surreal sql -e https://$SURREALDB_ENDPOINT
 ## Cleanup
 
 ```bash title="CLEANUP"
-kubectl delete -f tidb-monitor.yaml -n tidb-cluster
 kubectl delete -f tidb-cluster.yaml -n tidb-cluster
 helm uninstall surrealdb-tikv
 helm -n kube-system uninstall aws-load-balancer-controller


### PR DESCRIPTION
- Removes tidb nodes which are not useful in a surrealdb deployment
- Remove optional dashboard and monitor deployments

----
**Note this has not been verified as I don't have an AWS deployment. The pattern follows the GCP deployment pattern (but with 3 instances pd and kv for a highly consistent setup).**