### PR TITLE
fix: update idioms.mdx

### DIFF
--- a/src/content/doc-surrealql/datamodel/idioms.mdx
+++ b/src/content/doc-surrealql/datamodel/idioms.mdx
@@ -509,9 +509,15 @@ SELECT * OMIT obj.c.{ d, f } FROM person;
 ```surql title="Response"
 [
 	{
-		a: 1,
-		c: {
-			e: 4
+		age: 21,
+		id: person:1,
+		name: 'John',
+		obj: {
+			a: 1,
+			b: 2,
+			c: {
+				e: 4
+			}
 		}
 	}
 ]


### PR DESCRIPTION
The idioms.mdx page contains an incorrect output for an example query.

I would also suggest clarifying the usage of the idiom `.*` and instead using `*`. For instance, in this section, it’s referring to the dot notation but doesn’t use it in the queries.
``````mdx
##### Using `.*` in Queries

The `.*` idiom can also be used in queries to select all properties of an object or record.

##### Selecting All Properties

```surql
CREATE ONLY person:tobie SET name = 'tobie';
SELECT * FROM ONLY person:tobie;
```

**Result:**

```surql
{
  "id": "person:tobie",
  "name": "tobie"
}
```
``````