### PR TITLE
Note about type::thing when it gets a full record

### DIFF
--- a/src/content/doc-surrealql/functions/database/type.mdx
+++ b/src/content/doc-surrealql/functions/database/type.mdx
@@ -650,6 +650,16 @@ FOR $data IN [
 };
 ```
 
+If the second argument passed into `type::thing` is a record ID, the latter part of the ID (the record identifier) will be extracted and used.
+
+```surql
+type::thing("person", person:mat);
+
+-- person:mat
+```
+
+The output of the above function call will thus be `person:mat`, not `person:person:mat`.
+
 ## `type::uuid`
 
 The `type::uuid` function converts a value into a UUID.


### PR DESCRIPTION
Interesting bit about type::thing: if the second argument is a full record ID, it will extract the latter part and use that.