### PR TITLE
Add example of type::thing to turn array of objects into records

### DIFF
--- a/src/content/doc-surrealql/functions/database/type.mdx
+++ b/src/content/doc-surrealql/functions/database/type.mdx
@@ -600,6 +600,7 @@ The `type::thing` function converts a value into a record pointer definition.
 ```surql title="API DEFINITION"
 type::thing(any, any) -> record
 ```
+
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
 ```surql
@@ -607,7 +608,43 @@ LET $tb = "person";
 LET $id = "tobie";
 RETURN type::thing($tb, $id);
 ```
-<br />
+
+An example of this function being used to turn an array of objects into records to be created or upserted:
+
+```surql
+FOR $data IN [
+	{
+		id: 9,
+		name: 'Billy'
+	},
+	{
+		id: 10,
+		name: 'Bobby'
+	}
+] {
+	UPSERT type::thing('person', $data.id) CONTENT $data;
+};
+```
+
+An example of the same except in which the `num` field is to be used as the record's ID. In this case, it can be mapped with the [`array::map()`](/docs/surrealql/functions/database/array#arraymap) function to rename `num` as `id` so that the following `CONTENT` clause does not create both a `num` and an `id` with the same value.
+
+```surql
+FOR $data IN [
+	{
+		name: 'Billy',
+		num: 9
+	},
+    {
+		name: 'Bobby',
+		num: 10
+	},
+].map(|$o| {
+    id: $o.num,
+    name: $o.name
+}) {
+    UPSERT type::thing('person', $data.id) CONTENT $data;
+};
+```
 
 ## `type::uuid`
 


### PR DESCRIPTION
Adds an example showing how type::thing can be used to turn an array of objects into records.