### PR TITLE
DOC-343: show search bar mobile

### DIFF
--- a/src/components/Search.astro
+++ b/src/components/Search.astro
@@ -23,6 +23,10 @@ import { Icon } from 'astro-icon/components';
         }
     }
 
+	search-dialog :global(.search-shortcut) {
+		@apply max-md:hidden;
+	}
+
     search-dialog :global(.docs-search-message) {
         @apply w-full h-full flex items-center justify-center text-lg text-text/50;
     }

--- a/src/components/Sidebar/index.astro
+++ b/src/components/Sidebar/index.astro
@@ -207,7 +207,7 @@ const doc = metadata[collection];
 					</div>
 				</div>
             </Dropdown>
-			<div class="lg:hidden">
+			<div class="md:hidden">
 				<Search />
 			</div>
         </div>

--- a/src/components/Sidebar/index.astro
+++ b/src/components/Sidebar/index.astro
@@ -52,6 +52,7 @@ import LightWasm from '@img/icon/light/webassembly.png';
 import LightBook from '@img/icon/light/book-light.png';
 import LightSidekick from '@img/icon/light/sidekick-light.png';
 import LightUniversity from '@img/icon/light/university-light.png';
+import Search from '../Search.astro';
 
 type Props = {
     items: TSidebarItem[];
@@ -206,6 +207,9 @@ const doc = metadata[collection];
 					</div>
 				</div>
             </Dropdown>
+			<div class="lg:hidden">
+				<Search />
+			</div>
         </div>
     )}
     <div class="overflow-y-auto flex-grow pb-8">

--- a/src/components/layout/BaseLayout.astro
+++ b/src/components/layout/BaseLayout.astro
@@ -83,8 +83,8 @@ const url = new URL(
         <slot />
         <!-- <Footer bgMonochrome={footerBgMonochrome} /> -->
         <style>
-            body:has(#nav-mobile-menu:checked) {
-                @apply max-lg:overflow-hidden;
+            body:has(#sidebar-toggle:checked) {
+                @apply !overflow-hidden;
             }
 
             :global(a) {


### PR DESCRIPTION
- Able to show the searchbar on smaller devices. It would be displayed in the sidebar under the dropdown menu.
- Small fix where you could scroll entire page when sidebar was opened.