### PR TITLE
Add .Net to the list of supported embedding languages

### DIFF
--- a/src/content/doc-surrealdb/embedding/index.mdx
+++ b/src/content/doc-surrealdb/embedding/index.mdx
@@ -20,7 +20,7 @@ The following languages are supported:
 - [Rust](/docs/surrealdb/embedding/rust)
 - [JavaScript](/docs/surrealdb/embedding/javascript)
 - [Python](/docs/surrealdb/embedding/python)
-
+- [.Net](/docs/surrealdb/embedding/dotnet)
 
 
 


### PR DESCRIPTION
## Summary

The `.NET` was already listed in the sidebar but missing from the main page list of supported languages.
This PR adds `.NET` to the main page for consistency and clarity.

## Changes

- Added `.NET` to the supported languages list on the main page.

## Motivation

Ensures all supported languages are consistently documented across the sidebar and main content.
