### PR TITLE
Remove SURREAL_TICK_INTERVAL

### DIFF
--- a/src/content/doc-surrealdb/cli/env.mdx
+++ b/src/content/doc-surrealdb/cli/env.mdx
@@ -506,12 +506,6 @@ Environment variables can be used to tailor the behaviour of a running SurrealDB
       <td scope="row" data-label="Details">Sets the directory for storing temporary database files</td>
     </tr>
     <tr>
-      <td scope="row" data-label="Env var"><code>SURREAL_TICK_INTERVAL</code></td>
-      <td scope="row" data-label="Command">surreal start</td>
-      <td scope="row" data-label="Argument">tick-interval</td>
-      <td scope="row" data-label="Details">The interval at which to run node agent tick (including garbage collection).</td>
-    </tr>
-    <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_TOKEN</code></td>
       <td scope="row" data-label="Command">surreal export, import, sql</td>
       <td scope="row" data-label="Argument">token</td>


### PR DESCRIPTION
Env vars were added after https://github.com/surrealdb/surrealdb/pull/4780 but there was also one that was removed which hasn't been removed in the documentation yet.