### PR TITLE
Surreal start has nothing to do with namespace/database

### DIFF
--- a/src/content/doc-surrealdb/cli/start.mdx
+++ b/src/content/doc-surrealdb/cli/start.mdx
@@ -233,14 +233,12 @@ surreal start memory --user my_username --pass my_password
 
 The server is actively running, and should be left alone until you want to stop hosting the SurrealDB server.
 
-
 > [!NOTE]
 > The message "Started web server on 127.0.0.1:8000", indicates where the server is being hosted and must be accessed by clients. The location `127.0.0.1:8000` is the default, and can be manually changed by specifying the `--bind` option of the `surreal start` command.
 
+The `surreal start` command starts the server as a whole without regard to individual namespaces or databases.
 
-To access the SurrealDB server that you have started hosting, open a separate terminal which will act as the "client", while the previous terminal is still running the `surreal start` command described above. 
-
-In the new terminal, run the [`surreal sql` command](/docs/surrealdb/cli/sql) using the options shown below.
+To access the SurrealDB server that you have started hosting, open a new terminal which will act as the "client", while the previous terminal is still running the `surreal start` command described above. This is done using a separate [`surreal sql` command](/docs/surrealdb/cli/sql). A particular namespace and database can be specified using the `surreal sql` command, as seen below.
 
 ```bash
 surreal sql --endpoint http://127.0.0.1:8000 --namespace my_namespace --database my_database --auth-level root --username my_username --password my_password


### PR DESCRIPTION
PR to try to make it clear that surreal start doesn't take namespace or database arguments and that surreal sql is the place for that.