### PR TITLE
Fix DEFINE EVENT example

### DIFF
--- a/src/content/doc-surrealql/statements/define/event.mdx
+++ b/src/content/doc-surrealql/statements/define/event.mdx
@@ -17,7 +17,9 @@ Events allow you to define custom logic that is executed when a record is create
 ### Key Concepts
 
 - **Events**: Triggered after changes (create, update, delete) to records in a table.
+* **$event**: A preset parameter containing the type of event as a string, will always be one of "CREATE", "UPDATE", or "DELETE".
 - **$before / $after**: Refer to the record state before and after the modification. Learn more about the `$before` and `$after` parameters in the [parameters documentation](/docs/surrealql/parameters#before-after).
+- **$value**: The record in question. For a `CREATE` or `UPDATE` event, this will be the record after the changes were made. For a `DELETE` statement, this will be the record before it was deleted.
 - **WHEN condition**: Determines when the event should be triggered.
 
 ## Requirements
@@ -31,7 +33,7 @@ Events allow you to define custom logic that is executed when a record is create
 DEFINE EVENT [ OVERWRITE | IF NOT EXISTS ] @name ON [ TABLE ] @table [ WHEN @expression ] THEN @expression [ COMMENT @string ]
 ```
 
-### Parameters:
+### Clauses:
 
 - **OVERWRITE**: Replaces the existing event if it already exists.
 - **IF NOT EXISTS**: Only creates the event if it doesn't already exist.
@@ -39,25 +41,61 @@ DEFINE EVENT [ OVERWRITE | IF NOT EXISTS ] @name ON [ TABLE ] @table [ WHEN @exp
 - **THEN**: Specifies the action(s) to execute when the event is triggered.
 - **COMMENT**: Optional comment for describing the event.
 
-
 ## Example usage
 
 -  **Email Change Detection**: Create an event that logs whenever a user's email is updated.
 
-```surql
--- Create a new event whenever a user changes their email address
--- One-statement event
-DEFINE EVENT test ON TABLE user WHEN $before.email != $after.email THEN (
-        CREATE log SET user = $this, action = 'email_changed', old_email = $before.email, new_email = $after.email
-    );
-    UPSERT user:test SET email = 'old_email@test.com';
-    UPSERT user:test SET email = 'new_email@test.com';
-    SELECT count() FROM log WHERE action = 'email_changed';
-```
-
 In this example:
 - The `WHEN` clause checks if the email has changed.
 - The `THEN` clause records this change in a `log` table.
+
+```surql
+-- Create a new event whenever a user changes their email address
+-- One-statement event
+DEFINE EVENT OVERWRITE test ON TABLE user WHEN $before.email != $after.email THEN (
+    CREATE log SET 
+        user       = $value.id,
+        // Turn events like "CREATE" into string "email created"
+        action     = 'email' + ' ' + $event.lowercase() + 'd',
+        // `email` field may be NONE, log as '' if so
+        old_email  = $before.email ?? '',
+        new_email  = $after.email  ?? '',
+        at         = time::now()
+);
+UPSERT user:test SET email = 'old_email@test.com';
+UPSERT user:test SET email = 'new_email@test.com';
+DELETE user:test;
+SELECT * FROM log ORDER BY at ASC;
+```
+
+```surql title="Output"
+[
+	{
+		action: 'email created',
+		at: d'2024-11-25T02:59:41.003Z',
+		id: log:e3thw1l0q7xiapznar1f,
+		new_email: 'old_email@test.com',
+		old_email: '',
+		user: user:test
+	},
+	{
+		action: 'email updated',
+		at: d'2024-11-25T02:59:41.003Z',
+		id: log:uaarfyk191jgod06xobm,
+		new_email: 'new_email@test.com',
+		old_email: 'old_email@test.com',
+		user: user:test
+	},
+	{
+		action: 'email deleted',
+		at: d'2024-11-25T02:59:41.003Z',
+		id: log:mlkag8h1xotglpz9wt2i,
+		new_email: '',
+		old_email: 'new_email@test.com',
+		user: user:test
+	}
+]
+```
 
 ### More Complex Logic:
 


### PR DESCRIPTION
Resolves https://github.com/surrealdb/docs.surrealdb.com/issues/1021 in which @welpie21 kindly points out that the event is drawing from $this (the event) is accessing the log being created, instead of the user (which is located at $value). Also makes the example a little more fun + ensures that before_email and after_email are always present in the log. These may have the value NONE, in which case their field won't show up at all, and a log would probably rather see something like a '' empty string to show a lack of email.

https://github.com/surrealdb/docs.surrealdb.com/compare/fix-define-event-example?expand=1