### PR TITLE
SurrealKV versioning now disabled by default

### DIFF
--- a/src/content/doc-sdk-rust/methods/new.mdx
+++ b/src/content/doc-sdk-rust/methods/new.mdx
@@ -46,6 +46,19 @@ async fn main() -> surrealdb::Result<()> {
 }
 ```
 
+To make a new connection that includes SurrealKV versioning, add the "surreal-kv" feature flag to the `surrealdb` dependency in `Cargo.toml`, add the path to the folder containing the database inside `new()`, and call the `.versioned()` method.
+
+```rust
+use surrealdb::engine::local::SurrealKv;
+use surrealdb::Surreal;
+
+#[tokio::main]
+async fn main() -> surrealdb::Result<()> {
+    let db = Surreal::new::<SurrealKv>("path/to/database-folder").versioned().await?;
+    Ok(())
+}
+```
+
 ### See also
 
 * [.new() method on Docs.rs](https://docs.rs/surrealdb/latest/surrealdb/struct.Surreal.html#method.new)

--- a/src/content/doc-surrealdb/cli/start.mdx
+++ b/src/content/doc-surrealdb/cli/start.mdx
@@ -230,7 +230,8 @@ file:// is deprecated, please use surrealkv:// or rocksdb://
                     <li>`fdb` for FoundationDB</li>
                     <li>`indxdb` for IndexedDB</li>
                     <li>`memory` (or no argument) for in-memory storage</li>
-                    <li>`surrealkv` for SurrealKV</li>
+                    <li>`surrealkv` for SurrealKV without versioning (as of SurrealDB 2.1.1)</li>
+                    <li>`surrealkv+versioned` for SurrealKV with versioning (as of SurrealDB 2.1.1)</li>
                     <li>`tikv` for TiKV</li>
                 </ul>
             </td>
@@ -296,7 +297,8 @@ Since SurrealKV supports historical/temporal querying, you can user the `VERSION
 > [!IMPORTANT]
 > Although included in SurrealDB `2.0`, the storage engine itself is considered beta, and may require additional development and testing before it is ready for production use.
 
-To start a SurrealDB instance with SurrealKV, run the following command:
+To start a SurrealDB instance with SurrealKV without versioning, run the following command:
+
 ```bash
 surreal start -u root -p root  surrealkv://mydb
 ```
@@ -312,9 +314,9 @@ Y88b  d88P Y88b 888 888     888     Y8b.     888  888 888 888  .d88P 888   d88P
  'Y8888P'   'Y88888 888     888      'Y8888  'Y888888 888 8888888P'  8888888P'
 
 
-2024-09-12T13:23:48.714786Z  INFO surreal::env: Running 2.0.0-beta.2 for macos on aarch64
-2024-09-12T13:23:48.714846Z  INFO surrealdb::core::kvs::tr: Starting kvs store at surrealkv://mydb
-2024-09-12T13:23:48.716302Z  INFO surrealdb::core::kvs::tr: Started kvs store at surrealkv://mydb
+2024-12-30T05:35:33.812436Z  INFO surreal::env: Running 2.1.4 for macos on aarch64
+2024-12-30T05:35:33.812746Z  INFO surrealdb::core::kvs::ds: Starting kvs store at surrealkv://mydb
+2024-12-30T05:35:33.825951Z  INFO surrealdb::core::kvs::ds: Started kvs store at mydb with versions disabled
 ```
 
 ### Performance characteristics and trade-offs

--- a/src/content/doc-surrealql/statements/create.mdx
+++ b/src/content/doc-surrealql/statements/create.mdx
@@ -383,7 +383,7 @@ CREATE person:26, CREATE person:27 PARALLEL;
 
 <Since v="v2.0.0" />
 
-If you are using [SurrealKV as the storage engine](/docs/surrealdb/cli/start#surrealkv-beta), when creating a record you can specify a version for each record. This is useful for time-travel queries. You can query a specific version of a record by using the `VERSION` clause.
+If you are using [SurrealKV as the storage engine](/docs/surrealdb/cli/start#surrealkv-beta) with versioning enabled, when creating a record you can specify a version for each record. This is useful for time-travel queries. You can query a specific version of a record by using the `VERSION` clause.
 
 The `VERSION` clause is always followed by a [datetime](/docs/surrealql/datamodel/datetimes) and when the specified timestamp does not exist, an empty array is returned.
 

--- a/src/content/doc-surrealql/statements/select.mdx
+++ b/src/content/doc-surrealql/statements/select.mdx
@@ -739,7 +739,7 @@ SELECT * FROM ONLY table_name LIMIT 1;
 
 <Since v="v2.0.0" />
 
-When you are starting a new database with [SurrealKV as the storage engine](/docs/surrealdb/cli/start#surrealkv-beta), you can specify a version for each record. This is useful for time-travel queries. You can query a specific version of a record by using the `VERSION` clause. The `VERSION` clause is always followed by a [datetime](/docs/surrealql/datamodel/datetimes) and when the specified timestamp does not exist, an empty array is returned.
+When you are starting a new database with [SurrealKV as the storage engine](/docs/surrealdb/cli/start#surrealkv-beta) with versioning enabled, you can specify a version for each record. This is useful for time-travel queries. You can query a specific version of a record by using the `VERSION` clause. The `VERSION` clause is always followed by a [datetime](/docs/surrealql/datamodel/datetimes) and when the specified timestamp does not exist, an empty array is returned.
 
 
 > [!NOTE]


### PR DESCRIPTION
Documentation for https://github.com/surrealdb/surrealdb/pull/5163 which since 2.1.1 has made non-versioning the default for SurrealKV.