### PR TITLE
Add a few more examples of +versioned for SurrealKV

### DIFF
--- a/src/content/doc-sdk-javascript/engines/node.mdx
+++ b/src/content/doc-sdk-javascript/engines/node.mdx
@@ -79,6 +79,8 @@ const db = new Surreal({
 await db.connect("mem://");
 // Or we can start a persisted SurrealKV database
 await db.connect("surrealkv://demo");
+// Or a persisted SurrealKV database with versioning (temoral queries)
+await db.connect("surrealkv+versioned://demo");
 
 // Now use the JavaScript SDK as normal.
 

--- a/src/content/doc-sdk-rust/frameworks/actix.mdx
+++ b/src/content/doc-sdk-rust/frameworks/actix.mdx
@@ -23,7 +23,7 @@ surreal start --user root --pass root
 
 You can also use the [Start serving](/docs/surrealist/concepts/local-database-serving) button on [Surrealist](/docs/surrealist) to do the same if you have it installed locally.
 
-The database initiated by the [surreal start](/docs/surrealdb/cli/start) command stores data in memory by default, which then disappears every time the database is shut down. As such, you can simply use Ctrl+C every time you want to start the database anew with no existing definitions or data. To save data to disk which will persist after shutting down, add a [positional argument](/docs/surrealdb/cli/start#positional-argument) for one of the storage backends such as `rocksdb://mydatabase` or `surrealkv://mydatabase`.
+The database initiated by the [surreal start](/docs/surrealdb/cli/start) command stores data in memory by default, which then disappears every time the database is shut down. As such, you can simply use Ctrl+C every time you want to start the database anew with no existing definitions or data. To save data to disk which will persist after shutting down, add a [positional argument](/docs/surrealdb/cli/start#positional-argument) for one of the storage backends such as `rocksdb://mydatabase` or `surrealkv://mydatabase` (or `surrealkv+versioned//mydatabase` to include SurrealKV versioning).
 
 With the database running, we will now connect to the database "test" located in the namespace "test". You can connect to it by [creating a connection](/docs/surrealist/getting-started#creating-a-connection) inside Surrealist, or by using the following command to start an interactive shell.
 

--- a/src/content/doc-sdk-rust/frameworks/axum.mdx
+++ b/src/content/doc-sdk-rust/frameworks/axum.mdx
@@ -23,7 +23,7 @@ surreal start --user root --pass root
 
 You can also use the [Start serving](/docs/surrealist/concepts/local-database-serving) button on [Surrealist](/docs/surrealist) to do the same if you have it installed locally.
 
-The database initiated by the [surreal start](/docs/surrealdb/cli/start) command stores data in memory by default, which then disappears every time the database is shut down. As such, you can simply use Ctrl+C every time you want to start the database anew with no existing definitions or data. To save data to disk which will persist after shutting down, add a [positional argument](/docs/surrealdb/cli/start#positional-argument) for one of the storage backends such as `rocksdb://mydatabase` or `surrealkv://mydatabase`.
+The database initiated by the [surreal start](/docs/surrealdb/cli/start) command stores data in memory by default, which then disappears every time the database is shut down. As such, you can simply use Ctrl+C every time you want to start the database anew with no existing definitions or data. To save data to disk which will persist after shutting down, add a [positional argument](/docs/surrealdb/cli/start#positional-argument) for one of the storage backends such as `rocksdb://mydatabase` or `surrealkv://mydatabase` (or `surrealkv+versioned//mydatabase` to include SurrealKV versioning).
 
 With the database running, we will now connect to the database "test" located in the namespace "test". You can connect to it by [creating a connection](/docs/surrealist/getting-started#creating-a-connection) inside Surrealist, or by using the following command to start an interactive shell.
 

--- a/src/content/doc-sdk-rust/frameworks/egui.mdx
+++ b/src/content/doc-sdk-rust/frameworks/egui.mdx
@@ -19,7 +19,7 @@ surreal start --user root --pass root
 
 You can also use the [Start serving](/docs/surrealist/concepts/local-database-serving) button on [Surrealist](/docs/surrealist) to do the same if you have it installed locally.
 
-The database initiated by the [surreal start](/docs/surrealdb/cli/start) command stores data in memory by default, which then disappears every time the database is shut down. As such, you can simply use Ctrl+C every time you want to start the database anew with no existing definitions or data. To save data to disk which will persist after shutting down, add a [positional argument](/docs/surrealdb/cli/start#positional-argument) for one of the storage backends such as `rocksdb://mydatabase` or `surrealkv://mydatabase`.
+The database initiated by the [surreal start](/docs/surrealdb/cli/start) command stores data in memory by default, which then disappears every time the database is shut down. As such, you can simply use Ctrl+C every time you want to start the database anew with no existing definitions or data. To save data to disk which will persist after shutting down, add a [positional argument](/docs/surrealdb/cli/start#positional-argument) for one of the storage backends such as `rocksdb://mydatabase` or `surrealkv://mydatabase` (or `surrealkv+versioned//mydatabase` to include SurrealKV versioning).
 
 With the database running, it's time to start setting up the Rust code.
 

--- a/src/content/doc-sdk-rust/frameworks/rocket.mdx
+++ b/src/content/doc-sdk-rust/frameworks/rocket.mdx
@@ -23,7 +23,7 @@ surreal start --user root --pass root
 
 You can also use the [Start serving](/docs/surrealist/concepts/local-database-serving) button on [Surrealist](/docs/surrealist) to do the same if you have it installed locally.
 
-The database initiated by the [surreal start](/docs/surrealdb/cli/start) command stores data in memory by default, which then disappears every time the database is shut down. As such, you can simply use Ctrl+C every time you want to start the database anew with no existing definitions or data. To save data to disk which will persist after shutting down, add a [positional argument](/docs/surrealdb/cli/start#positional-argument) for one of the storage backends such as `rocksdb://mydatabase` or `surrealkv://mydatabase`.
+The database initiated by the [surreal start](/docs/surrealdb/cli/start) command stores data in memory by default, which then disappears every time the database is shut down. As such, you can simply use Ctrl+C every time you want to start the database anew with no existing definitions or data. To save data to disk which will persist after shutting down, add a [positional argument](/docs/surrealdb/cli/start#positional-argument) for one of the storage backends such as `rocksdb://mydatabase` or `surrealkv://mydatabase` (or `surrealkv+versioned//mydatabase` to include SurrealKV versioning).
 
 With the database running, we will now connect to the database "test" located in the namespace "test". You can connect to it by [creating a connection](/docs/surrealist/getting-started#creating-a-connection) inside Surrealist, or by using the following command to start an interactive shell.
 

--- a/src/content/doc-surrealdb/introduction/start.mdx
+++ b/src/content/doc-surrealdb/introduction/start.mdx
@@ -450,7 +450,8 @@ When starting SurrealDB through the command line, you can fully customize the da
 </a>
 
 After you have installed SurrealDB, you can start the database using the [`surreal start`](/docs/surrealdb/cli/start) command provided by the [SurrealDB CLI](/docs/surrealdb/cli).
-When your start the database, you must specify which storage engine to use. This can be done by providing the engine as as the connection URL protocol. The following examples demonstrate how to start SurrealDB using different storage engines.
+
+When you start the database, you must specify which storage engine to use. This can be done by providing the engine as as the connection URL protocol. The following examples demonstrate how to start SurrealDB using different storage engines.
 
 <Tabs groupId="node-package-manager">
   <TabItem value="memory" label="In-Memory">
@@ -460,7 +461,11 @@ When your start the database, you must specify which storage engine to use. This
   </TabItem>
   <TabItem value="surrealkv" label="Single Node On-Disk SurrealKV" default>
     ```bash
+	# Without versioning (temporal queries)
     surreal start -u root -p root surrealkv://mydb
+
+	# With versioning
+	surreal start -u root -p root surrealkv+versioned://mydb
     ```
   </TabItem>
   <TabItem value="rocksdb" label="Single Node On-Disk rocksDB">

--- a/src/content/doc-surrealkv/index.mdx
+++ b/src/content/doc-surrealkv/index.mdx
@@ -36,7 +36,7 @@ SurrealKV offers several key features that makes it a powerful and versatile dat
 
 - **Embedded Database**: SurrealKV is available for embedded environments.
 
-- **Built-in Versioning**: Track and access historical versions of your data.
+- **Built-in Versioning**: Start SurrealKV [in versioned mode](/docs/surrealdb/cli/start#surrealkv-beta) to track and access historical versions of your data.
 
 - **Compaction**: Efficient storage management through compaction.
 

--- a/src/content/doc-surrealkv/performance.mdx
+++ b/src/content/doc-surrealkv/performance.mdx
@@ -5,7 +5,7 @@ title: Performance characteristics | SurrealQL
 description: Learn about the performance characteristics of SurrealQL and how it optimizes query execution and resource usage in SurrealDB.
 ---
 
-# Performance characteristics and trade-offs
+# SurrealKV performance characteristics and trade-offs
 
 ## Strengths
 
@@ -21,15 +21,15 @@ Operationally, SurrealKV offers significant advantages. The compaction process r
 
 ## Limitations
 
-SurrealKV does have some important limitations to consider:
+SurrealKV does have some important limitations to consider, many of which pertain to SurrealKV [when versioning is enabled](/docs/surrealdb/cli/start#surrealkv-beta):
 
-Memory management is a key consideration, as the index must reside in memory. Memory usage scales with the number of unique keys, key size distribution, and the number of versions per key.
+* Memory management is a key consideration, as the index must reside in memory. Memory usage scales with the number of unique keys, key size distribution, and the number of versions per key.
 
-Write amplification is another factor to consider. Each update creates a new version, requiring periodic compaction. During compaction, space usage temporarily increases.
+* Write amplification is another factor to consider. Each update creates a new version, requiring periodic compaction. During compaction, space usage temporarily increases.
 
-Range query performance varies depending on several factors: key distribution, version history depth, and range size. Large ranges may require multiple disk reads to complete.
+* Range query performance varies depending on several factors: key distribution, version history depth, and range size. Large ranges may require multiple disk reads to complete.
 
-From an operational standpoint, regular compaction is necessary for space reclamation. System restart time increases with log size, and high-cardinality keyspaces can create memory pressure.
+* From an operational standpoint, regular compaction is necessary for space reclamation. System restart time increases with log size, and high-cardinality keyspaces can create memory pressure.
 
 ## Performance implications
 


### PR DESCRIPTION
There are currently only two pages with the info that `+versioned` is needed to start SurrealKV with versioning, so sprinkles a few more examples here and there.