### PR TITLE
Clarify what success for .query() means

### DIFF
--- a/src/content/doc-sdk-rust/methods/query.mdx
+++ b/src/content/doc-sdk-rust/methods/query.mdx
@@ -120,6 +120,83 @@ async fn main() -> surrealdb::Result<()> {
 }
 ```
 
+The return value from this method is `Result<Response, Error>`. A `Result::Ok(Response)` only means that the query or queries were successfully executed, but does not mean that each query contained in the `Response` was successful.
+
+Take the following code for example which contains one successful query, followed by one with incorrect syntax (an integer where a string is expected).
+
+```rust
+use surrealdb::engine::any::connect;
+
+#[tokio::main]
+async fn main() {
+    let db = connect("memory").await.unwrap();
+    let res = db.query("
+        LET $x = 9;
+        LET $x: string = 9") // valid SurrealQL but wrong type
+        .await;
+    println!("{res:?}");
+}
+```
+
+The `.query()` method returns an `Ok(Response)`, showing that the database was able to understand and process the queries, even though the latter returned an error.
+
+```
+Ok(Response { results: {0: (Stats { execution_time: Some(197.875µs) }, Ok(None)), 1: (Stats { execution_time: Some(207.625µs) }, Err(Db(SetCheck { value: "9", name: "x", check: "string" })))}, live_queries: {} })
+```
+
+But if the function contains input that the database is unable to parse into a query in the first place, an `Err` will be returned for the entire `.query()` call.
+If the `string` syntax is changed to something nonsensical like `sssss`, the database is unable to process the query in the first place and `.query()` will return an `Err` for the whole call.
+
+```rust
+use surrealdb::engine::any::connect;
+
+#[tokio::main]
+async fn main() {
+    let db = connect("memory").await.unwrap();
+    let res = db.query("
+        LET $x = 9;
+        Hi how are you? I'm really curious;") // invalid SurrealQL
+        .await;
+    println!("{res:?}");
+}
+```
+
+```
+Err(Db(InvalidQuery(RenderedError { errors: ["Unexpected token `an identifier`, expected Eof"], snippets: [Snippet { source: "LET $x = 9; Hi how are you? I'm really curious", truncation: None, location: Location { line: 1, column: 16 }, offset: 15, length: 3, label: None, kind: Error }] })))
+```
+
+The `Response` struct contains helper metods such as [`.check()`](https://docs.rs/surrealdb/latest/surrealdb/struct.Response.html#method.check) to check for errors, or [`.take_errors()`](https://docs.rs/surrealdb/latest/surrealdb/struct.Response.html#method.take_errors) which removes the errors from the main `Response`.
+
+```rust
+use surrealdb::engine::any::connect;
+
+#[tokio::main]
+async fn main() {
+    let db = connect("memory").await.unwrap();
+    db.use_ns("ns").use_db("db").await.unwrap();
+    let mut res = db
+        .query(
+        "LET $x = 9;
+        LET $x: string = 9;
+        LET $x: bool = 9;
+        CREATE person",
+        )
+        .await
+        .unwrap();
+
+    println!("Errors: {:?}\n", res.take_errors());
+    println!("Successes: {:?}", res);
+}
+```
+
+Output:
+
+```
+Errors: {1: Db(SetCheck { value: "9", name: "x", check: "string" }), 2: Db(SetCheck { value: "9", name: "x", check: "bool" })}
+
+Successes: Response { results: {0: (Stats { execution_time: Some(143.458µs) }, Ok(None)), 3: (Stats { execution_time: Some(1.463583ms) }, Ok(Array(Array([Object(Object({"id": Thing(Thing { tb: "person", id: String("aokn0fp36pmqlxprjhre") })}))]))))}, live_queries: {} }
+```
+
 ### Security when using the .query() method
 
 As the `.query()` method can be used to pass any SurrealQL query on to the database, it is an easy go-to when using complex queries. However, be sure to keep [the following best practices in mind](/docs/surrealdb/reference-guide/security-best-practices#query-safety) when doing so.

--- a/src/content/doc-sdk-rust/methods/query.mdx
+++ b/src/content/doc-sdk-rust/methods/query.mdx
@@ -145,7 +145,7 @@ Ok(Response { results: {0: (Stats { execution_time: Some(197.875µs) }, Ok(None)
 ```
 
 But if the function contains input that the database is unable to parse into a query in the first place, an `Err` will be returned for the entire `.query()` call.
-If the `string` syntax is changed to something nonsensical like `sssss`, the database is unable to process the query in the first place and `.query()` will return an `Err` for the whole call.
+If the `string` syntax is changed to something nonsensical like `Hi how are you?`, the database is unable to process the query in the first place and `.query()` will return an `Err` for the whole call.
 
 ```rust
 use surrealdb::engine::any::connect;
@@ -155,14 +155,14 @@ async fn main() {
     let db = connect("memory").await.unwrap();
     let res = db.query("
         LET $x = 9;
-        Hi how are you? I'm really curious;") // invalid SurrealQL
+        Hi how are you?;") // invalid SurrealQL
         .await;
     println!("{res:?}");
 }
 ```
 
 ```
-Err(Db(InvalidQuery(RenderedError { errors: ["Unexpected token `an identifier`, expected Eof"], snippets: [Snippet { source: "LET $x = 9; Hi how are you? I'm really curious", truncation: None, location: Location { line: 1, column: 16 }, offset: 15, length: 3, label: None, kind: Error }] })))
+Err(Db(InvalidQuery(RenderedError { errors: ["Unexpected token `an identifier`, expected Eof"], snippets: [Snippet { source: "LET $x = 9; Hi how are you?", truncation: None, location: Location { line: 1, column: 16 }, offset: 15, length: 3, label: None, kind: Error }] })))
 ```
 
 The `Response` struct contains helper metods such as [`.check()`](https://docs.rs/surrealdb/latest/surrealdb/struct.Response.html#method.check) to check for errors, or [`.take_errors()`](https://docs.rs/surrealdb/latest/surrealdb/struct.Response.html#method.take_errors) which removes the errors from the main `Response`.


### PR DESCRIPTION
Clarify that Ok() for .query() means the queries successfully executed, not necessarily that each one was a successful result.