### PR TITLE
Update .NET SDK docs for RecordId, Record inheritance, and data annotations

### DIFF
--- a/src/content/doc-sdk-dotnet/data-types.mdx
+++ b/src/content/doc-sdk-dotnet/data-types.mdx
@@ -235,45 +235,54 @@ public class RecordIdOfString : RecordIdOf<string>
 }
 ```
 
-### Working with a `RecordId`
+### Working with `RecordId`
+
+The `RecordId` type represents a reference to a specific record in SurrealDB.
+Unlike other types, it has **no public constructor**. To create a `RecordId`, use a tuple:
 
 ```csharp title="Constructing"
 // Table is "person"
 // Unique identifier on the table is "john"
-var rid = new RecordId("person", "john");
-
-// Alternatively, a RecordId can be inferred implicitly from a Tuple of 2 elements
-RecordId rid = ("person", "john");
-await client.Select(("person", "john"));
+RecordId personId = ("person", "john");
+// or
+var personId = (RecordId)("person", "john");
 ```
 
-You are not exclusively limited to the <code>string</code> type for the `Id` part. 
+This tuple is implicitly converted into a `RecordId` object.
+You can use it with all SDK methods:
+
+```csharp title="Using RecordId"
+await db.Select<Person>(("person", "john"));
+await db.Delete(("person", "john"));
+```
+
+You are not exclusively limited to the `string` type for the `Id` part.
 The next section contains examples of how to work with different data types in the `Id` field.
 
 ### Extracting data
 
 The .NET SDK handles serialization and deserialization of the `Table` and `Id` parts in Record Id.
-The serialization is done automatically when sending data to the server. 
+The serialization is done automatically when sending data to the server.
 However, deserialization may need to be done manually according to the data type of the `Id` field.
 Below are some examples:
 
 ```csharp title="Simple record id"
-var rid = new RecordId("person", "john");
+RecordId rid = ("person", "john");
 string table = rid.Table; // "person"
 string id = rid.DeserializeId<string>(); // "john"
 ```
 
 ```csharp title="Record id with simple data type (other than string)"
-var rid = new RecordId("table", 42);
+RecordId rid = ("table", 42);
 string table = rid.Table; // "table"
 int id = rid.DeserializeId<int>(); // 42
 ```
 
 ```csharp title="Record id with complex data types"
-var rid = new RecordId("table", new CityId { city: "London" });
-var id = rid.DeserializeId<CityId>(); // CityId { city: "London" }
+RecordId rid = ("table", new CityId { city = "London" });
+var id = rid.DeserializeId<CityId>(); // CityId { city = "London" }
 
