### PR TITLE
rv unused clause

### DIFF
--- a/src/content/doc-surrealql/statements/create.mdx
+++ b/src/content/doc-surrealql/statements/create.mdx
@@ -23,7 +23,6 @@ CREATE [ ONLY ] @targets
 	]
 	[ RETURN NONE | RETURN BEFORE | RETURN AFTER | RETURN DIFF | RETURN @statement_param, ... | RETURN VALUE @statement_param ]
 	[ TIMEOUT @duration ]
-	[ PARALLEL ]
 ;
 ```
 
@@ -369,15 +368,6 @@ The value for `TIMEOUT` is specified in seconds or milliseconds.
 -- Query attempting to create half a million `person` records
 CREATE |person:500000| SET age = 46, username = "john-smith" TIMEOUT 500ms;
 ```
-
-### Parallel
-
-The `PARALLEL` keyword can be used to specify that the statement should be processed concurrently, rather than sequentially. Similar to the `TIMEOUT` clause this is useful for more control over how your queries should behave, if that is needed.
-
-```surql
-CREATE person:26, CREATE person:27 PARALLEL;
-```
-
 
 ### `VERSION`
 

--- a/src/content/doc-surrealql/statements/delete.mdx
+++ b/src/content/doc-surrealql/statements/delete.mdx
@@ -16,7 +16,6 @@ DELETE [ FROM | ONLY ] @targets
 	[ WHERE @condition ]
 	[ RETURN NONE | RETURN BEFORE | RETURN AFTER | RETURN DIFF | RETURN @statement_param, ... ]
 	[ TIMEOUT @duration ]
-	[ PARALLEL ]
 	[ EXPLAIN [ FULL ]]
 ;
 ```

--- a/src/content/doc-surrealql/statements/relate.mdx
+++ b/src/content/doc-surrealql/statements/relate.mdx
@@ -34,7 +34,6 @@ RELATE [ ONLY ] @from_record -> @table -> @to_record
 	]
 	[ RETURN NONE | RETURN BEFORE | RETURN AFTER | RETURN DIFF | RETURN @statement_param, ... | RETURN VALUE @statement_param ]
 	[ TIMEOUT @duration ]
-	[ PARALLEL ]
 ;
 ```
 
@@ -396,16 +395,6 @@ SELECT * FROM person WHERE ->knows->person->(knows WHERE influencer = true) TIME
 ```
 
 Using a `TIMEOUT` is particularly useful when experimenting with complex queries with an extent that is difficult to imagine, especially if the query [is recursive](#recursive-graph-queries).
-
-### Using the `PARALLEL` clause
-
-When processing a large result set with many interconnected records, it may be desirable to use the `PARALLEL` keyword to signify that edges and remote records should be fetched and processed concurrently, rather than sequentially. This can be useful when you want to process a large result set in a short amount of time.
-
-```surql
--- Fetch and process the person, purchased and product targets in parallel
--- Select every product that was purchased by a person that purchased a product that person tobie also purchased
-SELECT ->purchased->product<-purchased<-person->purchased->product FROM person:tobie PARALLEL;
-```
 
 ### Deleting graph edges
 

--- a/src/content/doc-surrealql/statements/select.mdx
+++ b/src/content/doc-surrealql/statements/select.mdx
@@ -30,7 +30,6 @@ SELECT
 	[ START [ AT ] @start 0 ]
 	[ FETCH @fields ... ]
 	[ TIMEOUT @duration ]
-	[ PARALLEL ]
 	[ TEMPFILES ]
 	[ EXPLAIN [ FULL ]]
 ;
@@ -566,16 +565,6 @@ When processing a large result set with many interconnected records, it is possi
 -- Cancel this conditional filtering based on graph edge properties
 -- if it's not finished within 5 seconds
 SELECT * FROM person WHERE ->knows->person->(knows WHERE influencer = true) TIMEOUT 5s;
-```
-
-## The `PARALLEL` clause
-
-When processing a large result set with many interconnected records, it is possible to use the `PARALLEL` keyword to specify that the statement should be processed concurrently, rather than sequentially.
-
-```surql
--- Fetch and process the person, purchased and product targets in parallel
--- Select every product that was purchased by a person that purchased a product that person tobie also purchased
-SELECT ->purchased->product<-purchased<-person->purchased->product FROM person:tobie PARALLEL;
 ```
 
 ## The `TEMPFILES` clause

--- a/src/content/doc-surrealql/statements/update.mdx
+++ b/src/content/doc-surrealql/statements/update.mdx
@@ -31,7 +31,6 @@ UPDATE [ ONLY ] @targets
 	[ WHERE @condition ]
 	[ RETURN NONE | RETURN BEFORE | RETURN AFTER | RETURN DIFF | RETURN @statement_param, ... | RETURN VALUE @statement_param ]
 	[ TIMEOUT @duration ]
-	[ PARALLEL ]
 	[ EXPLAIN [ FULL ]]
 ;
 ```

--- a/src/content/doc-surrealql/statements/upsert.mdx
+++ b/src/content/doc-surrealql/statements/upsert.mdx
@@ -30,7 +30,6 @@ UPSERT [ ONLY ] @targets
     [ WHERE @condition ]
     [ RETURN NONE | RETURN BEFORE | RETURN AFTER | RETURN DIFF | RETURN @statement_param, ... | RETURN VALUE @statement_param ]
     [ TIMEOUT @duration ]
-    [ PARALLEL ]
 	[ EXPLAIN [ FULL ]]
 ;
 ```


### PR DESCRIPTION
PARALLEL [has been disabled](https://github.com/surrealdb/surrealdb/pull/5334) and is being redone so no use mentioning it in the docs.