### PR TITLE
Add info to BEGIN and COMMIT on early returns

### DIFF
--- a/src/content/doc-surrealql/statements/begin.mdx
+++ b/src/content/doc-surrealql/statements/begin.mdx
@@ -43,3 +43,37 @@ UPDATE account:two SET balance -= 300.00;
 -- the database would remain in its initial state.
 COMMIT TRANSACTION;
 ```
+
+## Returning early from a transaction
+
+While all transactions require a final `COMMIT` or `CANCEL` statement in order to run, an early return can take place via the following:
+
+* An error inside one of the statements inside the transaction,
+* A `THROW` statement to return early with an error,
+* A `RETURN` statement to return early. This is often used to customize the output of a transaction.
+
+An example of the above:
+
+```surql
+BEGIN;
+
+CREATE account:one SET balance = 135605.16;
+CREATE account:two SET balance = 91031.31, wants_to_send_money = true;
+
+IF !account:two.wants_to_send_money {
+    THROW "Customer doesn't want to send any money!";
+};
+
+LET $first = UPDATE ONLY account:one SET balance += 300.00;
+LET $second = UPDATE ONLY account:two SET balance -= 300.00;
+
+RETURN "Money sent! Status:\n" + <string>$first + '\n' + <string>$second;
+
+COMMIT;
+```
+
+```surql title="Output"
+'Money sent! Status:
+{ balance: 135905.16f, id: account:one }
+{ balance: 90731.31f, id: account:two, wants_to_send_money: true }'
+```

--- a/src/content/doc-surrealql/statements/commit.mdx
+++ b/src/content/doc-surrealql/statements/commit.mdx
@@ -36,5 +36,31 @@ COMMIT TRANSACTION;
 
 The following two options can be used at any point if a transaction must be cancelled without commiting the changes:
 
-* [CANCEL](/docs/surrealql/statements/cancel) to manually cancel the transaction,
+* [CANCEL](/docs/surrealql/statements/cancel) to manually cancel the transaction.
 * [THROW](/docs/surrealql/statements/throw) to cancel a transaction with an optional error message. THROW is the only way to cancel a transaction based on a condition, such as inside an [IF..ELSE](/docs/surrealql/statements/ifelse) block.
+
+In addition, a `RETURN` statement can be used to return early from a successful transaction. This is often used in order to return a customized output.
+
+```surql
+BEGIN;
+
+CREATE account:one SET balance = 135605.16;
+CREATE account:two SET balance = 91031.31, wants_to_send_money = true;
+
+IF !account:two.wants_to_send_money {
+    THROW "Customer doesn't want to send any money!";
+};
+
+LET $first = UPDATE ONLY account:one SET balance += 300.00;
+LET $second = UPDATE ONLY account:two SET balance -= 300.00;
+
+RETURN "Money sent! Status:\n" + <string>$first + '\n' + <string>$second;
+
+COMMIT;
+```
+
+```surql title="Output"
+'Money sent! Status:
+{ balance: 135905.16f, id: account:one }
+{ balance: 90731.31f, id: account:two, wants_to_send_money: true }'
+```


### PR DESCRIPTION
Adds some info on early returns to the BEGIN and COMMIT pages.

https://github.com/surrealdb/docs.surrealdb.com/issues/1252