### PR TITLE
Docs: fix typos in FAQ

### DIFF
--- a/src/content/doc-cloud/faqs/index.mdx
+++ b/src/content/doc-cloud/faqs/index.mdx
@@ -80,11 +80,11 @@ Surreal Cloud does not currently allow outgoing network requests, scripting, or 
 
 ### How secure is Surreal Cloud?
 
-Surreal Cloud is designed with security in mind and aims to provide robust protection for your data and applications. As detailed within our [Security Addendum](/legal/security-addendum) The platform leverages industry-standard security practices, including encryption at rest and in transit, network isolation, access controls and monitoring. For authentication, Surreal Cloud supports multi-factor authentication through the available identity providers that offer it to their users. We are also working towards ISO 27001 and SOC 2 compliance, with plans to expand to other industry-specific compliance programs in the future, such as HIPAA or PCI DSS.
+Surreal Cloud is designed with security in mind and aims to provide robust protection for your data and applications. As detailed within our [Security Addendum](/legal/security-addendum), the platform leverages industry-standard security practices, including encryption at rest and in transit, network isolation, access controls and monitoring. For authentication, Surreal Cloud supports multi-factor authentication through the available identity providers that offer it to their users. We are also working towards ISO 27001 and SOC 2 compliance, with plans to expand to other industry-specific compliance programs in the future, such as HIPAA or PCI DSS.
 
 Additionally, Surreal Cloud is built on top of SurrealDB, which provides powerful and flexible [security features](/docs/surrealdb/security/summary#product) that are available to all Surreal Cloud customers. SurrealDB is developed and maintained following modern [security practices](/docs/surrealdb/security/summary#process) to ensure early detection of security vulnerabilities and other security issues.
 
-We are happy to discuss the security of Surreal Cloud with customers assessing usage of the service for their workloads during the beta phase. Please [Contact Us!](/pricing/contact). 
+We are happy to discuss the security of Surreal Cloud with customers assessing usage of the service for their workloads during the beta phase. Please [Contact Us.](/pricing/contact)
 
 ### How can I report a security issue in Surreal Cloud?
 


### PR DESCRIPTION
Fixing small typos in the security FAQs