### PR TITLE
Update GitHub Actions documentation

### DIFF
--- a/src/content/doc-tutorials/using-github-actions.mdx
+++ b/src/content/doc-tutorials/using-github-actions.mdx
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Git checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Start SurrealDB
       uses: surrealdb/setup-surreal@v2
       with:
@@ -182,7 +182,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Git checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Start SurrealDB
       uses: surrealdb/setup-surreal@v2
       with:

--- a/src/content/doc-tutorials/using-github-actions.mdx
+++ b/src/content/doc-tutorials/using-github-actions.mdx
@@ -23,18 +23,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Git checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v2
     - name: Start SurrealDB
-      uses: surrealdb/setup-surreal@v1
+      uses: surrealdb/setup-surreal@v2
       with:
         surrealdb_version: latest
         surrealdb_port: 8000
         surrealdb_username: root
         surrealdb_password: root
-        surrealdb_auth: true
-        surrealdb_strict: true
+        surrealdb_auth: false
+        surrealdb_strict: false
         surrealdb_log: info
         surrealdb_additional_args: --allow-all
+        surrealdb_retry_count: 30
 ```
 
 ## Step 2: Customize Workflow Arguments
@@ -62,7 +63,7 @@ The official SurrealDB GitHub Action accepts several arguments to configure the 
                 latest
             </td>
             <td scope="row" data-label="Value">
-                latest, v1.x.x
+                latest, v2.x.x
             </td>
         </tr>
         <tr>
@@ -181,23 +182,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Git checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v2
     - name: Start SurrealDB
-      uses: surrealdb/setup-surreal@v1
+      uses: surrealdb/setup-surreal@v2
       with:
         surrealdb_version: latest
         surrealdb_port: 8000
         surrealdb_username: root
         surrealdb_password: root
-        surrealdb_auth: true
-        surrealdb_strict: true
-        surrealdb_log: debug
-        surrealdb_additional_args: --strict-mode --other-arg
+        surrealdb_auth: false
+        surrealdb_strict: false
+        surrealdb_log: info
+        surrealdb_additional_args: --allow-all
+        surrealdb_retry_count: 30
 ```
 
 ### Tips for Customization
 
-1. **Version Control**: Use specific versions to avoid unexpected changes. Example: surrealdb_version: v1.0.0.
+1. **Version Control**: Use specific versions to avoid unexpected changes. Example: surrealdb_version: v2.0.0.
 2. **Security**: Always use strong passwords for surrealdb_password and avoid using default credentials in production.
 3. **Logs**: Set an appropriate log level based on your needs. For debugging, use debug or trace.
 4. **Additional Arguments**: Utilise surrealdb_additional_args to pass any additional CLI arguments required by your setup.
@@ -218,4 +220,3 @@ Go to your repository on GitHub and navigate to the "Actions" tab. You should se
 ## Conclusion
 
 Using the official GitHub Action for SurrealDB simplifies the process of setting up and running SurrealDB in your CI/CD pipeline. Customise the workflow as per your project requirements, and ensure you follow best practices for security and version control. Happy coding!
-


### PR DESCRIPTION
Our GitHub Action docs are referencing the old version of `surrealdb/setup-surreal`.

https://surrealdb.com/docs/tutorials/using-github-actions

These changes update for the current usage recommendations of version 2.

https://github.com/surrealdb/setup-surreal?tab=readme-ov-file#usage