### PR TITLE
Change some instances of 'relationship' to 'relation'

### DIFF
--- a/src/content/doc-surrealdb/integration/rpc.mdx
+++ b/src/content/doc-surrealdb/integration/rpc.mdx
@@ -106,7 +106,7 @@ You can use the RPC protocol to perform the following actions:
         </tr>
         <tr>
             <td scope="row" data-label="Function"><a href="#relate"><code>relate [ in, relation, out, data? ]</code></a></td>
-            <td scope="row" data-label="Description"> Create graph relationships between created records </td>
+            <td scope="row" data-label="Description"> Create graph relations between created records </td>
         </tr>
         <tr>
             <td scope="row" data-label="Function"><a href="#merge"><code>merge [ thing, data ]</code></a></td>
@@ -1547,7 +1547,7 @@ If you do not specify the `table` parameter (i.e., set it to `null` or `none`), 
 - The `id` is generated based on the `table`, `in`, and `out` fields.
 - The relation is inserted into the `friendship` table.
 
-The `insert_relation` method is a powerful way to insert new relation records into your database, allowing you to specify the relation table and include detailed data for each relation. By understanding the parameters and how the method operates, you can effectively manage relationships between records in your database.
+The `insert_relation` method is a powerful way to insert new relation records into your database, allowing you to specify the relation table and include detailed data for each relation. By understanding the parameters and how the method operates, you can effectively manage relations between records in your database.
 
 > [!NOTE]
 > This method is particularly useful in databases that support graph-like relations, enabling complex data modeling and querying capabilities.

--- a/src/content/doc-surrealdb/models/document.mdx
+++ b/src/content/doc-surrealdb/models/document.mdx
@@ -13,7 +13,7 @@ import DarkLogo from "@img/icon/dark/mongodb.png";
 
 # Using SurrealDB as a Document Database
 
-One of the most popular models of database is the document model database. It provides a flexible way to store data, allowing for nested structures and relationships to be stored within a single document.
+One of the most popular models of database is the document model database. It provides a flexible way to store data, allowing for nested structures and relation to be stored within a single document.
 
 In a document database, data is stored in the form of documents—which usually resemble JSON objects—rather than in rows and columns. 
 

--- a/src/content/doc-surrealdb/models/full-text-search.mdx
+++ b/src/content/doc-surrealdb/models/full-text-search.mdx
@@ -57,7 +57,7 @@ SurrealDB combines multi-model data storage (document, graph, vector, etc.) with
 
 ## Advantages of SurrealDB for FTS
 
-- **Unified Model**: You can keep your data, relationships, and search logic in a single engine.
+- **Unified Model**: You can keep your data, relations, and search logic in a single engine.
 - **Flexible Schema**: SurrealDB can be schemaless, so adding new fields or text columns doesn’t require schema migrations.
 - **Powerful Query Language**: SurrealQL blends SQL-like syntax with searching syntax (@@ for FTS queries, advanced indexing features, etc.).
 - **Real-Time Updates**: SurrealDB can handle real-time changes, so newly inserted or updated text becomes searchable quickly.

--- a/src/content/doc-surrealdb/models/graph.mdx
+++ b/src/content/doc-surrealdb/models/graph.mdx
@@ -12,22 +12,22 @@ import DarkLogo from "@img/icon/dark/neo4j.png";
 
 # Using SurrealDB as a Graph Database
 
-A graph database is specifically designed to store data as nodes (sometimes called vertices) and edges (relationships between nodes). With this model, connections are front and center, making it easier (and often faster) to query highly connected datasets—like social networks, supply chain relationships, recommendation engines, or fraud detection graphs.
+A graph database is specifically designed to store data as nodes (sometimes called vertices) and edges (relations between nodes). With this model, connections are front and center, making it easier (and often faster) to query highly connected datasets—like social networks, supply chain relationships, recommendation engines, or fraud detection graphs.
 
-In a graph database, we typically care about both the entities in a system and how they relate to each other. It might be a user that “follows” another user, a product that “belongs” to a category, or a web page that “links to” another page. These relationships are first-class citizens, rather than just foreign keys or nested objects. This can enable powerful, intuitive traversal-based queries that more accurately reflect real-world systems.
+In a graph database, we typically care about both the entities in a system and how they relate to each other. It might be a user that “follows” another user, a product that “belongs” to a category, or a web page that “links to” another page. These relations are first-class citizens, rather than just foreign keys or nested objects. This can enable powerful, intuitive traversal-based queries that more accurately reflect real-world systems.
 
