### PR TITLE
Add warning about order of Points

### DIFF
--- a/src/content/doc-sdk-javascript/data-types.mdx
+++ b/src/content/doc-sdk-javascript/data-types.mdx
@@ -314,7 +314,7 @@ Geometry.coordinates
 
 #### `GeometryPoint`
 
-A point in space, made up of a long and lat coordinate, automatically converted to a float.
+A [point](/docs/surrealql/datamodel/geometries#point) in space, made up of a long and lat coordinate, automatically converted to a float.
 
 ```ts title="Signature"
 new GeometryPoint([long: number | Decimal, lat: number | Decimal]);

--- a/src/content/doc-sdk-php/data-types.mdx
+++ b/src/content/doc-sdk-php/data-types.mdx
@@ -293,7 +293,7 @@ Geometry.coordinates
 
 #### `GeometryPoint`
 
-A point in space, made up of a long and lat coordinate, automatically converted to a float.
+A [point](/docs/surrealql/datamodel/geometries#point) in space, made up of a long and lat coordinate, automatically converted to a float.
 
 ```php title="Signature"
 new GeometryPoint([int|float|Decimal $long, int|float|Decimal $lat]);

--- a/src/content/doc-sdk-python/data-types.mdx
+++ b/src/content/doc-sdk-python/data-types.mdx
@@ -276,7 +276,7 @@ Geometry.coordinates
 
 #### `GeometryPoint`
 
-A point in space, made up of a long and lat coordinate, automatically converted to a float.
+A [point](/docs/surrealql/datamodel/geometries#point) in space, made up of a long and lat coordinate, automatically converted to a float.
 
 ```python title="Signature"
 GeometryPoint([long: int | Decimal, lat: int | Decimal])

--- a/src/content/doc-surrealql/datamodel/geometries.mdx
+++ b/src/content/doc-surrealql/datamodel/geometries.mdx
@@ -51,6 +51,9 @@ SurrealDB makes working with GeoJSON easy, with support for `Point`, `LineString
 
 ## `Point`
 
+> [!NOTE]
+> Points are defined according to the GeoJSON spec, which specificies longitude before latitude. Many sites provide location data in the opposite order, so be sure to confirm that any data being used to create a `Point` is in the order `(longitude, latitude)`.
+
 The simplest form of GeoJSON that SurrealDB supports is a geolocation point. These can be written using two different formats. The first format is a simple 2-element tuple (longitude, latitude).
 
 ```surql


### PR DESCRIPTION
Adds an extra warning and some links from the SDKs so users are very aware that the GeoJSON spec order is used to create  point.