### PR TITLE
Note that INFO currently can only be used on its own

### DIFF
--- a/src/content/doc-surrealql/statements/info.mdx
+++ b/src/content/doc-surrealql/statements/info.mdx
@@ -22,6 +22,9 @@ INFO FOR [
 
 The information returned from an `INFO` command is an object containing items that almost always correspond to a matching [DEFINE](/docs/surrealql/statements/define) statement. For example, the `INFO FOR NS` command returns the information on the access methods, databases and users of a namespace, which are defined with `DEFINE ACCESS`, `DEFINE DATABASE` and `DEFINE USER` statements.
 
+> [!NOTE]
+> The output of an `INFO FOR` command currently can only be used on its own and not in a dynamic context, such as inside other queries or as the value of a parameter.
+
 ## Example usage
 
 There are a number of different `INFO` commands for retrieving the configuration at the different levels of the database.


### PR DESCRIPTION
Add a note that INFO currently can only be used on its own, not as a parameter or in other queries.