-But how do you “think” in a graph database? Instead of focusing on how to break data into tables (relational) or embed data in documents (document model), you concentrate on expressing data as nodes and defining the edges that describe relationships. This mindset puts the connections at the core of your design: each data point is a node with properties, and edges hold properties too, representing the context or metadata about those relationships.
+But how do you “think” in a graph database? Instead of focusing on how to break data into tables (relational) or embed data in documents (document model), you concentrate on expressing data as nodes and defining the edges that describe relations. This mindset puts the connections at the core of your design: each data point is a node with properties, and edges hold properties too, representing the context or metadata about those relations.
 
 ## Core Concepts of Graph-Oriented Modeling
 In any graph database, you deal with three fundamental elements:
 
 - **Nodes (Vertices)**: Represent main entities or “things.”,  In a social network for example, nodes might be people. In a knowledge graph, nodes might be concepts. In a product recommendation engine, nodes might be items or customers.
 
-- **Edges**: Represent relationships between nodes. These could be “follows,” “buys,” “likes,” “is a friend of,” “is in category,” etc. They can be directed or undirected, and they often include properties like timestamps or weights.
+- **Edges**: Represent relations between nodes. These could be “follows,” “buys,” “likes,” “is a friend of,” “is in category,” etc. They can be directed or undirected, and they often include properties like timestamps or weights.
 
 - **Properties**: Both nodes and edges can contain key-value pairs (properties). For a user node, properties might be name or age. For a “likes” edge, a property might be strength to indicate how strong the user’s affinity is.
 
-When you think in a graph, the modeling process shifts toward identifying the main entities in your application (the nodes) and how they relate to one another (the edges). Rather than flattening these relationships into foreign keys or embedding them in nested structures, you give them explicit representation and, often, explicit properties.
+When you think in a graph, the modeling process shifts toward identifying the main entities in your application (the nodes) and how they relate to one another (the edges). Rather than flattening these relations into foreign keys or embedding them in nested structures, you give them explicit representation and, often, explicit properties.
 
 ## Modelling data as a graph
 
@@ -54,11 +54,11 @@ When designing a graph database, follow these key steps:
 
 1. Identify your entities (nodes) - These represent the core objects in your system, such as Users, Posts, Companies, and Departments.
 
-2. Map relationships (edges) between nodes - Consider how entities connect and interact. For instance, Users may "follow" other Users, "own" Departments, or Posts may "mention" Companies.
+2. Map relations (edges) between nodes - Consider how entities connect and interact. For instance, Users may "follow" other Users, "own" Departments, or Posts may "mention" Companies.
 
 3. Define properties for both nodes and edges - Nodes like User may have properties such as username, email, and createdAt. Similarly, edges like FOLLOWS can store metadata like a since timestamp.
 
-4. Optimize for critical queries - Analyze your most important traversal patterns and queries. This helps determine which relationships to model explicitly. While similar to indexing in traditional databases, graph optimization often focuses on structuring relationships to enable efficient path traversals.
+4. Optimize for critical queries - Analyze your most important traversal patterns and queries. This helps determine which relations to model explicitly. While similar to indexing in traditional databases, graph optimization often focuses on structuring relations to enable efficient path traversals.
 
 This systematic approach ensures your graph model effectively captures both the entities and their interconnections while supporting performant queries across your data.
 
@@ -68,7 +68,7 @@ This systematic approach ensures your graph model effectively captures both the 
 
 In SurrealDB, nodes are typically just records in a table—like users, posts, companies, etc. SurrealDB introduces a new statement called [`RELATE`](/docs/surrealql/statements/relate) using this three-part structure. 
 
-Using the `RELATE` statement, we can create our primary relationships based on the major actions a person using our e-commerce store would take: wish list, cart, order and review. These will serve as our edge tables.
+Using the `RELATE` statement, we can create our primary relations based on the major actions a person using our e-commerce store would take: wish list, cart, order and review. These will serve as our edge tables.
 
 ```surql
 RELATE person:01GT2ZEF2G8AC8D7H7FMZ1ZYZ3 -> wishlist:ulid() -> product:01HGAR7A0R9BETTCMATM6SSXPT;
@@ -108,7 +108,7 @@ CONTENT {
 };
 ```
 
