### PR TITLE
Typo: Fixed typo on encoding functions

### DIFF
--- a/src/content/doc-surrealql/functions/database/encoding.mdx
+++ b/src/content/doc-surrealql/functions/database/encoding.mdx
@@ -39,7 +39,7 @@ These functions can be used to encode and decode data into other formats, such a
     </tr>
     <tr>
       <td scope="row" data-label="Function"><a href="#encodingcborencode"><code>encoding::cbor::encode()</code></a></td>
-      <td scope="row" data-label="Description">This function is used to decode data.</td>
+      <td scope="row" data-label="Description">This function is used to encode data.</td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
There was a small copy/paste error on the encoding function page. So I fixed it :)