### PR TITLE
Explain repeat recurse better

### DIFF
--- a/src/content/doc-surrealql/datamodel/idioms.mdx
+++ b/src/content/doc-surrealql/datamodel/idioms.mdx
@@ -963,9 +963,11 @@ SELECT @.{1..3}(->has->(?)) AS cities FROM planet;
 SELECT name.len()           AS length FROM planet;
 ```
 
-#### Using `@` and `{}` to combine results
+#### Using `{}` and `.@` to combine results
 
-The `@` symbol can also be used to refer to the current record when setting the structure of a recursive graph query. This allows not just the fields on the final depth of the query to be returned, but each one along the way as well.
+Inside the structure of a recursive graph query, the `@` symbol is used in the form of `.@` at the end of a path to inform the database that this is the path to be repeated during the recursion. This allows not just the fields on the final depth of the query to be returned, but each one along the way as well.
+
+Using `.@` in this way will return the fields for a depth of up to three levels.
 
 ```surql
 planet:earth
@@ -1003,7 +1005,47 @@ planet:earth
 }
 ```
 
-Using `.@` in this way will return the fields for a depth of up to three levels.
+The following two rules of thumb are a good way to understand how the syntax inside the structure of the query.
+
+* The individual fields inside a recursive query are simply populated at each point,
+* The field with `.@` is used as the gateway to the next depth.
+
+To see this visually, here is the unfolded output of the query above. The `name` and `id` fields appear at each point, while `contains` is used to move on to the next depth.
+
+```surql
+-- Original query
+planet:earth.{1..2}.{ name, id, contains: ->has->(?).@ };
+
+-- Unfolds to:
+planet:earth
+	.{
+		name, 
+		id,
+		contains: ->has->(?).{
+		  name, 
+		  id,
+		  contains: ->has->(?)
+	    }
+	};
+```
+
+Similarly, only one `.@` can be present inside such a query, as this is the path that is used to follow the recursive query until the end.
+
+```surql
+planet:earth
+	.{1..2}
+	.{
+		name, 
+		id,
+-- Query with ->has->(?) on the current record
+		contains: ->has->(?).@,
+        contains2: ->has->(?).@
+	};
+```
+
+```surql
+'Tried to use a `@` repeat recurse symbol in a position where it is not supported'
+```
 
 Here are some more simple examples of recursive queries and notes on the output they generate.
 

--- a/src/content/doc-surrealql/datamodel/idioms.mdx
+++ b/src/content/doc-surrealql/datamodel/idioms.mdx
@@ -967,8 +967,6 @@ SELECT name.len()           AS length FROM planet;
 
 Inside the structure of a recursive graph query, the `@` symbol is used in the form of `.@` at the end of a path to inform the database that this is the path to be repeated during the recursion. This allows not just the fields on the final depth of the query to be returned, but each one along the way as well.
 
-Using `.@` in this way will return the fields for a depth of up to three levels.
-
 ```surql
 planet:earth
 	.{1..2}

--- a/src/content/doc-surrealql/datamodel/idioms.mdx
+++ b/src/content/doc-surrealql/datamodel/idioms.mdx
@@ -1050,6 +1050,23 @@ planet:earth
 Here are some more simple examples of recursive queries and notes on the output they generate.
 
 ```surql
+INSERT INTO person [
+	{ id: person:tobie, name: 'Tobie', friends: [person:jaime, person:micha] },
+	{ id: person:jaime, name: 'Jaime', friends: [person:mary] },
+	{ id: person:micha, name: 'Micha', friends: [person:john] },
+	{ id: person:john, name: 'John' },
+	{ id: person:mary, name: 'Mary' },
+	{ id: person:tim, name: 'Tim' },
+];
+
+INSERT RELATION INTO knows [
+	{ id: knows:1, in: person:tobie, out: person:jaime },
+	{ id: knows:2, in: person:tobie, out: person:micha },
+	{ id: knows:3, in: person:micha, out: person:john },
+	{ id: knows:4, in: person:jaime, out: person:mary },
+	{ id: knows:5, in: person:mary, out: person:tim },
+];
+
 -- Any depth
 person:tobie.{..}(->knows->person).name;
 


### PR DESCRIPTION
The `.@` repeat recurse symbol could use some more explanation. Also adds the unfolded example that Micha provided.