### PR TITLE
docs: minor updates to examples in sample-industry-schemas.mdx

### DIFF
--- a/src/content/doc-surrealdb/reference-guide/sample-industry-schemas.mdx
+++ b/src/content/doc-surrealdb/reference-guide/sample-industry-schemas.mdx
@@ -97,8 +97,7 @@ CREATE sensor:one SET type = ["temperature", "pressure"], location = (50.0, 50.0
 -- And a reading for the sensor
 CREATE reading:[sensor:one, time::now()] SET 
     pressure = 600,
-// JSON object sourced from somewhere else, `weather` field is FLEXIBLE so
-// can be any object format
+    -- JSON object sourced from somewhere else, `weather` field is FLEXIBLE so can be any object format
     weather = { "temperature": 17.4, "humidity": 52.0, "wind_speed": 12.8 };
 
 -- Set up event to generate alerts
@@ -108,7 +107,7 @@ DEFINE EVENT alert_from_create ON reading WHEN $event = "CREATE" THEN {
     -- Select everything over the past 15 minutes up to but not including the present reading
     LET $recents_average = math::mean(SELECT VALUE pressure FROM reading:[$source, $time - 15m]..[$source, $time]);
     LET $drop = $recents_average - $after.pressure;
-    IF $drop {
+    IF $drop > 15 {
       CREATE alert SET
             equipment = $source,
             severity = "high",
@@ -341,7 +340,7 @@ DEFINE TABLE bank SCHEMAFULL;
 DEFINE FIELD name         ON bank TYPE string;
 DEFINE FIELD code         ON bank TYPE string;  -- e.g., BIC or internal short code
 DEFINE FIELD swift        ON bank TYPE option<string>;
-DEFINE FIELD supported_currencies ON bank TYPE array<string> ASSERT $value ALLINSIDE $CURRENCIES;
+DEFINE FIELD supported_currencies ON bank TYPE set<string> ASSERT $value ALLINSIDE $CURRENCIES;
 DEFINE FIELD interest_rate ON bank TYPE float DEFAULT 0.0;
 DEFINE FIELD historical_interest_rates ON bank TYPE array<{ rate: float, set_at: datetime }> DEFAULT [];
 DEFINE FIELD customers ON bank TYPE references<customer>;


### PR DESCRIPTION
- Ensure the [SCADA (Oil and Gas)](https://surrealdb.com/docs/surrealdb/reference-guide/sample-industry-schemas#scada-oil-and-gas) example’s alert only fires on a pressure drop > 15 PSI so the text (“Pressure drop over 15 PSI”) always matches the guard.
- Update the [Other bank-customer schema](https://surrealdb.com/docs/surrealdb/reference-guide/sample-industry-schemas#other-bank-customer-schema) example to use `set<string>` as the supported_currencies field type (previously `array<string>`).