### PR TITLE
Small event improvements

### DIFF
--- a/src/content/doc-surrealql/parameters.mdx
+++ b/src/content/doc-surrealql/parameters.mdx
@@ -109,7 +109,7 @@ DEFINE TABLE user SCHEMAFULL
 
 ### $event
 
-Represents the type of table event triggered on an event.
+Represents the type of table event triggered on an event. This parameter will be either "CREATE", "UPDATE", or "DELETE".
 
 ```surql
 DEFINE EVENT user_created ON TABLE user WHEN $event = "CREATE" THEN (

--- a/src/content/doc-surrealql/parameters.mdx
+++ b/src/content/doc-surrealql/parameters.mdx
@@ -109,7 +109,7 @@ DEFINE TABLE user SCHEMAFULL
 
 ### $event
 
-Represents the type of table event triggered on an event. This parameter will be either "CREATE", "UPDATE", or "DELETE".
+Represents the type of table event triggered on an event. This parameter will be one of either `"CREATE"`, `"UPDATE"`, or `"DELETE"`.
 
 ```surql
 DEFINE EVENT user_created ON TABLE user WHEN $event = "CREATE" THEN (

--- a/src/content/doc-surrealql/statements/delete.mdx
+++ b/src/content/doc-surrealql/statements/delete.mdx
@@ -173,7 +173,7 @@ DELETE person:tobie->bought WHERE out=product:iphone;
 
 While soft deletions do not exist natively in SurrealDB, they can be simulated by [defining an event](/docs/surrealql/statements/define/event) that reacts whenever a deletion occurs.
 
-The following example archives the data of a deleted record in another table so that it is
+The following example archives the data of a deleted record in another table. This can be combined with  [fewer permissions for the new table](/docs/surrealql/statements/define/table#defining-permissions) so that it can be accessed only by [system users](/docs/surrealql/statements/define/user) and not [record users](/docs/surrealql/statements/define/access/record).
 
 ```surql
 DEFINE EVENT archive_person ON TABLE person WHEN $event = "DELETE" THEN {


### PR DESCRIPTION
Two small changes:

1) Makes it clear in the parameters page that $event can be one of three values. This is already present in another page but best to make it available here too.
2) Finishes an incomplete sentence in the soft deletion section of the DELETE page which somehow got through unnoticed.