-var rid = new RecordId("table", ("London", 42));
+RecordId rid = ("table", ("London", 42));
 var id = rid.DeserializeId<(string, int)>(); // ("London", 42)
 ```
 

--- a/src/content/doc-sdk-dotnet/data-types.mdx
+++ b/src/content/doc-sdk-dotnet/data-types.mdx
@@ -309,5 +309,54 @@ var rid = new StringRecordId("person:john");
 
 // Alternatively, a StringRecordId can be inferred explicitly from a string
 var rid = (StringRecordId)"person:john";
-await client.Select((StringRecordId)"person:john");
+await client.Select<Person>((StringRecordId)"person:john");
+```
+
+### Inheriting from Record
+
+If your model class inherits from Record, it will automatically include an Id property of type `RecordId`.
+
+```csharp title="Inheriting from Record"
+public class Person : Record
+{
+    public string Name { get; set; } = string.Empty;
+}
+
+// Example usage
+var person = new Person { Name = "Alice" };
+Console.WriteLine(person.Id); // RecordId ("person", "…")
+```
+
+### Using Data Annotations
+
+The SDK supports attributes for serialization and deserialization.
+
+#### CBOR serialization
+
+Use [CborProperty](https://github.com/dahomey-technologies/Dahomey.Cbor) to map C# properties to SurrealDB fields:
+
+```csharp title="Using CborProperty"
+[CborProperty("first_name")]
+public string FirstName { get; set; } = string.Empty;
+```
+
+#### RecordIdJsonConverter
+
+Use RecordIdJsonConverter to indicate that a property should be serialized as a RecordId reference to another table:
+
+```csharp title="Using RecordIdJsonConverter"
+[RecordIdJsonConverter("payment_details")]
+public RecordId? PaymentDetails { get; set; }
+
+[RecordIdJsonConverter("payment_details")]
+public RecordId? PaymentDetails { get; set; }
+```
+
+#### Combining attributes
+You can combine both attributes on the same property:
+
+```csharp title="Combining attributes"
+[CborProperty("payment_details")]
+[RecordIdJsonConverter("payment_details")]
+public RecordId? PaymentDetails { get; set; }
 ```

--- a/src/content/doc-sdk-dotnet/data-types.mdx
+++ b/src/content/doc-sdk-dotnet/data-types.mdx
@@ -286,10 +286,10 @@ int id = rid.DeserializeId<int>(); // 42
 ```
 
 ```csharp title="Record id with complex data types"
-RecordId rid = ("table", new CityId { city = "London" });
+var rid = new RecordIdOf<CityId>("table", new CityId { city = "London" });
 var id = rid.DeserializeId<CityId>(); // CityId { city = "London" }
 
-RecordId rid = ("table", ("London", 42));
+var rid = new RecordIdOf<(string, int)>("table", ("London", 42));
 var id = rid.DeserializeId<(string, int)>(); // ("London", 42)
 ```
 

--- a/src/content/doc-sdk-dotnet/data-types.mdx
+++ b/src/content/doc-sdk-dotnet/data-types.mdx
@@ -237,8 +237,7 @@ public class RecordIdOfString : RecordIdOf<string>
 
 ### Working with `RecordId`
 
-The `RecordId` type represents a reference to a specific record in SurrealDB.
-Unlike other types, it has **no public constructor**. To create a `RecordId`, use a tuple:
+The simplest and most common way to construct a `RecordId` is with a tuple `(table, id)`.
 
 ```csharp title="Constructing"
 // Table is "person"
@@ -256,8 +255,16 @@ await db.Select<Person>(("person", "john"));
 await db.Delete(("person", "john"));
 ```
 
-You are not exclusively limited to the `string` type for the `Id` part.
-The next section contains examples of how to work with different data types in the `Id` field.
+You are not exclusively limited to the `string` type for the `Id` part. Several overloads exist for different `id` types:
+
+```csharp title="Constructing"
+RecordId rid1 = ("person", "alice");           // string
+RecordId rid2 = ("person", 123);               // int
+RecordId rid3 = ("person", 123L);              // long
+RecordId rid4 = ("person", (short)5);          // short
+RecordId rid5 = ("person", (byte)7);           // byte
+RecordId rid6 = ("person", Guid.NewGuid());    // Guid
+```
 
 ### Extracting data
 
@@ -311,6 +318,32 @@ var rid = new StringRecordId("person:john");
 var rid = (StringRecordId)"person:john";
 await client.Select<Person>((StringRecordId)"person:john");
 ```
+
+### Working with `RecordIdOfString`
+
+For string-based identifiers, you can also use the specialized type RecordIdOfString:
+
+```csharp title="Using RecordIdOfString"
+var rid = new RecordIdOfString("person", "john");
+// or
+Console.WriteLine(rid.Table); // "person"
+Console.WriteLine(rid.Id);    // "john"
+```
+
+### Working with `RecordIdOf<T>`
+
+For complex or structured identifiers, use the generic type RecordIdOf\<T\>:
+
+```csharp title="Using RecordIdOf<T>"
+public class CityId
+{
+    public string City { get; set; } = string.Empty;
+}
+
+var rid = new RecordIdOf<CityId>("city", new CityId { City = "London" });
+```
+
+This enables strongly-typed IDs that map directly to your domain objects.
 
 ### Inheriting from Record
 

--- a/src/content/doc-surrealdb/embedding/index.mdx
+++ b/src/content/doc-surrealdb/embedding/index.mdx
@@ -20,7 +20,7 @@ The following languages are supported:
 - [Rust](/docs/surrealdb/embedding/rust)
 - [JavaScript](/docs/surrealdb/embedding/javascript)
 - [Python](/docs/surrealdb/embedding/python)
-
+- [.Net](/docs/surrealdb/embedding/dotnet)
 
 
 


### PR DESCRIPTION
## Summary

This PR updates the .NET SDK documentation to reflect the current implementation of `RecordId` and clarify related model usage.

## Changes

- **`RecordId` construction**
  - Clarified that `RecordId` cannot be created with `new` (all constructors are `internal`).
  - Documented the supported construction patterns:
    - Tuple implicit conversions: `(string, id)` where `id` can be `string`, `int`, `long`, `short`, `byte`, or `Guid`.
    - `RecordIdOfString` and `StringRecordId` for string-based identifiers.
    - `RecordIdOf<T>` for complex/structured identifiers.

- **`Record` inheritance**
  - Clarified that inheriting from `Record` automatically adds an `Id` property of type `RecordId`.

- **Data annotations**
  - Documented usage of:
    - `[CborProperty]` for CBOR serialization.
    - `[RecordIdJsonConverter("table")]` for record references.
    - Standard validation attributes like `[EmailAddress]`.

## Notes

These updates replace outdated documentation (particularly for `RecordId`) and align the .NET SDK docs with the current behavior and API surface.
