### PR TITLE
Change ISO to RFC

### DIFF
--- a/src/content/doc-surrealdb/integration/cbor.mdx
+++ b/src/content/doc-surrealdb/integration/cbor.mdx
@@ -28,7 +28,7 @@ SurrealDB extends the [CBOR](https://www.rfc-editor.org/rfc/rfc8949.html) protoc
                 [Tag 0](#tag-0)
             </td>
             <td scope="row" data-label="Value">
-                [Datetime](/docs/surrealql/datamodel/datetimes) ([ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) string)
+                [Datetime](/docs/surrealql/datamodel/datetimes) ([RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339)(https://www.iso.org/iso-8601-date-and-time-format.html) string)
             </td>
         </tr>
         <tr>
@@ -196,7 +196,7 @@ SurrealDB extends the [CBOR](https://www.rfc-editor.org/rfc/rfc8949.html) protoc
 
 ### Tag 0
 
-A [datetime](/docs/surrealql/datamodel/datetimes) represented in an [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) string.
+A [datetime](/docs/surrealql/datamodel/datetimes) represented in an [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339) string.
 
 Adopted from the [Iana Specification](https://www.iana.org/assignments/cbor-tags/cbor-tags.xhtml).
 

--- a/src/content/doc-surrealdb/integration/cbor.mdx
+++ b/src/content/doc-surrealdb/integration/cbor.mdx
@@ -28,7 +28,7 @@ SurrealDB extends the [CBOR](https://www.rfc-editor.org/rfc/rfc8949.html) protoc
                 [Tag 0](#tag-0)
             </td>
             <td scope="row" data-label="Value">
-                [Datetime](/docs/surrealql/datamodel/datetimes) ([RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339)(https://www.iso.org/iso-8601-date-and-time-format.html) string)
+                [Datetime](/docs/surrealql/datamodel/datetimes) ([RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339) string)
             </td>
         </tr>
         <tr>

--- a/src/content/doc-surrealql/datamodel/formatters.mdx
+++ b/src/content/doc-surrealql/datamodel/formatters.mdx
@@ -84,7 +84,7 @@ The [string::is_datetime](/docs/surrealql/functions/database/string#stringisdate
   <tr>
     <td scope="row" data-label="Specifier">%u</td>
     <td scope="row" data-label="Example">7</td>
-    <td scope="row" data-label="Description">Day of the week. Monday = 1, Tuesday = 2, ..., Sunday = 7. (ISO 8601)</td>
+    <td scope="row" data-label="Description">Day of the week. Monday = 1, Tuesday = 2, ..., Sunday = 7. ([RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339))</td>
   </tr>
   <tr>
     <td scope="row" data-label="Specifier">%U</td>
@@ -99,17 +99,17 @@ The [string::is_datetime](/docs/surrealql/functions/database/string#stringisdate
   <tr>
     <td scope="row" data-label="Specifier">%G</td>
     <td scope="row" data-label="Example">2001</td>
-    <td scope="row" data-label="Description">Same as %Y but uses the year number in ISO 8601 week date.</td>
+    <td scope="row" data-label="Description">Same as %Y but uses the year number in [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339) week date.</td>
   </tr>
   <tr>
     <td scope="row" data-label="Specifier">%g</td>
     <td scope="row" data-label="Example">01</td>
-    <td scope="row" data-label="Description">Same as %y but uses the year number in ISO 8601 week date.</td>
+    <td scope="row" data-label="Description">Same as %y but uses the year number in [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339) week date.</td>
   </tr>
   <tr>
     <td scope="row" data-label="Specifier">%V</td>
     <td scope="row" data-label="Example">27</td>
-    <td scope="row" data-label="Description">Same as %U but uses the week number in ISO 8601 week date (01 to 53).</td>
+    <td scope="row" data-label="Description">Same as %U but uses the week number in [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339) week date (01 to 53).</td>
   </tr>
   <tr>
     <td scope="row" data-label="Specifier">%j</td>
@@ -129,7 +129,7 @@ The [string::is_datetime](/docs/surrealql/functions/database/string#stringisdate
   <tr>
     <td scope="row" data-label="Specifier">%F</td>
     <td scope="row" data-label="Example">2001-07-08</td>
-    <td scope="row" data-label="Description">Year-month-day format (ISO 8601). Same as %Y-%m-%d.</td>
+    <td scope="row" data-label="Description">Year-month-day format ([RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339)). Same as %Y-%m-%d.</td>
   </tr>
   <tr>
     <td scope="row" data-label="Specifier">%v</td>
@@ -258,7 +258,7 @@ The [string::is_datetime](/docs/surrealql/functions/database/string#stringisdate
   <tr>
     <td scope="row" data-label="Specifier">%F</td>
     <td scope="row" data-label="Example">2001-07-08</td>
-    <td scope="row" data-label="Description">Year-month-day format (ISO 8601). Same as %Y-%m-%d.</td>
+    <td scope="row" data-label="Description">Year-month-day format ([RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339)). Same as %Y-%m-%d.</td>
   </tr>
   <tr>
     <td scope="row" data-label="Specifier">%v</td>
@@ -316,7 +316,7 @@ The [string::is_datetime](/docs/surrealql/functions/database/string#stringisdate
   <tr>
     <td scope="row" data-label="Specifier">%+</td>
     <td scope="row" data-label="Example">2001-07-08T00:34:59.026490+09:30</td>
-    <td scope="row" data-label="Description">ISO 8601 / RFC 3339 date &amp; time format.</td>
+    <td scope="row" data-label="Description">[RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339) / RFC 3339 date &amp; time format.</td>
   </tr>
   <tr>
     <td scope="row" data-label="Specifier">%s</td>

--- a/src/content/doc-surrealql/datamodel/index.mdx
+++ b/src/content/doc-surrealql/datamodel/index.mdx
@@ -67,7 +67,7 @@ SurrealQL allows you to describe data with specific data types. These data types
                 <code>datetime</code>
             </td>
             <td scope="row" data-label="Description">
-                An ISO 8601 compliant data type that stores a date with time and time zone.
+                An [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339) compliant data type that stores a date with time and time zone.
             </td>
         </tr>
         <tr>

--- a/src/content/doc-surrealql/datamodel/strings.mdx
+++ b/src/content/doc-surrealql/datamodel/strings.mdx
@@ -117,7 +117,7 @@ true
 
 ### Datetime literal values using the `d` prefix {#datetime}
 
-The `d` prefix tells the parser that the contents of the string represent a [`datetime`](/docs/surrealql/datamodel/datetimes). The parser expects `datetime` values to have a valid ISO 8601 format. Here are a few examples:
+The `d` prefix tells the parser that the contents of the string represent a [`datetime`](/docs/surrealql/datamodel/datetimes). The parser expects `datetime` values to have a valid [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339) format. Here are a few examples:
 
 
 ```surql

--- a/src/content/doc-surrealql/functions/database/string.mdx
+++ b/src/content/doc-surrealql/functions/database/string.mdx
@@ -855,7 +855,7 @@ RETURN string::is_datetime("2015-09-05 23:56:04", "%Y-%m-%d %H:%M:%S");
 true
 ```
 
-This can be useful when validating datetimes obtained from other sources that do not use the ISO 8601 format.
+This can be useful when validating datetimes obtained from other sources that do not use the [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339) format.
 
 ```surql
 RETURN string::is_datetime("5sep2024pm012345.6789", "%d%b%Y%p%I%M%S%.f");


### PR DESCRIPTION
Clarifies that SurrealDB datetimes are the RFC 3339 format.