### PR TITLE
Change default password from root to secret

### DIFF
--- a/src/content/doc-cloud/advanced-topics/migrating-data.mdx
+++ b/src/content/doc-cloud/advanced-topics/migrating-data.mdx
@@ -16,7 +16,7 @@ Surreal Cloud is a hosted version of SurrealDB, providing a fully managed, scala
 
 ```bash
 # Example export command to export data to a file called `export.surql` in the downloads directory.
-surreal export --conn <connection-url> --user root --pass root --ns test --db test downloads/export.surql
+surreal export --conn <connection-url> --user root --pass secret --ns test --db test downloads/export.surql
 ``` 
 
 2. This will create a file called `export.surql` in the current directory.
@@ -25,5 +25,5 @@ surreal export --conn <connection-url> --user root --pass root --ns test --db te
 
 
 ```bash
-surreal import --conn <connection-url> --user root --pass root --ns test --db test downloads/export.surql
+surreal import --conn <connection-url> --user root --pass secret --ns test --db test downloads/export.surql
 ```

--- a/src/content/doc-integrations/Embeddings/anthropic.mdx
+++ b/src/content/doc-integrations/Embeddings/anthropic.mdx
@@ -25,7 +25,7 @@ import voyageai, anthropic, asyncio, os
 
 DB_URI     = "http://localhost:8000/rpc"
 DB_USER    = "root"
-DB_PASS    = "root"
+DB_PASS    = "secret"
 NAMESPACE  = "demo"
 DATABASE   = "demo"
 TABLE_NAME = "rag_docs"

--- a/src/content/doc-integrations/Embeddings/bedrock.mdx
+++ b/src/content/doc-integrations/Embeddings/bedrock.mdx
@@ -77,7 +77,7 @@ TABLE = "TechDocs"                      # table name
 async def ingest():
     db = Surreal("ws://localhost:8000/rpc")
     await db.connect()
-    await db.signin({"user":"root","pass":"root"})
+    await db.signin({"user":"root","pass":"secret"})
     await db.use("test","test")         # <namespace>, <database>
 
     # ----- schema & HNSW index (idempotent) -----
@@ -115,7 +115,7 @@ async def search(query: str, k: int = 3):
     # ---- SurrealDB KNN query -----------------
     db = Surreal("ws://localhost:8000/rpc")
     await db.connect()
