### PR TITLE
Update reference guide with missing topics

### DIFF
--- a/src/content/doc-surrealdb/reference-guide/index.mdx
+++ b/src/content/doc-surrealdb/reference-guide/index.mdx
@@ -27,9 +27,12 @@ These guides will help you dig deeper into some of the core concepts and feature
 
 To get started, select a guide from the sidebar or use the search functionality to find a specific topic of interest.
 
--  [Full-Text Search](/docs/surrealdb/reference-guide/full-text-search)
--  [Graph Relations](/docs/surrealdb/reference-guide/graph-relations)
--  [Observability](/docs/surrealdb/reference-guide/observability)
--  [Security Best Practices](/docs/surrealdb/reference-guide/security-best-practices)
--  [Vector Search](/docs/surrealdb/reference-guide/vector-search)
--  [Performance Best Practices](/docs/surrealdb/reference-guide/performance-best-practices)
+- [Full-Text Search](/docs/surrealdb/reference-guide/full-text-search)
+- [Graph Relations](/docs/surrealdb/reference-guide/graph-relations)
+- [Observability](/docs/surrealdb/reference-guide/observability)
+- [Security Best Practices](/docs/surrealdb/reference-guide/security-best-practices)
+- [Vector Search](/docs/surrealdb/reference-guide/vector-search)
+- [Performance Best Practices](/docs/surrealdb/reference-guide/performance-best-practices)
+- [Sample Industry Schemas](/docs/surrealdb/reference-guide/sample-industry-schemas)
+- [Schema Best Practices](/docs/surrealdb/reference-guide/schema-creation-best-practices)
+


### PR DESCRIPTION
This pull request adds two new documentation links that were listed in the sidebar but missing in the main content page

New documentation links:

* Added a link to the "Sample Industry Schemas".
* Added a link to the "Schema Best Practices".