### PR TITLE
Fix typos in SurrealDB Docs

### DIFF
--- a/src/content/doc-surrealdb/deployment/amazon.mdx
+++ b/src/content/doc-surrealdb/deployment/amazon.mdx
@@ -34,12 +34,12 @@ This deployment guide covers setting up a highly available SurrealDB cluster bac
 - AWS CLI [installed](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) and [configured](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html) with your user's credentials
 - [`eksctl`](https://eksctl.io/installation/) installed
 
-> [!NOTE: COST CONSIDERATIONS ]
->Provisioning the environment in your AWS account will create resources and there will be cost associated with them. The cleanup section provides a guide to remove them, preventing further charges.
+> [!NOTE: COST CONSIDERATIONS]
+> Provisioning the environment in your AWS account will create resources and there will be cost associated with them. The cleanup section provides a guide to remove them, preventing further charges.
 
 
 > [!IMPORTANT]
-> This guide was tested in eu-west-1 (Ireland region) and it follows TiKV best practices for scalability and high availability. It will provision up to 12 Amazon Elastic Compute Cloud (Amazon EC2) instances, several Amazon Elastic Block Storage (Amazon EBS) drives, and up to three Amazon Elastic Loadbalancers (Amazon ELB). The forecasted cost to run this guide is of $5 USD per hour.
+> This guide was tested in `eu-west-1` (Ireland region) and it follows TiKV best practices for scalability and high availability. It will provision up to 12 Amazon Elastic Compute Cloud (Amazon EC2) instances, several Amazon Elastic Block Storage (Amazon EBS) drives, and up to three Amazon Elastic Loadbalancers (Amazon ELB). The forecasted cost to run this guide is $5 USD per hour.
 
 ## Building an EKS Cluster
 This section outlines how to build a cluster by using the [`eksctl`](https://eksctl.io/) tool. The following is the configuration that will be used to build the cluster:
@@ -243,7 +243,7 @@ curl -O https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-cont
 
 aws iam create-policy \
     --policy-name AWSLoadBalancerControllerIAMPolicy \
-    --policy-document rocksdb://iam_policy.json
+    --policy-document file://iam_policy.json
 
 eksctl create iamserviceaccount \
   --cluster=$CLUSTER_NAME \

--- a/src/content/doc-surrealdb/deployment/azure.mdx
+++ b/src/content/doc-surrealdb/deployment/azure.mdx
@@ -288,9 +288,9 @@ sdb-datastore-tikv-2                       1/1     Running   0          3m12s
 Now that we have a TiDB cluster running, we can deploy SurrealDB using the official Helm chart.
 The deploy will use the latest SurrealDB Docker image and make it accessible on internet.
 
-1. Get the TiKV PD service url:
+1. Get the TiKV PD service URL:
 
-```bash title="Get TiKV PD service url"
+```bash title="Get TiKV PD service URL"
 $ kubectl get service sdb-datastore-pd
 
 NAME               TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)    AGE

--- a/src/content/doc-surrealdb/deployment/azure.mdx
+++ b/src/content/doc-surrealdb/deployment/azure.mdx
@@ -288,9 +288,9 @@ sdb-datastore-tikv-2                       1/1     Running   0          3m12s
 Now that we have a TiDB cluster running, we can deploy SurrealDB using the official Helm chart.
 The deploy will use the latest SurrealDB Docker image and make it accessible on internet.
 
-1. Get the TIKV PD service url:
+1. Get the TiKV PD service url:
 
-```bash title="Get TIKV PD service url"
+```bash title="Get TiKV PD service url"
 $ kubectl get service sdb-datastore-pd
 
 NAME               TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)    AGE

--- a/src/content/doc-surrealdb/deployment/fly.mdx
+++ b/src/content/doc-surrealdb/deployment/fly.mdx
@@ -45,7 +45,7 @@ EXPOSE 8080
 CMD ["start", "--bind", "0.0.0.0:8080", "file://data/srdb.db"]
 ```
 
->[!IMPORTANT]
+> [!IMPORTANT]
 > The `file://` prefix for starting SurrealDB will be deprecated in the next major release, we advise to please use `surrealkv://` or `rocksdb://` as a storage engine
 
 ## Generate fly.toml

--- a/src/content/doc-surrealdb/deployment/google.mdx
+++ b/src/content/doc-surrealdb/deployment/google.mdx
@@ -21,11 +21,11 @@ import DarkLogo from "@img/icon/dark/google.png";
 
 # Deploy on Google Kubernetes Engine (GKE)
 
