### PR TITLE
Add section to define the TYPE for the id field

### DIFF
--- a/src/content/doc-surrealql/statements/define/field.mdx
+++ b/src/content/doc-surrealql/statements/define/field.mdx
@@ -640,6 +640,20 @@ DEFINE FIELD filter ON TABLE search_settings TYPE
 ```
 
 
+## Defining a `TYPE` for the `id` field
+
+The `DEFINE FIELD` statement can be defined for the `id` field to specify the acceptable types of IDs.
+
+```surql
+DEFINE FIELD id ON TABLE something TYPE string;
+DEFINE FIELD id ON TABLE something TYPE int;
+DEFINE FIELD id ON TABLE something TYPE uuid;
+
+-- using multiple data types for a Complex Record ID
+DEFINE FIELD id ON TABLE log TYPE [record, "info" | "warn" | "error", datetime];
+```
+
+
 ## Defining a reference
 
 <Since v="v2.2.0" />

--- a/src/content/doc-surrealql/statements/define/field.mdx
+++ b/src/content/doc-surrealql/statements/define/field.mdx
@@ -642,7 +642,7 @@ DEFINE FIELD filter ON TABLE search_settings TYPE
 
 ## Defining a `TYPE` for the `id` field
 
-The `DEFINE FIELD` statement can be defined for the `id` field to specify the acceptable types of IDs.
+The `DEFINE FIELD` statement can be defined for the `id` field to specify the acceptable types of IDs, including complex record IDs.
 
 ```surql
 DEFINE FIELD id ON TABLE something TYPE string;
@@ -651,8 +651,32 @@ DEFINE FIELD id ON TABLE something TYPE uuid;
 
 -- using multiple data types for a Complex Record ID
 DEFINE FIELD id ON TABLE log TYPE [record, "info" | "warn" | "error", datetime];
+
+-- Incorrect ID format, generates an error
+CREATE log SET level = "info", time = time::now(), message = "Database started";
+
+-- Acceptable ID format
+CREATE log:[user:one, "info", time::now()] SET message = "Database started";
 ```
 
+```surql title="Output"
+-------- Query --------
+
+"Found 'c6zdrbyuo1xmgm30stl0' for field `id`, with record `log:c6zdrbyuo1xmgm30stl0`, but expected a [record, 'info' | 'warn' | 'error', datetime]"
+
+-------- Query --------
+
+[
+	{
+		id: log:[
+			user:one,
+			'info',
+			d'2025-03-25T03:36:16.323Z'
+		],
+		message: 'Database started'
+	}
+]
+```
 
 ## Defining a reference
 


### PR DESCRIPTION
Add a section which explains to define the TYPE for the id field of a record.

Fixes #1241