### PR TITLE
Mention that parameters are set on the connection level

### DIFF
--- a/src/content/doc-surrealql/parameters.mdx
+++ b/src/content/doc-surrealql/parameters.mdx
@@ -53,6 +53,19 @@ RETURN $founders.name;
 ]
 ```
 
+Parameters persist across the current connection, and thus can be reused between different namespaces and databases. In the example below, a created `person` record assigned to a parameter is reused in a query in a completely different namespace and database.
+
+```surql
+LET $billy = CREATE ONLY person:billy SET name = "Billy";
+-- Fails as `person:billy` already exists
+CREATE person CONTENT $billy;
+
+USE NAMESPACE other_namespace;
+USE DATABASE other_database;
+-- Succeeds as `person:billy` does not yet exist in this namespace and database
+CREATE person CONTENT $billy;
+```
+
 Parameters can be defined using SurrealQL as shown above, or can be passed in using the client libraries as request variables.
 
 ## Defining parameters within client libraries


### PR DESCRIPTION
Clarifies that parameters are set on the connection level, allowing them to be reused across namespaces and databases.