-This article will guide you through the process of setting up a highly available SurrealDB clutter backed by TIKV on a GKE Autopilot cluster.
+This article will guide you through the process of setting up a highly available SurrealDB cluster backed by TiKV on a GKE Autopilot cluster.
 
 ## What is GKE?
 
-[Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine) is a managed Kubernetes service offered by Google Cloud Platform. In this guide we will create a [GKE Autopilot](https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-overview) cluster, which removes the need to manage the underlaying compute nodes.
+[Google Kubernetes Engine](https://cloud.google.com/kubernetes-engine) is a managed Kubernetes service offered by Google Cloud Platform. In this guide we will create a [GKE Autopilot](https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-overview) cluster, which removes the need to manage the underlying compute nodes.
 
 ## What is TiKV?
 [TiKV](https://tikv.org/) is a cloud-native transactional key/value store built by PingCAP and that integrates well with Kubernetes thanks to their tidb-operator.
@@ -199,9 +199,9 @@ Now that we have a TiDB cluster running, we can deploy SurrealDB using the offic
 
 The deploy will use the latest SurrealDB Docker image and make it accessible on internet
 
-1. Get the TIKV PD service url:
+1. Get the TiKV PD service url:
 
-```bash title="Get TIKV PD service url"
+```bash title="Get TiKV PD service url"
 kubectl get svc/sdb-datastore-pd
 NAME       TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)    AGE
 sdb-datastore-pd   ClusterIP   10.96.208.25   <none>        2379/TCP   10h

--- a/src/content/doc-surrealdb/deployment/google.mdx
+++ b/src/content/doc-surrealdb/deployment/google.mdx
@@ -199,9 +199,9 @@ Now that we have a TiDB cluster running, we can deploy SurrealDB using the offic
 
 The deploy will use the latest SurrealDB Docker image and make it accessible on internet
 
-1. Get the TiKV PD service url:
+1. Get the TiKV PD service URL:
 
-```bash title="Get TiKV PD service url"
+```bash title="Get TiKV PD service URL"
 kubectl get svc/sdb-datastore-pd
 NAME       TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)    AGE
 sdb-datastore-pd   ClusterIP   10.96.208.25   <none>        2379/TCP   10h

--- a/src/content/doc-surrealdb/deployment/kubernetes.mdx
+++ b/src/content/doc-surrealdb/deployment/kubernetes.mdx
@@ -159,7 +159,7 @@ For this guide, we will use the SurrealDB Helm chart. Run the following commands
 helm repo add surrealdb https://helm.surrealdb.com
 helm repo update
 ```
-### 2. Get the TiKV PD service url:
+### 2. Get the TiKV PD service URL:
 
 ```bash title="Get TiKV PD service URL"
 kubectl get -n tikv svc/basic-pd

--- a/src/content/doc-surrealdb/deployment/kubernetes.mdx
+++ b/src/content/doc-surrealdb/deployment/kubernetes.mdx
@@ -29,10 +29,10 @@ At the end, we will run a few experiments using SurrealQL to verify that we can 
 
 For this guide, we need to install:
 
