### PR TITLE
Recommend profile.relase for Rust SDK

### DIFF
--- a/src/content/doc-sdk-rust/setup.mdx
+++ b/src/content/doc-sdk-rust/setup.mdx
@@ -30,6 +30,17 @@ cargo add serde --features derive
 
 The examples inside this SDK manual assume that all of these crates and features are present.
 
+To maximize performance when compiling in release mode, it is recommended to use the following profile inside `Cargo.toml`, the same as [the profile used by SurrealDB](https://github.com/surrealdb/surrealdb/blob/main/Cargo.toml#L45C1-L50C18) when building each version for release.
+
+```toml
+[profile.release]
+lto = true
+strip = true
+opt-level = 3
+panic = 'abort'
+codegen-units = 1
+```
+
 ### Start SurrealDB
 
 Before using `cargo run` to try out your code, make sure that the SurrealDB server is running by using the [`surreal start`](/docs/surrealdb/cli/start) command. The following command will start an in-memory server with a single root user at the default address `127.0.0.1:8000`.


### PR DESCRIPTION
Adds a recommendation for Rust SDK users building in release mode to use the same release profile that SurrealDB itself does.