### PR TITLE
Add docs for new javascript function timeout env

### DIFF
--- a/src/content/doc-surrealdb/cli/env.mdx
+++ b/src/content/doc-surrealdb/cli/env.mdx
@@ -159,6 +159,11 @@ Environment variables can be used to tailor the behaviour of a running SurrealDB
       <td scope="row" data-label="Notes">Maximum stack size of the JavaScript function runtime.</td>
     </tr>
     <tr>
+      <td scope="row" data-label="Env var"><code>SURREAL_SCRIPTING_MAX_TIME_LIMIT</code></td>
+      <td scope="row" data-label="Default">5000 (5000 milliseconds or 5 seconds)</td>
+      <td scope="row" data-label="Notes">Maximum allowed time that a JavaScript function is allowed to run for.</td>
+    </tr>
+    <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_SCRIPTING_MAX_STACK_SIZE</code></td>
       <td scope="row" data-label="Default">2097152 (2 MiB)</td>
       <td scope="row" data-label="Notes">Maximum memory limit of the JavaScript function runtime.</td>


### PR DESCRIPTION
Adds docs for the new `SURREAL_SCRIPTING_MAX_TIME_LIMIT` environment variable introduced in surrealdb/surrealdb#5597