### PR TITLE
Add example of max number of items in an array

### DIFF
--- a/src/content/doc-surrealql/statements/define/field.mdx
+++ b/src/content/doc-surrealql/statements/define/field.mdx
@@ -70,7 +70,7 @@ DEFINE FIELD user_id ON TABLE user TYPE uuid|int;
 
 ### Array type
 
-You can also set a field to have the array data type. The array data type can be used to store a list of values. You can also set the data type of the array's contents.
+You can also set a field to have the array data type. The array data type can be used to store a list of values. You can also set the data type of the array's contents, as well as the maximum number of items that it can hold.
 
 ```surql
 -- Set a field to have the array data type
@@ -81,6 +81,9 @@ DEFINE FIELD posts ON TABLE user TYPE array;
 
 -- Set a field to have the array object data type
 DEFINE FIELD emails ON TABLE user TYPE array<object>;
+
+-- Field for a block in a game showing the possible directions a character can move next
+DEFINE FIELD next_paths ON TABLE block TYPE array<"north" | "east" | "south" | "west", 4>;
 ```
 
 ### Making a field optional

--- a/src/content/doc-surrealql/statements/define/field.mdx
+++ b/src/content/doc-surrealql/statements/define/field.mdx
@@ -82,7 +82,8 @@ DEFINE FIELD posts ON TABLE user TYPE array;
 -- Set a field to have the array object data type
 DEFINE FIELD emails ON TABLE user TYPE array<object>;
 
--- Field for a block in a game showing the possible directions a character can move next
+-- Field for a block in a game showing the possible directions a character can move next.
+-- The array can contain no more than four directions
 DEFINE FIELD next_paths ON TABLE block TYPE array<"north" | "east" | "south" | "west", 4>;
 ```
 


### PR DESCRIPTION
Adds another example inside DEFINE FIELD that includes specifying the maximum number of items in an array.