### PR TITLE
Add example of THROW inside DEFINE ACCESS

### DIFF
--- a/src/content/doc-surrealql/statements/access.mdx
+++ b/src/content/doc-surrealql/statements/access.mdx
@@ -479,3 +479,52 @@ ACCESS api PURGE REVOKED FOR 90d;
 ```surql
 ACCESS api PURGE EXPIRED, REVOKED FOR 1y;
 ```
+
+## Improving error output
+
+To improve the output of an error message inside an `ACCESS` statement, a [`THROW`](/docs/surrealql/statements/throw) statement can be used.
+
+Follow these steps to see the output in practice.
+
+First, start the SurrealDB server with a root user:
+
+```bash
+surreal start --user root --pass root
+```
+
+Log in as the root user, choose the namespace `test` and database `test`, and run the following `DEFINE ACCESS` command.
+
+```surql
+DEFINE ACCESS account ON DATABASE TYPE RECORD
+    SIGNUP ({
+    IF $email = "me@me.com" {
+        THROW "That's my email!!!"
+    } ELSE {
+        CREATE user SET email = $email, pass = crypto::argon2::generate($pass)}   
+    })
+    SIGNIN ( SELECT * FROM user WHERE email = $email AND crypto::argon2::compare(pass, $pass) )
+    DURATION FOR TOKEN 15m, FOR SESSION 12h
+;
+```
+
+As the `THROW` statement checks for the email address `me@me.com`, this can be tested using CURL at the [`signup`](https://surrealdb.com/docs/surrealdb/integration/http#signup) endpoint via the following command.
+
+```bash
+curl -X POST -H "Accept: application/json" -d '{"ns":"test","db":"test","ac":"account", "email": "me@me.com", "pass": "strongpassword"}' http://localhost:8000/signup
+```
+
+The error output shows the user-defined error message `That's my email!!!`.
+
+```bash title="Output"
+{"code":400,"details":"Request problems detected","description":"There is a problem with your request. Refer to the documentation for further information.","information":"There was a problem with the database: An error occurred: That's my email!!!"
+```
+
+In all other cases, the signup process will work, returning a token.
+
+```bash
+curl -X POST -H "Accept: application/json" -d '{"ns":"test","db":"test","ac":"account", "email": "someotheremail@me.com", "pass": "strongpassword"}' http://localhost:8000/signup
+```
+
+```bash title="Output"
+{"code":200,"details":"Authentication succeeded","token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJpYXQiOjE3NDYwNzIxOTAsIm5iZiI6MTc0NjA3MjE5MCwiZXhwIjoxNzQ2MDczMDkwLCJpc3MiOiJTdXJyZWFsREIiLCJqdGkiOiI3YTc0ZjQ5ZS02OWMxLTRiMjMtYmRhNy05YThkNTNjNWFiZmIiLCJOUyI6InRlc3QiLCJEQiI6InRlc3QiLCJBQyI6ImFjY291bnQiLCJJRCI6InVzZXI6b2tlZjN5bmI4eXJkd2l3b3h1YjEifQ.4t1xwVkl36PeTFuBj0d41D6A-bwCx7LoNoLlj6yokA8wOKwEa1ldjBzTldZEmylLgP5-q8D4wp6f9Y6ntBZyPA","refresh":null}
+```

--- a/src/content/doc-surrealql/statements/access.mdx
+++ b/src/content/doc-surrealql/statements/access.mdx
@@ -507,7 +507,7 @@ DEFINE ACCESS account ON DATABASE TYPE RECORD
 ;
 ```
 
-As the `THROW` statement checks for the email address `me@me.com`, this can be tested using CURL at the [`signup`](https://surrealdb.com/docs/surrealdb/integration/http#signup) endpoint via the following command.
+As the `THROW` statement checks for the email address `me@me.com`, this can be tested using CURL at the [`signup`](/docs/surrealdb/integration/http#signup) endpoint via the following command.
 
 ```bash
 curl -X POST -H "Accept: application/json" -d '{"ns":"test","db":"test","ac":"account", "email": "me@me.com", "pass": "strongpassword"}' http://localhost:8000/signup


### PR DESCRIPTION
Closes https://github.com/surrealdb/surrealdb/issues/4564

Adds example of THROW used inside a DEFINE ACCESS statement and how to test the output.