### PR TITLE
docs: fix typo in documentation (later -> latter)

### DIFF
--- a/src/content/doc-surrealdb/security/summary.mdx
+++ b/src/content/doc-surrealdb/security/summary.mdx
@@ -105,7 +105,7 @@ SurrealDB releases security advisories whenever a significant security issue has
 
 
 ### Software Composition Analysis
-SurrealDB includes SCA in its development process by using both the Cargo Deny binary crate for Rust code as well as Dependabot in its CI/CD pipelines. The later ensures that changes including dependencies with known vulnerabilities cannot be merged unless those vulnerabilities are explicitly acknowledged in a public file; this usually requires either updating or replacing the affected dependency. The former provides notification of emerging vulnerabilities in dependencies that are currently being used by SurrealDB so that they can be updated or replaced.
+SurrealDB includes SCA in its development process by using both the Cargo Deny binary crate for Rust code as well as Dependabot in its CI/CD pipelines. The latter ensures that changes including dependencies with known vulnerabilities cannot be merged unless those vulnerabilities are explicitly acknowledged in a public file; this usually requires either updating or replacing the affected dependency. The former provides notification of emerging vulnerabilities in dependencies that are currently being used by SurrealDB so that they can be updated or replaced.
 - [Github: Security Policy (Dependencies)](https://github.com/surrealdb/surrealdb/security/policy#dependencies)
 - [Github: Cargo Deny Configuration](https://github.com/surrealdb/surrealdb/blob/main/deny.toml)
 


### PR DESCRIPTION
This pull request fixes a minor typo in the documentation. The word "later" was incorrectly used and has been corrected to "latter" to accurately reflect the intended meaning.

**Changes Made**
Corrected "later" to "latter" in the relevant documentation section.
**Rationale**
Using "latter" aligns with the intended meaning and improves the clarity and accuracy of the documentation.