### PR TITLE
Clarify that :rand() is the default

### DIFF
--- a/src/content/doc-surrealql/datamodel/ids.mdx
+++ b/src/content/doc-surrealql/datamodel/ids.mdx
@@ -86,13 +86,18 @@ CREATE temperature:['London', $now] SET
 ```
 
 ### Generating Record IDs
+
 Record IDs can be generated with a number of built-in ID generation functions. These allow for record IDs to be generated using cryptographically-secure randomly-generated identifiers (which are suitable for dispersion across a distributed datastore), sequentially incrementing `ULID` Record identifiers, and `UUID` version 7 Record idenfitifiers.
 
 ```surql
 // Generate a random record ID
 // Charset: `abcdefghijklmnopqrstuvwxyz0123456789`
 // ID Length: 20 characters long
+CREATE temperature SET time = time::now(), celsius = 37.5;
+// :rand() is the default random ID format, so this
+// is identical to the above CREATE statement
 CREATE temperature:rand() SET time = time::now(), celsius = 37.5;
+
 // Generate a ULID-based record ID
 CREATE temperature:ulid() SET time = time::now(), celsius = 37.5;
 // Generate a UUIDv7-based record ID


### PR DESCRIPTION
Small clarification that :rand() is called by default so that the reader knows that `CREATE temperature` and `CREATE temperature:rand()` are identical.