### PR TITLE
Add example of custom message for ASSERT

### DIFF
--- a/src/content/doc-surrealql/statements/define/field.mdx
+++ b/src/content/doc-surrealql/statements/define/field.mdx
@@ -319,13 +319,30 @@ DEFINE FIELD email ON TABLE user TYPE string
 
 You can take your field definitions even further by using asserts. Assert can be used to ensure that your data remains consistent. For example you can use asserts to ensure that a field is always a valid email address, or that a number is always positive.
 
-### Email is required
-
 ```surql
 -- Give the user table an email field. Store it in a string
 DEFINE FIELD email ON TABLE user TYPE string
   -- Check if the value is a properly formatted email address
   ASSERT string::is::email($value);
+```
+
+As the `ASSERT` clause expects an expression that returns a boolean, an assertion with a custom message can be manually created by returning `true` in one case and using a [`THROW`](/docs/surrealql/statements/throw) clause otherwise.
+
+```surql
+DEFINE FIELD num ON data TYPE int ASSERT {
+    IF $input % 2 = 0 {
+        RETURN true
+    } ELSE {
+        THROW "Tried to make a " + <string>$this + " but `num` field requires an even number"
+    }
+};
+
+CREATE data SET num = 11;
+```
+
+```surql title="Error output"
+'An error occurred: Tried to make a { id: data:syoz25pra8hc0af980tu, num: 11 }
+but `num` field requires an even number'
 ```
 
 ### Making a field `READONLY`


### PR DESCRIPTION
Since ASSERT expects a bool, users can manually implement it too by returning true in certain cases and using THROW to return a custom message too.