### PR TITLE
Array sort natural lexical

### DIFF
--- a/src/content/doc-surrealql/clauses/order_by.mdx
+++ b/src/content/doc-surrealql/clauses/order_by.mdx
@@ -16,13 +16,10 @@ It is also worth noting that `COLLATE` ignores unicode order. e.g. 'á' comes af
 ## Syntax
 
 ```syntax title="Clause Syntax"
-[ ORDER [ BY ]
-		@fields [
-			RAND()
-			| COLLATE
-			| NUMERIC
-		] [ ASC | DESC ] ...
-	]
+[ ORDER [ BY ] 
+	@field [ COLLATE ] [ NUMERIC ] [ ASC | DESC ], ...
+	| RAND() ]
+]
 ```
 
 ## Examples
@@ -43,9 +40,12 @@ SELECT * FROM <table> ORDER BY <field> DESC;
 -- Order records by multiple fields independently
 SELECT * FROM <table> ORDER BY <field> ASC, <field2> DESC;
 
--- Order text fields with Unicode collation
+-- Order text fields with lexical collation instead of Unicode order
 SELECT * FROM <table> ORDER BY <field> COLLATE ASC;
 
 -- Order text fields with which include numeric values
 SELECT * FROM <table> ORDER BY <field> NUMERIC ASC;
+
+-- COLLATE and NUMERIC can be used together
+SELECT * FROM <table> ORDER BY <field> COLLATE NUMERIC ASC;
 ```

--- a/src/content/doc-surrealql/functions/database/array.mdx
+++ b/src/content/doc-surrealql/functions/database/array.mdx
@@ -1715,7 +1715,8 @@ RETURN array::sort([1, 2, 1, null, "something", 3, 3, 4, 0], "desc");
 
 ## `array::sort_lexical`
 
-<Since v="v2.2.2" />
+> [!NOTE]
+> Only available in nightly, will be available in the next release. 
 
 The `array::sort_natural_lexical` function sorts the values in an array in ascending or descending order, with alphabetical strings sorted in lexical order instead of unicode list order.
 
@@ -1753,7 +1754,8 @@ The following example shows that `array::sort_lexical` will sort strings in lexi
 
 ## `array::sort_natural`
 
-<Since v="v2.2.2" />
+> [!NOTE]
+> Only available in nightly, will be available in the next release. 
 
 The `array::sort_natural` function sorts the values in an array in ascending or descending order, with numeric strings sorted in numeric order instead of regular string order.
 
@@ -1793,7 +1795,8 @@ Note that strings sorted in numeric order will still appear after actual numbers
 
 ## `array::sort_natural_lexical`
 
-<Since v="v2.2.2" />
+> [!NOTE]
+> Only available in nightly, will be available in the next release. 
 
 
 The `array::sort_natural_lexical` function sorts the values in an array in ascending or descending order, while sorting numeric strings in numeric order and alphabetical strings in lexical order.

--- a/src/content/doc-surrealql/functions/database/array.mdx
+++ b/src/content/doc-surrealql/functions/database/array.mdx
@@ -213,6 +213,18 @@ These functions can be used when working with, and manipulating arrays of data.
       <td scope="row" data-label="Description">Sorts the values in an array in ascending or descending order</td>
     </tr>
     <tr>
+      <td scope="row" data-label="Function"><a href="#arraysort_lexical"><code>array::sort_lexical()</code></a></td>
+      <td scope="row" data-label="Description">Sorts the values in an array, with strings sorted lexically</td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Function"><a href="#arraysort_natural"><code>array::sort_natural()</code></a></td>
+      <td scope="row" data-label="Description">Sorts the values in an array, with numeric strings sorted numerically</td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Function"><a href="#arraysort_natural_lexical"><code>array::sort_natural_lexical()</code></a></td>
+      <td scope="row" data-label="Description">Sorts the values in an array, applying both natural numeric and lexical ordering to strings</td>
+    </tr>
+    <tr>
       <td scope="row" data-label="Function"><a href="#arraysortasc"><code>array::sort::asc()</code></a></td>
       <td scope="row" data-label="Description">Sorts the values in an array in ascending order</td>
     </tr>
@@ -1701,7 +1713,120 @@ RETURN array::sort([1, 2, 1, null, "something", 3, 3, 4, 0], "desc");
 [ "something", 4, 3, 3, 2, 1, 1, 9, null ]
 ```
 