-    await db.signin({"user":"root","pass":"root"})
+    await db.signin({"user":"root","pass":"secret"})
     await db.use("test","test")
 
     result = await db.query(`

--- a/src/content/doc-integrations/Embeddings/gemini.mdx
+++ b/src/content/doc-integrations/Embeddings/gemini.mdx
@@ -26,7 +26,7 @@ import asyncio
 
 DB_URI        = "http://localhost:8000/rpc"
 DB_USER       = "root"
-DB_PASS       = "root"
+DB_PASS       = "secret"
 NAMESPACE     = "demo"
 DATABASE      = "demo"
 TABLE_NAME    = "knowledge_docs"           # <── renamed

--- a/src/content/doc-integrations/Embeddings/jina-embeddings.mdx
+++ b/src/content/doc-integrations/Embeddings/jina-embeddings.mdx
@@ -17,7 +17,7 @@ SurrealDB's native k-nearest-neighbour search (HNSW, brute-force or M-Tree) lets
 pip install surrealdb requests           # async SurrealDB client + HTTP for Jina
 
 # Start SurrealDB server
-surreal start --user root --pass root --bind 0.0.0.0:8000 file:/data/db
+surreal start --user root --pass secret --bind 0.0.0.0:8000 file:/data/db
 ```
 
 ## Create embeddings
@@ -67,7 +67,7 @@ from surrealdb import AsyncSurreal
 
 async def ingest():
     async with AsyncSurreal("ws://localhost:8000/rpc") as db:
-        await db.signin({"username": "root", "password": "root"})
+        await db.signin({"username": "root", "password": "secret"})
         await db.use("media", "demo")                # namespace, database
 
         # Define schema and indexes
@@ -105,7 +105,7 @@ async def text2image(query: str, k: int = 3) -> List[Dict[str, Any]]:
     q_vec = get_embeddings([{"text": query}])[0]
 
     async with AsyncSurreal("ws://localhost:8000/rpc") as db:
-        await db.signin({"username": "root", "password": "root"})
+        await db.signin({"username": "root", "password": "secret"})
         await db.use("media", "demo")
 
         result = await db.query("""
@@ -136,7 +136,7 @@ async def image2text(query_image_url: str, k: int = 3) -> List[Dict[str, Any]]:
     q_vec = get_embeddings([{"image": query_image_url}])[0]
 
     async with AsyncSurreal("ws://localhost:8000/rpc") as db:
-        await db.signin({"username": "root", "password": "root"})
+        await db.signin({"username": "root", "password": "secret"})
         await db.use("media", "demo")
 
         result = await db.query("""

--- a/src/content/doc-integrations/Embeddings/llama.mdx
+++ b/src/content/doc-integrations/Embeddings/llama.mdx
@@ -97,7 +97,7 @@ class SurrealRAG:
         namespace: str = "rag",
         database: str = "demo",
         username: str = "root",
-        password: str = "root"
+        password: str = "secret"
     ):
         """Initialize the RAG client.
         

--- a/src/content/doc-integrations/Embeddings/mistral.mdx
+++ b/src/content/doc-integrations/Embeddings/mistral.mdx
@@ -37,7 +37,7 @@ import os, asyncio
 # ----- 1.1 · Config -----------------------------------------------------------------
 SDB_URL  = os.getenv("SDB_URL", "http://localhost:8000/rpc")
 SDB_USER = os.getenv("SDB_USER", "root")
-SDB_PASS = os.getenv("SDB_PASS", "root")
+SDB_PASS = os.getenv("SDB_PASS", "secret")
 NS, DB   = "demo", "demo"
 TABLE    = "mistral_docs"
 MODEL    = "mistral-embed"
@@ -135,7 +135,7 @@ from surrealdb import Surreal
 
 SDB_URL  = os.getenv("SDB_URL", "http://localhost:8000/rpc")
 SDB_USER = os.getenv("SDB_USER", "root")
-SDB_PASS = os.getenv("SDB_PASS", "root")
+SDB_PASS = os.getenv("SDB_PASS", "secret")
 NS, DB, TABLE = "demo", "demo", "mistral_docs"
 MODEL   = "mistral-embed"
 KEY     = os.environ["MISTRAL_API_KEY"]  # export first!
@@ -211,7 +211,7 @@ from surrealdb import Surreal
 
 SDB_URL    = os.getenv("SDB_URL", "http://localhost:8000/rpc")
 SDB_USER   = os.getenv("SDB_USER", "root")
-SDB_PASS   = os.getenv("SDB_PASS", "root")
+SDB_PASS   = os.getenv("SDB_PASS", "secret")
 NS         = "demo"
 DB         = "demo"
 TABLE      = "mistral_docs"

--- a/src/content/doc-integrations/Embeddings/mixedbread.mdx
+++ b/src/content/doc-integrations/Embeddings/mixedbread.mdx
@@ -44,7 +44,7 @@ TABLE = "ProductDocs"
 
 async def ingest():
     async with Surreal("ws://localhost:8000/rpc") as db:
-        await db.signin({"username": "root", "password": "root"})
+        await db.signin({"username": "root", "password": "secret"})
         await db.use("shop", "demo")             # namespace, database
 
         # ── schema + HNSW index (idempotent) ────────────────────────────────
@@ -72,7 +72,7 @@ async def search(query: str, k: int = 3):
     q_vec = model.embed(query)               # vectorise the query
 
     async with Surreal("ws://localhost:8000/rpc") as db:
-        await db.signin({"username": "root", "password": "root"})
+        await db.signin({"username": "root", "password": "secret"})
         await db.use("shop", "demo")
 
         result = await db.query(`

--- a/src/content/doc-integrations/Embeddings/nvidia.mdx
+++ b/src/content/doc-integrations/Embeddings/nvidia.mdx
@@ -20,7 +20,7 @@ pip install surrealdb requests
 *Run a local SurrealDB instance first, e.g.*
 
 ```bash
-surreal start --user root --pass root --bind 0.0.0.0:8000 file:/data/db
+surreal start --user root --pass secret --bind 0.0.0.0:8000 file:/data/db
 ```
 
 ## Prepare an Nvidia session
@@ -84,7 +84,7 @@ async def ingest(texts: List[str], vectors: List[List[float]], table: str = "Gpu
     """
     try:
         async with AsyncSurreal("ws://localhost:8000/rpc") as db:
-            await db.signin({"username": "root", "password": "root"})
+            await db.signin({"username": "root", "password": "secret"})
             await db.use("test", "test")
 
             # ---- idempotent schema & HNSW index ----
@@ -125,7 +125,7 @@ async def search(query: str, k: int = 3, table: str = "GpuDocs") -> List[Dict[st
 
         # ----- SurrealDB KNN query --------------
         async with AsyncSurreal("ws://localhost:8000/rpc") as db:
-            await db.signin({"username": "root", "password": "root"})
+            await db.signin({"username": "root", "password": "secret"})
             await db.use("test", "test")
 
             result = await db.query("""
@@ -205,7 +205,7 @@ TABLE = "GpuDocs"                              # our table name
 
 async def ingest():
     async with AsyncSurreal("ws://localhost:8000/rpc") as db:
-        await db.signin({"username": "root", "password": "root"})
+        await db.signin({"username": "root", "password": "secret"})
         await db.use("test", "test")               # <namespace>, <database>
 
         # ---- idempotent schema & HNSW index ----
@@ -236,7 +236,7 @@ async def search(query: str, k: int = 3) -> List[Dict[str, Any]]:
 
     # ----- SurrealDB KNN query --------------
     async with AsyncSurreal("ws://localhost:8000/rpc") as db:
-        await db.signin({"username": "root", "password": "root"})
+        await db.signin({"username": "root", "password": "secret"})
         await db.use("test", "test")
 
         result = await db.query("""

--- a/src/content/doc-integrations/Embeddings/ollama.mdx
+++ b/src/content/doc-integrations/Embeddings/ollama.mdx
@@ -37,7 +37,7 @@ async def main():
     # ----- connect to SurrealDB ------------------------------------------------
     db = Surreal("ws://localhost:8000/rpc")
     await db.connect()
-    await db.signin({"user": "root", "pass": "root"})
+    await db.signin({"user": "root", "pass": "secret"})
     await db.use("test", "test")          # <namespace>, <database>
 
     # ----- generate an embedding with Ollama -----------------------------------

--- a/src/content/doc-integrations/Embeddings/openai.mdx
+++ b/src/content/doc-integrations/Embeddings/openai.mdx
@@ -23,7 +23,7 @@ SurrealDB must be running somewhere.
 For local testing you can spin it up quickly:
 
 ```bash
-docker run -p 8000:8000 surrealdb/surrealdb:latest start --user root --pass root memory
+docker run -p 8000:8000 surrealdb/surrealdb:latest start --user root --pass secret memory
 ```
 
 ## Set up the OpenAI & SurrealDB clients
@@ -42,7 +42,7 @@ TEXTS = [
 
 async def init_db() -> Surreal:
     db = Surreal("ws://localhost:8000/rpc")          # change URL if remote
-    await db.signin({"username": "root", "password": "root"})
+    await db.signin({"username": "root", "password": "secret"})
     await db.use("demo_ns", "demo_db")
     return db
 ```

--- a/src/content/doc-integrations/Embeddings/upstage.mdx
+++ b/src/content/doc-integrations/Embeddings/upstage.mdx
@@ -42,7 +42,7 @@ import requests, asyncio, os
 
 SDB_URL     = os.getenv("SDB_URL", "http://localhost:8000/rpc")
 SDB_USER    = "root"
-SDB_PASS    = "root"
+SDB_PASS    = "secret"
 NS, DB      = "demo", "demo"
 TABLE       = "solar_docs"
 UP_API_KEY  = os.environ["UPSTAGE_API_KEY"]        # export first!

--- a/src/content/doc-integrations/Embeddings/voyage.mdx
+++ b/src/content/doc-integrations/Embeddings/voyage.mdx
@@ -27,7 +27,7 @@ import voyageai, asyncio, os
 
 SDB_URL   = os.getenv("SDB_URL", "http://localhost:8000/rpc")
 SDB_USER  = "root"
-SDB_PASS  = "root"
+SDB_PASS  = "secret"
 NS, DB    = "demo", "demo"
 TABLE     = "voyage_docs"
 API_KEY   = os.environ["VOYAGE_API_KEY"]

--- a/src/content/doc-integrations/Frameworks/camel.mdx
+++ b/src/content/doc-integrations/Frameworks/camel.mdx
@@ -43,7 +43,7 @@ class SurrealStorage(VectorStorage):
         namespace: str = "agents",
         database: str = "demo",
         user: str = "root",
-        password: str = "root",
+        password: str = "secret",
     ):
         super().__init__(distance)
         self.url = url
@@ -144,7 +144,7 @@ storage = SurrealStorage(
     vector_dim=768,
     distance=VectorDistance.COSINE,
     user="root",  # Explicitly set credentials
-    password="root"
+    password="secret"
 )
 
 async def demo():
@@ -177,7 +177,7 @@ from camel.retrievers import VectorRetriever
 surreal_storage = SurrealStorage(
     vector_dim=1536,
     user="root",
-    password="root"
+    password="secret"
 )
 
 # Retriever with any embedding model Camel supports

--- a/src/content/doc-integrations/Frameworks/crewai.mdx
+++ b/src/content/doc-integrations/Frameworks/crewai.mdx
@@ -27,7 +27,7 @@ pip install "crewai[tools]" surrealdb openai
 
 # (optional) run SurrealDB locally – single binary, no deps
 docker run --pull always -p 8000:8000 surrealdb/surrealdb:latest \
-       start --user root --pass root file:/data/db
+       start --user root --pass secret file:/data/db
 ````
 
 SurrealDB v2 ships native HNSW and M-Tree indexes, so you get ANN vector search
@@ -87,7 +87,7 @@ class SurrealStorage(RAGStorage):
         namespace: str = "crew",
         database: str = "memories",
         user: str = "root",
-        password: str = "root",
+        password: str = "secret",
     ):
         super().__init__(typ, allow_reset, embedder_config, crew)
         self.url, self.ns, self.db = url, namespace, database

--- a/src/content/doc-integrations/Frameworks/dagster.mdx
+++ b/src/content/doc-integrations/Frameworks/dagster.mdx
@@ -15,7 +15,7 @@ Dagster is a powerful tool for building data pipelines and workflows. It is a po
 pip install dagster surrealdb openai  # or swap out OpenAI for any embedder
 # optional – launch a local SurrealDB daemon
 docker run -p 8000:8000 surrealdb/surrealdb:latest \
-       start --user root --pass root file:/data/db
+       start --user root --pass secret file:/data/db
 ```
 
 ## A Dagster "SurrealResource"
@@ -45,7 +45,7 @@ class SurrealConfig(dg.Config):
     namespace: str = dg.Field(str, default_value="dagster")
     database: str = dg.Field(str, default_value="vector")
     user: str = dg.Field(str, default_value="root")
-    password: str = dg.Field(str, default_value="root")
+    password: str = dg.Field(str, default_value="secret")
 
 
 @dg.resource(config_schema=SurrealConfig)

--- a/src/content/doc-integrations/Frameworks/deepeval.mdx
+++ b/src/content/doc-integrations/Frameworks/deepeval.mdx
@@ -20,7 +20,7 @@ SurrealDB's *native* vector engine, allows you to store vectors, documents and m
 pip install deepeval surrealdb openai   # swap OpenAI for any embedder you like
 # optional – start a local SurrealDB node
 docker run -p 8000:8000 surrealdb/surrealdb:latest \
-       start --user root --pass root file:/data/db
+       start --user root --pass secret file:/data/db
 ```
 
 > [!NOTE]
@@ -69,7 +69,7 @@ class SurrealRAG:
         namespace: str = "rag",
         database: str = "demo",
         user: str = "root",
-        password: str = "root",
+        password: str = "secret",
     ):
         self.url = url
         self.namespace = namespace

--- a/src/content/doc-integrations/Frameworks/dynamiq.mdx
+++ b/src/content/doc-integrations/Frameworks/dynamiq.mdx
@@ -15,7 +15,7 @@ Dynamiq is a Python framework for building multi-agent LLM systems with SurrealD
 pip install dynamiq surrealdb openai         # swap OpenAI for any embedder you like
 # one-liner dev DB
 docker run -p 8000:8000 surrealdb/surrealdb:latest \
-       start --user root --pass root file:/data/db
+       start --user root --pass secret file:/data/db
 ```
 
 SurrealDB ≥ v1.5 has built-in HNSW / M-Tree vector indexes, queried with SurrealQL's `<| K |>` operator and [`vector::distance::*` functions](/docs/surrealql/functions/database/vector).
@@ -68,7 +68,7 @@ class SurrealConnection:
         namespace: str = "dynamiq",
         database: str = "rag",
         user: str = "root",
-        password: str = "root",
+        password: str = "secret",
     ):
         self.url = url
         self.namespace = namespace

--- a/src/content/doc-integrations/Frameworks/feast.mdx
+++ b/src/content/doc-integrations/Frameworks/feast.mdx
@@ -42,7 +42,7 @@ class SurrealOnlineStore(OnlineStore):
         namespace: str = "feast",
         database: str = "online",
         user: str = "root",
-        password: str = "root",
+        password: str = "secret",
         **_,
     ):
         self.url = url

--- a/src/content/doc-integrations/Frameworks/googleagent.mdx
+++ b/src/content/doc-integrations/Frameworks/googleagent.mdx
@@ -25,7 +25,7 @@ Below is a concise walkthrough that shows:
 ```bash
 pip install google-adk google-genai surrealdb    # ADK + Gemini SDK + SurrealDB
 docker run -p 8000:8000 surrealdb/surrealdb:latest \
-       start --user root --pass root file:/data/db   # optional local DB
+       start --user root --pass secret file:/data/db   # optional local DB
 export GOOGLE_API_KEY=<your-Gemini-key>
 ```
 
@@ -69,7 +69,7 @@ class SurrealConfig:
     namespace: str = "agent"
     database: str = "demo"
     username: str = "root"
-    password: str = "root"
+    password: str = "secret"
 
 class SurrealRetriever:
     """SurrealDB-powered retrieval tool for Google Agent."""

--- a/src/content/doc-integrations/Frameworks/langchain.mdx
+++ b/src/content/doc-integrations/Frameworks/langchain.mdx
@@ -80,7 +80,7 @@ from langchain_ollama import OllamaEmbeddings
 from surrealdb import Surreal
 
 conn = Surreal("ws://localhost:8000/rpc")
-conn.signin({"username": "root", "password": "root"})
+conn.signin({"username": "root", "password": "secret"})
 conn.use("langchain", "demo")
 vector_store = SurrealDBVectorStore(OllamaEmbeddings(model="llama3.2"), conn)
 

--- a/src/content/doc-integrations/Frameworks/llama-index.mdx
+++ b/src/content/doc-integrations/Frameworks/llama-index.mdx
@@ -34,7 +34,7 @@ import asyncio, os
 # — connection details —
 DB_URL   = os.getenv("SDB_URL", "http://localhost:8000/rpc")
 DB_USER  = os.getenv("SDB_USER", "root")
-DB_PASS  = os.getenv("SDB_PASS", "root")
+DB_PASS  = os.getenv("SDB_PASS", "secret")
 NS, DB   = "demo", "demo"
 TABLE    = "llama_chunks"
 

--- a/src/content/doc-integrations/Frameworks/smolagents.mdx
+++ b/src/content/doc-integrations/Frameworks/smolagents.mdx
@@ -52,7 +52,7 @@ class GroceryQueryTool(Tool):
         self.dbname = "demo"
         self.table = "groceries"
         self.user = os.getenv("SURREAL_USER", "root")
-        self.pw = os.getenv("SURREAL_PASS", "root")
+        self.pw = os.getenv("SURREAL_PASS", "secret")
 
         self.emb = TextEmbedding(model_name="jinaai/jina-embeddings-v2-base-en")
 

--- a/src/content/doc-integrations/data-management/unstructured.mdx
+++ b/src/content/doc-integrations/data-management/unstructured.mdx
@@ -61,7 +61,7 @@ class SDBWriter(Writer):
         if self.db is None:
             self.db = Surreal(self.cfg.url)
             await self.db.connect()
-            await self.db.signin({"user": "root", "pass": "root"})
+            await self.db.signin({"user": "root", "pass": "secret"})
             await self.db.use("reports", "corp")          # namespace / database
             await self.db.query(f"""
                 DEFINE TABLE IF NOT EXISTS {self.cfg.table};

--- a/src/content/doc-sdk-dotnet/core/authentication.mdx
+++ b/src/content/doc-sdk-dotnet/core/authentication.mdx
@@ -233,7 +233,7 @@ await db.SignIn(credentials)
 
 ```csharp
 // Sign in as root user
-await db.SignIn(new RootAuth { Username = "root", Password = "root" });
+await db.SignIn(new RootAuth { Username = "root", Password = "secret" });
 ```
 
 </TabItem>

--- a/src/content/doc-sdk-dotnet/methods/signin.mdx
+++ b/src/content/doc-sdk-dotnet/methods/signin.mdx
@@ -56,7 +56,7 @@ await db.SignIn(credentials)
 
 ```csharp
 // Sign in as root user
-await db.SignIn(new RootAuth { Username = "root", Password = "root" });
+await db.SignIn(new RootAuth { Username = "root", Password = "secret" });
 ```
 
 </TabItem>

--- a/src/content/doc-sdk-dotnet/start.mdx
+++ b/src/content/doc-sdk-dotnet/start.mdx
@@ -46,7 +46,7 @@ const string TABLE = "person";
 
 using var db = new SurrealDbClient("ws://127.0.0.1:8000/rpc");
 
-await db.SignIn(new RootAuth { Username = "root", Password = "root" });
+await db.SignIn(new RootAuth { Username = "root", Password = "secret" });
 await db.Use("test", "test");
 
 var person = new Person

--- a/src/content/doc-sdk-golang/methods/signin.mdx
+++ b/src/content/doc-sdk-golang/methods/signin.mdx
@@ -49,7 +49,7 @@ await db.SignIn(credentials)
 // Sign in to authentication `db` using the root user
 	authData := &surrealdb.Auth{
 		Username: "root", // use your setup username
-		Password: "root", // use your setup password
+		Password: "secret", // use your setup password
 	}
 	token, err := db.SignIn(authData)
 	if err != nil {
@@ -65,7 +65,7 @@ await db.SignIn(credentials)
 // Sign in to authentication `db` using the root user
 	authData := &surrealdb.Auth{
 		Username: "root", // use your setup username
-		Password: "root", // use your setup password
+		Password: "secret", // use your setup password
         Namespace = "test", 
 	}
 	token, err := db.SignIn(authData)
@@ -82,7 +82,7 @@ await db.SignIn(credentials)
 // Sign in to authentication `db` using the root user
 	authData := &surrealdb.Auth{
 		Username: "root", // use your setup username
-		Password: "root", // use your setup password
+		Password: "secret", // use your setup password
         Namespace = "test", 
         Database = "test", 
 	}
@@ -100,7 +100,7 @@ await db.SignIn(credentials)
 // Sign in to authentication `db` using the root user
 	authData := &surrealdb.Auth{
 		Username: "root", // use your setup username
-		Password: "root", // use your setup password
+		Password: "secret", // use your setup password
         Namespace = "test", 
         Database = "test", 
         Access = "user",
@@ -121,7 +121,7 @@ await db.SignIn(credentials)
 // Sign in to authentication `db` using the root user
 	authData := &surrealdb.Auth{
 		Username: "root", // use your setup username
-		Password: "root", // use your setup password
+		Password: "secret", // use your setup password
         Namespace = "test", 
         Database = "test", 
         Scope = "user",

--- a/src/content/doc-sdk-golang/methods/signup.mdx
+++ b/src/content/doc-sdk-golang/methods/signup.mdx
@@ -49,7 +49,7 @@ await db.SignUp(credentials)
 // Sign in to authentication `db` using the root user
 	authData := &surrealdb.Auth{
 		Username: "root", // use your setup username
-		Password: "root", // use your setup password
+		Password: "secret", // use your setup password
         Namespace = "test", 
         Database = "test", 
         Access = "user",
@@ -69,7 +69,7 @@ await db.SignUp(credentials)
 // Sign in to authentication `db` using the root user
 	authData := &surrealdb.Auth{
 		Username: "root", // use your setup username
-		Password: "root", // use your setup password
+		Password: "secret", // use your setup password
         Namespace = "test", 
         Database = "test", 
         Scope = "user",

--- a/src/content/doc-sdk-golang/start.mdx
+++ b/src/content/doc-sdk-golang/start.mdx
@@ -52,7 +52,7 @@ func main() {
 	// Sign in to authentication `db`
 	authData := &surrealdb.Auth{
 		Username: "root", // use your setup username
-		Password: "root", // use your setup password
+		Password: "secret", // use your setup password
 	}
 	token, err := db.SignIn(authData)
 	if err != nil {

--- a/src/content/doc-sdk-java/core/handling-authentication.mdx
+++ b/src/content/doc-sdk-java/core/handling-authentication.mdx
@@ -67,13 +67,13 @@ public class Example {
             driver.useNs("example").useDb("example");
 
 			// Authenticate as root user
-			driver.signin(new Root("root", "root"));
+			driver.signin(new Root("root", "secret"));
 
 			// Authenticate as a namespace user
-			driver.signin(new Namespace("root", "root", "ns"));
+			driver.signin(new Namespace("root", "secret", "ns"));
 
 			// Authenticate as a database user
-            driver.signin(new Database("root", "root", "ns", "db"));
+            driver.signin(new Database("root", "secret", "ns", "db"));
 		}
 	}
 

--- a/src/content/doc-sdk-php/core/authentication.mdx
+++ b/src/content/doc-sdk-php/core/authentication.mdx
@@ -75,7 +75,7 @@ To signin with credentials, you can use the [`signin`](/docs/sdk/php/methods/sig
 		```php
 		$token = $db->signin([
 			"username" => "root",
-			"password" => "root"
+			"password" => "secret"
 		]);
 		```
 	</TabItem>
@@ -84,7 +84,7 @@ To signin with credentials, you can use the [`signin`](/docs/sdk/php/methods/sig
 		```php
 		$token = $db->signin([
 			"username" => "root",
-			"password" => "root",
+			"password" => "secret",
 			"namespace" => "surrealdb"
 		]);
 		```
@@ -94,7 +94,7 @@ To signin with credentials, you can use the [`signin`](/docs/sdk/php/methods/sig
 		```php
 		$token = $db->signin([
 			"username" => "root",
-			"password" => "root",
+			"password" => "secret",
 			"namespace" => "surrealdb",
 			"database" => "surrealdb"
 		]);
@@ -105,7 +105,7 @@ To signin with credentials, you can use the [`signin`](/docs/sdk/php/methods/sig
 		```php
 		$token = $db->signin([
 			"email" => "user@email.com",
-			"pass" => "root",
+			"pass" => "secret",
 			"namespace" => "surrealdb",
 			"database" => "surrealdb",
 			"scope" => "user"
@@ -117,7 +117,7 @@ To signin with credentials, you can use the [`signin`](/docs/sdk/php/methods/sig
 		```php
 		$token = $db->signin([
 			"email" => "user@email.com",
-			"pass" => "root",
+			"pass" => "secret",
 			"namespace" => "surrealdb",
 			"database" => "surrealdb",
 			"access" => "user"

--- a/src/content/doc-sdk-rust/concepts/authenticating-users.mdx
+++ b/src/content/doc-sdk-rust/concepts/authenticating-users.mdx
@@ -208,7 +208,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     db.signin(Root {
         username: "root",
-        password: "root",
+        password: "secret",
     })
     .await?;
 

--- a/src/content/doc-sdk-rust/concepts/concurrency.mdx
+++ b/src/content/doc-sdk-rust/concepts/concurrency.mdx
@@ -14,13 +14,13 @@ While the Rust SDK for SurrealDB uses the tokio async runtime, the operation of 
 Start a running database using the following command:
 
 ```
-surreal start --user root --pass root 
+surreal start --user root --pass secret 
 ```
 
 To follow along interactively, connect [using Surrealist](/docs/surrealist/getting-started#creating-a-connection) or the following command to open up the CLI:
 
 ```
-surrealdb % surreal sql --user root --pass root --ns namespace --db database --pretty
+surrealdb % surreal sql --user root --pass secret --ns namespace --db database --pretty
 ```
 
 Then use the `cargo add` command to add the `surrealdb` and `tokio` crates. The dependencies inside `Cargo.toml` should look something like this:
@@ -60,7 +60,7 @@ impl DbType {
         db.use_ns("namespace").use_db("database").await?;
         db.signin(Root {
             username: "root",
-            password: "root",
+            password: "secret",
         })
         .await?;
         Ok(db)
@@ -147,7 +147,7 @@ impl DbType {
         db.use_ns("namespace").use_db("database").await?;
         db.signin(Root {
             username: "root",
-            password: "root",
+            password: "secret",
         })
         .await?;
         Ok(db)

--- a/src/content/doc-sdk-rust/concepts/fetch.mdx
+++ b/src/content/doc-sdk-rust/concepts/fetch.mdx
@@ -10,13 +10,13 @@ description: All the fields of a SurrealDB linked record can be fetched and dese
 Start a running database using the following command:
 
 ```
-surreal start --user root --pass root 
+surreal start --user root --pass secret 
 ```
 
 To follow along interactively, connect [using Surrealist](/docs/surrealist/getting-started#creating-a-connection) or the following command to open up the CLI:
 
 ```
-surrealdb % surreal sql --user root --pass root --ns namespace --db database --pretty
+surrealdb % surreal sql --user root --pass secret --ns namespace --db database --pretty
 ```
 
 Then use the `cargo add` command to add three crates: `surrealdb` and `tokio`, and with `serde` with the "serde_derive" feature (`cargo add serde --features serde_derive`). The dependencies inside `Cargo.toml` should look something like this:
@@ -160,7 +160,7 @@ async fn main() -> surrealdb::Result<()> {
     // Sign in into the server
     db.signin(Root {
         username: "root",
-        password: "root",
+        password: "secret",
     })
     .await?;
 

--- a/src/content/doc-sdk-rust/concepts/flexible-typing.mdx
+++ b/src/content/doc-sdk-rust/concepts/flexible-typing.mdx
@@ -24,13 +24,13 @@ However, sometimes you will need to work with types that have a more dynamic str
 Start a running database using the following command:
 
 ```
-surreal start --user root --pass root 
+surreal start --user root --pass secret 
 ```
 
 To follow along interactively, connect [using Surrealist](/docs/surrealist/getting-started#creating-a-connection) or the following command to open up the CLI:
 
 ```
-surrealdb % surreal sql --user root --pass root --ns namespace --db database --pretty
+surrealdb % surreal sql --user root --pass secret --ns namespace --db database --pretty
 ```
 
 Then use the `cargo add` command to add four crates: `surrealdb`, `serde`, `serde_json`, and `tokio`. Your `Cargo.toml` file should look something like this.
@@ -67,7 +67,7 @@ async fn main() -> Result<(), Error> {
     // Sign in into the server
     db.signin(Root {
         username: "root",
-        password: "root",
+        password: "secret",
     })
     .await?;
 
@@ -127,7 +127,7 @@ async fn main() -> Result<(), Error> {
     // Sign in into the server
     db.signin(Root {
         username: "root",
-        password: "root",
+        password: "secret",
     })
     .await?;
 
@@ -170,7 +170,7 @@ async fn main() -> Result<(), Error> {
     // Sign in into the server
     db.signin(Root {
         username: "root",
-        password: "root",
+        password: "secret",
     })
     .await?;
 
@@ -217,7 +217,7 @@ async fn main() -> Result<(), Error> {
     // Sign in into the server
     db.signin(Root {
         username: "root",
-        password: "root",
+        password: "secret",
     })
     .await?;
 

--- a/src/content/doc-sdk-rust/concepts/live.mdx
+++ b/src/content/doc-sdk-rust/concepts/live.mdx
@@ -14,13 +14,13 @@ A [`LIVE SELECT`](/docs/surrealql/statements/live) statement creates a session t
 Start a running database using the following command:
 
 ```
-surreal start --user root --pass root 
+surreal start --user root --pass secret 
 ```
 
 To follow along interactively, connect [using Surrealist](/docs/surrealist/getting-started#creating-a-connection) or the following command to open up the CLI:
 
 ```
-surrealdb % surreal sql --user root --pass root --ns namespace --db database --pretty
+surrealdb % surreal sql --user root --pass secret --ns namespace --db database --pretty
 ```
 
 Then use the `cargo add` command to add four crates: `surrealdb` and `tokio`, the `futures` crate for the [`StreamExt`](https://docs.rs/futures/latest/futures/stream/trait.StreamExt.html) trait needed to use the async stream, as well as with `serde` with the "serde_derive" feature (`cargo add serde --features serde_derive`). The dependencies inside `Cargo.toml` should look something like this:
@@ -62,7 +62,7 @@ async fn main() -> surrealdb::Result<()> {
 
     db.signin(Root {
         username: "root",
-        password: "root",
+        password: "secret",
     })
     .await?;
 

--- a/src/content/doc-sdk-rust/concepts/transaction.mdx
+++ b/src/content/doc-sdk-rust/concepts/transaction.mdx
@@ -16,13 +16,13 @@ The [`.query()`](https://docs.rs/surrealdb/latest/surrealdb/struct.Surreal.html#
 Start a running database using the following command:
 
 ```
-surreal start --user root --pass root 
+surreal start --user root --pass secret 
 ```
 
 To follow along interactively, connect [using Surrealist](/docs/surrealist/getting-started#creating-a-connection) or the following command to open up the CLI:
 
 ```
-surrealdb % surreal sql --user root --pass root --ns namespace --db database --pretty
+surrealdb % surreal sql --user root --pass secret --ns namespace --db database --pretty
 ```
 
 Then use the `cargo add` command to add the `surrealdb` and `tokio` crates. The dependencies inside `Cargo.toml` should look something like this:
@@ -46,7 +46,7 @@ async fn main() -> surrealdb::Result<()> {
 
 	db.signin(Root {
 		username: "root",
-		password: "root",
+		password: "secret",
 	})
 	.await?;
 
@@ -95,7 +95,7 @@ async fn main() -> surrealdb::Result<()> {
 
 	db.signin(Root {
 		username: "root",
-		password: "root",
+		password: "secret",
 	})
 	.await?;
 

--- a/src/content/doc-sdk-rust/frameworks/actix.mdx
+++ b/src/content/doc-sdk-rust/frameworks/actix.mdx
@@ -18,7 +18,7 @@ The following tutorial will set up a server with SurrealDB and [Actix Web](https
 First, open up a terminal window and use the following command to start an empty database.
 
 ```bash
-surreal start --user root --pass root
+surreal start --user root --pass secret
 ```
 
 You can also use the [Start serving](/docs/surrealist/concepts/local-database-serving) button on [Surrealist](/docs/surrealist) to do the same if you have it installed locally.
@@ -28,7 +28,7 @@ The database initiated by the [surreal start](/docs/surrealdb/cli/start) command
 With the database running, we will now connect to the database "test" located in the namespace "test". You can connect to it by [creating a connection](/docs/surrealist/getting-started#creating-a-connection) inside Surrealist, or by using the following command to start an interactive shell.
 
 ```bash
-surreal sql --user root --pass root --ns test --db test --pretty
+surreal sql --user root --pass secret --ns test --db test --pretty
 ```
 
 Next, create a new Rust project with the command `cargo new your_project_name`, go into the newly created directory, and use `cargo add` to add each of the following dependencies:
@@ -101,7 +101,7 @@ DB.connect::<Ws>("localhost:8000").await?;
 
 DB.signin(Root {
     username: "root",
-    password: "root",
+    password: "secret",
 })
 .await?;
 
@@ -512,7 +512,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     DB.signin(Root {
         username: "root",
-        password: "root",
+        password: "secret",
     })
     .await?;
 

--- a/src/content/doc-sdk-rust/frameworks/axum.mdx
+++ b/src/content/doc-sdk-rust/frameworks/axum.mdx
@@ -18,7 +18,7 @@ The following tutorial will set up a server with SurrealDB and [Axum](https://do
 First, open up a terminal window and use the following command to start an empty database.
 
 ```bash
-surreal start --user root --pass root
+surreal start --user root --pass secret
 ```
 
 You can also use the [Start serving](/docs/surrealist/concepts/local-database-serving) button on [Surrealist](/docs/surrealist) to do the same if you have it installed locally.
@@ -28,7 +28,7 @@ The database initiated by the [surreal start](/docs/surrealdb/cli/start) command
 With the database running, we will now connect to the database "test" located in the namespace "test". You can connect to it by [creating a connection](/docs/surrealist/getting-started#creating-a-connection) inside Surrealist, or by using the following command to start an interactive shell.
 
 ```bash
-surreal sql --user root --pass root --ns test --db test --pretty
+surreal sql --user root --pass secret --ns test --db test --pretty
 ```
 
 Next, create a new Rust project with the command `cargo new your_project_name`, go into the newly created directory, and use `cargo add` to add each of the following dependencies:
@@ -104,7 +104,7 @@ DB.connect::<Ws>("localhost:8000").await?;
 
 DB.signin(Root {
     username: "root",
-    password: "root",
+    password: "secret",
 })
 .await?;
 
@@ -490,7 +490,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     DB.signin(Root {
         username: "root",
-        password: "root",
+        password: "secret",
     })
     .await?;
 

--- a/src/content/doc-sdk-rust/frameworks/egui.mdx
+++ b/src/content/doc-sdk-rust/frameworks/egui.mdx
@@ -14,7 +14,7 @@ The following tutorial will set up a small app with Egui that uses SurrealDB as 
 First, open up a terminal window and use the following command to start an empty database.
 
 ```bash
-surreal start --user root --pass root
+surreal start --user root --pass secret
 ```
 
 You can also use the [Start serving](/docs/surrealist/concepts/local-database-serving) button on [Surrealist](/docs/surrealist) to do the same if you have it installed locally.
@@ -68,7 +68,7 @@ fn main() -> Result<(), Error> {
 
             db.signin(Root {
                 username: "root",
-                password: "root",
+                password: "secret",
             })
             .await?;
 
@@ -229,7 +229,7 @@ fn main() -> Result<(), Error> {
 
             db.signin(Root {
                 username: "root",
-                password: "root",
+                password: "secret",
             })
             .await?;
 
@@ -446,7 +446,7 @@ The last command will allow the user to sign back in as the root user. To make i
 Command::SignInRoot => {
     self.signin(Root {
         username: "root",
-        password: "root",
+        password: "secret",
     })
     .await?;
     Ok(format!("Back to root!"))
@@ -678,7 +678,7 @@ impl Database {
             Command::SignInRoot => {
                 self.signin(Root {
                     username: "root",
-                    password: "root",
+                    password: "secret",
                 })
                 .await?;
                 Ok(format!("Back to root!"))
@@ -770,7 +770,7 @@ fn main() -> Result<(), Error> {
 
             db.signin(Root {
                 username: "root",
-                password: "root",
+                password: "secret",
             })
             .await?;
 

--- a/src/content/doc-sdk-rust/frameworks/rocket.mdx
+++ b/src/content/doc-sdk-rust/frameworks/rocket.mdx
@@ -18,7 +18,7 @@ The following tutorial will set up a server with SurrealDB and [Rocket](https://
 First, open up a terminal window and use the following command to start an empty database.
 
 ```bash
-surreal start --user root --pass root
+surreal start --user root --pass secret
 ```
 
 You can also use the [Start serving](/docs/surrealist/concepts/local-database-serving) button on [Surrealist](/docs/surrealist) to do the same if you have it installed locally.
@@ -28,7 +28,7 @@ The database initiated by the [surreal start](/docs/surrealdb/cli/start) command
 With the database running, we will now connect to the database "test" located in the namespace "test". You can connect to it by [creating a connection](/docs/surrealist/getting-started#creating-a-connection) inside Surrealist, or by using the following command to start an interactive shell.
 
 ```bash
-surreal sql --user root --pass root --ns test --db test --pretty
+surreal sql --user root --pass secret --ns test --db test --pretty
 ```
 
 Next, create a new Rust project with the command `cargo new your_project_name`, go into the newly created directory, and use `cargo add` to add each of the following dependencies:
@@ -107,7 +107,7 @@ async fn init() -> Result<(), surrealdb::Error> {
 
     DB.signin(Root {
         username: "root",
-        password: "root",
+        password: "secret",
     })
     .await?;
 
@@ -542,7 +542,7 @@ async fn init() -> Result<(), surrealdb::Error> {
 
     DB.signin(Root {
         username: "root",
-        password: "root",
+        password: "secret",
     })
     .await?;
 

--- a/src/content/doc-sdk-rust/methods/create.mdx
+++ b/src/content/doc-sdk-rust/methods/create.mdx
@@ -67,7 +67,7 @@ async fn main() -> surrealdb::Result<()> {
     let db = connect("ws://localhost:8000").await?;
     db.signin(Root {
         username: "root",
-        password: "root",
+        password: "secret",
     })
     .await?;
     db.use_ns("ns").use_db("db").await?;

--- a/src/content/doc-sdk-rust/methods/delete.mdx
+++ b/src/content/doc-sdk-rust/methods/delete.mdx
@@ -52,7 +52,7 @@ async fn main() -> surrealdb::Result<()> {
     let db = connect("ws://localhost:8000").await?;
     db.signin(Root {
         username: "root",
-        password: "root",
+        password: "secret",
     })
     .await?;
     db.use_ns("ns").use_db("db").await?;

--- a/src/content/doc-sdk-rust/methods/export.mdx
+++ b/src/content/doc-sdk-rust/methods/export.mdx
@@ -53,7 +53,7 @@ async fn main() -> surrealdb::Result<()> {
     let db = connect("http://localhost:8000").await?;
     db.signin(Root {
         username: "root",
-        password: "root",
+        password: "secret",
     })
     .await?;
     db.use_ns("ns").use_db("db").await?;
@@ -79,7 +79,7 @@ async fn main() -> surrealdb::Result<()> {
     let db = connect("http://localhost:8000").await?;
     db.signin(Root {
         username: "root",
-        password: "root",
+        password: "secret",
     })
     .await?;
     db.use_ns("ns").use_db("db").await?;
@@ -164,7 +164,7 @@ async fn main() -> surrealdb::Result<()> {
     let db = connect("http://localhost:8000").await?;
     db.signin(Root {
         username: "root",
-        password: "root",
+        password: "secret",
     })
     .await?;
     db.use_ns("ns").use_db("db").await?;

--- a/src/content/doc-sdk-rust/methods/import.mdx
+++ b/src/content/doc-sdk-rust/methods/import.mdx
@@ -27,7 +27,7 @@ async fn main() -> surrealdb::Result<()> {
     let db = connect("http://localhost:8000").await?;
     db.signin(Root {
         username: "root",
-        password: "root",
+        password: "secret",
     })
     .await?;
     db.use_ns("ns").use_db("db").await?;

--- a/src/content/doc-sdk-rust/methods/insert.mdx
+++ b/src/content/doc-sdk-rust/methods/insert.mdx
@@ -82,7 +82,7 @@ async fn main() -> surrealdb::Result<()> {
 
     db.signin(Root {
         username: "root",
-        password: "root",
+        password: "secret",
     })
     .await?;
 
@@ -134,7 +134,7 @@ async fn main() -> surrealdb::Result<()> {
 
     db.signin(Root {
         username: "root",
-        password: "root",
+        password: "secret",
     })
     .await?;
 
@@ -196,7 +196,7 @@ async fn main() -> surrealdb::Result<()> {
 
     db.signin(Root {
         username: "root",
-        password: "root",
+        password: "secret",
     })
     .await?;
 
@@ -260,7 +260,7 @@ async fn main() -> surrealdb::Result<()> {
 
     db.signin(Root {
         username: "root",
-        password: "root",
+        password: "secret",
     })
     .await?;
 

--- a/src/content/doc-sdk-rust/methods/query.mdx
+++ b/src/content/doc-sdk-rust/methods/query.mdx
@@ -51,7 +51,7 @@ async fn main() -> surrealdb::Result<()> {
 
     db.signin(Root {
         username: "root",
-        password: "root",
+        password: "secret",
     })
     .await?;
 
@@ -96,7 +96,7 @@ async fn main() -> surrealdb::Result<()> {
 
     db.signin(Root {
         username: "root",
-        password: "root",
+        password: "secret",
     })
     .await?;
 
@@ -164,7 +164,7 @@ async fn main() -> surrealdb::Result<()> {
 
     db.signin(Root {
         username: "root",
-        password: "root",
+        password: "secret",
     })
     .await?;
 

--- a/src/content/doc-sdk-rust/methods/run.mdx
+++ b/src/content/doc-sdk-rust/methods/run.mdx
@@ -49,7 +49,7 @@ async fn main() -> surrealdb::Result<()> {
 
     db.signin(Root {
         username: "root",
-        password: "root",
+        password: "secret",
     })
     .await?;
 
@@ -70,7 +70,7 @@ async fn main() -> surrealdb::Result<()> {
     let db = connect("ws://localhost:8000").await?;
     db.signin(Root {
         username: "root",
-        password: "root",
+        password: "secret",
     })
     .await?;
     db.use_ns("ns").use_db("db").await?;
@@ -103,7 +103,7 @@ async fn main() -> surrealdb::Result<()> {
     let db = connect("ws://localhost:8000").await?;
     db.signin(Root {
         username: "root",
-        password: "root",
+        password: "secret",
     })
     .await?;
     db.use_ns("ns").use_db("db").await?;

--- a/src/content/doc-sdk-rust/methods/select-live.mdx
+++ b/src/content/doc-sdk-rust/methods/select-live.mdx
@@ -61,7 +61,7 @@ async fn main() -> surrealdb::Result<()> {
 
     db.signin(Root {
         username: "root",
-        password: "root",
+        password: "secret",
     })
     .await?;
 
@@ -82,7 +82,7 @@ async fn main() -> surrealdb::Result<()> {
 Then connect to it using Surrealist or open a new terminal window with the following command.
 
 ```
-surreal sql --namespace ns --database db --user root --pass root --pretty
+surreal sql --namespace ns --database db --user root --pass secret --pretty
 ```
 
 You can then use queries like the following to work with some `person` records.

--- a/src/content/doc-sdk-rust/methods/select.mdx
+++ b/src/content/doc-sdk-rust/methods/select.mdx
@@ -67,7 +67,7 @@ async fn main() -> surrealdb::Result<()> {
 	// Sign in
 	db.signin(Root {
 		username: "root",
-		password: "root",
+		password: "secret",
 	})
 	.await?;
 

--- a/src/content/doc-sdk-rust/methods/set.mdx
+++ b/src/content/doc-sdk-rust/methods/set.mdx
@@ -73,7 +73,7 @@ async fn main() -> surrealdb::Result<()> {
 
     db.signin(Root {
         username: "root",
-        password: "root",
+        password: "secret",
     })
     .await?;
 

--- a/src/content/doc-sdk-rust/methods/unset.mdx
+++ b/src/content/doc-sdk-rust/methods/unset.mdx
@@ -33,7 +33,7 @@ async fn main() -> surrealdb::Result<()> {
 
     db.signin(Root {
         username: "root",
-        password: "root",
+        password: "secret",
     })
     .await?;
 

--- a/src/content/doc-sdk-rust/methods/update.mdx
+++ b/src/content/doc-sdk-rust/methods/update.mdx
@@ -87,7 +87,7 @@ async fn main() -> surrealdb::Result<()> {
 
     db.signin(Root {
         username: "root",
-        password: "root",
+        password: "secret",
     })
     .await?;
 
@@ -188,7 +188,7 @@ async fn main() -> surrealdb::Result<()> {
 
     db.signin(Root {
         username: "root",
-        password: "root",
+        password: "secret",
     })
     .await?;
 
@@ -297,7 +297,7 @@ async fn main() -> surrealdb::Result<()> {
 
     db.signin(Root {
         username: "root",
-        password: "root",
+        password: "secret",
     })
     .await?;
 

--- a/src/content/doc-sdk-rust/methods/upsert.mdx
+++ b/src/content/doc-sdk-rust/methods/upsert.mdx
@@ -89,7 +89,7 @@ async fn main() -> surrealdb::Result<()> {
 
     db.signin(Root {
         username: "root",
-        password: "root",
+        password: "secret",
     })
     .await?;
 
@@ -184,7 +184,7 @@ async fn main() -> surrealdb::Result<()> {
 
     db.signin(Root {
         username: "root",
-        password: "root",
+        password: "secret",
     })
     .await?;
 
@@ -282,7 +282,7 @@ async fn main() -> surrealdb::Result<()> {
 
     db.signin(Root {
         username: "root",
-        password: "root",
+        password: "secret",
     })
     .await?;
 

--- a/src/content/doc-sdk-rust/methods/wait-for.mdx
+++ b/src/content/doc-sdk-rust/methods/wait-for.mdx
@@ -81,7 +81,7 @@ async fn main() -> surrealdb::Result<()> {
     // At this point the connection has already been established but the database hasn't been selected yet.
     db.signin(Root {
         username: "root",
-        password: "root",
+        password: "secret",
     })
     .await
     .unwrap();

--- a/src/content/doc-sdk-rust/setup.mdx
+++ b/src/content/doc-sdk-rust/setup.mdx
@@ -46,7 +46,7 @@ codegen-units = 1
 Before using `cargo run` to try out your code, make sure that the SurrealDB server is running by using the [`surreal start`](/docs/surrealdb/cli/start) command. The following command will start an in-memory server with a single root user at the default address `127.0.0.1:8000`.
 
 ```bash
-surreal start --user root --pass root
+surreal start --user root --pass secret
 ```
 
 If you prefer to do everything through Surrealist, you can also use the [`Start serving`](/docs/surrealist/concepts/local-database-serving) button to do the same as long as you have Surrealist installed locally on your computer.
@@ -69,7 +69,7 @@ async fn main() -> surrealdb::Result<()> {
     // Signin as a namespace, database, or root user
     db.signin(Root {
         username: "root",
-        password: "root",
+        password: "secret",
     })
     .await?;
 
@@ -187,7 +187,7 @@ async fn main() -> surrealdb::Result<()> {
 
     db.signin(Root {
         username: "root",
-        password: "root",
+        password: "secret",
     })
     .await?;
 
@@ -280,7 +280,7 @@ async fn main() -> surrealdb::Result<()> {
     // Sign in to the server
     DB.signin(Root {
         username: "root",
-        password: "root",
+        password: "secret",
     })
     .await?;
     // Select a namespace + database
@@ -295,14 +295,14 @@ async fn main() -> surrealdb::Result<()> {
 Besides printing out the results inside the Rust code above, you can sign in to the database using the CLI or Surrealist to view them.
 
 ```bash
-surreal sql --user root --pass root --namespace test --database test --pretty
+surreal sql --user root --pass secret --namespace test --database test --pretty
 ```
 
 Inside Surrealist, do the following:
 
 * Hover over the current connection and click on "Change connection"
 * Hover over "New connection" and click the pencil icon
-* Change the "Method" to "root". Enter "root" for both username and password.
+* Change the "Method" to "root". Enter "root" for the username and "secret" for the password.
 * You will now be connected as the root user, and can define and then select the namespace and databases called "test".
 
 Here is the last query in the example above to get started:

--- a/src/content/doc-surrealdb/cli/env.mdx
+++ b/src/content/doc-surrealdb/cli/env.mdx
@@ -820,7 +820,7 @@ As each of these environment variables correspond to a flag passed into a comman
 For example, take the following command to start the database.
 
 ```bash
-surreal start --user root --pass root --allow-net --deny-funcs "crypto::md5, http::post, http::delete"
+surreal start --user root --pass secret --allow-net --deny-funcs "crypto::md5, http::post, http::delete"
 ```
 
 If we now wanted to use environment variables instead of the `--allow-net` and `--deny-funcs` flags, we would use the `SURREAL_CAPS_ALLOW_NET` and `SURREAL_CAPS_DENY_FUNC` environment variables.
@@ -835,7 +835,7 @@ The command would then look like the following:
 ```bash
 SURREAL_CAPS_ALLOW_NET
 SURREAL_CAPS_DENY_FUNC="crypto::md5, http::post, http::delete"
-surreal start --user root --pass root
+surreal start --user root --pass secret
 ```
 </TabItem>
 
@@ -843,7 +843,7 @@ surreal start --user root --pass root
 ```powershell
 $env:SURREAL_CAPS_ALLOW_NET
 $env:SURREAL_CAPS_DENY_FUNC="crypto::md5, http::post, http::delete"
-surreal start --user root --pass root
+surreal start --user root --pass secret
 ```
 </TabItem>
 </Tabs>

--- a/src/content/doc-surrealdb/cli/export.mdx
+++ b/src/content/doc-surrealdb/cli/export.mdx
@@ -217,7 +217,7 @@ surreal export [OPTIONS] --namespace <NAMESPACE> --database <DATABASE> [FILE]
 To perform a SurrealQL database export into a local file, in a terminal run the `surreal export` command with the required arguments.
 
 ```bash
-surreal export --conn http://localhost:8000 --user root --pass root --ns test --db test export.surql
+surreal export --conn http://localhost:8000 --user root --pass secret --ns test --db test export.surql
 ```
 
 Using token-based authentication

--- a/src/content/doc-surrealdb/cli/help.mdx
+++ b/src/content/doc-surrealdb/cli/help.mdx
@@ -72,5 +72,5 @@ For individual commands, such as `surreal start` and `surreal sql`, a help promp
 
 ```bash
 surreal start --help
-surreal start --user root --pass root --strict --help
+surreal start --user root --pass secret --strict --help
 ```

--- a/src/content/doc-surrealdb/cli/import.mdx
+++ b/src/content/doc-surrealdb/cli/import.mdx
@@ -108,7 +108,7 @@ The import command imports a SurrealQL script file into a local or remote Surrea
 To perform a SurrealQL database import from a local file, in a terminal run the `surreal import` command with the required arguments.
 
 ```bash
-surreal import --conn http://localhost:8000 --user root --pass root --ns test --db test downloads/surreal_deal_v1.surql
+surreal import --conn http://localhost:8000 --user root --pass secret --ns test --db test downloads/surreal_deal_v1.surql
 ```
 
 Using token-based authentication:

--- a/src/content/doc-surrealdb/cli/index.mdx
+++ b/src/content/doc-surrealdb/cli/index.mdx
@@ -22,7 +22,7 @@ When starting with the CLI, the most commonly used commands are [`surreal start`
 For a quickstart, [`surreal start`](/docs/surrealdb/cli/start) and [`surreal sql`](/docs/surrealdb/cli/sql) will be enough to get you started.
 
 ```bash
-surreal start --user root --pass root
+surreal start --user root --pass secret
 ```
 Unless you specify otherwise, the CLI will start a database in memory that serves at `127.0.0.1:8000 or (http://localhost:8000)`. This database has a single root user named `root` and a password `root`.
 

--- a/src/content/doc-surrealdb/cli/ml/export.mdx
+++ b/src/content/doc-surrealdb/cli/ml/export.mdx
@@ -125,7 +125,7 @@ The ML export command is used to export an existing machine learning model from 
 To perform a SurrealQL database import from a local file, in a terminal run the `surreal import` command with the required arguments.
 
 ```bash
-surreal ml export --conn http://localhost:8000 --user root --pass root --ns test --db test --name my-surrealml-model --version 1.0.0 my-surrealml-model.surml
+surreal ml export --conn http://localhost:8000 --user root --pass secret --ns test --db test --name my-surrealml-model --version 1.0.0 my-surrealml-model.surml
 ```
 
 Using token-based authentication:

--- a/src/content/doc-surrealdb/cli/ml/import.mdx
+++ b/src/content/doc-surrealdb/cli/ml/import.mdx
@@ -108,7 +108,7 @@ The ML import command is used to import a new machine learning model into Surrea
 To perform a SurrealQL database import from a local file, in a terminal run the `surreal import` command with the required arguments.
 
 ```bash
-surreal ml import --conn http://localhost:8000 --user root --pass root --ns test --db test my-surrealml-model.surml
+surreal ml import --conn http://localhost:8000 --user root --pass secret --ns test --db test my-surrealml-model.surml
 ```
 
 Using token-based authentication:

--- a/src/content/doc-surrealdb/cli/start.mdx
+++ b/src/content/doc-surrealdb/cli/start.mdx
@@ -426,7 +426,7 @@ As `surreal start` is the command with by far the largest number of options, a f
 An instance with a single root user, able to connect to the internet but unable to use three functions:
 
 ```bash
-surreal start --user root --pass root --allow-net --deny-funcs "crypto::md5, http::post, http::delete"
+surreal start --user root --pass secret --allow-net --deny-funcs "crypto::md5, http::post, http::delete"
 ```
 
 An instance with more verbose logging that uses RocksDB as its storage engine:

--- a/src/content/doc-surrealdb/installation/running/docker.mdx
+++ b/src/content/doc-surrealdb/installation/running/docker.mdx
@@ -58,19 +58,19 @@ To set up access as an authenticated user, configure your initial root-level use
 The following command starts the database with a top-level user named `root` with a password also set to `root`. The root user will be persisted in storage, which means you don't have to include the command line arguments next time you start SurrealDB.
 
 ```bash
-docker run --rm --pull always -p 80:8000 -v /mydata:/mydata surrealdb/surrealdb:latest start --user root --pass root rocksdb:mydatabase.db
+docker run --rm --pull always -p 80:8000 -v /mydata:/mydata surrealdb/surrealdb:latest start --user root --pass secret rocksdb:mydatabase.db
 ```
 
 In order to change the default port that SurrealDB uses for web connections and from database clients you can use the Docker *`-p`* command line argument to tunnel the port to the internal SurrealDB port which SurrealDB is served on. The following command starts the database on port `80`.
 
 ```bash
-docker run --rm --pull always -p 80:8000 -v /mydata:/mydata surrealdb/surrealdb:latest start --user root --pass root rocksdb:/mydata/mydatabase.db
+docker run --rm --pull always -p 80:8000 -v /mydata:/mydata surrealdb/surrealdb:latest start --user root --pass secret rocksdb:/mydata/mydatabase.db
 ```
 
 After running the above command, you should see the SurrealDB server startup successfully.
 
 ```bash
-docker run --rm --pull always -p 80:8000 -v /local-dir:/container-dir surrealdb/surrealdb:latest start --user root --pass root rocksdb:/container-dir/mydatabase.db
+docker run --rm --pull always -p 80:8000 -v /local-dir:/container-dir surrealdb/surrealdb:latest start --user root --pass secret rocksdb:/container-dir/mydatabase.db
 
 2023-08-30T15:06:34.788739Z  INFO surreal::dbs: ✅🔒 Authentication is enabled 🔒✅
 2023-08-30T15:06:34.788821Z  INFO surrealdb::kvs::ds: Starting kvs store in rocksdb:/container-dir/mydatabase.db

--- a/src/content/doc-surrealdb/installation/running/file.mdx
+++ b/src/content/doc-surrealdb/installation/running/file.mdx
@@ -28,18 +28,18 @@ surreal start --unauthenticated rocksdb:mydatabase.db
 However, for anything but simple testing, it is better to configure your initial root-level user by setting the *`--user`* and *`--pass`* command-line arguments. The following command starts the database with a top-level user named root with a password also set to `root`. The root user will be persisted in storage, which means you don't have to include the command line arguments next time you start SurrealDB.
 
 ```bash
-surreal start --user root --pass root rocksdb:mydatabase.db
+surreal start --user root --pass secret rocksdb:mydatabase.db
 ```
 
 In order to change the default port that SurrealDB uses for web connections and from database clients you can use the *`--bind`* argument. The following command starts the database on port `8080`.
 
 ```bash
-surreal start --user root --pass root --bind 0.0.0.0:8080 rocksdb://path/to/mydatabase
+surreal start --user root --pass secret --bind 0.0.0.0:8080 rocksdb://path/to/mydatabase
 ```
 After running the above command, you should see the SurrealDB server startup successfully.
 
 ```bash
-surreal start --user root --pass root --bind 0.0.0.0:8080 rocksdb:mydatabase.db
+surreal start --user root --pass secret --bind 0.0.0.0:8080 rocksdb:mydatabase.db
 2023-08-30T15:06:34.788739Z  INFO surreal::dbs: ✅🔒 Authentication is enabled 🔒✅
 2023-08-30T15:06:34.788821Z  INFO surrealdb::kvs::ds: Starting kvs store in file:mydatabase.db
 2023-08-30T15:06:34.788859Z  INFO surrealdb::kvs::ds: Started kvs store in file:mydatabase.db

--- a/src/content/doc-surrealdb/installation/running/memory.mdx
+++ b/src/content/doc-surrealdb/installation/running/memory.mdx
@@ -34,7 +34,7 @@ surreal start --unauthenticated memory
 However, for anything but simple testing, it is better to configure your initial root-level user by setting the *`--user`* and *`--pass`* command-line arguments. The following command starts the database with a top-level user named `root` with a password also set to `root`.
 
 ```bash
-surreal start --user root --pass root memory
+surreal start --user root --pass secret memory
 ```
 
 The previous command will bootstrap the server with the provided initial credentials, you can now remove those args and rely on [DEFINE USER](/docs/surrealql/statements/define/user) to change the password or create more users.
@@ -45,13 +45,13 @@ surreal start --user username --pass 123456 memory
 In order to change the default port that SurrealDB uses for web connections and from database clients you can use the *`--bind`* argument. The following command starts the database on port `8080`.
 
 ```bash
-surreal start --user root --pass root --bind 0.0.0.0:8080 memory
+surreal start --user root --pass secret --bind 0.0.0.0:8080 memory
 ```
 
 After running the above command, you should see the SurrealDB server startup successfully.
 
 ```bash
-surreal start --user root --pass root --bind 0.0.0.0:8080 memory
+surreal start --user root --pass secret --bind 0.0.0.0:8080 memory
 2023-08-30T15:06:34.788821Z  INFO surrealdb::kvs::ds: Starting kvs store in memory
 2023-08-30T15:06:34.788859Z  INFO surrealdb::kvs::ds: Started kvs store in memory
 2023-08-30T15:06:34.789222Z  INFO surrealdb::kvs::ds: Initial credentials were provided and no existing root-level users were found: create the initial user 'root'.

--- a/src/content/doc-surrealdb/installation/running/tikv.mdx
+++ b/src/content/doc-surrealdb/installation/running/tikv.mdx
@@ -31,17 +31,17 @@ surreal start --log debug tikv://127.0.0.1:2379
 In order to keep SurrealDB secure, configure your initial root-level user by setting the *`--user`* and *`--pass`* command-line arguments. The following command starts the database with a top-level user named root with a password also set to `root`. The root user will be persisted in storage, which means you don't have to include the command line arguments next time you start SurrealDB.
 
 ```bash
-surreal start --user root --pass root tikv://127.0.0.1:2379
+surreal start --user root --pass secret tikv://127.0.0.1:2379
 ```
 In order to change the default port that SurrealDB uses for web connections and from database clients you can use the *`--bind`* argument. The following command starts the database on port `8080`.
 
 ```bash
-surreal start --user root --pass root --bind 0.0.0.0:8080 tikv://127.0.0.1:2379
+surreal start --user root --pass secret --bind 0.0.0.0:8080 tikv://127.0.0.1:2379
 ```
 After running the above command, you should see the SurrealDB server startup successfully.
 
 ```bash
-surreal start --user root --pass root --bind 0.0.0.0:8080 tikv://127.0.0.1:2379
+surreal start --user root --pass secret --bind 0.0.0.0:8080 tikv://127.0.0.1:2379
 2025-02-14T12:16:28.660617Z  INFO surreal::env: Running 2.2.0 for macos on aarch64
 2025-02-14T12:16:28.660678Z  INFO surrealdb::core::kvs::ds: Connecting to kvs store at tikv://127.0.0.1:2379
 2025-02-14T12:16:28.660825Z  INFO tikv_client::common::security: connect to rpc server at endpoint: "http://127.0.0.1:2379"

--- a/src/content/doc-surrealdb/installation/upgrading/migrating-data-to-2.x.mdx
+++ b/src/content/doc-surrealdb/installation/upgrading/migrating-data-to-2.x.mdx
@@ -65,7 +65,7 @@ The `surreal fix` command above has been created specifically for 1.x instances.
 
 ```bash
 # Example export command to export data to a file called `export.surql` in the downloads directory.
-surreal export --conn http://localhost:8000 --user root --pass root --ns test --db test downloads/export.surql
+surreal export --conn http://localhost:8000 --user root --pass secret --ns test --db test downloads/export.surql
 ```
 
 2. This will create a file called `export.surql` in the current directory.
@@ -74,7 +74,7 @@ surreal export --conn http://localhost:8000 --user root --pass root --ns test --
 
 
 ```bash
-surreal import --conn http://localhost:8000 --user root --pass root --ns test --db test downloads/export.surql
+surreal import --conn http://localhost:8000 --user root --pass secret --ns test --db test downloads/export.surql
 ```
 
 ## Troubleshooting

--- a/src/content/doc-surrealdb/introduction/start.mdx
+++ b/src/content/doc-surrealdb/introduction/start.mdx
@@ -108,19 +108,19 @@ To start your database, run the start command specific to your machine.
 ### macOS or Linux
 
 ```bash
-surreal start memory -A --user root --pass root
+surreal start memory -A --user root --pass secret
 ```
 ### Windows
 
 ```shell
-surreal.exe start memory -A --user root --pass root
+surreal.exe start memory -A --user root --pass secret
 ```
 
 Here's what each segment of this command does:
 
 - `surreal start`: This initiates the process of starting the SurrealDB database server.
 - `-A`: Enable all capabilities.
-- `--user root --pass root`: These flags set the initial username and password to access the database. Here both are set as root. Once the initial credentials are created, they are persisted in the datastore, which means you don't have to include the command line arguments next time you start SurrealDB. Instead, they should be securely stored in [environment variables](/docs/surrealdb/cli/env) or some form of secret management system.
+- `--user root --pass secret`: These flags set the initial username and password to access the database. Here both are set as root. Once the initial credentials are created, they are persisted in the datastore, which means you don't have to include the command line arguments next time you start SurrealDB. Instead, they should be securely stored in [environment variables](/docs/surrealdb/cli/env) or some form of secret management system.
 - `memory`: This argument indicates that the database should be run in memory. Databases run in memory can have quicker data access times because they're not reading and writing from disk, but the data will be lost when the server is restarted. 
 */}
 

--- a/src/content/doc-surrealdb/querying/surrealql/cli.mdx
+++ b/src/content/doc-surrealdb/querying/surrealql/cli.mdx
@@ -21,7 +21,7 @@ After installing the SurrealDB CLI, you can start writing SurrealQL queries by r
 To start a SurrealDB server, run the surreal start command, using the options below. This example serves the database at the default location (http://localhost:8000), with a username and password.
 
 ```bash
-surreal start --endpoint http://localhost:8000 --user root --pass root
+surreal start --endpoint http://localhost:8000 --user root --pass secret
 ```
 
 The server is actively running, and should be left alone until you want to stop hosting the SurrealDB server.

--- a/src/content/doc-surrealml/index.mdx
+++ b/src/content/doc-surrealml/index.mdx
@@ -217,7 +217,7 @@ SurMlFile.upload(
     namespace="test",
     database="test",
     username="root",
-    password="root"
+    password="secret"
 )
 
 ```

--- a/src/content/doc-surrealql/demo.mdx
+++ b/src/content/doc-surrealql/demo.mdx
@@ -49,7 +49,7 @@ Secondly, [start the server](/docs/surrealdb/cli/start).
 
 ```bash
 # Create a new in-memory server
-surreal start --user root --pass root --allow-all
+surreal start --user root --pass secret --allow-all
 ```
 
 Lastly, use the [import command](/docs/surrealdb/cli/import) to add the dataset.
@@ -57,13 +57,13 @@ Lastly, use the [import command](/docs/surrealdb/cli/import) to add the dataset.
 Use the command below to import the [surreal deal store dataset](https://datasets.surrealdb.com/surreal-deal-store.surql):
 
 ```bash
-surreal import --conn http://localhost:8000 --user root --pass root --ns test --db test surreal-deal-store.surql
+surreal import --conn http://localhost:8000 --user root --pass secret --ns test --db test surreal-deal-store.surql
 ```
 
 To import the surreal downloaded the [Surreal Deal store (mini)](https://datasets.surrealdb.com/surreal-deal-store-mini.surql) use the command below:
 
 ```bash
-surreal import --conn http://localhost:8000 --user root --pass root --ns test --db test surreal-deal-store-mini.surql
+surreal import --conn http://localhost:8000 --user root --pass secret --ns test --db test surreal-deal-store-mini.surql
 ```
 
 Please be aware that the import process might take a few seconds.
@@ -75,7 +75,7 @@ First, start the surrealdb server
 
 ```bash
 # Create a new in-memory server
-surreal start --user root --pass root --allow-all
+surreal start --user root --pass secret --allow-all
 ```
 
 Then, download the file and load it into the database

--- a/src/content/doc-surrealql/statements/access.mdx
+++ b/src/content/doc-surrealql/statements/access.mdx
@@ -489,7 +489,7 @@ Follow these steps to see the output in practice.
 First, start the SurrealDB server with a root user:
 
 ```bash
-surreal start --user root --pass root
+surreal start --user root --pass secret
 ```
 
 Log in as the root user, choose the namespace `test` and database `test`, and run the following `DEFINE ACCESS` command.

--- a/src/content/doc-surrealql/statements/define/bucket.mdx
+++ b/src/content/doc-surrealql/statements/define/bucket.mdx
@@ -77,11 +77,11 @@ The following command can be used to start running an instance in which a bucket
 
 ```bash
 # Unix
-SURREAL_FILE_ALLOWLIST="/" surreal start --user root --pass root --allow-experimental files
+SURREAL_FILE_ALLOWLIST="/" surreal start --user root --pass secret --allow-experimental files
 
 # Windows (PowerShell)
 $env:SURREAL_FILE_ALLOWLIST = "/" 
-surreal start --user root --pass root --allow-experimental files
+surreal start --user root --pass secret --allow-experimental files
 ```
 
 ### Global backend

--- a/src/content/doc-tutorials/connect-to-surrealdb-via-ngrok-tunnel.mdx
+++ b/src/content/doc-tutorials/connect-to-surrealdb-via-ngrok-tunnel.mdx
@@ -32,7 +32,7 @@ There are two ways to connect to a SurrealDB instance via Ngrok tunnel.
 Open your command line or terminal and run the following command to [start SurrealDB](/docs/surrealdb/introduction/start).
     
 ```bash
-surreal start memory -A --user root --pass root
+surreal start memory -A --user root --pass secret
 ```
     
 We use the default username and password `root`. You can replace it with your own credentials if you have set them up.
@@ -57,7 +57,7 @@ Now, let's [connect to your SurrealDB instance](/docs/surrealdb/cli/sql) using t
 Run the following command in a new terminal window/tab, replacing **`[ngrok-address]`** with the actual Ngrok forwarding address you noted earlier:
     
 ```bash
-surreal sql --conn wss://[ngrok-address] --user root --pass root --ns test --db test --pretty
+surreal sql --conn wss://[ngrok-address] --user root --pass secret --ns test --db test --pretty
 ```
     
 ### Verify the Connection

--- a/src/content/doc-tutorials/integrate-auth0-as-authentication-provider.mdx
+++ b/src/content/doc-tutorials/integrate-auth0-as-authentication-provider.mdx
@@ -33,7 +33,7 @@ This guide assumes the following:
 
 ```bash
 docker run --rm --pull always -p 8000:8000 surrealdb/surrealdb:latest \
-  start --user root --pass root
+  start --user root --pass secret
 ```
 
 To run the SurrealQL statements mentioned in this guide, you will also need an interactive shell.

--- a/src/content/doc-tutorials/integrate-aws-cognito-as-authentication-provider.mdx
+++ b/src/content/doc-tutorials/integrate-aws-cognito-as-authentication-provider.mdx
@@ -34,7 +34,7 @@ This guide assumes the following:
 
 ```bash
 docker run --rm --pull always -p 8000:8000 surrealdb/surrealdb:latest \
-  start --user root --pass root
+  start --user root --pass secret
 ```
 
 To run the SurrealQL statements mentioned in this guide, you will also need an interactive shell.

--- a/src/content/doc-tutorials/working-with-surrealdb-over-http-via-postman.mdx
+++ b/src/content/doc-tutorials/working-with-surrealdb-over-http-via-postman.mdx
@@ -27,7 +27,7 @@ Before forking the Collection from Postman, ensure that you have your SurrealDB 
 To do so run the [Start command](/docs/surrealdb/cli/start) in your terminal: 
 
 ```surql
-surreal start --user root --pass root
+surreal start --user root --pass secret
 ```
 
 The above command starts SurrealDB with [authentication](/docs/surrealdb/cli/start#authentication) and specifies that the user and password are `root`. Note that this is just for demonstration purposes. You can replace `root` in both instances with any other value.


### PR DESCRIPTION
99% of the time the default password in the docs is "root", which is the same as the username and may give the impression that it has some relation to being a root user. This changes the password in this case to "secret" which makes the commands and examples a bit clearer in showing which is the name and which is the password.