### PR TITLE
Documents INFO FOR INDEX + concurrent indexing

### DIFF
--- a/src/content/doc-surrealql/functions/database/sleep.mdx
+++ b/src/content/doc-surrealql/functions/database/sleep.mdx
@@ -90,34 +90,40 @@ INFO FOR INDEX unique_name ON TABLE user;
 
 ```surql title="Possible output"
 -------- Query 1 --------
-{
-	building: {
-		count: 0,
-		status: 'initial'
-	}
+{ 
+    building: {
+        initial: 0,
+        pending: 0,
+        status: 'indexing', 
+        updated: 0
+    }
 }
 
 -------- Query 2 --------
-{
-	building: {
-		count: 17250,
-		status: 'initial'
-	}
+{ 
+    building: {
+        initial: 100,
+        pending: 20,
+        status: 'indexing', 
+        updated: 0
+    }
 }
 
 -------- Query 3 --------
-{
-	building: {
-		count: 33542,
-		status: 'initial'
-	}
+{ 
+    building: {
+        initial: 100,
+        pending: 4,
+        status: 'indexing', 
+        updated: 16
+    }
 }
 
 -------- Query 4 --------
 {
-	building: {
-		status: 'built'
-	}
+    building: {
+        status: 'ready'
+    }
 }
 ```
 

--- a/src/content/doc-surrealql/statements/define/indexes.mdx
+++ b/src/content/doc-surrealql/statements/define/indexes.mdx
@@ -371,26 +371,24 @@ INFO FOR INDEX test ON user;
         updated: 80
     }
 }
