### PR TITLE
doc: update CLI tool documentation for starting surreal sql interactive shell

### DIFF
--- a/src/content/doc-surrealdb/cli/index.mdx
+++ b/src/content/doc-surrealdb/cli/index.mdx
@@ -29,7 +29,7 @@ Unless you specify otherwise, the CLI will start a database in memory that serve
 In another window, you can then open up an interactive shell to make queries using the  `surreal sql` command.
 
 ```bash
-surreal sql --endpoint http://localhost:8000 --namespace ns --database db --pretty
+surreal sql --endpoint http://localhost:8000 --namespace ns --database db --auth-level root --username root --password root --pretty
 ```
 
 > [!WARNING]


### PR DESCRIPTION
While following the [getting started](https://surrealdb.com/docs/surrealdb/cli#getting-started) documentation for **CLI tool**, I ran into the following permissions related error:

```
% surreal sql --endpoint http://localhost:8000 --namespace ns --database db --pretty

#
#  Welcome to the SurrealDB SQL shell
#
#  How to use this shell:
#    - Different statements within a query should be separated by a (;) semicolon.
#    - To create a multi-line query, end your lines with a (\) backslash, and press enter.
#    - To exit, send a SIGTERM or press CTRL+C
#
#  Consult https://surrealdb.com/docs/cli/sql for further instructions
#
#  SurrealDB version: 2.1.2
#
		
ns/db> CREATE person SET age = 20;
There was a problem with the database: There was a problem with the database: IAM error: Not enough permissions to perform this action
```

Updating the surreal sql command with authentication information helps to resolve this issue:

```
% surreal sql --endpoint http://localhost:8000 --namespace ns --database db --auth-level root --username root --password root --pretty

#
#  Welcome to the SurrealDB SQL shell
#
#  How to use this shell:
#    - Different statements within a query should be separated by a (;) semicolon.
#    - To create a multi-line query, end your lines with a (\) backslash, and press enter.
#    - To exit, send a SIGTERM or press CTRL+C
#
#  Consult https://surrealdb.com/docs/cli/sql for further instructions
#
#  SurrealDB version: 2.1.2
#
		
ns/db> CREATE person SET age = 20;
-- Query 1 (execution time: 1.143319ms)
[
	{
		age: 20,
		id: person:jbm6mz7837tdc4hq51zj
	}
]

```