### PR TITLE
Rewrite RELATE, add examples of filtering recursive queries

### DIFF
--- a/src/content/doc-surrealql/datamodel/idioms.mdx
+++ b/src/content/doc-surrealql/datamodel/idioms.mdx
@@ -1071,7 +1071,7 @@ RETURN $third_degree.{
 
 Possible output of the final query:
 
-```surql
+```surql title="Output for third_degree_friends query"
 {
 	original_person: person:1,
 	third_degree_friends: [

--- a/src/content/doc-surrealql/datamodel/idioms.mdx
+++ b/src/content/doc-surrealql/datamodel/idioms.mdx
@@ -1042,6 +1042,51 @@ Recursive queries follow a few rules to determine how far to traverse and what t
 * If it has already passed the minimum depth, it returns the last valid value.
 * During each iteration, if it encounters an array value, all dead end values are automatically filtered out, ensuring no empty paths are included.
 
+#### Filtering recursive fields
+
+Recursive syntax is not just useful in creating recursive queries, but parsing them as well. Take the following example that creates some `person` records, gives each of them two friends, and then traverses the `friends_with` graph for the first `person` records to find its friends, friends of friends, and friends of friends of friends. Since every level except the last contains another `connections` field, adding a `.{some_number}.connections` to a `RETURN` statement is all that is needed to drill down to a certain depth.
+
+```surql
+CREATE |person:1..20| SET name = id.id() RETURN NONE;
+FOR $person IN SELECT * FROM person {
+    LET $friends = (SELECT * FROM person WHERE id != $person.id ORDER BY rand() LIMIT 2);
+    RELATE $person->friends_with->$friends;
+};
+
+LET $third_degree = person:1.{..3}.{ id, connections: ->friends_with->person.@ };
+// Object containing array of arrays of arrays of 'person'
+RETURN $third_degree;
+// All connections: an array of arrays of arrays of 'person'
+RETURN $third_degree.connections;
+// Secondary connections: an array of arrays of 'person'
+RETURN $third_degree.{2}.connections;
+// Tertiary connections: an array of 'person'
+RETURN $third_degree.{3}.connections;
+// Tertiary connections with aliased fields and original 'person' info
+RETURN $third_degree.{
+		original_person: id, 
+		third_degree_friends: connections.{2}.connections
+};
+```
+
+Possible output of the final query:
+
+```surql
+{
+	original_person: person:1,
+	third_degree_friends: [
+		person:13,
+		person:3,
+		person:14,
+		person:10,
+		person:8,
+		person:3,
+		person:3,
+		person:14
+	]
+}
+```
+
 ## Combining Idiom Parts
 
 Idioms can combine multiple parts to navigate complex data structures seamlessly.

--- a/src/content/doc-surrealql/statements/relate.mdx
+++ b/src/content/doc-surrealql/statements/relate.mdx
@@ -42,31 +42,96 @@ RELATE [ ONLY ] @from_record -> @table -> @to_record
 ```
 
 > [!NOTE]
-> `RELATE` will create a relation regardless of whether the records to relate to exist or not. As such, it is advisable to create the records you want to relate to before using `RELATE`, or to at least ensure that they exist before making a query on the relation. If the records to relate to don't exist, a query on the relation will still work but will return an empty array. To override this default behaviour and return an error if no records exist to relate, you can add the `ENFORCED` keyword to a [`DEFINE TABLE`](/docs/surrealql/statements/define/table) statement.
+> `RELATE` will create a relation regardless of whether the records to relate to exist or not. As such, it is advisable to create the records you want to relate to before using `RELATE`, or to at least ensure that they exist before making a query on the relation. If the records to relate to don't exist, a query on the relation will still work but will return an empty array. To override this behaviour and return an error if no records exist to relate, you can use a [`DEFINE TABLE`](/docs/surrealql/statements/define/table) statement that includes the `ENFORCED` keyword.
 
 ### Example usage
 
 #### Basic usage
 
-The following query shows the basic structure of the `RELATE` statement, which creates a relationship between a record in the person table and a record in the article table.
+The following query shows the basic structure of the `RELATE` statement, which creates a relationship between a record in the `person` table and a record in the `article` table.
 
 ```surql
-RELATE person:l19zjikkw1p1h9o6ixrg->wrote->article:8nkk6uj4yprt49z7y3zm;
+CREATE person:aristotle, article:on_sleep_and_sleeplessness;
+RELATE person:aristotle->wrote->article:on_sleep_and_sleeplessness;
 ```
 
 ```surql title="Response"
 [
 	{
 		id: wrote:bpbrj5kd7smu3ahlf55r,
-		in: person:l19zjikkw1p1h9o6ixrg,
-		out: article:8nkk6uj4yprt49z7y3zm
+		in: person:aristotle,
+		out: article:on_sleep_and_sleeplessness
 	}
 ]
 ```
 
 There is no relationship information stored in either the `person` or `article` table.
 
-Instead, an edge table (in this case a table called `wrote`) stores the relationship information. The structure `in -> id -> out` mirrors the record IDs from the `RELATE` statement, with the addition of the automatically generated ID for the `wrote` edge table.
+```surql
+SELECT * FROM person, article;
+```
+
+```surql title="Response"
+[
+	{
+		id: person:aristotle
+	},
+	{
+		id: article:on_sleep_and_sleeplessness
+	}
+]
+```
+
+Instead, an edge table (in this case a table called `wrote`) stores the relationship information.
+
+```surql
+SELECT * FROM wrote;
+```
+
+The structure `in -> id -> out` mirrors the record IDs from the `RELATE` statement, with the addition of the automatically generated ID for the `wrote` edge table.
+
+```surql title="Response"
+[
+	{
+		id: wrote:bpbrj5kd7smu3ahlf55r,
+		in: person:aristotle,
+		out: article:on_sleep_and_sleeplessness
+	}
+]
+```
+
+The same structure can be used in a `SELECT` query, as well as directly from a record ID.
+
+```surql
+-- Aristotle's id and the articles he wrote
+SELECT id, ->wrote->article FROM person:aristotle;
+-- Every `person`'s id and written articles
+-- Same output as above as the database has a single `person` record
+SELECT id, ->wrote->article FROM person;
+-- Directly follow the path from Aristotle to his written articles
+RETURN person:aristotle->wrote->article;
+```
+
+```surql title="Response"
+-------- Query --------
+
+[
+	{
+		"->wrote": {
+			"->article": [
+				article:on_sleep_and_sleeplessness
+			]
+		},
+		id: person:aristotle
+	}
+]
+
+-------- Query --------
+
+[
+	article:on_sleep_and_sleeplessness
+]
+```
 
 By default, the edge table gets created as a schemaless table when you execute the `RELATE` statement. You can make the table schemafull by [defining a schema](/docs/surrealql/statements/define/table).
 
@@ -78,7 +143,13 @@ DEFINE INDEX unique_relationships
     COLUMNS in, out UNIQUE;
 ```
 
-Edge tables are bi-directional by default. To enforce unidirectional relationships, you can restrict the type definition using a [`DEFINE FIELD`](/docs/surrealql/statements/define/field) definition.
+As edge tables are bi-directional by default, there is nothing stopping a query like the following in which an article writes a person instead of the other way around.
+
+```surql
+RELATE article:on_sleep_and_sleeplessness->wrote->person:aristotle;
+```
+
+To enforce unidirectional relationships, you can restrict the type definition using a [`DEFINE FIELD`](/docs/surrealql/statements/define/field) definition.
 
 ```surql
 DEFINE FIELD in  ON TABLE wrote TYPE record<person>;
@@ -87,7 +158,7 @@ DEFINE FIELD out ON TABLE wrote TYPE record<article>;
 
 #### Always two there are - no more, no less
 
-A `RELATE` statement that involves an array instead of a single id will not fail. Instead, it will create a graph edge for each record in the array:
+A `RELATE` statement that involves an array instead of a single id will not fail. Instead, it will create a graph edge for each record in the array.
 
 ```surql
 INSERT INTO cat (id) VALUES ("mr_meow"), ("mrs_meow"), ("kitten");

--- a/src/content/doc-surrealql/statements/relate.mdx
+++ b/src/content/doc-surrealql/statements/relate.mdx
@@ -810,9 +810,10 @@ As the query that uses aliases does not maintain the original graph structure, a
 
 Being able to set fields on graph tables opens up a large variety of custom query methods, one of which is explored here.
 
-Imagine a database that holds detailed information on the relations between NPCs in a game that are made to be as realistic as possible. Two of the characters have a rocky past but finally a happy conclusion in which they end up married. During this period, we might have tracked their relationship by adding and removing graph edges between the two of them as they move from a stage of being friends, to dating, to hating each other, to finally ending up married.
+Imagine a database that holds detailed information on the relations between NPCs in a game that are made to be as realistic as possible. Two of the characters have a rocky past but finally end up married. During this period, we might have tracked their relationship by adding and removing graph edges between the two of them as they move from a stage of being friends, to dating, to hating each other, to finally ending up married.
 
 ```surql
+CREATE person:one, person:two;
 -- These three relations would end up deleted
 RELATE person:one->friends_with->person:two;
 RELATE person:one->dating->person:two;
@@ -824,6 +825,7 @@ RELATE person:one->married->person:two;
 This works well to track the current state of the relationship, but creating a more general table such as `knows` along with a number of fields can be a better method to track the changing relationship over time. The following shows the relationship between the two `person` records, along with a third record called `person:three` who went to the same school and once dated `person:one`.
 
 ```surql
+CREATE person:one, person:two, person:three;
 RELATE person:one->knows->person:two SET
     has_been_friends = true,
     has_dated = true,
@@ -838,9 +840,29 @@ RELATE person:one->knows->person:three SET
 With these fields in place, it is possible to use a `WHERE` clause to do refined searches on relationships of a certain type.
 
 ```surql
-SELECT id, ->knows->person FROM person:one;
-SELECT id, ->knows[WHERE has_dated]->person FROM person:one;
-SELECT id, ->knows[WHERE same_high_school AND has_dated]->person FROM person:one;
+SELECT 
+	->knows->person AS knows,
+	->knows[WHERE has_dated]->person AS has_dated,
+	->knows[WHERE same_high_school AND has_dated]->person AS dated_and_same_school
+ FROM person:one;
+```
+
+```surql title="Response"
+[
+	{
+		dated_and_same_school: [
+			person:three
+		],
+		has_dated: [
+			person:two,
+			person:three
+		],
+		knows: [
+			person:two,
+			person:three
+		]
+	}
+]
 ```
 
 Because the `WHERE` clause simply checks for [truthiness](/docs/surrealql/datamodel/values#values-and-truthiness) (whether a value is present and not empty), these fields do not necessarily need to be booleans and can even be complex objects.
@@ -876,3 +898,164 @@ SELECT id, ->knows[WHERE same_high_school AND has_dated.to > d'2020-12-25']->per
 ```
 
 ### Recursive graph queries
+
+<Since v="v2.1.0" />
+
+Graph edges can also be queried recursively. For a full explanation of this syntax, see the page on [recursive paths](/docs/surrealql/datamodel/idioms#recursive-paths).
+
+Take the following example which creates five cities, each of which is connected to the next by some type of road of random length.
+
+```surql
+CREATE |city:1..5| SET name = <string>id.id() + 'ville';
+FOR $pair IN (<array>(1..=5)).windows(2) {
+  	LET $city1 = type::thing("city", $pair[0]);
+    LET $city2 = type::thing("city", $pair[1]);
+    RELATE $city1->to->$city2 SET 
+        type = rand::enum(["train", "road", "bike path"]),
+        distance = <int>(rand::float() * 100).ceil()
+};
+```
+
+While it is possible to manually move three levels down this road network, it involves a good deal of manual typing.
+
+```surql
+SELECT ->to->city->to->city->to->city AS fourth_city FROM city:1;
+```
+
+```surql title="Response"
+[
+	{
+		fourth_city: [
+			city:4
+		]
+	}
+]
+```
+
+This can be replaced by a `@` to refer to the current record, followed by `.{3}` to represent three levels down the 
+
+```surql
+SELECT @.{3}->to->city AS fourth_city FROM city:1;
+```
+
+A traditional query to show the final road info from `city:1` to the city three stops away would look like this.
+
+```surql
+SELECT ->to->city->to->city->to.* AS third_journey FROM city:1;
+```
+
+```surql title="Response"
+[
+	{
+		fourth_city: [
+			[
+				{
+					distance: 80,
+					id: to:sw2pery99jomfhibzfrh,
+					in: city:3,
+					out: city:4,
+					type: 'train'
+				}
+			]
+		]
+	}
+]
+```
+
+To use the same query recursively, wrap the part that must be repeated (`->to->city`) inside parentheses. This will ensure that the `.{2}` part of the query only repeats `->to->city` twice, and not the final `->to.*` portion.
+
+```surql
+SELECT @.{2}(->to->city)->to.* AS third_journey FROM city:1;
+```
+
+A range can be added inside the `{}` braces. The following query that uses a range of 1 to 20 will follow the `->to->city` path up to 20 times, but will stop at the 5th and final depth because the next level returns an empty array.
+
+```surql
+city:1.{1..20}->to->city;
+```
+
+```surql title="Response"
+[
+	city:5
+]
+```
+
+Ranges can be followed with the destructuring operator to collect fields on each depth, returning them in a single response. The following query goes five depths down the `to` graph table, returning each city and road along the way.
+
+```surql
+SELECT @.{1..5}.{ 
+    id, 
+    next_roads: ->to.*,
+    next_cities: ->to->city
+} FROM city;
+```
+
+```surql title="Response"
+[
+	{
+		id: city:1,
+		next_cities: [
+			city:2
+		],
+		next_roads: [
+			{
+				distance: 33,
+				id: to:bl6i9djau0pg24pqrwd9,
+				in: city:1,
+				out: city:2,
+				type: 'road'
+			}
+		]
+	},
+	{
+		id: city:2,
+		next_cities: [
+			city:3
+		],
+		next_roads: [
+			{
+				distance: 45,
+				id: to:ybugfnlzv6kcrkaj49ig,
+				in: city:2,
+				out: city:3,
+				type: 'road'
+			}
+		]
+	},
+	{
+		id: city:3,
+		next_cities: [
+			city:4
+		],
+		next_roads: [
+			{
+				distance: 80,
+				id: to:sw2pery99jomfhibzfrh,
+				in: city:3,
+				out: city:4,
+				type: 'train'
+			}
+		]
+	},
+	{
+		id: city:4,
+		next_cities: [
+			city:5
+		],
+		next_roads: [
+			{
+				distance: 29,
+				id: to:42hlspf4z5lpqceyv68p,
+				in: city:4,
+				out: city:5,
+				type: 'train'
+			}
+		]
+	},
+	{
+		id: city:5,
+		next_cities: [],
+		next_roads: []
+	}
+]
+```

--- a/src/content/doc-surrealql/statements/relate.mdx
+++ b/src/content/doc-surrealql/statements/relate.mdx
@@ -714,14 +714,14 @@ SELECT ->friends_with->cat->friends_with->cat AS friends_of_friends FROM cat:one
 However, an alias might not be preferred in a case where you have multiple graph queries that resolve to the fields of a large nested structure. Take the following data for example:
 
 ```surql
-CREATE country:usa        SET name = "USA";
+CREATE country:usa SET name = "USA";
 CREATE state:pennsylvania SET population = 12970000;
-CREATE state:michigan     SET population = 10030000;
+CREATE state:michigan SET population = 10030000;
 CREATE city:philadelphia, city:pittsburgh, city:detroit, city:grand_rapids;
 
-RELATE country:usa       ->contains->[state:pennsylvania, state:michigan];
+RELATE country:usa->contains->[state:pennsylvania, state:michigan];
 RELATE state:pennsylvania->contains->[city:philadelphia, city:pittsburgh];
-RELATE state:michigan    ->contains->[city:detroit, city:grand_rapids];
+RELATE state:michigan->contains->[city:detroit, city:grand_rapids];
 ```
 
 A query on the states and cities of these records using aliases would return the data in a structure remade to fit the aliases declared in the query.

--- a/src/content/doc-surrealql/statements/relate.mdx
+++ b/src/content/doc-surrealql/statements/relate.mdx
@@ -17,7 +17,7 @@ Edges created using the RELATE statement are nearly identical to tables created 
 The key differences are that:
 
 - Edge tables are deleted once there are no existing relationships left.
-- Edge tables have two required fields `in` and `out`, which specify the directions of the relationships. These cannot be modified in schema declarations except to specify that they must be of a certain record type or to add assertions.
+- Edge tables have two required fields `in` and `out`, which specify the directions of the relationships. These cannot be modified in schema declarations except to specify that they must be of a certain record type or to [add assertions](/docs/surrealql/statements/define/field#asserting-rules-on-fields).
 
 Otherwise, edge tables behave like normal tables in terms of [updating](/docs/surrealql/statements/update), [defining a schema](/docs/surrealql/statements/define/table) or [indexes](/docs/surrealql/statements/define/indexes).
 
@@ -42,12 +42,11 @@ RELATE [ ONLY ] @from_record -> @table -> @to_record
 ```
 
 > [!NOTE]
-> `RELATE` will create a relation regardless of whether the records to relate to exist or not. As such, it is advisable to create the records you want to relate to before using `RELATE`, or to at least ensure that they exist before making a query on the relation. You can do this using the [CREATE statement](/docs/surrealql/statements/create). If the records to relate to don't exist, a query on the relation will still work without an error but will return an empty array. To override this default behaviour and return an error if no records exist to relate, you can add the `ENFORCED` keyword to a [`DEFINE TABLE`](/docs/surrealql/statements/define/table) statement.
+> `RELATE` will create a relation regardless of whether the records to relate to exist or not. As such, it is advisable to create the records you want to relate to before using `RELATE`, or to at least ensure that they exist before making a query on the relation. If the records to relate to don't exist, a query on the relation will still work but will return an empty array. To override this default behaviour and return an error if no records exist to relate, you can add the `ENFORCED` keyword to a [`DEFINE TABLE`](/docs/surrealql/statements/define/table) statement.
 
+### Example usage
 
-## Example usage
-
-### Basic usage
+#### Basic usage
 
 The following query shows the basic structure of the `RELATE` statement, which creates a relationship between a record in the person table and a record in the article table.
 
@@ -58,18 +57,18 @@ RELATE person:l19zjikkw1p1h9o6ixrg->wrote->article:8nkk6uj4yprt49z7y3zm;
 ```surql title="Response"
 [
 	{
-		"id": "wrote:ctwsll49k37a7rmqz9rr",
-		"in": "person:l19zjikkw1p1h9o6ixrg",
-		"out": "article:8nkk6uj4yprt49z7y3zm"
+		id: wrote:bpbrj5kd7smu3ahlf55r,
+		in: person:l19zjikkw1p1h9o6ixrg,
+		out: article:8nkk6uj4yprt49z7y3zm
 	}
 ]
 ```
 
-There is no relationship information stored in either the person or article table.
+There is no relationship information stored in either the `person` or `article` table.
 
 Instead, an edge table (in this case a table called `wrote`) stores the relationship information. The structure `in -> id -> out` mirrors the record IDs from the `RELATE` statement, with the addition of the automatically generated ID for the `wrote` edge table.
 
-By default, the edge table gets created as a schemaless table when you execute the `RELATE` statement. You can however make the table schemafull by either [defining a schema](/docs/surrealql/statements/define/table) before or after executing the RELATE statement.
+By default, the edge table gets created as a schemaless table when you execute the `RELATE` statement. You can make the table schemafull by [defining a schema](/docs/surrealql/statements/define/table).
 
 A common use case is to make sure only unique relationships get created. You can do that by [defining an index](/docs/surrealql/statements/define/indexes).
 
@@ -78,14 +77,15 @@ DEFINE INDEX unique_relationships
     ON TABLE wrote
     COLUMNS in, out UNIQUE;
 ```
-Edge tables are bi-directional by default. To enforce unidirectional relationships, you can restrict the type definition using field definition.
+
+Edge tables are bi-directional by default. To enforce unidirectional relationships, you can restrict the type definition using a [`DEFINE FIELD`](/docs/surrealql/statements/define/field) definition.
 
 ```surql
 DEFINE FIELD in  ON TABLE wrote TYPE record<person>;
 DEFINE FIELD out ON TABLE wrote TYPE record<article>;
 ```
 
-### Always two there are - no more, no less
+#### Always two there are - no more, no less
 
 A `RELATE` statement that involves an array instead of a single id will not fail. Instead, it will create a graph edge for each record in the array:
 
@@ -96,20 +96,20 @@ RELATE [cat:mr_meow, cat:mrs_meow]->parent_of->cat:kitten;
 
 ```surql title="Response"
 [
-    {
-        "id": "parent_of:7ypx27tgoa9lrsa4s6fm",
-        "in": "cat:mr_meow",
-        "out": "cat:kitten"
-    },
-    {
-        "id": "parent_of:mw08ri5e1jgh78wp1c1p",
-        "in": "cat:mrs_meow",
-        "out": "cat:kitten"
-    }
+	{
+		id: parent_of:uahudi4qr68k640fcjbg,
+		in: cat:mr_meow,
+		out: cat:kitten
+	},
+	{
+		id: parent_of:hi79yfazjppv8b3kyi36,
+		in: cat:mrs_meow,
+		out: cat:kitten
+	}
 ]
 ```
 
-Similarly, a `RELATE` statement that involves two arrays will return a number of graph edges equal to their product (in this case 2 * 2):
+Similarly, a `RELATE` statement that involves two arrays will return a number of graph edges equal to their product (2 * 2 in this case):
 
 ```surql
 CREATE cat:kitten2;
@@ -118,30 +118,30 @@ RELATE [cat:mr_meow, cat:mrs_meow]->parent_of->[cat:kitten, cat:kitten2];
 
 ```surql title="Response"
 [
-    {
-        "id": "parent_of:kvgu19yulq347b8xksxw",
-        "in": "cat:mr_meow",
-        "out": "cat:kitten"
-    },
-    {
-        "id": "parent_of:xxvj5pkxci3k9bqm6br9",
-        "in": "cat:mr_meow",
-        "out": "cat:kitten2"
-    },
-    {
-        "id": "parent_of:e4xwvecwwm6sxq1xe0yr",
-        "in": "cat:mrs_meow",
-        "out": "cat:kitten"
-    },
-    {
-        "id": "parent_of:ub9t2mm948jfuup6r6c4",
-        "in": "cat:mrs_meow",
-        "out": "cat:kitten2"
-    }
+	{
+		id: parent_of:ysbab20nv5568ogba6ns,
+		in: cat:mr_meow,
+		out: cat:kitten
+	},
+	{
+		id: parent_of:0ltm6xr94pkblyxf0m6c,
+		in: cat:mr_meow,
+		out: cat:kitten2
+	},
+	{
+		id: parent_of:71cfl0nvj5frve0r1npv,
+		in: cat:mrs_meow,
+		out: cat:kitten
+	},
+	{
+		id: parent_of:4gbid7nzo6cwr1t8k090,
+		in: cat:mrs_meow,
+		out: cat:kitten2
+	}
 ]
 ```
 
-## Adding data using `SET` and `CONTENT`
+### Adding data using `SET` and `CONTENT`
 
 Graph edges are standalone tables that can hold other fields besides the default `in`, `out`, and `id`. These can be added during a `RELATE` statement or during an `UPDATE` in the same manner as any other SurrealDB table.
 
@@ -169,12 +169,14 @@ UPDATE wrote SET
 ```
 
 ```surql title="Response"
-    {
-        "id": "wrote:s51jjewpw953ahysbhak",
-        "in": "person:l19zjikkw1p1h9o6ixrg",
-        "out": "article:8nkk6uj4yprt49z7y3zm",
-        "description": "article written by person:l19zjikkw1p1h9o6ixrg"
-    }
+[
+	{
+		description: 'article written by person:l19zjikkw1p1h9o6ixrg',
+		id: wrote:bpbrj5kd7smu3ahlf55r,
+		in: person:l19zjikkw1p1h9o6ixrg,
+		out: article:8nkk6uj4yprt49z7y3zm
+	}
+]
 ```
 
 ### Passing variables in `CONTENT` and `SET`
@@ -194,14 +196,16 @@ RELATE person:l19zjikkw1p1h9o6ixrg->wrote->article:8nkk6uj4yprt49z7y3zm
 ```
 
 ```surql title="Response"
-    {
-        "id": "wrote:ctwsll49k37a7rmqz9rr",
-        "in": "person:l19zjikkw1p1h9o6ixrg",
-        "out": "article:8nkk6uj4yprt49z7y3zm",
-        "time": {
-            "written": "2021-09-29T14:00:00Z"
-        }
-    }
+[
+	{
+		id: wrote:63tzplfgz5akg6vimvcj,
+		in: person:l19zjikkw1p1h9o6ixrg,
+		out: article:8nkk6uj4yprt49z7y3zm,
+		time: {
+			written: d'2024-11-25T06:51:45.608Z'
+		}
+	}
+]
 ```
 
 Below is an example of how you can pass a variable in the `SET` block:
@@ -214,24 +218,26 @@ RELATE person:l19zjikkw1p1h9o6ixrg->wrote->article:8nkk6uj4yprt49z7y3zm
 ```
 
 ```surql title="Response"
-    {
-        "id": "wrote:ctwsll49k37a7rmqz9rr",
-        "in": "person:l19zjikkw1p1h9o6ixrg",
-        "out": "article:8nkk6uj4yprt49z7y3zm",
-        "time": {
-            "written": "2021-09-29T14:00:00Z"
-        }
-    }
+[
+	{
+		id: wrote:h2ukwhybxqlt1f7sdtck,
+		in: person:l19zjikkw1p1h9o6ixrg,
+		out: article:8nkk6uj4yprt49z7y3zm,
+		time: {
+			written: d'2024-11-25T06:52:04.871Z'
+		}
+	}
+]
 ```
 
-## Creating a single relation with the `ONLY` keyword
+### Creating a single relation with the `ONLY` keyword
 Using the ONLY keyword, just an object for the relation in question will be returned. This, instead of an array with a single object.
 
 ```surql
 RELATE ONLY person:l19zjikkw1p1h9o6ixrg->wrote->article:8nkk6uj4yprt49z7y3zm;
 ```
 
-## Basics of querying graphs
+## Querying graphs
 
 Let's look at how the above gets queried, for more examples see the [SELECT docs](/docs/surrealql/statements/select).
 
@@ -304,7 +310,7 @@ person:tobie
 
 Putting it all together it would be: based on all the products Tobie purchased, which person also purchased those products and what did they purchase?
 
-## Using expressions in graph queries
+### Using expressions in graph queries
 
 You can use expressions to filter relations based on specific conditions using the `WHERE` clause.
 
@@ -315,7 +321,7 @@ For example, suppose we want to limit the query to only take recent purchases in
 SELECT ->purchased->product<-purchased<-person->(purchased WHERE created_at > time::now() - 3w)->product FROM person:tobie;
 ```
 
-## Bidirectional relation querying
+### Bidirectional relation querying
 
 Sometimes a relation is such that it is impossible to determine which record is located at the `in` part of a graph table, and which is located at the `out` part. This is the case when a relationship is truly bidirectional and equal, such as a friendship, marriage, or sister cities:
 
@@ -408,7 +414,7 @@ RELATE city:daejeon->sister_of->city:calgary;
 -- "Database index `only_one_sister_city` already contains '[city:calgary, city:daejeon]', with record `sister_of:npab0uoxogmrvpwsvfoa`"
 ```
 
-## Refining the `in` and `out` fields of a relation
+### Refining the `in` and `out` fields of a relation
 
 As mentioned above, the `in` and `out` fields of a graph table are mandatory but can be modified to specify their record type or make assertions.
 
@@ -441,8 +447,7 @@ RELATE author:hesse->wrote->book:demian;
 "Found book:demian for field `out`, with record `wrote:le3ntnyv2lb943km9gxk`, but field must conform to: $value.language = 'English'"
 ```
 
-
-## Structure of queries on relations
+### Structure of queries on relations
 
 Using an alias is a common practice in both regular and relation queries in SurrealDB to make output more readable and collapse nested structures. You can create an alias using the `AS` clause.
 
@@ -563,7 +568,7 @@ FROM country:usa;
 
 As the query that uses aliases does not maintain the original graph structure, adding `population` would require clever renaming such as `->contains->state.population AS state_populations` to make it clear that the numbers represent state and not city populations.
 
-## Using [`LET`](/docs/surrealql/statements/let) parameters in RELATE statements
+### Using [`LET`](/docs/surrealql/statements/let) parameters in RELATE statements
 
 You can also use [parameters](/docs/surrealql/parameters) to specify the record IDs.
 
@@ -580,7 +585,7 @@ LET $article = (SELECT VALUE id FROM article);
 RELATE $person->wrote->$article SET time.written = time::now();
 ```
 
-## Modifying output with the [`RETURN`](/docs/surrealql/statements/return) clause
+### Modifying output with the [`RETURN`](/docs/surrealql/statements/return) clause
 
 By default, the relate statement returns the record value once the changes have been made. To change the return value of each record, specify a RETURN clause, specifying either `NONE`, `BEFORE`, `AFTER`, `DIFF`, or a comma-separated list of specific fields to return.
 
@@ -610,17 +615,20 @@ RELATE person:l19zjikkw1p1h9o6ixrg->wrote->article:8nkk6uj4yprt49z7y3zm
     SET time.written = time::now()
     RETURN time;
 ```
-## Using `TIMEOUT` clause
 
-When processing a large result set with many interconnected records, it is possible to use the `TIMEOUT` keyword to specify a timeout duration for the statement. If the statement continues beyond this duration, then the transaction will fail, and the statement will return an error.
+### Using the `TIMEOUT` clause
+
+Adding the `TIMEOUT` keyword to specify a timeout duration for the statement can be useful when processing a large result set with many interconnected records. If the statement continues beyond this duration, then the transaction will fail, and the statement will return an error.
 
 ```surql
 -- Cancel this conditional filtering based on graph edge properties
 -- if it's not finished within 5 seconds
 SELECT * FROM person WHERE ->knows->person->(knows WHERE influencer = true) TIMEOUT 5s;
+
+
 ```
 
-## Using `PARALLEL` clause
+### Using the `PARALLEL` clause
 
 When processing a large result set with many interconnected records, it is possible to use the `PARALLEL` keyword to signify that edges and remote records should be fetched and processed concurrently, rather than sequentially. This can be useful when you want to process a large result set in a short amount of time.
 
@@ -630,7 +638,7 @@ When processing a large result set with many interconnected records, it is possi
 SELECT ->purchased->product<-purchased<-person->purchased->product FROM person:tobie PARALLEL;
 ```
 
-## Deleting graph edges
+### Deleting graph edges
 
 You can also delete graph edges between two records in the database by using the [DELETE statement](/docs/surrealql/statements/delete).
 
@@ -644,9 +652,9 @@ RELATE person:tobie->bought->product:iphone;
 
 [
 	{
-		"id": "bought:ctwsll49k37a7rmqz9rr",
-		"in": "person:tobie",
-		"out": "product:iphone"
+		id: bought:ctwsll49k37a7rmqz9rr,
+		in: person:tobie,
+		out: product:iphone
 	}
 ]
 ```
@@ -685,7 +693,7 @@ SELECT * FROM likes;
 ]
 ```
 
-## Multiple graph tables vs. fields
+### Multiple graph tables vs. fields
 
 Imagine a database that holds detailed information on the relations between NPCs in a game that are made to be as realistic as possible. Two of the characters have a rocky past but finally a happy conclusion in which they end up married. During this period, we might have tracked their relationship by adding and removing graph edges between the two of them as they move from a stage of being friends, to dating, to hating each other, to finally ending up married.
 

--- a/src/content/doc-surrealql/statements/relate.mdx
+++ b/src/content/doc-surrealql/statements/relate.mdx
@@ -932,7 +932,7 @@ SELECT ->to->city->to->city->to->city AS fourth_city FROM city:1;
 ]
 ```
 
-This can be replaced by a `@` to refer to the current record, followed by `.{3}` to represent three levels down the 
+This can be replaced by a `@` to refer to the current record, followed by `.{3}` to represent three levels down the `to` graph edge. A level between 1 and 256 can be specified here.
 
 ```surql
 SELECT @.{3}->to->city AS fourth_city FROM city:1;
@@ -1058,4 +1058,84 @@ SELECT @.{1..5}.{
 		next_roads: []
 	}
 ]
+```
+
+As noted above, a `TIMEOUT` can be set for queries that may be computationally expensive. This is particularly useful when experimenting with recursive queries, which, if care is not taken, can run all the way to the maximum possible depth of 256.
+
+Take the following example with two `person` records that like each other. Following the `likes` edge will run until the query recurses 256 times and gives up.
+
+```surql
+CREATE person:one, person:two;
+RELATE person:one->likes->person:two;
+RELATE person:two->likes->person:one;
+-- Open-ended range
+person:one.{..}->likes->person;
+```
+
+```surql title="Response"
+'Exceeded the idiom recursion limit of 256.'
+```
+
+Take the following example in which three `person` records of created, each of which likes the other two `person` records. A query on the `->likes->person` path shows that the number of records doubles each time.
+
+```surql
+CREATE |person:1..3|;
+FOR $person IN (SELECT * FROM person) {
+  LET $others = (SELECT * FROM person WHERE id != $person.id);
+    FOR $other IN $others {
+        RELATE $person->likes->$other;
+    }
+};
+RETURN [
+	person:1.{2}->likes->person,
+	person:1.{3}->likes->person,
+	person:1.{4}->likes->person
+];
+```
+
+```surql title="Response"
+[
+	[
+		person:1,
+		person:2,
+		person:1,
+		person:3
+	],
+	[
+		person:3,
+		person:2,
+		person:1,
+		person:3,
+		person:3,
+		person:2,
+		person:1,
+		person:2
+	],
+	[
+		person:1,
+		person:2,
+		person:1,
+		person:3,
+		person:3,
+		person:2,
+		person:1,
+		person:2,
+		person:1,
+		person:2,
+		person:1,
+		person:3,
+		person:3,
+		person:2,
+		person:1,
+		person:3
+	]
+]
+```
+
+Since an open-ended range can be specified in a recursive query, this would result in a full 256 attempts to recurse, multiplying the number of results by two each time for a total of 115792089237316195423570985008687907853269984665640564039457584007913129639936 records by the end.
+
+When experimenting with recursive queries, especially open-ended ranges, it is thus recommended to use a timeout.
+
+```surql
+SELECT @.{..}.{ id, likes: ->likes->person.@ } FROM person TIMEOUT 1s;
 ```

--- a/src/content/doc-surrealql/statements/relate.mdx
+++ b/src/content/doc-surrealql/statements/relate.mdx
@@ -220,110 +220,234 @@ Let's look at the two ways you can add record data in the `RELATE` statement. Bo
 
 ```surql
 RELATE person:l19zjikkw1p1h9o6ixrg->wrote->article:8nkk6uj4yprt49z7y3zm
-    SET time.written = time::now();
+    SET 
+		metadata.time_written = time::now(),
+		metadata.location = "Tallinn";
 
 
 RELATE person:l19zjikkw1p1h9o6ixrg->wrote->article:8nkk6uj4yprt49z7y3zm
 	CONTENT {
-		time: {
-			written: time::now()
+		metadata: {
+			time_written: time::now(),
+			location: "Tallinn"
 		}
 	};
-```
-
-Here is an example of a graph edge being updated in the same way as any other SurrealDB record:
-
-```surql
--- Add a small synopsis composed of the table name and article ID
-UPDATE wrote SET
-    description = meta::tb(out) + ' written by ' + <string>in;
 ```
 
 ```surql title="Response"
 [
 	{
-		description: 'article written by person:l19zjikkw1p1h9o6ixrg',
-		id: wrote:bpbrj5kd7smu3ahlf55r,
+		id: wrote:rva8hentypdu8lcgwjmf,
 		in: person:l19zjikkw1p1h9o6ixrg,
+		metadata: {
+			location: 'Tallinn',
+			time_written: d'2024-11-26T01:52:01.169Z'
+		},
 		out: article:8nkk6uj4yprt49z7y3zm
 	}
 ]
 ```
 
-### Passing variables in `CONTENT` and `SET`
-
-<Since v="v1.5.0" />
-
-You can also pass variables in the `CONTENT` block. This is useful when you want to pass a variable that is not a record ID.
+Here is an example of the graph edge being updated in the same way as any other SurrealDB record:
 
 ```surql
-LET $time = time::now();
-RELATE person:l19zjikkw1p1h9o6ixrg->wrote->article:8nkk6uj4yprt49z7y3zm
-    CONTENT {
-        time: {
-            written: $time
-        }
-    };
+-- Add a small synopsis composed of the table name and article ID
+UPDATE wrote SET
+    metadata.description = meta::tb(out) + ' written by ' + <string>in;
 ```
 
 ```surql title="Response"
 [
 	{
-		id: wrote:63tzplfgz5akg6vimvcj,
+		id: wrote:k9d8ynbfxgb8jqjv2ob5,
 		in: person:l19zjikkw1p1h9o6ixrg,
-		out: article:8nkk6uj4yprt49z7y3zm,
-		time: {
-			written: d'2024-11-25T06:51:45.608Z'
-		}
-	}
-]
-```
-
-Below is an example of how you can pass a variable in the `SET` block:
-
-```surql
-LET $time = time::now();
-
-RELATE person:l19zjikkw1p1h9o6ixrg->wrote->article:8nkk6uj4yprt49z7y3zm
-    SET time.written = $time;
-```
-
-```surql title="Response"
-[
-	{
-		id: wrote:h2ukwhybxqlt1f7sdtck,
-		in: person:l19zjikkw1p1h9o6ixrg,
-		out: article:8nkk6uj4yprt49z7y3zm,
-		time: {
-			written: d'2024-11-25T06:52:04.871Z'
-		}
+		metadata: {
+			description: 'article written by person:l19zjikkw1p1h9o6ixrg',
+			location: 'Tallinn',
+			time_written: d'2024-11-26T01:53:51.350Z'
+		},
+		out: article:8nkk6uj4yprt49z7y3zm
 	}
 ]
 ```
 
 ### Creating a single relation with the `ONLY` keyword
+
 Using the ONLY keyword, just an object for the relation in question will be returned. This, instead of an array with a single object.
 
 ```surql
 RELATE ONLY person:l19zjikkw1p1h9o6ixrg->wrote->article:8nkk6uj4yprt49z7y3zm;
 ```
 
+```surql title="Response"
+{
+	id: wrote:k9f1rqn3oikolr1560u3,
+	in: person:l19zjikkw1p1h9o6ixrg,
+	out: article:8nkk6uj4yprt49z7y3zm
+}
+```
+
+### Using [`LET`](/docs/surrealql/statements/let) parameters in RELATE statements
+
+You can also use [parameters](/docs/surrealql/parameters) to specify the record IDs.
+
+```surql
+-- These two statements store the result of the subquery in a parameter
+-- The subquery returns an array of IDs
+LET $person =  (SELECT VALUE id FROM person);
+LET $article = (SELECT VALUE id FROM article);
+
+-- This statement creates a relationship record for every combination of Record IDs
+-- Such that if we have 10 records each in the person and article table
+-- We get 100 records in the wrote edge table (10*10 = 100)
+-- In this case it would mean that each article would have 10 authors
+RELATE $person->wrote->$article SET time.written = time::now();
+```
+
+### Modifying output with the [`RETURN`](/docs/surrealql/statements/return) clause
+
+By default, the relate statement returns the record value once the changes have been made. To change the return value of each record, specify a RETURN clause, specifying either `NONE`, `BEFORE`, `AFTER`, `DIFF`, or a comma-separated list of specific fields to return.
+
+```surql
+-- Don't return any result
+RELATE person:l19zjikkw1p1h9o6ixrg->wrote->article:8nkk6uj4yprt49z7y3zm
+    SET time.written = time::now()
+    RETURN NONE;
+
+-- Return the changeset diff
+RELATE person:l19zjikkw1p1h9o6ixrg->wrote->article:8nkk6uj4yprt49z7y3zm
+    SET time.written = time::now()
+    RETURN DIFF;
+
+-- Return the record before changes were applied
+RELATE person:l19zjikkw1p1h9o6ixrg->wrote->article:8nkk6uj4yprt49z7y3zm
+    SET time.written = time::now()
+    RETURN BEFORE;
+
+-- Return the record after changes were applied (the default)
+RELATE person:l19zjikkw1p1h9o6ixrg->wrote->article:8nkk6uj4yprt49z7y3zm
+    SET time.written = time::now()
+    RETURN AFTER;
+
+-- Return a specific field only from the updated records
+RELATE person:l19zjikkw1p1h9o6ixrg->wrote->article:8nkk6uj4yprt49z7y3zm
+    SET time.written = time::now()
+    RETURN time;
+```
+
+### Using the `TIMEOUT` clause
+
+Adding the `TIMEOUT` keyword to specify a timeout duration for the statement can be useful when processing a large result set with many interconnected records. If the statement continues beyond this duration, then the transaction will fail, and the statement will return an error.
+
+```surql
+-- Cancel this conditional filtering based on graph edge properties
+-- if not finished within 5 seconds
+SELECT * FROM person WHERE ->knows->person->(knows WHERE influencer = true) TIMEOUT 5s;
+```
+
+Using a `TIMEOUT` is particularly useful when experimenting with complex queries with an extent that is difficult to imagine, especially if the query [is recursive](#recursive-graph-queries).
+
+### Using the `PARALLEL` clause
+
+When processing a large result set with many interconnected records, it may be desirable to use the `PARALLEL` keyword to signify that edges and remote records should be fetched and processed concurrently, rather than sequentially. This can be useful when you want to process a large result set in a short amount of time.
+
+```surql
+-- Fetch and process the person, purchased and product targets in parallel
+-- Select every product that was purchased by a person that purchased a product that person tobie also purchased
+SELECT ->purchased->product<-purchased<-person->purchased->product FROM person:tobie PARALLEL;
+```
+
+### Deleting graph edges
+
+You can also delete graph edges between two records in the database by using the [DELETE statement](/docs/surrealql/statements/delete).
+
+For example the graph edge below:
+
+```surql
+RELATE person:tobie->bought->product:iphone;
+```
+
+```surql title="Response"
+
+[
+	{
+		id: bought:ctwsll49k37a7rmqz9rr,
+		in: person:tobie,
+		out: product:iphone
+	}
+]
+```
+
+Can be deleted by:
+
+```surql
+DELETE person:tobie->bought WHERE out=product:iphone RETURN BEFORE;
+```
+
+As mentioned above, a graph edge will also automatically be deleted if it is no longer connected to a record at both `in` and `out`.
+
+```surql
+-- Create three people
+CREATE person:one, person:two, person:three;
+
+-- And a love triangle involving them all
+RELATE person:one  ->likes->person:two;
+RELATE person:two  ->likes->person:three;
+RELATE person:three->likes->person:one;
+
+-- Person two moves to Venus permanently, so delete
+DELETE person:two;
+
+-- Only one `likes` relationship is left
+SELECT * FROM likes;
+```
+
+```surql title="Output"
+[
+	{
+		id: likes:55szjin5yfqwl4sbmy1f,
+		in: person:three,
+		out: person:one
+	}
+]
+```
+
 ## Querying graphs
 
-Let's look at how the above gets queried, for more examples see the [SELECT docs](/docs/surrealql/statements/select).
+### Different ways to reach similar results
 
-For the questions below, each of the queries will give you the same answer. Note that whether `->` and `<-` are parsed as `in` or `out` depends on their direction in relation to the graph edge `wrote`. An arrow pointing towards `wrote` corresponds to `in`, and vice versa.
+For the questions below, each of the queries will give you largely the same answer. Note that whether `->` and `<-` are parsed as `in` or `out` depends on their direction in relation to the graph edge `wrote`. An arrow pointing towards `wrote` corresponds to `in`, and vice versa.
 
-The following examples show how to make similar queries in a number of different ways, in the context of `person` records that `wrote` one or more `article`s.
+The following examples show how to make similar queries in a number of different ways, in the context of a database with one person who wrote two articles.
+
+```surql
+CREATE 
+	person:aristotle,
+	article:on_sleep_and_sleeplessness,
+	article:on_dreams;
+RELATE person:aristotle->wrote->[
+		article:on_sleep_and_sleeplessness,
+		article:on_dreams
+	]
+	// Written sometime around the year 330 BC
+	SET time_written = d"-0330-01-01";
+```
 
 Who wrote the articles?
 
 ```surql
+-- All queries lead to `person:artistotle` twice,
+-- via different paths and thus different field names
+-- and/or structure
+
+-- Directly from the `wrote` table
 SELECT in FROM wrote;
 
+-- From a single `person` record
 SELECT ->wrote.in FROM person;
 SELECT ->wrote<-person FROM person;
 
+-- From two `article` records
 SELECT <-wrote.in FROM article;
 SELECT <-wrote<-person FROM article;
 ```
@@ -343,10 +467,12 @@ SELECT <-wrote->article FROM article;
 When was the article written?
 
 ```surql
-SELECT time.written as time_written FROM wrote;
-SELECT ->wrote.time.written as time_written FROM person;
-SELECT <-wrote.time.written as time_written FROM article;
+SELECT time_written FROM wrote;
+SELECT ->wrote.time_written as time_written FROM person;
+SELECT <-wrote.time_written as time_written FROM article;
 ```
+
+### Parsing graph queries
 
 For a more complicated query like the one below you can use a simple rule of thumb:
 Place the subject in front of the graph selection, then read it backward.
@@ -359,53 +485,83 @@ SELECT ->purchased->product<-purchased<-person->purchased->product FROM person:t
 person:tobie->purchased->product<-purchased<-person->purchased->product SELECT
 ```
 
-Reading this backwards then makes more sense: <br/>
+Reading this backwards then makes more sense:
 
-Select every product that was purchased by a person who purchased a product that was also purchased by person Tobie.
+> Select every product that was purchased by a person who purchased a product that was also purchased by person Tobie.
 
-Alternatively, you can break it down into steps.
+Alternatively, you can break it down into steps over multiple lines.
 
 ```surql
 -- Starting with Tobie
 person:tobie
-
--- and his purchased products
+-- move on to his purchased products
 ->purchased->product
-
--- that were also purchased by persons
+-- that were also purchased by persons...
 <-purchased<-person
-
 -- what are all of those persons' purchased products?
 ->purchased->product
 ```
 
-Putting it all together it would be: based on all the products Tobie purchased, which person also purchased those products and what did they purchase?
+Putting it all together it would be: based on all the products Tobie purchased, which person also purchased those products and what did they purchase? This sort of query could be used on a social network site to recommend to the user `person:tobie` a list of people that have similar interests.
 
-### Using expressions in graph queries
+### Using parentheses to refine graph query logic
 
-You can use expressions to filter relations based on specific conditions using the `WHERE` clause.
+Parentheses can be added at any step of a graph query to refine the logic, such as filtering relations based on specific conditions using the `WHERE` clause.
 
 For example, suppose we want to limit the query to only take recent purchases into account. We can filter `purchased` graph edge to only include purchases made in last 3 weeks:
 
 ```surql
 -- Select products purchased by people in the last 3 weeks who have purchased the same products that tobie purchased
-SELECT ->purchased->product<-purchased<-person->(purchased WHERE created_at > time::now() - 3w)->product FROM person:tobie;
+SELECT 
+	->purchased->product
+	<-purchased<-person->(purchased WHERE created_at > time::now() - 3w)
+	->purchased->product
+FROM person:tobie;
+```
+
+If the `purchased` graph table can lead to both a `product` or a `subscription`, they can both be added to the query.
+
+```surql
+SELECT 
+	->purchased->(product, subscription)
+	<-purchased<-person
+	->purchased->(product, subscription)
+FROM person:tobie;
+```
+
+The `?` wildcard operator can also be used to search for any and all linked records. The following query will allow purchased `product`, `subscription`, `insurance`, or any other linked records to show up.
+
+```surql
+SELECT 
+	->purchased->(?)
+	<-purchased<-person
+	->purchased->(?)
+FROM person:tobie;
 ```
 
 ### Bidirectional relation querying
 
-Sometimes a relation is such that it is impossible to determine which record is located at the `in` part of a graph table, and which is located at the `out` part. This is the case when a relationship is truly bidirectional and equal, such as a friendship, marriage, or sister cities:
+All of the queries up to now have been clear about what sort of record is found at the `in` and `out` fields: `in` is the record that is doing something, while `out` is the record that has something done to it:
+
+* A `person` who writes an `article`: the person **writes**, the article **is written**.
+* A `person` who purchases a `product`: the person **purchases**, the product **is purchased**.
+
+However, sometimes a relation is such that it is impossible to determine which record is located at the `in` part of a graph table, and which is located at the `out` part. This is the case when a relationship is truly bidirectional and equal, such as a friendship, marriage, or sister cities:
 
 ```surql
 CREATE city:calgary, city:daejeon;
 RELATE city:calgary->sister_of->city:daejeon;
-
-SELECT id, ->sister_of->city AS sister_cities FROM city;
 ```
+
+This relation could just as well have been established with the statement `RELATE city:daejeon->sister_of->city:calgary`.
 
 In such a case, a query on the relationship makes it appear as if one city has a twin city but the other does not.
 
 ```surql
+SELECT id, ->sister_of->city AS sister_cities FROM city;
+```
+
+```surql title="Response"
 [
 	{
 		id: city:calgary,
@@ -470,7 +626,7 @@ SELECT id, array::complement(<->sister_of<->city, [id]) AS sister_cities FROM ci
 ]
 ```
 
-When using `RELATE` for this sort of relationship, you may want to [define a field](/docs/surrealql/statements/define/field) as a unique key based on the ordered record IDs involved.
+Adding a unique key is a good practice for this sort of relation, as it will prevent it from being created twice. This can be done by [defining a field](/docs/surrealql/statements/define/field) as a unique key based on the ordered record IDs involved, followed by a [`DEFINE INDEX`](/docs/surrealql/statements/define/field) statement.
 
 ```surql
 DEFINE FIELD key ON TABLE sister_of VALUE <string>array::sort([in, out]);
@@ -496,7 +652,7 @@ DEFINE FIELD in ON TABLE wrote TYPE record<author>;
 DEFINE FIELD out ON TABLE wrote TYPE record<book>;
 ```
 
-But this will be ignored:
+But any attempt to outright redefine the `in` or `out` fields as a different type will be ignored.
 
 ```surql
 DEFINE FIELD in ON TABLE wrote TYPE string;
@@ -558,14 +714,14 @@ SELECT ->friends_with->cat->friends_with->cat AS friends_of_friends FROM cat:one
 However, an alias might not be preferred in a case where you have multiple graph queries that resolve to the fields of a large nested structure. Take the following data for example:
 
 ```surql
-CREATE country:usa SET name = "USA";
+CREATE country:usa        SET name = "USA";
 CREATE state:pennsylvania SET population = 12970000;
-CREATE state:michigan SET population = 10030000;
+CREATE state:michigan     SET population = 10030000;
 CREATE city:philadelphia, city:pittsburgh, city:detroit, city:grand_rapids;
 
-RELATE country:usa->contains->[state:pennsylvania, state:michigan];
+RELATE country:usa       ->contains->[state:pennsylvania, state:michigan];
 RELATE state:pennsylvania->contains->[city:philadelphia, city:pittsburgh];
-RELATE state:michigan->contains->[city:detroit, city:grand_rapids];
+RELATE state:michigan    ->contains->[city:detroit, city:grand_rapids];
 ```
 
 A query on the states and cities of these records using aliases would return the data in a structure remade to fit the aliases declared in the query.
@@ -607,6 +763,17 @@ SELECT
 FROM country:usa;
 ```
 
+If using SurrealDB versions 2.0 and above, [destructuring syntax](/docs/surrealql/datamodel/idioms#destructuring) can be used to reduce some typing. Here is the same query as the last using destructuring syntax instead of one line for each field.
+
+```surql
+SELECT
+    id,
+	-- access id and population on a single line
+    ->contains->state.{id, population},
+    ->contains->state->contains->city.id
+FROM country:usa;
+```
+
 ```surql title="Output"
 [
 	{
@@ -639,132 +806,9 @@ FROM country:usa;
 
 As the query that uses aliases does not maintain the original graph structure, adding `population` would require clever renaming such as `->contains->state.population AS state_populations` to make it clear that the numbers represent state and not city populations.
 
-### Using [`LET`](/docs/surrealql/statements/let) parameters in RELATE statements
-
-You can also use [parameters](/docs/surrealql/parameters) to specify the record IDs.
-
-```surql
--- These two statements store the result of the subquery in a parameter
--- The subquery returns an array of IDs
-LET $person = (SELECT VALUE id FROM person);
-LET $article = (SELECT VALUE id FROM article);
-
--- This statement creates a relationship record for every combination of Record IDs
--- Such that if we have 10 records each in the person and article table
--- We get 100 records in the wrote edge table (10*10 = 100)
--- In this case it would mean that each article would have 10 authors
-RELATE $person->wrote->$article SET time.written = time::now();
-```
-
-### Modifying output with the [`RETURN`](/docs/surrealql/statements/return) clause
-
-By default, the relate statement returns the record value once the changes have been made. To change the return value of each record, specify a RETURN clause, specifying either `NONE`, `BEFORE`, `AFTER`, `DIFF`, or a comma-separated list of specific fields to return.
-
-```surql
--- Don't return any result
-RELATE person:l19zjikkw1p1h9o6ixrg->wrote->article:8nkk6uj4yprt49z7y3zm
-    SET time.written = time::now()
-    RETURN NONE;
-
--- Return the changeset diff
-RELATE person:l19zjikkw1p1h9o6ixrg->wrote->article:8nkk6uj4yprt49z7y3zm
-    SET time.written = time::now()
-    RETURN DIFF;
-
--- Return the record before changes were applied
-RELATE person:l19zjikkw1p1h9o6ixrg->wrote->article:8nkk6uj4yprt49z7y3zm
-    SET time.written = time::now()
-    RETURN BEFORE;
-
--- Return the record after changes were applied (the default)
-RELATE person:l19zjikkw1p1h9o6ixrg->wrote->article:8nkk6uj4yprt49z7y3zm
-    SET time.written = time::now()
-    RETURN AFTER;
-
--- Return a specific field only from the updated records
-RELATE person:l19zjikkw1p1h9o6ixrg->wrote->article:8nkk6uj4yprt49z7y3zm
-    SET time.written = time::now()
-    RETURN time;
-```
-
-### Using the `TIMEOUT` clause
-
-Adding the `TIMEOUT` keyword to specify a timeout duration for the statement can be useful when processing a large result set with many interconnected records. If the statement continues beyond this duration, then the transaction will fail, and the statement will return an error.
-
-```surql
--- Cancel this conditional filtering based on graph edge properties
--- if it's not finished within 5 seconds
-SELECT * FROM person WHERE ->knows->person->(knows WHERE influencer = true) TIMEOUT 5s;
-
-
-```
-
-### Using the `PARALLEL` clause
-
-When processing a large result set with many interconnected records, it is possible to use the `PARALLEL` keyword to signify that edges and remote records should be fetched and processed concurrently, rather than sequentially. This can be useful when you want to process a large result set in a short amount of time.
-
-```surql
--- Fetch and process the person, purchased and product targets in parallel
--- Select every product that was purchased by a person that purchased a product that person tobie also purchased
-SELECT ->purchased->product<-purchased<-person->purchased->product FROM person:tobie PARALLEL;
-```
-
-### Deleting graph edges
-
-You can also delete graph edges between two records in the database by using the [DELETE statement](/docs/surrealql/statements/delete).
-
-For example the graph edge below:
-
-```surql
-RELATE person:tobie->bought->product:iphone;
-```
-
-```surql title="Response"
-
-[
-	{
-		id: bought:ctwsll49k37a7rmqz9rr,
-		in: person:tobie,
-		out: product:iphone
-	}
-]
-```
-
-Can be deleted by:
-
-```surql
-DELETE person:tobie->bought WHERE out=product:iphone;
-```
-
-As mentioned above, a graph edge will also automatically be deleted if it is no longer connected to a record at both `in` and `out`.
-
-```surql
--- Create three people
-CREATE person:one, person:two, person:three;
-
--- And a love triangle involving them all
-RELATE person:one->likes->person:two;
-RELATE person:two->likes->person:three;
-RELATE person:three->likes->person:one;
-
--- Person two moves to Venus permanently, so delete
-DELETE person:two;
-
--- Only one `likes` relationship is left
-SELECT * FROM likes;
-```
-
-```surql title="Output"
-[
-	{
-		id: likes:55szjin5yfqwl4sbmy1f,
-		in: person:three,
-		out: person:one
-	}
-]
-```
-
 ### Multiple graph tables vs. fields
+
+Being able to set fields on graph tables opens up a large variety of custom query methods, one of which is explored here.
 
 Imagine a database that holds detailed information on the relations between NPCs in a game that are made to be as realistic as possible. Two of the characters have a rocky past but finally a happy conclusion in which they end up married. During this period, we might have tracked their relationship by adding and removing graph edges between the two of them as they move from a stage of being friends, to dating, to hating each other, to finally ending up married.
 
@@ -830,3 +874,5 @@ With these objects, a jealous `person:two` could do a check on `person:one` to s
 ```surql
 SELECT id, ->knows[WHERE same_high_school AND has_dated.to > d'2020-12-25']->person FROM person:one;
 ```
+
+### Recursive graph queries

--- a/src/content/doc-surrealql/statements/relate.mdx
+++ b/src/content/doc-surrealql/statements/relate.mdx
@@ -8,22 +8,18 @@ import Since from '@components/shared/Since.astro'
 
 # `RELATE` statement
 
-The `RELATE` statement can be used to generate graph edges between two records in the database.
+The `RELATE` statement can be used to generate graph edges between two records in the database. This allows you to traverse related records efficiently without needing to pull data from multiple tables and merging that data together using SQL JOINs.
 
-This allows you to traverse related records efficiently without needing to pull data from multiple tables and merging that data together using SQL JOINs.
-
-Edges created using the RELATE statement are nearly identical to tables created using other statements, and can contain data.
-
-The key differences are that:
+Edges created using the RELATE statement are nearly identical to tables created using other statements, and can contain data. The key differences are that:
 
 - Edge tables are deleted once there are no existing relationships left.
 - Edge tables have two required fields `in` and `out`, which specify the directions of the relationships. These cannot be modified in schema declarations except to specify that they must be of a certain record type or to [add assertions](/docs/surrealql/statements/define/field#asserting-rules-on-fields).
 
 Otherwise, edge tables behave like normal tables in terms of [updating](/docs/surrealql/statements/update), [defining a schema](/docs/surrealql/statements/define/table) or [indexes](/docs/surrealql/statements/define/indexes).
 
-[Record links](/docs/surrealql/datamodel/records) are the alternative option when connecting data, and simply consist of a field with record IDs that serve as uni-directional links. The key differences are that graph relations
+Another option for connecting data is using [record links](/docs/surrealql/datamodel/records). Record links consist of a field with record IDs that serve as uni-directional links. The key differences are that graph relations have the following benefits over record links:
 
-- Are kept in a separate table as opposed to a field inside a record.
+- They are kept in a separate table as opposed to a field inside a record.
 - Offer bi-directional querying.
 - Offer referential integrity.
 - Allow you to store data alongside the relationship.

--- a/src/content/doc-surrealql/statements/relate.mdx
+++ b/src/content/doc-surrealql/statements/relate.mdx
@@ -42,7 +42,7 @@ RELATE [ ONLY ] @from_record -> @table -> @to_record
 ```
 
 > [!NOTE]
-> `RELATE` will create a relation regardless of whether the records to relate to exist or not. As such, it is advisable to create the records you want to relate to before using `RELATE`, or to at least ensure that they exist before making a query on the relation. If the records to relate to don't exist, a query on the relation will still work but will return an empty array. To override this behaviour and return an error if no records exist to relate, you can use a [`DEFINE TABLE`](/docs/surrealql/statements/define/table) statement that includes the `ENFORCED` keyword.
+> `RELATE` will create a relation regardless of whether the records to relate to exist or not. As such, it is advisable to [create the records](/docs/surrealql/statements/create) you want to relate to before using `RELATE`, or to at least ensure that they exist before making a query on the relation. If the records to relate to don't exist, a query on the relation will still work but will return an empty array. To override this behaviour and return an error if no records exist to relate, you can use a [`DEFINE TABLE`](/docs/surrealql/statements/define/table) statement that includes the `ENFORCED` keyword.
 
 ### Example usage
 

--- a/src/content/doc-surrealql/statements/relate.mdx
+++ b/src/content/doc-surrealql/statements/relate.mdx
@@ -267,6 +267,54 @@ UPDATE wrote SET
 ]
 ```
 
+### Passing variables in `CONTENT` and `SET`
+
+<Since v="v1.5.0" />
+
+You can also pass variables in the `CONTENT` block. This is useful when you want to pass a variable that is not a record ID.
+
+```surql
+LET $time = time::now();
+RELATE person:l19zjikkw1p1h9o6ixrg->wrote->article:8nkk6uj4yprt49z7y3zm
+    CONTENT {
+        time: {
+            written: $time
+        }
+    };
+```
+
+```surql title="Response"
+    {
+        "id": "wrote:ctwsll49k37a7rmqz9rr",
+        "in": "person:l19zjikkw1p1h9o6ixrg",
+        "out": "article:8nkk6uj4yprt49z7y3zm",
+        "time": {
+            "written": "2021-09-29T14:00:00Z"
+        }
+    }
+```
+
+Below is an example of how you can pass a variable in the `SET` block:
+
+```surql
+LET $time = time::now();
+
+RELATE person:l19zjikkw1p1h9o6ixrg->wrote->article:8nkk6uj4yprt49z7y3zm
+    SET time.written = $time;
+```
+
+```surql title="Response"
+    {
+        "id": "wrote:ctwsll49k37a7rmqz9rr",
+        "in": "person:l19zjikkw1p1h9o6ixrg",
+        "out": "article:8nkk6uj4yprt49z7y3zm",
+        "time": {
+            "written": "2021-09-29T14:00:00Z"
+        }
+    }
+```
+
+
 ### Creating a single relation with the `ONLY` keyword
 
 Using the ONLY keyword, just an object for the relation in question will be returned. This, instead of an array with a single object.


### PR DESCRIPTION
Does the following:

* Full proofreading and rewrite of RELATE to make it easier to follow and in order of increasing difficulty,
* Adds some examples to RELATE of recursive paths,
* Notes inside the idioms page that the recursive syntax is also useful for filtering the very queries that generate them.

Notes on the RELATE rewrite:

* Starts with named instead of random record IDs (e.g. person:aristotle) to make it more obvious that the 'wrote' table will get a random ID by default (and to make it easier to read the output)
* Restructures the menu on the right so that the page is clearly divided into two sections: 1 the statement, 2 graph querying. The #### levels disappear from the menu but looks cleaner in this way IMO
* Adds more output examples and examples that span multiple queries
* Notes that TIMEOUT is now quite useful because recursive queries if not careful can run on forever (friend of a friend of a friend of a friend...)
* 