### PR TITLE
Add note that fields are defined inside DEFINE FIELD, not DEFINE TABLE

### DIFF
--- a/src/content/doc-surrealql/statements/define/table.mdx
+++ b/src/content/doc-surrealql/statements/define/table.mdx
@@ -8,7 +8,10 @@ import Since from '@components/shared/Since.astro'
 
 # `DEFINE TABLE` statement
 
-The `DEFINE TABLE` statement allows you to declare your table by name, enabling you to apply strict controls to a table's schema by making it `SCHEMAFULL`, create a foreign table view, and set permissions specifying what operations can be performed on the field.
+The `DEFINE TABLE` statement allows you to declare your table by name, enabling you to apply strict controls to a table's schema by making it `SCHEMAFULL`, create a foreign table view, and set permissions specifying what operations can be performed on the table.
+
+> [!NOTE]
+> The fields of a table are not defined using `DEFINE FIELD`, but via individual [`DEFINE FIELD`](/docs/surrealql/statements/define/field) statements.
 
 ## Requirements
 
@@ -38,6 +41,7 @@ DEFINE TABLE [ OVERWRITE | IF NOT EXISTS ] @name
 ```
 
 ## Example usage
+
 Below shows how you can create a table using the `DEFINE TABLE` statement.
 
 ```surql

--- a/src/content/doc-surrealql/statements/define/table.mdx
+++ b/src/content/doc-surrealql/statements/define/table.mdx
@@ -11,7 +11,7 @@ import Since from '@components/shared/Since.astro'
 The `DEFINE TABLE` statement allows you to declare your table by name, enabling you to apply strict controls to a table's schema by making it `SCHEMAFULL`, create a foreign table view, and set permissions specifying what operations can be performed on the table.
 
 > [!NOTE]
-> The fields of a table are not defined using `DEFINE FIELD`, but via individual [`DEFINE FIELD`](/docs/surrealql/statements/define/field) statements.
+> The fields of a table are not defined using `DEFINE TABLE`, but via individual [`DEFINE FIELD`](/docs/surrealql/statements/define/field) statements.
 
 ## Requirements
 

--- a/src/content/doc-surrealql/statements/define/table.mdx
+++ b/src/content/doc-surrealql/statements/define/table.mdx
@@ -375,7 +375,6 @@ With `TYPE NORMAL`, you can specify a table to only store "normal" records, and 
 ```surql
 -- Since it's default, we can also omit the TYPE clause
 DEFINE TABLE person TYPE NORMAL;
-
 ```
 
 With `TYPE RELATION`, you can specify a table to only store relational type content, and restrict what kind of relations can be stored.
@@ -391,7 +390,6 @@ DEFINE TABLE likes TYPE RELATION IN user OUT post;
 -- To allow a link to one of a possible set of record types, use the | operator
 DEFINE TABLE likes TYPE RELATION FROM user TO post|video;
 DEFINE TABLE likes TYPE RELATION IN user OUT post|video;
-
 ```
 
 ```surql


### PR DESCRIPTION
Ensure that casual readers know that the fields of a table are defined in a separate statement.