### PR TITLE
New default for SURREAL_WEBSOCKET_MAX_CONCURRENT_REQUESTS

### DIFF
--- a/src/content/doc-surrealdb/cli/env.mdx
+++ b/src/content/doc-surrealdb/cli/env.mdx
@@ -180,7 +180,7 @@ Environment variables can be used to tailor the behaviour of a running SurrealDB
     </tr>
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_WEBSOCKET_MAX_CONCURRENT_REQUESTS</code></td>
-      <td scope="row" data-label="Default">24</td>
+      <td scope="row" data-label="Default">4 times the number of CPU cores, minimum 12</td>
       <td scope="row" data-label="Notes">Maximum concurrent tasks that can be handled on each WebSocket.</td>
     </tr>
     <tr>


### PR DESCRIPTION
The env var SURREAL_WEBSOCKET_MAX_CONCURRENT_REQUESTS has changed its default value: https://github.com/surrealdb/surrealdb/pull/5384