-We can both create our `order` relationship and use it at the same time to fetch connected data from both the `product` and `person` tables. 
+We can both create our `order` relation and use it at the same time to fetch connected data from both the `product` and `person` tables. 
 
 Notice that the direction of the arrow changes based on the table we are fetching from.
 
@@ -118,7 +118,7 @@ However, the `RELATE` statement creates a bidirectional graph by default, meanin
 
 ### Querying Graph Data in SurrealDB
 
-Graph queries in SurrealDB use SurrealQL, which supports traversing relationships with special syntax. For example:
+Graph queries in SurrealDB use SurrealQL, which supports traversing relations with special syntax. For example:
 
 ```surql
 SELECT ->wrote->posts.* AS userPosts
@@ -141,7 +141,7 @@ Here, `<-wrote-.*` means “traverse any node that has a wrote edge pointing to 
 
 These are the nodes in your graph. They look like documents, but in SurrealDB you can also connect them via edges.
 
-### Creating Edges (Relationships)
+### Creating Edges (Relations)
 SurrealDB provides a special syntax to RELATE nodes:
 
 ```surql
@@ -152,11 +152,11 @@ RELATE users:alice->wrote->posts:helloworld CONTENT {
 Here’s what’s happening:
 
 - users:alice is the user node you’re referencing (assuming SurrealDB recognized or assigned alice as the record’s ID).
-- ->wrote-> is the name of the relationship (edge) that indicates the direction and type of connection.
+- ->wrote-> is the name of the relation (edge) that indicates the direction and type of connection.
 - posts:helloworld is the post node you’re connecting to.
 - CONTENT `{ ... }` defines properties on this edge, such as created_at.
 
-This single statement creates an edge from the alice user node to the helloworld post node, labeling the relationship as wrote. The edge can store its own properties just like a node.
+This single statement creates an edge from the alice user node to the helloworld post node, labeling the relation as `wrote`. The edge can store its own properties just like a node.
 
 ## Using Neo4j as a reference
 

--- a/src/content/doc-surrealdb/models/vector.mdx
+++ b/src/content/doc-surrealdb/models/vector.mdx
@@ -9,7 +9,7 @@ description: In this guide, you will
 
 A vector database is specialized for storing these high-dimensional vectors and for efficiently performing queries such as nearest neighbor search or similarity search. Rather than searching on exact values or text-based queries, vector databases let you search based on semantic similarity. For instance, in a text embedding scenario, you can find documents that are semantically similar to a given query, even if they do not share the same keywords.
 
-But how do you “think” in a vector database? Unlike relational or document models, where the focus is on well-defined schemas and relationships, vector databases revolve around embeddings—numerical representations of objects (like text, images, audio snippets, etc.) in a continuous vector space. You have to design data structures and queries to exploit these embeddings for similarity search or AI-driven retrieval.
+But how do you “think” in a vector database? Unlike relational or document models, where the focus is on well-defined schemas and relations, vector databases revolve around embeddings—numerical representations of objects (like text, images, audio snippets, etc.) in a continuous vector space. You have to design data structures and queries to exploit these embeddings for similarity search or AI-driven retrieval.
 
 In this guide, you’ll learn about the basics of vector databases, how they differ from other data models, and how SurrealDB—a multi-model database—can store and query vector data alongside documents, graphs, and more.
 
@@ -44,7 +44,7 @@ The most common operation is to find the k-nearest neighbors of a query vector. 
 Some queries combine classical filters (e.g., a user’s location or a date range) with vector similarity. This means you might need a system that can do both vector-based filtering and typical attribute-based queries, ideally in one seamless environment.
 
 ## SurrealDB as a Vector Database
-Although SurrealDB is commonly discussed for its multi-model capabilities—supporting documents, tables, and graph relationships—it also has the ability to store and index vectors. This makes SurrealDB a powerful “one-stop shop” if you need:
+Although SurrealDB is commonly discussed for its multi-model capabilities—supporting documents, tables, and graph relations—it also has the ability to store and index vectors. This makes SurrealDB a powerful “one-stop shop” if you need:
 
 - Document/graph capabilities for typical data interactions, plus
 - Vector search to power semantic queries, AI recommendations, or advanced content retrieval.

--- a/src/content/doc-surrealdb/querying/surrealql/index.mdx
+++ b/src/content/doc-surrealdb/querying/surrealql/index.mdx
@@ -45,7 +45,7 @@ SurrealQL offers several key features that make it a powerful tool for working w
 
 - **Data Manipulation**: With SurrealQL, you can easily insert, update, and delete records in your SurrealDB database, allowing you to manage your data effectively.
 
-- **Graph relationships**: SurrealQL supports graph relationships, allowing you to define and query relationships between records in your database.
+- **Graph relations**: SurrealQL supports graph relations, allowing you to define and query relations between records in your database.
 
 - **Schema Management**: SurrealQL provides features for creating and modifying database schemas, allowing you to define the structure of your data and enforce data integrity.
 

--- a/src/content/doc-surrealist/concepts/designing-the-database-schema.mdx
+++ b/src/content/doc-surrealist/concepts/designing-the-database-schema.mdx
@@ -9,7 +9,7 @@ import ImageDesigner from "@img/image/surrealist/designer.png";
 
 # Designing the database schema
 
-The Designer view allows you to graphically visualise, design, and modify your database schema in real time. This view can speed up the creation of tables, indexes, fields, and more. Additionally it will plot your current schema into a diagram representation to  view the structure of your database and relationships between its tables.
+The Designer view allows you to graphically visualise, design, and modify your database schema in real time. This view can speed up the creation of tables, indexes, fields, and more. Additionally it will plot your current schema into a diagram representation to  view the structure of your database and relations between its tables.
 
 
 <Image

--- a/src/content/doc-surrealist/concepts/explore-database-records.mdx
+++ b/src/content/doc-surrealist/concepts/explore-database-records.mdx
@@ -28,7 +28,7 @@ As the name implies, the tables panel will list out all tables in the database. 
 
 ### Record explorer panel
 
-After selecting a table in the tables panel, the records in this table are listed out here, grouped into navigable pages. You can press any record to open it in the inspector panel where you can view and edit record contents and view its relationships.
+After selecting a table in the tables panel, the records in this table are listed out here, grouped into navigable pages. You can press any record to open it in the inspector panel where you can view and edit record contents and view its relations.
 
 Pressing the ▼ button in the top right of this panel expands an input in which you can enter a [WHERE](/docs/surrealql/statements/select#filter-queries-using-the-where-clause) clause to filter down the displayed records on certain conditions.
 
@@ -36,4 +36,4 @@ Additionally, the + button can be used to manually create new records in the cur
 
 ### Inspector panel
 
-The inspector panel, although available globally, is mostly used in the Explorer view to view and edit the contents of a record. You can also use the inspector to view and follow the relationships of a record, as well as delete records.
+The inspector panel, although available globally, is mostly used in the Explorer view to view and edit the contents of a record. You can also use the inspector to view and follow the relations of a record, as well as delete records.

--- a/src/content/doc-surrealql/datamodel/idioms.mdx
+++ b/src/content/doc-surrealql/datamodel/idioms.mdx
@@ -21,7 +21,7 @@ An idiom is made up of one or more **parts**, each of which can be one of severa
 - [**Last**](#last-element): Access the last element of an array.
 - [**Where**](#where-filter): Filter elements based on a condition.
 - [**Method**](#method-chaining): Call a method on the current data.
-- [**Graph**](#graph-navigation): Navigate through graph relationships.
+- [**Graph**](#graph-navigation): Navigate through graph relations.
 - [**Destructure**](#destructuring): Destructure nested objects.
 - [**Optional**](#optional-parts): Indicate that the following part is optional.
 - [**Recurse**](#recursive-paths): Recursively traverse paths such as graph and record links.
@@ -398,7 +398,7 @@ To learn more about string method chaining in SurrealQL, see the [string functio
 
 ## Graph Navigation
 
-SurrealDB can also be used in the context of graph databases, where data is stored and navigated using graph traversal idioms. The [`RELATE` statement](/docs/surrealql/statements/relate) is used to create relationships between records. This allows you to traverse related records efficiently without needing to pull data from multiple tables and merging that data together using SQL JOINs.
+SurrealDB can also be used in the context of graph databases, where data is stored and navigated using graph traversal idioms. The [`RELATE` statement](/docs/surrealql/statements/relate) is used to create relations between records. This allows you to traverse related records efficiently without needing to pull data from multiple tables and merging that data together using SQL JOINs.
 
 
 For example, let's consider the following data:
@@ -415,7 +415,7 @@ RELATE explorer:local_guide->assisted->explorer:drake;
 
 ```
 
-```surql title="Retrieve all relationships from Drake"
+```surql title="Retrieve all relations from Drake"
 SELECT 
     *,
     ->? AS actions,
@@ -448,9 +448,9 @@ FROM explorer:drake;
 Explanation:
 
 - `*`: Selects all fields of `explorer:drake`.
-- `->? AS actions`: Retrieves all outgoing relationships from Drake and aliases them as actions.
-- `<-? AS was`: Retrieves all incoming relationships to Drake and aliases them as was.
-- `<->? AS involved_in`: Retrieves all relationships connected to Drake, regardless of direction, and aliases them as involved_in.
+- `->? AS actions`: Retrieves all outgoing relations from Drake and aliases them as actions.
+- `<-? AS was`: Retrieves all incoming relations to Drake and aliases them as was.
+- `<->? AS involved_in`: Retrieves all relations connected to Drake, regardless of direction, and aliases them as involved_in.
 
 
 ## Destructuring
@@ -822,6 +822,17 @@ SELECT
 	->has->country->has->(province, state) AS state_provinces,
 	-- Or use (?) to show any type of record located at `out`
 	->has->(?)->has->(?)->has->(?) AS cities
+FROM planet:earth;
+```
+
+```surql
+SELECT 
+	-- Show all `country` records located at `out`
+	->has->country AS countries,
+	-- Show all `province` or `state` records located at `out`	
+	->has->country->has->(province, state) AS state_provinces,
+	-- Or use ? to show any type of record located at `out`
+	->has->?->has->?->has->? AS cities
 FROM planet:earth;
 ```
 
@@ -1542,4 +1553,4 @@ SELECT friends[WHERE age > 18].name FROM person WHERE id = r'person:5';
 
 # Summary
 
-Idioms in SurrealQL are a powerful tool for navigating and manipulating data within your database. By understanding and effectively using idiom parts, you can write expressive and efficient queries that handle complex data structures with ease. Whether you're accessing nested fields, filtering arrays, or traversing graph relationships, idioms provide the flexibility you need to interact with your data seamlessly.
+Idioms in SurrealQL are a powerful tool for navigating and manipulating data within your database. By understanding and effectively using idiom parts, you can write expressive and efficient queries that handle complex data structures with ease. Whether you're accessing nested fields, filtering arrays, or traversing graph relations, idioms provide the flexibility you need to interact with your data seamlessly.

--- a/src/content/doc-surrealql/datamodel/records.mdx
+++ b/src/content/doc-surrealql/datamodel/records.mdx
@@ -90,7 +90,7 @@ SELECT friends.friends.friends.name FROM person:tobie;
 
 In SurrealDB, embedding record links within records is a powerful feature allowing efficient querying and data retrieval. However, it also has a drawback: When an embedded record is deleted or changed, the parent record will not automatically reflect that change. This leads to stale references or “NONE” entries that can accumulate over time.
 
-For referential integrity between records, we recommend using the [`RELATE`](/docs/surrealql/statements/relate) statement to create relationships that automatically update when the referenced record is deleted or changed.
+For referential integrity between records, we recommend using the [`RELATE`](/docs/surrealql/statements/relate) statement to create relations that automatically update when the referenced record is deleted or changed.
 
 ## Next steps
 

--- a/src/content/doc-surrealql/demo.mdx
+++ b/src/content/doc-surrealql/demo.mdx
@@ -23,7 +23,7 @@ To quickly test out SurrealDB and SurrealQL functionality, we've included two de
 Surreal Deal Store is our new and improved demo dataset based on our [SurrealDB Store](https://surrealdb.store/).
 The dataset is made up of 12 tables using both [graph relations](/docs/surrealql/statements/relate) and [record links](/docs/surrealql/datamodel/records).
 
-In the diagram below, the nodes in pink are the [standard tables](/docs/surrealql/statements/define/table), the ones in purple represent the [edge tables](/docs/surrealql/statements/relate) which shows relationships between records and SurrealDB as a graph database. While the nodes in gray are the [pre-computed table views](/docs/surrealql/statements/define/table).
+In the diagram below, the nodes in pink are the [standard tables](/docs/surrealql/statements/define/table), the ones in purple represent the [edge tables](/docs/surrealql/statements/relate) which shows relations between records and SurrealDB as a graph database. While the nodes in gray are the [pre-computed table views](/docs/surrealql/statements/define/table).
 
 <Image
   alt="Surreal Deal Data Model"

--- a/src/content/doc-surrealql/index.mdx
+++ b/src/content/doc-surrealql/index.mdx
@@ -38,7 +38,7 @@ SurrealQL offers several key features that make it a powerful tool for working w
 
 - **Data Manipulation**: With SurrealQL, you can easily insert, update, and delete records in your SurrealDB database, allowing you to manage your data effectively.
 
-- **Graph relationships**: SurrealQL supports graph relationships, allowing you to define and query relationships between records in your database.
+- **Graph relations**: SurrealQL supports graph relations, allowing you to define and query relations between records in your database.
 
 - **Schema Management**: SurrealQL provides features for creating and modifying database schemas, allowing you to define the structure of your data and enforce data integrity.
 

--- a/src/content/doc-surrealql/statements/create.mdx
+++ b/src/content/doc-surrealql/statements/create.mdx
@@ -12,7 +12,7 @@ import Since from '@components/shared/Since.astro'
 The `CREATE` statement can be used to add a record to the database. If the record already exists, the statement will give an error.
 
 > [!NOTE]
-> This statement can not be used to create graph relationships. For that, use the [`RELATE`](/docs/surrealql/statements/relate) statement.
+> This statement can not be used to create graph relations. For that, use the [`RELATE`](/docs/surrealql/statements/relate) statement.
 
 ### Statement syntax
 

--- a/src/content/doc-surrealql/statements/define/event.mdx
+++ b/src/content/doc-surrealql/statements/define/event.mdx
@@ -99,7 +99,7 @@ SELECT * FROM log ORDER BY at ASC;
 
 ### More Complex Logic:
 
--  **Purchase Event with Multiple Actions**: Log a purchase and establish relationships between the customer and product.
+-  **Purchase Event with Multiple Actions**: Log a purchase and establish relations between the customer and product.
 
 ```surql
 DEFINE EVENT purchase_made ON TABLE purchase
@@ -123,7 +123,7 @@ DEFINE EVENT purchase_made ON TABLE purchase
 ```
 
 In this example:
-- We perform multiple actions when a purchase is created: establishing relationships using the [RELATE](/docs/surrealql/statements/relate) statement and creating a log entry.
+- We perform multiple actions when a purchase is created: establishing relations using the [RELATE](/docs/surrealql/statements/relate) statement and creating a log entry.
 
 ## Specific events
 

--- a/src/content/doc-surrealql/statements/insert.mdx
+++ b/src/content/doc-surrealql/statements/insert.mdx
@@ -223,7 +223,7 @@ INSERT INTO person [
 
 The `INSERT` statement can also be used to add records into relation tables. The `@what` part of the syntax can be either a single object or an array of objects.
 
-Learn more about creating relationships between tables in the [RELATE](/docs/surrealql/statements/relate) statement. For example:
+Learn more about creating relations between tables in the [RELATE](/docs/surrealql/statements/relate) statement. For example:
 
 ```surql
 -- Insert records into the person table

--- a/src/content/doc-surrealql/statements/relate.mdx
+++ b/src/content/doc-surrealql/statements/relate.mdx
@@ -12,15 +12,15 @@ The `RELATE` statement can be used to generate graph edges between two records i
 
 Edges created using the RELATE statement are nearly identical to tables created using other statements, and can contain data. The key differences are that:
 
-- Edge tables are deleted once there are no existing relationships left.
-- Edge tables have two required fields `in` and `out`, which specify the directions of the relationships. These cannot be modified in schema declarations except to specify that they must be of a certain record type or to [add assertions](/docs/surrealql/statements/define/field#asserting-rules-on-fields).
+- Edge tables are deleted once there are no existing relations left.
+- Edge tables have two required fields `in` and `out`, which specify the directions of the relations. These cannot be modified in schema declarations except to specify that they must be of a certain record type or to [add assertions](/docs/surrealql/statements/define/field#asserting-rules-on-fields).
 
 Otherwise, edge tables behave like normal tables in terms of [updating](/docs/surrealql/statements/update), [defining a schema](/docs/surrealql/statements/define/table) or [indexes](/docs/surrealql/statements/define/indexes).
 
 Another option for connecting data is using [record links](/docs/surrealql/datamodel/records). Record links consist of a field with record IDs that serve as unidirectional links by default, or bidirectional links if reference tracking is used. The key differences are that graph relations have the following benefits over record links:
 
 - Graph relations are kept in a separate table as opposed to a field inside a record.
-- Graph relations allow you to store data alongside the relationship.
+- Graph relations allow you to store data alongside the relation.
 - Graph relations have their own syntax that makes it easy to build and visualize edge queries.
 
 Graph relations offer built-in bidirectional querying and referential integrity. As of SurrealDB 2.2.0, record links also offer these two advantages if they are defined inside a [`DEFINE FIELD`](/docs/surrealql/statements/define/field) statement using the `REFERENCES` clause. For more information, see [the page on record references](/docs/surrealql/datamodel/references).
@@ -45,7 +45,7 @@ RELATE [ ONLY ] @from_record -> @table -> @to_record
 
 #### Basic usage
 
-The following query shows the basic structure of the `RELATE` statement, which creates a relationship between a record in the `person` table and a record in the `article` table.
+The following query shows the basic structure of the `RELATE` statement, which creates a relation between a record in the `person` table and a record in the `article` table.
 
 ```surql
 CREATE person:aristotle, article:on_sleep_and_sleeplessness;
@@ -62,7 +62,7 @@ RELATE person:aristotle->wrote->article:on_sleep_and_sleeplessness;
 ]
 ```
 
-There is no relationship information stored in either the `person` or `article` table.
+There is no relation information stored in either the `person` or `article` table.
 
 ```surql
 SELECT * FROM person, article;
@@ -79,7 +79,7 @@ SELECT * FROM person, article;
 ]
 ```
 
-Instead, an edge table (in this case a table called `wrote`) stores the relationship information.
+Instead, an edge table (in this case a table called `wrote`) stores the relation information.
 
 ```surql
 SELECT * FROM wrote;
@@ -132,10 +132,10 @@ RETURN person:aristotle->wrote->article;
 
 By default, the edge table gets created as a schemaless table when you execute the `RELATE` statement. You can make the table schemafull by [defining a schema](/docs/surrealql/statements/define/table).
 
-A common use case is to make sure only unique relationships get created. You can do that by [defining an index](/docs/surrealql/statements/define/indexes).
+A common use case is to make sure only unique relations get created. You can do that by [defining an index](/docs/surrealql/statements/define/indexes).
 
 ```surql
-DEFINE INDEX unique_relationships
+DEFINE INDEX unique_relations
     ON TABLE wrote
     COLUMNS in, out UNIQUE;
 ```
@@ -146,7 +146,7 @@ As edge tables are bidirectional by default, there is nothing stopping a query l
 RELATE article:on_sleep_and_sleeplessness->wrote->person:aristotle;
 ```
 
-To enforce unidirectional relationships, you can restrict the type definition using a [`DEFINE FIELD`](/docs/surrealql/statements/define/field) definition.
+To enforce unidirectional relations, you can restrict the type definition using a [`DEFINE FIELD`](/docs/surrealql/statements/define/field) definition.
 
 ```surql
 DEFINE FIELD in  ON TABLE wrote TYPE record<person>;
@@ -342,7 +342,7 @@ You can also use [parameters](/docs/surrealql/parameters) to specify the record 
 LET $person =  (SELECT VALUE id FROM person);
 LET $article = (SELECT VALUE id FROM article);
 
--- This statement creates a relationship record for every combination of Record IDs
+-- This statement creates a relation record for every combination of Record IDs
 -- Such that if we have 10 records each in the person and article table
 -- We get 100 records in the wrote edge table (10*10 = 100)
 -- In this case it would mean that each article would have 10 authors
@@ -448,7 +448,7 @@ RELATE person:three->likes->person:one;
 -- Person two moves to Venus permanently, so delete
 DELETE person:two;
 
--- Only one `likes` relationship is left
+-- Only one `likes` relation is left
 SELECT * FROM likes;
 ```
 
@@ -847,7 +847,7 @@ RELATE city:calgary->sister_of->city:daejeon;
 
 This relation could just as well have been established with the statement `RELATE city:daejeon->sister_of->city:calgary`.
 
-In such a case, a query on the relationship makes it appear as if one city has a twin city but the other does not.
+In such a case, a query on the relation makes it appear as if one city has a twin city but the other does not.
 
 ```surql
 SELECT id, ->sister_of->city AS sister_cities FROM city;
@@ -1129,7 +1129,7 @@ RELATE person:one->knows->person:three SET
     has_dated = true;
 ```
 
-With these fields in place, it is possible to use a `WHERE` clause to do refined searches on relationships of a certain type.
+With these fields in place, it is possible to use a `WHERE` clause to do refined searches on relations of a certain type.
 
 ```surql
 SELECT 
@@ -1183,7 +1183,7 @@ RELATE person:one->knows->person:three SET
 	};
 ```
 
-With these objects, a jealous `person:two` could do a check on `person:one` to see how many relationships with `has_dated` have an end time that overlaps with the `has_dated` period of `person:one` and `person:two`.
+With these objects, a jealous `person:two` could do a check on `person:one` to see how many relations with `has_dated` have an end time that overlaps with the `has_dated` period of `person:one` and `person:two`.
 
 ```surql
 SELECT id, ->knows[WHERE same_high_school AND has_dated.to > d'2020-12-25']->person FROM person:one;

--- a/src/content/doc-surrealql/statements/update.mdx
+++ b/src/content/doc-surrealql/statements/update.mdx
@@ -13,7 +13,7 @@ import TabItem from "@components/Tabs/TabItem.astro";
 The `UPDATE` statement can be used to update existing records in the database. If the record does not exist, the statement will succeed but no records will be updated.
 
 > [!NOTE]
-> This statement can not be used to create graph relationships. For that, use the [`RELATE`](/docs/surrealql/statements/relate) or [`INSERT`](/docs/surrealql/statements/insert) statement.
+> This statement can not be used to create graph relations. For that, use the [`RELATE`](/docs/surrealql/statements/relate) or [`INSERT`](/docs/surrealql/statements/insert) statement.
 
 > [!NOTE]
 > UPDATE on a single record in SurrealDB 1.x will create the record if it does not exist. This behaviour is no longer the case in SurrealDB 2.0. To update and create a record if it does not exist in SurrealDB 2.0, use the [`UPSERT`](/docs/surrealql/statements/upsert) statement.

--- a/src/content/doc-tutorials/define-a-schema.mdx
+++ b/src/content/doc-tutorials/define-a-schema.mdx
@@ -12,7 +12,7 @@ When starting a new database project, there are a couple of early decisions to b
 
 While this might look like many decisions, you are Defining a Schema.
 
-A Schema defines the structure and organisation of data. It dictates how data is stored, organised, and manipulated. Schemas can specify tables, fields (columns), data types, constraints, and relationships between tables.
+A Schema defines the structure and organisation of data. It dictates how data is stored, organised, and manipulated. Schemas can specify tables, fields (columns), data types, constraints, and relations between tables.
 
 In summary, a schema is the primary way to ensure your data acts as expected.
 

--- a/src/content/doc-tutorials/working-with-surrealdb-over-http-via-postman.mdx
+++ b/src/content/doc-tutorials/working-with-surrealdb-over-http-via-postman.mdx
@@ -9,7 +9,7 @@ description: In this tutorial, you will learn how to query the SurrealDB RESTful
 
 SurrealDB provides a RESTful HTTP API for interacting with the database. 
 
-In this tutorial, you will learn how to query SurrealDB endpoints via the [Postman collection](https://postman.com/surrealdb/workspace/surrealdb/collection/19100500-3da237f3-588b-4252-8882-6d487c11116a). SurrealDB supports requests via HTTP & Rest with which you can handle different queries from creating simple tables to having Graph relationships between complex tables.
+In this tutorial, you will learn how to query SurrealDB endpoints via the [Postman collection](https://postman.com/surrealdb/workspace/surrealdb/collection/19100500-3da237f3-588b-4252-8882-6d487c11116a). SurrealDB supports requests via HTTP & Rest with which you can handle different queries from creating simple tables to having Graph relations between complex tables.
 
 Check out the [HTTP & Rest integration documentation](/docs/surrealdb/integration/http) for a detailed list of all the endpoints supported.
 


### PR DESCRIPTION
This is a bit of a tricky subject as relation and relationship can often be used interchangeably, but for the most part when talking about a graph relation we use the word relation, and the official terms like "insert_relation" in the SDKs do the same. The -ship suffix makes nouns about the state of being of a thing, rather than the thing itself, so that can be a bit of a guiding light when choosing between one and the other.

This PR changes relationship to relation when it refers to the link itself, leaving 'relationship' alone when it refers to the quality of a relation ("This is the case when a relationship is truly bidirectional and equal...") or in set terms like "Customer Relationship Management" that have nothing to do with SurrealQL.