### PR TITLE
GraphQL not yet available for Cloud

### DIFF
--- a/src/content/doc-cloud/faqs/index.mdx
+++ b/src/content/doc-cloud/faqs/index.mdx
@@ -59,14 +59,15 @@ You need to create a User first. Head to the [connect via SDK](/docs/cloud/conne
 
 Currently, you can not backup your data with Surreal Cloud (Beta). However, you can use the [`export` command](/docs/surrealdb/cli/export) to backup your data via the SurrealDB CLI. 
 
-
 ### What are the limits of the Surreal Cloud (Beta)?
 
-It is not currently possible to configure CLI arguments or environment variables in Surreal Cloud (Beta).
+It is not currently possible to configure [CLI](/docs/surrealdb/cli) arguments or environment variables in Surreal Cloud (Beta).
 
 Surreal Cloud (Beta) nodes run with the default [SurrealDB capabilities](/docs/surrealdb/security/capabilities) except for allowing network access to the Cloud API for the purposes of authenticating with Surrealist.
 
 Surreal Cloud (Beta) does not currently allow outgoing network requests, scripting, or guest access. All functions, RPC methods and all HTTP routes are allowed.
+
+[GraphQL support](/docs/surrealdb/querying/graphql) is not yet enabled on Surreal Cloud (Beta) instances.
 
 > [!NOTE]
 > Free Tier instances surpassing the 1GB free storage allowance will be limited to data retrieval only. Unless you upgrade to a paid tier, you will not be able to create new data.


### PR DESCRIPTION
Adds GraphQL as one of the features not yet enabled for Surreal Cloud.