### PR TITLE
Update outdated links

### DIFF
--- a/src/content/doc-surrealdb/embedding/javascript.mdx
+++ b/src/content/doc-surrealdb/embedding/javascript.mdx
@@ -23,7 +23,7 @@ import DarkLogo from "@img/icon/dark/javascript.png";
 
 SurrealDB is designed to be run in many different ways, and environments. Due to the [separation of the storage and compute](/docs/surrealdb/introduction/architecture) layers, SurrealDB can be run in embedded mode, from within your JavaScript environments. 
 
-You can embed SurrealDB in both browser and server environments. In browser environments using the [Wasm engine](/docs/sdk/javascript/engines/wasm), SurrealDB can be run as an in-memory database, or it can persist data using IndexedDB. In server environments using the [Node.js engine](/docs/sdk/javascript/engines/nodejs), SurrealDB can be run as an embedded database, backed by either an in-memory engine or [SurrealKV](/docs/surrealdb/cli/start#surrealkv-beta).
+You can embed SurrealDB in both browser and server environments. In browser environments using the [Wasm engine](/docs/sdk/javascript/engines/wasm), SurrealDB can be run as an in-memory database, or it can persist data using IndexedDB. In server environments using the [Node.js engine](/docs/sdk/javascript/engines/node), SurrealDB can be run as an embedded database, backed by either an in-memory engine or [SurrealKV](/docs/surrealdb/cli/start#surrealkv-beta).
 
 In this document, we will cover how to embed SurrealDB in both browser and server environments.
 
@@ -34,6 +34,6 @@ For more information on how to embed SurrealDB in browser environments, please s
 
 ## Server
 
-In server environments, you can use the [Node.js engine](/docs/sdk/javascript/engines/nodejs) to run SurrealDB as an embedded database. 
+In server environments, you can use the [Node.js engine](/docs/sdk/javascript/engines/node) to run SurrealDB as an embedded database. 
 
-For more information on how to embed SurrealDB in server environments, please see the [Node.js engine](/docs/sdk/javascript/engines/nodejs) documentation.
+For more information on how to embed SurrealDB in server environments, please see the [Node.js engine](/docs/sdk/javascript/engines/node) documentation.


### PR DESCRIPTION
The location of these documentation pages have changed,

Current: https://surrealdb.com/docs/sdk/javascript/engines/nodejs

Updated: https://surrealdb.com/docs/sdk/javascript/engines/node