### PR TITLE
Redo syntax for ORDER BY

### DIFF
--- a/src/content/doc-surrealql/statements/select.mdx
+++ b/src/content/doc-surrealql/statements/select.mdx
@@ -21,15 +21,10 @@ SELECT
 	FROM [ ONLY ] @targets
 	[ WITH [ NOINDEX | INDEX @indexes ... ]]
 	[ WHERE @conditions ]
-	[ SPLIT [ ON ] @field ... ]
-	[ GROUP [ BY ] @fields ... ]
-	[ ORDER [ BY ]
-		@fields [
-			RAND()
-			| COLLATE
-			| NUMERIC
-		] [ ASC | DESC ] ...
-	]
+	[ SPLIT [ ON ] @field, ... ]
+	[ GROUP [ BY ] @field, ... ]
+	[ ORDER [ BY ] @field, ... [ COLLATE ] [ NUMERIC ] | RAND() ]
+	[ ASC | DESC ]
 	[ LIMIT [ BY ] @limit ]
 	[ START [ AT ] @start ]
 	[ FETCH @fields ... ]


### PR DESCRIPTION
The syntax for ORDER BY seems to be as follows:

- Choose one or more fields to order by, then add COLLATE if wished, also add NUMERIC if wished. Or:
- Choose RAND().