-<br />
+## `array::sort_lexical`
+
+<Since v="v2.2.2" />
+
+The `array::sort_natural_lexical` function sorts the values in an array in ascending or descending order, with alphabetical strings sorted in lexical order instead of unicode list order.
+
+```surql title="API DEFINITION"
+array::sort_lexical(array) -> array
+```
+
+The function also accepts a second boolean parameter which determines the sorting direction. The second parameter can be `true` for ascending order, or `false` for descending order.
+
+```surql title="API DEFINITION"
+array::sort_lexical(array, bool) -> array
+```
+The function also accepts a second string parameter which determines the sorting direction. The second parameter can be `'asc'` for ascending order, or `'desc'` for descending order.
+
+```surql title="API DEFINITION"
+array::sort_lexical(array, string) -> array
+```
+
+The following example shows that `array::sort_lexical` will sort strings in lexical (alphabetical) order instead of Unicode list order. As an accented 'Á' is listed later in Unicode than regular ASCII letters, the function `array::sort` will show the name 'Álvares' listed after the word 'senhor', but `array::sort_lexical` will show the name at the front of the array instead.
+
+```surql
+['Obrigado', 'senhor', 'Álvares'].sort();
+['Obrigado', 'senhor', 'Álvares'].sort_lexical();
+```
+
+```surql title="Output"
+-------- Query 1 (443.209µs) --------
+
+[ 'Obrigado', 'senhor', 'Álvares' ]
+
+-------- Query 2 (457.542µs) --------
+
+[ 'Álvares', 'Obrigado', 'senhor' ]
+```
+
+## `array::sort_natural`
+
+<Since v="v2.2.2" />
+
+The `array::sort_natural` function sorts the values in an array in ascending or descending order, with numeric strings sorted in numeric order instead of regular string order.
+
+```surql title="API DEFINITION"
+array::sort_natural(array) -> array
+```
+
+The function also accepts a second boolean parameter which determines the sorting direction. The second parameter can be `true` for ascending order, or `false` for descending order.
+
+```surql title="API DEFINITION"
+array::sort_natural(array, bool) -> array
+```
+The function also accepts a second string parameter which determines the sorting direction. The second parameter can be `'asc'` for ascending order, or `'desc'` for descending order.
+
+```surql title="API DEFINITION"
+array::sort_natural(array, string) -> array
+```
+
+The following example shows that `array::sort_natural` will sort numeric strings as if they were numbers. The `array::sort` function, on the other hand, treats a string like '3' as greater than '11' due to the first character in '3' being greater than '1'.
+
+```surql
+[8, 9, 10, '3', '2.2', '11'].sort();
+[8, 9, 10, '3', '2.2', '11'].sort_natural();
+```
+
+```surql title="Output"
+-------- Query --------
+
+[ 8, 9, 10, '11', '2.2', '3' ]
+
+-------- Query 2 (332.667µs) --------
+
+[ 8, 9, 10, '2.2', '3', '11' ]
+```
+
+## `array::sort_natural_lexical`
+
+<Since v="v2.2.2" />
+
+
+The `array::sort_natural_lexical` function sorts the values in an array in ascending or descending order, while sorting numeric strings in numeric order and alphabetical strings in lexical order.
+
+```surql title="API DEFINITION"
+array::sort_natural_lexical(array) -> array
+```
+
+The function also accepts a second boolean parameter which determines the sorting direction. The second parameter can be `true` for ascending order, or `false` for descending order.
+
+```surql title="API DEFINITION"
+array::sort_natural_lexical(array, bool) -> array
+```
+The function also accepts a second string parameter which determines the sorting direction. The second parameter can be `'asc'` for ascending order, or `'desc'` for descending order.
+
+```surql title="API DEFINITION"
+array::sort_natural_lexical(array, string) -> array
+```
+
+The following example shows that `array::sort_natural_lexical` will sort numeric strings as if they were numbers, and alphabetical strings in lexical order instead of Unicode order. The `array::sort` function, on the other hand, treats a string like '3' as greater than '11' due to the first character in '3' being greater than '1', and sorts the name 'Álvares' after the string 'senhor' because the 'Á' character comes after regular ASCII characters in Unicode.
+
+```surql
+['Obrigado', 'senhor', 'Álvares', 8, 9, 10, '3', '2.2', '11'].sort();
+['Obrigado', 'senhor', 'Álvares', 8, 9, 10, '3', '2.2', '11'].sort_natural_lexical();
+```
+
+```surql title="Output"
+-------- Query --------
+
+[ 8, 9, 10, '11', '2.2', '3', 'Obrigado', 'senhor', 'Álvares' ]
+
+-------- Query 2 (332.667µs) --------
+
+[ 8, 9, 10, '2.2', '3', '11', 'Álvares', 'Obrigado', 'senhor' ]
+```
 
 ## `array::sort::asc`
 

--- a/src/content/doc-surrealql/functions/database/array.mdx
+++ b/src/content/doc-surrealql/functions/database/array.mdx
@@ -1774,6 +1774,8 @@ array::sort_natural(array, string) -> array
 
 The following example shows that `array::sort_natural` will sort numeric strings as if they were numbers. The `array::sort` function, on the other hand, treats a string like '3' as greater than '11' due to the first character in '3' being greater than '1'.
 
+Note that strings sorted in numeric order will still appear after actual numbers, as [a string will always be greater than a number](/docs/surrealql/datamodel/values).
+
 ```surql
 [8, 9, 10, '3', '2.2', '11'].sort();
 [8, 9, 10, '3', '2.2', '11'].sort_natural();

--- a/src/content/doc-surrealql/statements/select.mdx
+++ b/src/content/doc-surrealql/statements/select.mdx
@@ -23,8 +23,9 @@ SELECT
 	[ WHERE @conditions ]
 	[ SPLIT [ ON ] @field, ... ]
 	[ GROUP [ BY ] @field, ... ]
-	[ ORDER [ BY ] @field, ... [ COLLATE ] [ NUMERIC ] | RAND() ]
-	[ ASC | DESC ]
+	[ ORDER [ BY ] 
+		@field [ COLLATE ] [ NUMERIC ] [ ASC | DESC ], ...
+		| RAND() ]
 	[ LIMIT [ BY ] @limit ]
 	[ START [ AT ] @start ]
 	[ FETCH @fields ... ]


### PR DESCRIPTION
Documentation for https://github.com/surrealdb/surrealdb/pull/5585

Also includes some changes to the syntax in both the SELECT and CLAUSE page. This seems to be the gist of it:

* Order by, then possibly COLLATE and/or NUMERIC, then ASC/DESC, then repeat with any other fields...
* Or just rand() and call it a day