### PR TITLE
Improve string join docs

### DIFF
--- a/src/content/doc-surrealql/functions/database/string.mdx
+++ b/src/content/doc-surrealql/functions/database/string.mdx
@@ -306,6 +306,7 @@ true
 ## `string::join`
 
 The `string::join` function joins strings together with a delimiter.
+If you want to join an array of strings use [`array::join`](docs/surrealql/functions/database/array#arrayjoin).
 
 ```surql title="API DEFINITION"
 string::join(string, string...) -> string


### PR DESCRIPTION
If you want to join an array of strings, it can be confusing where to go, so added link to `array::join` to the `string::join` docs.