### PR TITLE
Add tip for when using array::filter

### DIFF
--- a/src/content/doc-surrealql/functions/database/array.mdx
+++ b/src/content/doc-surrealql/functions/database/array.mdx
@@ -680,6 +680,40 @@ The `array::filter` function can also take a [closure](/docs/surrealql/datamodel
 ]
 ```
 
+Note that the function checks whether the output of the inner closure [is truthy](/docs/surrealql/datamodel/values#values-and-truthiness), as opposed to only expecting a `bool`. As any and all values can be checked for truthiness, simply passing the closure argument as its output is enough to filter out values that are not truthy, such as `NONE` values and empty arrays.
+
+```surql
+[1,2,3,NONE,0,"",{},[]].filter(|$v| $v);
+```
+
+```surql title="Response"
+[1,2,3]
+```
+
+A more real-life example of this pattern in which only the `person` records that have been seen by another are returned:
+
+```surql
+CREATE person:one, person:two;
+RELATE person:one->sees->person:two;
+
+(SELECT 
+  id, 
+  <-sees<-person AS is_seen_by
+FROM person)
+    .filter(|$person| $person.is_seen_by);
+```
+
+```surql title="Response"
+[
+	{
+		id: person:two,
+		is_seen_by: [
+			person:one
+		]
+	}
+]
+```
+
 <br />
 
 ## `array::filter_index`


### PR DESCRIPTION
Adds a tip: Because the inner closure in array::filter is checked for truthiness and not just a boolean value, you can just pass on any value and if it's not truthy it will be filtered out. Especially useful in graph queries