### PR TITLE
Fix navigation menu on mobile devices

### DIFF
--- a/src/components/RenderDoc.astro
+++ b/src/components/RenderDoc.astro
@@ -68,7 +68,7 @@ const breadcrumb = await generateBreadcrumb(collection, slug);
 >
     <div class="flex bg-background flex-grow justify-between">
         <div class:list={[
-            "min-w-[350px] border-r border-border bg-background flag-sidebar-container",
+            "min-w-[350px] border-r border-border bg-background flag-sidebar-container z-10",
             "max-lg:fixed max-lg:top-14 max-lg:left-0 max-lg:w-full transition-transform duration-300"
         ]}>
             <div class="sticky top-0 max-h-screen h-screen">


### PR DESCRIPTION
Code blocks were rendering on top of the navigation menu on mobile devices