### PR TITLE
Mention which four variables are specifically protected

### DIFF
--- a/src/content/doc-surrealql/parameters.mdx
+++ b/src/content/doc-surrealql/parameters.mdx
@@ -66,7 +66,34 @@ let people = await surreal.query("SELECT * FROM article WHERE status INSIDE $sta
 
 ## Reserved variable names
 
-SurrealDB automatically predefines certain variables depending on the type of operation being performed. For example, `$this` and `$parent` are automatically predefined for subqueries so that the fields of one can be compared to another if necessary. Other predefined variables like `$session` give access to parts of the current database configuration. You should not declare new parameters of your own using the same names as the predefined variables below.
+SurrealDB automatically predefines certain variables depending on the type of operation being performed. For example, `$this` and `$parent` are automatically predefined for subqueries so that the fields of one can be compared to another if necessary. In addition, the predefined variables `$access`, `$auth`, `$token`, and `$session` are protected variables used to give access to parts of the current database configuration and can never be overwritten.
+
+```surql
+LET $access = true;
+LET $auth = 10;
+LET $token = "Mytoken";
+LET $session = rand::int(0, 100);
+```
+
+```surql title="Output"
+-------- Query 1 --------
+
+"'access' is a protected variable and cannot be set"
+
+-------- Query 2 --------
+
+"'auth' is a protected variable and cannot be set"
+
+-------- Query 3 --------
+
+"'token' is a protected variable and cannot be set"
+
+-------- Query 4 --------
+
+"'session' is a protected variable and cannot be set"
+```
+
+Other predefined variables listed below are not specifically protected, but should not be used in order to avoid unexpected behaviour.
 
 ### $before, $after
 


### PR DESCRIPTION
Adds a bit of info to the parameters page to show exactly which four variables can never be set by a user.