### PR TITLE
Fix SurrealQL `record::refs()` function typos

### DIFF
--- a/src/content/doc-surrealql/functions/database/record.mdx
+++ b/src/content/doc-surrealql/functions/database/record.mdx
@@ -35,8 +35,8 @@ These functions can be used to retrieve specific metadata from a SurrealDB Recor
       <td scope="row" data-label="Description">Extracts and returns the table name from a SurrealDB Record ID</td>
     </tr>
     <tr>
-      <td scope="row" data-label="Function"><a href="#recordtb"><code>record::refs()</code></a></td>
-      <td scope="row" data-label="Description">Extracts and returns the table name from a SurrealDB Record ID</td>
+      <td scope="row" data-label="Function"><a href="#recordrefs"><code>record::refs()</code></a></td>
+      <td scope="row" data-label="Description">Extracts and returns the record IDs of any records that have a record link along with a `REFERENCES` clause</td>
     </tr>
   </tbody>
 </table>

--- a/src/content/doc-surrealql/functions/database/record.mdx
+++ b/src/content/doc-surrealql/functions/database/record.mdx
@@ -87,6 +87,23 @@ RETURN record::id(person:tobie);
 "tobie"
 ```
 
+## `record::tb`
+
+The `record::tb` function extracts and returns the table name from a SurrealDB Record ID.
+
+```surql title="API DEFINITION"
+record::tb(record) -> string
+```
+The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
+
+```surql
+RETURN record::tb(person:tobie);
+
+"person"
+```
+
+<br /><br />
+
 ## `record::refs`
 
 <Since v="v2.2.0" />
@@ -185,25 +202,6 @@ person:two.refs('dog', 'acquaintances');
 	dog:mr_bark
 ]
 ```
-
-## `record::tb`
-
-The `record::tb` function extracts and returns the table name from a SurrealDB Record ID.
-
-```surql title="API DEFINITION"
-record::tb(record) -> string
-```
-The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
-
-```surql
-RETURN record::tb(person:tobie);
-
-"person"
-```
-
-<br /><br />
-
-
 
 ## Method chaining
 


### PR DESCRIPTION
On the documentation page for the SurrealQL record function module, the function `record::refs()` is listed with the description and hyperlink of the `record::tb()` function.

This commit updates the `record::refs()` function with the correct definition and hyperlink.