### PR TITLE
Fix query syntax in SurrealQL DEFINE TABLE statement page

### DIFF
--- a/src/content/doc-surrealql/statements/define/table.mdx
+++ b/src/content/doc-surrealql/statements/define/table.mdx
@@ -73,7 +73,7 @@ CREATE reading SET story = "there was a database";
 
 -- Replay changes to the reading table since a certain date
 -- Must be after the timestamp at which the changefeed began
-SHOW CHANGES FOR TABLE reading SINCE u"2023-09-07T01:23:52Z" LIMIT 10;
+SHOW CHANGES FOR TABLE reading SINCE d"2023-09-07T01:23:52Z" LIMIT 10;
 
 -- Alternatively, show the changes for the table since a version number
 SHOW CHANGES FOR TABLE reading SINCE 0 LIMIT 10;


### PR DESCRIPTION
In the SurrealQL documentation page for the DEFINE TABLE statement, one of the query examples has a literal date value created using `u"2023-09-07T01:23:52Z"`, which is the syntax for a literal UUID value.

This commit changes this to `d"2023-09-07T01:23:52Z"`, using the syntax for a literal date value.