### PR TITLE
Improve array::transpose + add examples

### DIFF
--- a/src/content/doc-surrealql/functions/database/array.mdx
+++ b/src/content/doc-surrealql/functions/database/array.mdx
@@ -1823,7 +1823,7 @@ RETURN array::transpose([
 
 The output shows the same blocks, but lined up top to bottom instead of left to right.
 
-```surql title="Output"
+```surql
 [
 	[
 		'🟦',

--- a/src/content/doc-surrealql/functions/database/array.mdx
+++ b/src/content/doc-surrealql/functions/database/array.mdx
@@ -224,7 +224,7 @@ These functions can be used when working with, and manipulating arrays of data.
     </tr>
     <tr>
       <td scope="row" data-label="Function"><a href="#arraytranspose"><code>array::transpose()</code></a></td>
-      <td scope="row" data-label="Description">Performs 2d array transposition on two arrays</td>
+      <td scope="row" data-label="Description">Performs 2d array transposition on arrays</td>
     </tr>
     <tr>
       <td scope="row" data-label="Function"><a href="#arrayunion"><code>array::union()</code></a></td>
@@ -1790,8 +1790,9 @@ The `array::transpose` function is used to perform 2d array transposition but it
 
 
 ```surql title="API DEFINITION"
-array::transpose(array, array) -> array<array>
+array::transpose(array<array>) -> array<array>
 ```
+
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
 ```surql
@@ -1800,7 +1801,68 @@ RETURN array::transpose([[0, 1], [2, 3]]);
 [ [0, 2], [1, 3] ]
 ```
 
-<br />
+The layering of the above example can be visualized as follows.
+
+```
+0 1
+2 3
+↓ ↓ 
+0 1   
+2 3
+```
+
+Imagining a Rubik's Cube is another easy way to conceptualize this function.
+
+```surql
+RETURN array::transpose([
+    ['🟦', '🟥', '🟩'],
+    ['⬜', '🟦', '🟨'],
+    ['🟧', '🟧', '🟥']
+]);
+```
+
+The output shows the same blocks, but lined up top to bottom instead of left to right.
+
+```surql title="Output"
+[
+	[
+		'🟦',
+		'⬜',
+		'🟧'
+	],
+	[
+		'🟥',
+		'🟦',
+		'🟧'
+	],
+	[
+		'🟩',
+		'🟨',
+		'🟥'
+	]
+]
+```
+
+Another example of the function used for the statistics of two people:
+
+```surql
+[["Name", "Age"], ["Billy", 25], ["Alice", 30]].transpose();
+```
+
+```surql title="Output"
+[
+	[
+		'Name',
+		'Billy',
+		'Alice'
+	],
+	[
+		'Age',
+		25,
+		30
+	]
+]
+```
 
 ## `array::union`
 


### PR DESCRIPTION
Corrects the signature of array::transpose and adds a few examples.