### PR TITLE
Example of how transactions can be used for tests

### DIFF
--- a/src/content/doc-surrealql/transactions.mdx
+++ b/src/content/doc-surrealql/transactions.mdx
@@ -130,3 +130,49 @@ SELECT * FROM account;
 ]
 ```
 
+## Using transactions to test code for errors
+
+As failed transactions automatically roll back any changes made, a transaction with a final `THROW` statement can be used as a confirmation that no errors have taken place inside a group of queries.
+
+Take the following example that creates a unique index and then inserts some records to make sure that the database logic is functioning as expected. However, as names are not necessarily unique, the index soon gives an error and cancels the transaction before `THROW` can be reached.
+
+```surql
+BEGIN TRANSACTION;
+DEFINE INDEX unique_name ON TABLE person FIELDS name UNIQUE;
+
+INSERT INTO person [
+    { name: 'Agatha Christie', born: d'1890-09-15' },
+    { name: 'Billy Billerson', born: d'1979-09-11' },
+	-- Pretend there are is 10,000 more objects here
+    { name: 'Agatha Christie', born: d'1955-05-15' },
+];
+
+THROW "Reached the end";
+COMMIT TRANSACTION;
+```
+
+The output is not the expected 'An error occurred: Reached the end' message, showing that not all queries were successful.
+
+```surql title="Output"
+"Database index `unique_name` already contains 'Agatha Christie', with record `person:qs4bpvl96sf9x40b3567`"
+```
+
+If the index is redefined to be less strict, the statetements will work and the expected output will be reached, confirming that no errors occurred during the test.
+
+```surql
+BEGIN TRANSACTION;
+DEFINE INDEX OVERWRITE unique_person ON TABLE person FIELDS name, born UNIQUE;
+
+INSERT INTO person [
+    { name: 'Agatha Christie', born: d'1890-09-15' },
+    { name: 'Billy Billerson', born: d'1979-09-11' },
+    { name: 'Agatha Christie', born: d'1955-05-15' },
+];
+
+THROW "Reached the end";
+COMMIT TRANSACTION;
+```
+
+```surql title="Expected output"
+'An error occurred: Reached the end'
+```


### PR DESCRIPTION
Adds an example of how a transaction can be used for simple testing.