### PR TITLE
Documents info for root system information

### DIFF
--- a/src/content/doc-surrealql/statements/info.mdx
+++ b/src/content/doc-surrealql/statements/info.mdx
@@ -29,7 +29,10 @@ There are a number of different `INFO` commands for retrieving the configuration
 ## System  information
 
 ### Root information
-The top-level ROOT command returns information regarding the users and namespaces which exists within the SurrealDB system.
+The top-level ROOT command returns information regarding:
+- The users and namespaces which exists within the SurrealDB system.
+- The memory allocated by SurrealDB itself. Note that this may not match what the operating system reports, as it also includes memory consumed by third-party libraries or pre-allocated memory.
+- The level of parallelism: This number indicates the number of available hardware threads.
 
 > [!NOTE]
 > You must be authenticated as a top-level root user to execute this command.
@@ -45,6 +48,10 @@ INFO FOR ROOT;
     "namespaces": {
         "ns": "DEFINE NAMESPACE ns"
     },
+	"system": {
+		"memory_allocated": 57844023,
+		"parallelism": 12
+	},
     "users": {
         "example": "DEFINE USER example ON ROOT PASSHASH '$argon2id$v=19$m=19456,t=2,p=1$S8ggGUFSZY9B6+ZUJADNAw$jcFYLOrx1tq+/YlVk63QNZcP+VbsGD8lpFPvM59aZF4' ROLES OWNER"
     }


### PR DESCRIPTION
Relates to https://github.com/surrealdb/surrealdb/pull/5227 and  https://github.com/surrealdb/surrealdb/pull/5238

Here is the addition:
https://deploy-preview-1054--surrealdb-docs.netlify.app/docs/surrealql/statements/info/#root-information