### PR TITLE
rv JDK typo

### DIFF
--- a/src/content/doc-sdk-rust/index.mdx
+++ b/src/content/doc-sdk-rust/index.mdx
@@ -36,7 +36,7 @@ import DarkRocketLogo from "@img/icon/dark/rocket.png";
 The SurrealDB SDK for Rust is the primary method of interacting with SurrealDB from client-side, server-side applications, systems, APIs, embedded systems, and IOT devices. The Rust SDK has support for robust error handling and type-safe operations, using an asynchronous API for efficient concurrent database interactions. You can use the Rust SDK to interact with your SurrealDB database instances, or to run SurrealDB as an embedded database within your Rust application, with functionality for executing queries, managing data, running database functions, authenticating to the database, building user signup and authentication functionality, and subscribing to data changes with live queries.
 
 > [!IMPORTANT]
-> The SDK requires Rust JDK version `1.80.1` or greater, and is available as a [crate](https://crates.io/crates/surrealdb).
+> The SDK requires Rust version `1.80.1` or greater, and is available as a [crate](https://crates.io/crates/surrealdb).
 
 > [!NOTE]
 > The SDK works seamlessly with SurrealDB versions `v2.0.0` to <Version />, ensuring compatibility with the latest version.


### PR DESCRIPTION
Somehow the word JDK slipped in here. 1.80.1 refers to the minimum Rust version. Resolves https://github.com/surrealdb/docs.surrealdb.com/issues/1075