### PR TITLE
refactor: Add optional VALUE statements

### DIFF
--- a/src/content/doc-surrealql/statements/create.mdx
+++ b/src/content/doc-surrealql/statements/create.mdx
@@ -21,7 +21,7 @@ CREATE [ ONLY ] @targets
 	[ CONTENT @value
 	  | SET @field = @value ...
 	]
-	[ RETURN NONE | RETURN BEFORE | RETURN AFTER | RETURN DIFF | RETURN @statement_param, ... ]
+	[ RETURN NONE | RETURN BEFORE | RETURN AFTER | RETURN DIFF | RETURN [ VALUE ] @statement_param, ... ]
 	[ TIMEOUT @duration ]
 	[ PARALLEL ]
 ;

--- a/src/content/doc-surrealql/statements/create.mdx
+++ b/src/content/doc-surrealql/statements/create.mdx
@@ -21,7 +21,7 @@ CREATE [ ONLY ] @targets
 	[ CONTENT @value
 	  | SET @field = @value ...
 	]
-	[ RETURN NONE | RETURN BEFORE | RETURN AFTER | RETURN DIFF | RETURN [ VALUE ] @statement_param, ... ]
+	[ RETURN NONE | RETURN BEFORE | RETURN AFTER | RETURN DIFF | RETURN @statement_param | RETURN VALUE @statement_param, ... ]
 	[ TIMEOUT @duration ]
 	[ PARALLEL ]
 ;

--- a/src/content/doc-surrealql/statements/create.mdx
+++ b/src/content/doc-surrealql/statements/create.mdx
@@ -21,7 +21,7 @@ CREATE [ ONLY ] @targets
 	[ CONTENT @value
 	  | SET @field = @value ...
 	]
-	[ RETURN NONE | RETURN BEFORE | RETURN AFTER | RETURN DIFF | RETURN @statement_param | RETURN VALUE @statement_param, ... ]
+	[ RETURN NONE | RETURN BEFORE | RETURN AFTER | RETURN DIFF | RETURN @statement_param, ... | RETURN VALUE @statement_param ]
 	[ TIMEOUT @duration ]
 	[ PARALLEL ]
 ;

--- a/src/content/doc-surrealql/statements/insert.mdx
+++ b/src/content/doc-surrealql/statements/insert.mdx
@@ -18,7 +18,7 @@ INSERT [ IGNORE | RELATION ] INTO @what
 	  | (@fields) VALUES (@values)
 		[ ON DUPLICATE KEY UPDATE @field = @value ... ]
 	]
-	[ RETURN NONE | RETURN BEFORE | RETURN AFTER | RETURN DIFF | RETURN [ VALUE ] @statement_param, ... ]
+	[ RETURN NONE | RETURN BEFORE | RETURN AFTER | RETURN DIFF | RETURN @statement_param | RETURN VALUE @statement_param, ... ]
 ;
 ```
 

--- a/src/content/doc-surrealql/statements/insert.mdx
+++ b/src/content/doc-surrealql/statements/insert.mdx
@@ -18,7 +18,7 @@ INSERT [ IGNORE | RELATION ] INTO @what
 	  | (@fields) VALUES (@values)
 		[ ON DUPLICATE KEY UPDATE @field = @value ... ]
 	]
-	[ RETURN NONE | RETURN BEFORE | RETURN AFTER | RETURN DIFF | RETURN @statement_param, ... ]
+	[ RETURN NONE | RETURN BEFORE | RETURN AFTER | RETURN DIFF | RETURN [ VALUE ] @statement_param, ... ]
 ;
 ```
 

--- a/src/content/doc-surrealql/statements/insert.mdx
+++ b/src/content/doc-surrealql/statements/insert.mdx
@@ -18,7 +18,7 @@ INSERT [ IGNORE | RELATION ] INTO @what
 	  | (@fields) VALUES (@values)
 		[ ON DUPLICATE KEY UPDATE @field = @value ... ]
 	]
