### PR TITLE
Add a slash hint

### DIFF
--- a/src/content/doc-surrealdb/cli/start.mdx
+++ b/src/content/doc-surrealdb/cli/start.mdx
@@ -222,6 +222,13 @@ When using a path argument with SurrealDB, we recommend not using the `file://` 
 > [!WARNING]
 > FoundationDB support is deprecated in SurrealDB `3.0`. Please plan to migrate to a supported storage backend.
 
+### Absolute vs. relative paths
+
+The datastorage flavour (`rocksdb`, `surrealkv`, etc.) followed by `:` or `://` will be recognized as a relative path. Any other number of slashes such as `rocksdb:/path` or `surrealkv:///path` will be interpreted as an absolute path. As a short absolute path of this nature will often require elevated permissions, the output for this command may end in this sort of error.
+
+> Failed to create RocksDB directory: `Os { code: 30, kind: ReadOnlyFilesystem, message: "Read-only file system" }`.
+
+If you see this error without having intended to start the server on an absolute path, it is likely that the path passed in unintentionally contains either one slash or more than two slashes.
 
 <table>
     <thead>


### PR DESCRIPTION
Sometimes a user will pass in a single path by mistake (e.g. rocksdb:/path or surrealkv:/path) which is interpreted as an absolute path, then if permissions aren't high enough it ends in a cryptic message. This adds some advice in that case.