### PR TITLE
Add tip on using bools to speed things up a bit

### DIFF
--- a/src/content/doc-surrealdb/reference-guide/performance-best-practices.mdx
+++ b/src/content/doc-surrealdb/reference-guide/performance-best-practices.mdx
@@ -133,8 +133,7 @@ TAURI_LOG_LEVEL=off cargo tauri build
 
 ### Selecting single records
 
-Certain queries in SurrealDB can be more efficiently written in certain ways which ensure that full table scans or
-indexes are not necessary when executing the query.
+Certain queries in SurrealDB can be more efficiently written in certain ways which ensure that full table scans or indexes are not necessary when executing the query.
 
 In traditional SQL, the following query can be used to query for a particular row from a table:
 
@@ -183,6 +182,32 @@ FROM user:19374837491, user:12647931632;
 -- Selecting a range of IDs
 SELECT *
 FROM user:12647931632..=19374837491;
+```
+
+### Simplifying logic in `WHERE` clauses
+
+If a `WHERE` clause cannot be avoided, performance can still be improved by optimizing the portion after the `WHERE` clause. As a boolean check is the simplest possible operation, having a boolean field that can be used in a `WHERE` clause can significantly improve performance.
+
+```surql
+-- Fill up the database a bit with 10,000 records
+CREATE |person:10000| SET
+    random_data = rand::string(1000),
+    data_length = random_data.len(),
+    is_short = data_length < 10 RETURN NONE;
+-- Add one outlier
+CREATE person:one SET
+    random_data = "HI!",
+    data_length = random_data.len(),
+    is_short = data_length < 10 RETURN NONE;
+
+-- Function call + compare operation: slowest
+SELECT * FROM person WHERE random_data.len() < 10;
+-- Compare operation: much faster
+SELECT * FROM person WHERE data_length < 10;
+-- Boolean check: even faster
+SELECT * FROM person WHERE is_short;
+-- Direct record access: almost instantaneous
+SELECT * FROM person:one;
 ```
 
 ## Using indexes

--- a/src/content/doc-surrealql/datamodel/booleans.mdx
+++ b/src/content/doc-surrealql/datamodel/booleans.mdx
@@ -43,3 +43,30 @@ CREATE person SET
     very_interested = trUE;
 ```
 
+## Booleans in `WHERE` clauses
+
+When performing a query on the database, accessing a record's ID directly or using a [record range](/docs/surrealql/datamodel/ids#record-ranges) allows performance to be significantly sped up by avoiding the table scan which is used when a `WHERE` clause is included.
+
+However, if a `WHERE` clause is unavoidable, performance can still be improved by simplifying the portion after the clause as much as possible. As a boolean is the simplest possible datatype, having a boolean field that can be used in a `WHERE` clause can significantly improve performance compared to a more complex operation.
+
+```surql
+-- Fill up the database a bit with 10,000 records
+CREATE |person:10000| SET
+    random_data = rand::string(1000),
+    data_length = random_data.len(),
+    is_short = data_length < 10 RETURN NONE;
+-- Add one outlier
+CREATE person:one SET
+    random_data = "HI!",
+    data_length = random_data.len(),
+    is_short = data_length < 10 RETURN NONE;
+
+-- Function call + compare operation: slowest
+SELECT * FROM person WHERE random_data.len() < 10;
+-- Compare operation: much faster
+SELECT * FROM person WHERE data_length < 10;
+-- Boolean check: even faster
+SELECT * FROM person WHERE is_short;
+-- Direct record access: almost instantaneous
+SELECT * FROM person:one;
+```


### PR DESCRIPTION
Adds a tip for when WHERE can't be avoided: try to simplify the operation as much as possible, if possible by making it a quick bool check. The same tip is included in both the performance page as well as the boolean page which is quite small at the moment.