### PR TITLE
array::fold() is useful for bulk insert

### DIFF
--- a/src/content/doc-surrealql/functions/database/array.mdx
+++ b/src/content/doc-surrealql/functions/database/array.mdx
@@ -886,6 +886,17 @@ As the output above shows, it is often nice to know which item of the array one 
 "I_don't_like_whitespace"
 ```
 
+The `array::fold()` function can be used to generate an array of values that can then be passed on to statements like [`INSERT`](/docs/surrealql/statements/insert) for bulk insertion.
+
+```surql
+INSERT INTO person (
+  -- Create 1000 objects with a random ULID
+    (<array>0..1000).fold([], |$v, $_| {
+    $v.append( { id: rand::ulid() });
+    })
+);
+```
+
 This function is also useful for aggregating the results of graph queries. The following shows a graph table called `to` that holds the distance from one city to another. The `array::fold()` function can then be used to pass an object along that tracks the first and last city, while accumulating the distance and number of trips along the way.
 
 ```surql


### PR DESCRIPTION
Extra example for array::fold() showing that it can be used to create an array of objects suitable for bulk insertion.