-- [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/) : To manage the Kubernetes cluster
-- [`helm`](https://helm.sh/docs/intro/install/) : To install SurrealDB server and TiKV
-- [`KIND`](https://kind.sigs.k8s.io/) and [Docker](https://www.docker.com/) :To run a local Kubernetes cluster inside a Docker container
-- [`Surreal CLI`](/install) : To interact with the SurrealDB server
+- [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/): To manage the Kubernetes cluster
+- [`helm`](https://helm.sh/docs/intro/install/): To install SurrealDB server and TiKV
+- [`KIND`](https://kind.sigs.k8s.io/) and [Docker](https://www.docker.com/): To run a local Kubernetes cluster inside a Docker container
+- [`Surreal CLI`](/install): To interact with the SurrealDB server
 
 ## Create `KIND` Cluster
 
@@ -42,7 +42,7 @@ Run the following command to create a cluster:
 
 ### 1. Let’s create a new cluster:
 
-```bash title="Crete new cluster"
+```bash title="Create new cluster"
 kind create cluster -n surreal-demo
 ```
 
@@ -159,9 +159,9 @@ For this guide, we will use the SurrealDB Helm chart. Run the following commands
 helm repo add surrealdb https://helm.surrealdb.com
 helm repo update
 ```
-### 2. Get the TIKV PD service url:
+### 2. Get the TiKV PD service url:
 
-```bash title="Get TIKV PD service URL"
+```bash title="Get TiKV PD service URL"
 kubectl get -n tikv svc/basic-pd
 ```
 the output of this command should look like this:
@@ -187,8 +187,11 @@ helm install --set surrealdb.path=$TIKV_URL --set surrealdb.unauthenticated=true
 ```bash
 surreal sql -e http://...
 > DEFINE USER root ON ROOT PASSWORD 'StrongSecretPassword!' ROLES OWNER;
+```
 
 Verify you can connect to the database with the new credentials:
+
+```bash
 surreal sql -u root -p 'StrongSecretPassword!' -e http://...
 > INFO FOR ROOT
 [{ namespaces: { }, users: { root: "DEFINE USER root ON ROOT PASSHASH '...' ROLES OWNER" } }]
@@ -276,9 +279,9 @@ ns/db>
 ```
 
 > [!NOTE]
-> Given we are using KIND, we use  `port-forwarding`  for demonstration purposes.
-> In a full-featured Kubernetes cluster, you could set  `ingress.enabled=true`  when installing the SurrealDB Helm Chart and it would create a Load Balancer in front of the SurrealDB server pods.
+> Given we are using KIND, we use `port-forwarding` for demonstration purposes.
+> In a full-featured Kubernetes cluster, you could set `ingress.enabled=true` when installing the SurrealDB Helm Chart and it would create a Load Balancer in front of the SurrealDB server pods.
 
 
 ## Conclusion
-This guide demonstrated how to deploy SurrealDB on Kubernetes using TiKV as a datastore. From here, you could try and deploy to [`EKS`](https://aws.amazon.com/eks/) , [`GKE`](https://cloud.google.com/kubernetes-engine) or [`AKS`](https://azure.microsoft.com/en-us/products/kubernetes-service) , and play with the different configurations for the TiKV cluster.
+This guide demonstrated how to deploy SurrealDB on Kubernetes using TiKV as a datastore. From here, you could try and deploy to [`EKS`](https://aws.amazon.com/eks/), [`GKE`](https://cloud.google.com/kubernetes-engine) or [`AKS`](https://azure.microsoft.com/en-us/products/kubernetes-service), and play with the different configurations for the TiKV cluster.

--- a/src/content/doc-surrealdb/faqs/index.mdx
+++ b/src/content/doc-surrealdb/faqs/index.mdx
@@ -23,8 +23,11 @@ You can also check some of our new features for <Version />:
 
 ## How do I scale SurrealDB?
 
-SurrealDB can be scaled vertically on a single-node, by adding more compute power and memory to a server instance. SurrealDB can also be scaled horizontally by sitting infront of, and connecting to a [TiKV](https://tikv.org/) to store data. TiKV is a highly scalable, low latency, and easy to use key-value datastore. TiKV supports raw and transaction-based querying with ACID compliance, and support for multiple concurrent readers and writers. The design of TiKV is inspired by distributed systems from Google, such as BigTable, Spanner, and Percolator, and some of the latest achievements in academia in recent years, such as the Raft consensus algorithm.
-, or [FoundationDB](https://www.foundationdb.org/) distributed cluster. When running in this mode, SurrealDB offloads the storage to the key-value store, operating as an advanced query engine layer. It is then possible to increase the number of SurrealDB nodes as required, in order to handle the query and transaction processing requirements.
+SurrealDB can be scaled vertically on a single node by adding more compute power and memory to a server instance.
+
+SurrealDB can also be scaled horizontally by sitting in front of and connecting to a [TiKV](https://tikv.org/) to store data. TiKV is a highly scalable, low latency, and easy to use key-value datastore. TiKV supports raw and transaction-based querying with ACID compliance, and support for multiple concurrent readers and writers. The design of TiKV is inspired by distributed systems from Google, such as BigTable, Spanner, and Percolator, and some of the latest achievements in academia in recent years, such as the Raft consensus algorithm.
+
+When running in [FoundationDB](https://www.foundationdb.org/) distributed cluster mode, SurrealDB offloads the storage to the key-value store, operating as an advanced query engine layer. It is then possible to increase the number of SurrealDB nodes as required, in order to handle the query and transaction processing requirements.
 
 ## What is the license for SurrealDB?
 

--- a/src/content/doc-surrealdb/introduction/architecture.mdx
+++ b/src/content/doc-surrealdb/introduction/architecture.mdx
@@ -15,7 +15,7 @@ This page aims to give details about some of the core architecture choices of Su
 
 ## Query layer
 
-The SurrealDB query layer (otherwise known as the compute layer) handles queries from the client, analysing which records need to be selected, created, updated, or deleted. To begin with, the query engine runs the SurrealQL query through a `parser`, returning a parsed query definition. The parsed query is then run through the `executor` which breaks up each statement within the query, managing those transactions which should be run within the same transaction. Next, each statement is run through the `iterator` which determines which data should be fetched from the key-value storage engine, and handles index query planning, grouping, ordering, and limiting. Finally, each record is passed through the `document` processor, processing permissions, and determining which data is merged, altered, and stored on disk.
+The SurrealDB query layer (otherwise known as the compute layer) handles queries from the client, analyzing which records need to be selected, created, updated, or deleted. To begin with, the query engine runs the SurrealQL query through a `parser`, returning a parsed query definition. The parsed query is then run through the `executor` which breaks up each statement within the query, managing those transactions which should be run within the same transaction. Next, each statement is run through the `iterator` which determines which data should be fetched from the key-value storage engine, and handles index query planning, grouping, ordering, and limiting. Finally, each record is passed through the `document` processor, processing permissions, and determining which data is merged, altered, and stored on disk.
 
 ## Storage layer
 
@@ -35,7 +35,7 @@ When running in a web browser, SurrealDB can be configured to use [IndexedDB](ht
 
 ## Deployment architecture with TiKV or FoundationDB
 
-When you have deployed an HA cluster (High Availability), you will have a deployment that resembles the following configuration
+When you have deployed an HA cluster (High Availability), you will have a deployment that resembles the following configuration:
 
 <Image
     alt="Storage_Cluster"
@@ -45,9 +45,9 @@ When you have deployed an HA cluster (High Availability), you will have a deploy
     }}
 />
 
-The HA deployment of your storage layer (TiKV, or FoundationDB) is the stateful part of the system.
+The HA deployment of your storage layer (TiKV or FoundationDB) is the stateful part of the system.
 The rules governing the availability guarantees are covered in the documentation of those systems.
 SurrealDB clusters do not have state at the time of writing.
 Any necessary communication is either avoided by design, or communicated via the storage layer which maintains consistency.
-This makes deploying SurrealDB really convenient, since your fault tolerance is equal to the number of replicas (minus 1, the bare minum number of instances).
+This makes deploying SurrealDB really convenient, since your fault tolerance is equal to the number of replicas (minus 1, the bare minimum number of instances).
 Even though we do have bootstrapping, by design nodes can come and go as they please without much interference.

--- a/src/content/doc-surrealdb/reference-guide/vector-search.mdx
+++ b/src/content/doc-surrealdb/reference-guide/vector-search.mdx
@@ -17,7 +17,7 @@ import DarkDistanceMetrics from "@img/image/dark/distance-metrics.png";
 
 # Vector Search
 
-SurrealDB supports [Full-Text Search](/docs/surrealdb/reference-guide/full-text-search) and Vector Search. Full-Text search(FTS) involves indexing documents using the [FTS index](/docs/surrealql/statements/define/indexes#full-text-search-index) and breaking down the content of the document into smaller tokens with the help of [analysers](/docs/surrealql/statements/define/analyzer) and [tokenizers](/docs/surrealql/statements/define/analyzer#tokenizers).
+SurrealDB supports [Full-Text Search](/docs/surrealdb/reference-guide/full-text-search) and Vector Search. Full-Text search(FTS) involves indexing documents using the [FTS index](/docs/surrealql/statements/define/indexes#full-text-search-index) and breaking down the content of the document into smaller tokens with the help of [analyzers](/docs/surrealql/statements/define/analyzer) and [tokenizers](/docs/surrealql/statements/define/analyzer#tokenizers).
 
 Vector Search in SurrealDB is introduced to support efficient and accurate searching of high-dimensional data. This guide will walk you through the essentials of working with vectors in SurrealDB, from storing vectors in embeddings to performing computations and optimizing searches with various indexing strategies.
 


### PR DESCRIPTION
- Fixed typos in “underlying”, “create”, “cluster”, and “minimum”
- More consistent spelling of “TiKV” (with the lowercase “i”)
- More consistent spelling of “analyzer” (US English spelling prevails throughout the rest of the docs)
- More consistent spelling of “URL” in deployment docs
- Changed IAM policy document path to `file://`
- Some punctuation and whitespace fixes
- Tried to reconstruct the missing text in “How do I scale SurrealDB?” FAQ section about FoundationDB