### PR TITLE
Add example of unique key for ON DUPLICATE KEY UPDATE

### DIFF
--- a/src/content/doc-surrealql/statements/insert.mdx
+++ b/src/content/doc-surrealql/statements/insert.mdx
@@ -49,7 +49,7 @@ INSERT INTO
 	VALUES  ('Acme Inc.', '1967-05-03'), ('Apple Inc.', '1976-04-01');
 ```
 
-When using the `VALUES` clause, it is possible to update records which already exist by specifying an `ON DUPLICATE KEY UPDATE` clause. This clause also allows incrementing and decrementing numeric values, and adding or removing values from arrays. To increment a numeric value, or to add an item to an array, use the `+=` operator. To decrement a numeric value, or to remove an value from an array, use the `-=` operator.
+It is possible to update records which already exist or violate a unique index by specifying an `ON DUPLICATE KEY UPDATE` clause. This clause also allows incrementing and decrementing numeric values, and adding or removing values from arrays. To increment a numeric value, or to add an item to an array, use the `+=` operator. To decrement a numeric value, or to remove an value from an array, use the `-=` operator.
 
 ```surql
 INSERT INTO product (name, url) VALUES ('Salesforce', 'salesforce.com') ON DUPLICATE KEY UPDATE tags += 'crm';
@@ -62,6 +62,47 @@ INSERT INTO city (id, population, at_year) VALUES ("Calgary", 1665000, 2024)
 ON DUPLICATE KEY UPDATE
 	population = $input.population,
 	at_year = $input.at_year;
+```
+
+An example of `ON DUPLICATE KEY UPDATE` when a unique key is encountered shows the same behaviour as that with a duplicate record:
+
+```surql
+DEFINE FIELD for ON user_data TYPE record<user>;
+DEFINE INDEX one_user ON user_data FIELDS for UNIQUE;
+
+INSERT INTO user_data {
+    for: user:one,
+    some: "data"
+} ON DUPLICATE KEY UPDATE times_updated += 1, last_edited = time::now();
+
+INSERT INTO user_data {
+    for: user:one,
+    some_more: "data"
+} ON DUPLICATE KEY UPDATE times_updated += 1, last_edited = time::now();
+```
+
+```surql title="Output"
+-------- Query --------
+
+[
+	{
+		for: user:one,
+		id: user_data:kp78dubsxmp4f04x0de3,
+		some: 'data'
+	}
+]
+
+-------- Query --------
+
+[
+	{
+		for: user:one,
+		id: user_data:kp78dubsxmp4f04x0de3,
+		last_edited: d'2025-07-14T05:15:52.146Z',
+		some: 'data',
+		times_updated: 1
+	}
+]
 ```
 
 Using the insert statement, it is possible to copy records easily between tables. The records being copied will have the same id in the new table, but the record id will signify the new table name.


### PR DESCRIPTION
It turns out that ON DUPLICATE KEY UPDATE also applies to a unique index, which is convenient.