-	[ RETURN NONE | RETURN BEFORE | RETURN AFTER | RETURN DIFF | RETURN @statement_param | RETURN VALUE @statement_param, ... ]
+	[ RETURN NONE | RETURN BEFORE | RETURN AFTER | RETURN DIFF | RETURN @statement_param, ... | RETURN VALUE @statement_param ]
 ;
 ```
 

--- a/src/content/doc-surrealql/statements/relate.mdx
+++ b/src/content/doc-surrealql/statements/relate.mdx
@@ -31,7 +31,7 @@ RELATE [ ONLY ] @from_record -> @table -> @to_record
 	[ CONTENT @value
 	  | SET @field = @value ...
 	]
-	[ RETURN NONE | RETURN BEFORE | RETURN AFTER | RETURN DIFF | RETURN [ VALUE ] @statement_param, ... ]
+	[ RETURN NONE | RETURN BEFORE | RETURN AFTER | RETURN DIFF | RETURN @statement_param | RETURN VALUE @statement_param, ... ]
 	[ TIMEOUT @duration ]
 	[ PARALLEL ]
 ;

--- a/src/content/doc-surrealql/statements/relate.mdx
+++ b/src/content/doc-surrealql/statements/relate.mdx
@@ -31,7 +31,7 @@ RELATE [ ONLY ] @from_record -> @table -> @to_record
 	[ CONTENT @value
 	  | SET @field = @value ...
 	]
-	[ RETURN NONE | RETURN BEFORE | RETURN AFTER | RETURN DIFF | RETURN @statement_param, ... ]
+	[ RETURN NONE | RETURN BEFORE | RETURN AFTER | RETURN DIFF | RETURN [ VALUE ] @statement_param, ... ]
 	[ TIMEOUT @duration ]
 	[ PARALLEL ]
 ;

--- a/src/content/doc-surrealql/statements/relate.mdx
+++ b/src/content/doc-surrealql/statements/relate.mdx
@@ -31,7 +31,7 @@ RELATE [ ONLY ] @from_record -> @table -> @to_record
 	[ CONTENT @value
 	  | SET @field = @value ...
 	]
-	[ RETURN NONE | RETURN BEFORE | RETURN AFTER | RETURN DIFF | RETURN @statement_param | RETURN VALUE @statement_param, ... ]
+	[ RETURN NONE | RETURN BEFORE | RETURN AFTER | RETURN DIFF | RETURN @statement_param, ... | RETURN VALUE @statement_param ]
 	[ TIMEOUT @duration ]
 	[ PARALLEL ]
 ;

--- a/src/content/doc-surrealql/statements/update.mdx
+++ b/src/content/doc-surrealql/statements/update.mdx
@@ -29,7 +29,7 @@ UPDATE [ ONLY ] @targets
 	  | [ SET @field = @value, ... | UNSET @field, ... ]
 	]
 	[ WHERE @condition ]
-	[ RETURN NONE | RETURN BEFORE | RETURN AFTER | RETURN DIFF | RETURN [ VALUE ] @statement_param, ... ]
+	[ RETURN NONE | RETURN BEFORE | RETURN AFTER | RETURN DIFF | RETURN @statement_param | RETURN VALUE @statement_param, ... ]
 	[ TIMEOUT @duration ]
 	[ PARALLEL ]
 ;

--- a/src/content/doc-surrealql/statements/update.mdx
+++ b/src/content/doc-surrealql/statements/update.mdx
@@ -29,7 +29,7 @@ UPDATE [ ONLY ] @targets
 	  | [ SET @field = @value, ... | UNSET @field, ... ]
 	]
 	[ WHERE @condition ]
-	[ RETURN NONE | RETURN BEFORE | RETURN AFTER | RETURN DIFF | RETURN @statement_param, ... ]
+	[ RETURN NONE | RETURN BEFORE | RETURN AFTER | RETURN DIFF | RETURN [ VALUE ] @statement_param, ... ]
 	[ TIMEOUT @duration ]
 	[ PARALLEL ]
 ;

--- a/src/content/doc-surrealql/statements/update.mdx
+++ b/src/content/doc-surrealql/statements/update.mdx
@@ -29,7 +29,7 @@ UPDATE [ ONLY ] @targets
 	  | [ SET @field = @value, ... | UNSET @field, ... ]
 	]
 	[ WHERE @condition ]
-	[ RETURN NONE | RETURN BEFORE | RETURN AFTER | RETURN DIFF | RETURN @statement_param | RETURN VALUE @statement_param, ... ]
+	[ RETURN NONE | RETURN BEFORE | RETURN AFTER | RETURN DIFF | RETURN @statement_param, ... | RETURN VALUE @statement_param ]
 	[ TIMEOUT @duration ]
 	[ PARALLEL ]
 ;

--- a/src/content/doc-surrealql/statements/upsert.mdx
+++ b/src/content/doc-surrealql/statements/upsert.mdx
@@ -28,7 +28,7 @@ UPSERT [ ONLY ] @targets
       | [ SET @field = @value, ... | UNSET @field, ... ]
     ]
     [ WHERE @condition ]
-    [ RETURN NONE | RETURN BEFORE | RETURN AFTER | RETURN DIFF | RETURN @statement_param | RETURN VALUE @statement_param, ... ]
+    [ RETURN NONE | RETURN BEFORE | RETURN AFTER | RETURN DIFF | RETURN @statement_param, ... | RETURN VALUE @statement_param ]
     [ TIMEOUT @duration ]
     [ PARALLEL ]
 ;

--- a/src/content/doc-surrealql/statements/upsert.mdx
+++ b/src/content/doc-surrealql/statements/upsert.mdx
@@ -28,7 +28,7 @@ UPSERT [ ONLY ] @targets
       | [ SET @field = @value, ... | UNSET @field, ... ]
     ]
     [ WHERE @condition ]
-    [ RETURN NONE | RETURN BEFORE | RETURN AFTER | RETURN DIFF | RETURN [ VALUE ] @statement_param, ... ]
+    [ RETURN NONE | RETURN BEFORE | RETURN AFTER | RETURN DIFF | RETURN @statement_param | RETURN VALUE @statement_param, ... ]
     [ TIMEOUT @duration ]
     [ PARALLEL ]
 ;

--- a/src/content/doc-surrealql/statements/upsert.mdx
+++ b/src/content/doc-surrealql/statements/upsert.mdx
@@ -28,7 +28,7 @@ UPSERT [ ONLY ] @targets
       | [ SET @field = @value, ... | UNSET @field, ... ]
     ]
     [ WHERE @condition ]
-    [ RETURN NONE | RETURN BEFORE | RETURN AFTER | RETURN DIFF | RETURN @statement_param, ... ]
+    [ RETURN NONE | RETURN BEFORE | RETURN AFTER | RETURN DIFF | RETURN [ VALUE ] @statement_param, ... ]
     [ TIMEOUT @duration ]
     [ PARALLEL ]
 ;


### PR DESCRIPTION
It is possible in certain `RETURN` statements to utilize the `VALUE` clause.
[Surrealist Example](https://surrealist.app/mini?query=--+Returns+object+as+default%0AUPSERT+ONLY+sequence%3Atask1+SET+%60value%60+%2B%3D+1%3B%0A%0A--+Returns+%60value%60+using+idioms%0A%28UPSERT+ONLY+sequence%3Atask1+SET+%60value%60+%2B%3D+1%29.%60value%60%3B%0A%0A--+Returns+object+of+%60value%60+using+RETURN+statement%0AUPSERT+ONLY+sequence%3Atask1+SET+%60value%60+%2B%3D+1+RETURN+%60value%60%3B%0A%0A--+Returns+%60VALUE%60+using+RETURN+statement+%28undocumented%29%0AUPSERT+ONLY+sequence%3Atask1+SET+%60value%60+%2B%3D+1+RETURN+VALUE+%60value%60%3B&orientation=horizontal&nonumbers=true)
```surql
-- Returns object as default
UPSERT ONLY sequence:task1 SET `value` += 1;

-- Returns `value` using idioms
(UPSERT ONLY sequence:task1 SET `value` += 1).`value`;

-- Returns object of `value` using RETURN statement
UPSERT ONLY sequence:task1 SET `value` += 1 RETURN `value`;

-- Returns `VALUE` using RETURN statement (undocumented)
UPSERT ONLY sequence:task1 SET `value` += 1 RETURN VALUE `value`;
```
output:
```surql
-------- Query --------
{
  id: sequence:task1,
  value: 1
}

-------- Query --------
2

-------- Query --------
{
  value: 3
}

-------- Query --------
4

```