+```
+The indexing process consists of two stages: **initial** and **update**.
 
-The indexing process consists of two stages: initial and update:
+1. **Initial Stage:**
 
-1. Initial stage:
+   During this stage, SurrealDB indexes all existing records. The number of indexed records is represented by the `initial` property. While this stage is in progress, any new inserts, updates, or deletions are tracked as `pending`.
 
-During this stage, SurrealDB indexes all existing records. The number of indexed records at this stage is represented by the `initial` property. While this stage is in progress, any new inserts, updates, or deletions that occur are tracked as `pending`.
+2. **Update Stage:**
 
-2. Update stage:
+   Once the initial stage is completed, SurrealDB begins indexing the pending records accumulated during the initial phase. At this point:
+   
+   - The `initial` count remains stable.
+   - The `pending` count should gradually decrease as these records are processed; however, it may temporarily increase if new modifications occur during indexing.
+   - The `updated` property indicates the number of pending records that have been indexed during this stage.
 
-Once the initial stage is completed, SurrealDB begins indexing the pending records accumulated during the initial phase. At this point:
-- The `initial` count remains stable
-- The `pending` count should gradually decrease as these records get indexed, but it may temporarily increase if new records are modified while indexing is still ongoing.
-- The updated property represents the number of pending records currently being processed.
+When both stages are complete, the index status changes to **ready**, meaning that the index is now automatically updated within the same transaction that inserts, updates, or deletes records.
 
-Once the initial stage is complete, the process begins indexing the pending records.
-At this point, the number of initial records remains stable, while the `pending` count should decrease as those records are processed. Note that it may still increase if new modifications occur.
-The `updated` property indicates the number of pending records that have been indexed during this stage.
-
-When both stages are completed, the index status changes to 'ready', meaning the index is now automatically updated within the same transaction that inserts, updates, or deletes records.
-
+```
 -- Query
 
 {

--- a/src/content/doc-surrealql/statements/define/indexes.mdx
+++ b/src/content/doc-surrealql/statements/define/indexes.mdx
@@ -388,7 +388,7 @@ The indexing process consists of two stages: **initial** and **update**.
 
 When both stages are complete, the index status changes to **ready**, meaning that the index is now automatically updated within the same transaction that inserts, updates, or deletes records.
 
-```
+```surql
 -- Query
 
 {

--- a/src/content/doc-surrealql/statements/define/indexes.mdx
+++ b/src/content/doc-surrealql/statements/define/indexes.mdx
@@ -349,30 +349,53 @@ Building indexes can be lengthy and may time out before they're completed. Use t
 ```surql
 -- Create an INDEX concurrently
 DEFINE INDEX test ON user FIELDS email CONCURRENTLY;
-INFO FOR INDEX test ON TABLE user;
-INFO FOR INDEX test ON TABLE user;
+INFO FOR INDEX test ON user;
+INFO FOR INDEX test ON user;
 ```
+
+When building an index concurrently, SurrealDB starts the index creation as a background process. You can monitor the status of this process using the `INFO FOR INDEX` statement. The output includes a building block that provides several key details:
 
 ```surql
 -- Check the indexing status
-INFO FOR INDEX test ON TABLE user;
+INFO FOR INDEX test ON user;
 ```
 
 ```surql title="Possible response"
 -- Query
 
-{
-	building: {
-		count: 0,
-		status: 'initial'
-	}
+{ 
+    building:  {
+        initial: 8143,
+        pending: 19,
+        status: 'indexing', 
+        updated: 80
+    }
 }
+
+The indexing process consists of two stages: initial and update:
+
+1. Initial stage:
+
+During this stage, SurrealDB indexes all existing records. The number of indexed records at this stage is represented by the `initial` property. While this stage is in progress, any new inserts, updates, or deletions that occur are tracked as `pending`.
+
+2. Update stage:
+
+Once the initial stage is completed, SurrealDB begins indexing the pending records accumulated during the initial phase. At this point:
+- The `initial` count remains stable
+- The `pending` count should gradually decrease as these records get indexed, but it may temporarily increase if new records are modified while indexing is still ongoing.
+- The updated property represents the number of pending records currently being processed.
+
+Once the initial stage is complete, the process begins indexing the pending records.
+At this point, the number of initial records remains stable, while the `pending` count should decrease as those records are processed. Note that it may still increase if new modifications occur.
+The `updated` property indicates the number of pending records that have been indexed during this stage.
+
+When both stages are completed, the index status changes to 'ready', meaning the index is now automatically updated within the same transaction that inserts, updates, or deletes records.
 
 -- Query
 
 {
 	building: {
-		status: 'built'
+		status: 'ready'
 	}
 }
 ```

--- a/src/content/doc-surrealql/statements/info.mdx
+++ b/src/content/doc-surrealql/statements/info.mdx
@@ -16,7 +16,7 @@ INFO FOR [
 	| DB | DATABASE
 	| TABLE @table
 	| USER @user [ON @level]
-    | INDEX @index ON @level
+    | INDEX @index ON @table
 ];
 ```
 
@@ -194,45 +194,51 @@ However, when the `CONCURRENTLY` clause is used, the index will build in the bac
 ```surql
 CREATE |user:50000| SET name = id.id() RETURN NONE;
 DEFINE INDEX unique_name ON TABLE user FIELDS name UNIQUE CONCURRENTLY;
-INFO FOR INDEX unique_name ON TABLE user;
+INFO FOR INDEX unique_name ON user;
 SLEEP 50ms;
-INFO FOR INDEX unique_name ON TABLE user;
+INFO FOR INDEX unique_name ON user;
 SLEEP 50ms;
-INFO FOR INDEX unique_name ON TABLE user;
+INFO FOR INDEX unique_name ON user;
 SLEEP 50ms;
-INFO FOR INDEX unique_name ON TABLE user;
+INFO FOR INDEX unique_name ON user;
 ```
 
 ```surql title="Possible output"
 -------- Query 1 --------
-{
-	building: {
-		count: 0,
-		status: 'initial'
-	}
+{ 
+    building: {
+        initial: 0,
+        pending: 0,
+        status: 'indexing', 
+        updated: 0
+    }
 }
 
 -------- Query 2 --------
-{
-	building: {
-		count: 17250,
-		status: 'initial'
-	}
+{ 
+    building: {
+        initial: 100,
+        pending: 20,
+        status: 'indexing', 
+        updated: 0
+    }
 }
 
 -------- Query 3 --------
-{
-	building: {
-		count: 33542,
-		status: 'initial'
-	}
+{ 
+    building: {
+        initial: 100,
+        pending: 4,
+        status: 'indexing', 
+        updated: 16
+    }
 }
 
 -------- Query 4 --------
 {
-	building: {
-		status: 'built'
-	}
+    building: {
+        status: 'ready'
+    }
 }
 ```
 


### PR DESCRIPTION
Improves concurrent indexing documentation.
Document the modifications done on INFO FOR INDEX on v2.2

The PR for SurrealDB:
https://github.com/surrealdb/surrealdb/pull/5482

The updated pages:
https://deploy-preview-1158--surrealdb-docs.netlify.app/docs/surrealql/statements/info/#index-information
https://deploy-preview-1158--surrealdb-docs.netlify.app/docs/surrealql/statements/define/indexes/#using-concurrently-clause
https://deploy-preview-1158--surrealdb-docs.netlify.app/docs/surrealql/functions/database/sleep/#sleep-during-parallel-operations

