### PR TITLE
Change warning to note for record functions

### DIFF
--- a/src/content/doc-surrealql/functions/database/meta.mdx
+++ b/src/content/doc-surrealql/functions/database/meta.mdx
@@ -9,7 +9,7 @@ import Since from '@components/shared/Since.astro'
 
 # Meta functions
 
-> [!WARNING]
+> [!NOTE]
 > As of version 2.0, these functions are now part of SurrealDB's [record](/docs/surrealql/functions/database/record) functions.
 
 

--- a/src/content/doc-surrealql/functions/database/record.mdx
+++ b/src/content/doc-surrealql/functions/database/record.mdx
@@ -9,10 +9,8 @@ import Since from '@components/shared/Since.astro'
 
 # Record functions
 
-Record functions before SurrealDB 2.0 were located inside the module [meta](/docs/surrealql/functions/database/meta).
-
-> [!WARNING]
-> This function was known as `record::exists` in versions of SurrrealDB before 2.0. The behaviour has not changed.
+> [!NOTE]
+> Record functions before SurrealDB 2.0 were located inside the module [meta](/docs/surrealql/functions/database/meta). Their behaviour has not changed.
 
 These functions can be used to retrieve specific metadata from a SurrealDB Record ID.
 


### PR DESCRIPTION
The warnings on the top of the record functions page should be replaced with a single note that just mentions that they used to be inside the meta:: module.