### PR TITLE
Add Rust SDK page on new crate changes

### DIFF
--- a/src/content/doc-sdk-rust/concepts/rust_after-3.0.mdx
+++ b/src/content/doc-sdk-rust/concepts/rust_after-3.0.mdx
@@ -1,13 +1,11 @@
 ---
-sidebar_position: 7
-sidebar_label: After 3.0
+sidebar_position: 9
+sidebar_label: Types after version 3.0
 title: Using the Rust crate after SurrealDB 3.0
-description: Many structural changes were implemented in SurrealDB 3.0, bringing large improviments to working with types in the Rust SDK.
+description: Many structural changes were implemented in SurrealDB 3.0, bringing large improvements to working with types in the Rust SDK.
 ---
 
 import Since from "@components/shared/Since.astro";
-
-<Since v="v3.0.0-alpha.11" />
 
 # The `surrealdb-types` crate
 
@@ -17,7 +15,7 @@ This crate was separated from the SurrealDB core to decouple types and type conv
 
 # The `SurrealValue` trait
 
-The main difference between SurrealDB 3.0 and previous versions for Rust users is the existence of a `SurrealValue` trait that can be derived in the 
+The main difference between SurrealDB 3.0 and previous versions for Rust users is the existence of a `SurrealValue` trait that can be derived automatically. Deriving this trait is all that is needed to use a Rust type for serialization and deserialization.
 
 ```rust
 use surrealdb::engine::any::connect;
@@ -46,6 +44,8 @@ async fn main() {
     println!("{bobby:?}");
 }
 ```
+
+The `SurrealValue` trait can be implemented manually via three methods: one to indicate the matching SurrealDB type, a second to convert into a SurrealDB Value, and a third to convert out of a SurrealDB Value.
 
 ```rust
 #[derive(Debug)]
@@ -87,38 +87,9 @@ async fn main() {
 }
 ```
 
-This trait can be implemented manually via three methods: one to indicate the matching SurrealDB type, a second to convert into a SurrealDB Value, and a third to convert out of a SurrealDB Value.
+An example of successful and unsuccessful conversions into the usercreated `MyOwnDateTime` struct:
 
 ```rust
-use surrealdb::engine::any::connect;
-use surrealdb_types::{
-    Datetime, Kind, SurrealValue, Value,
-    anyhow::{self, anyhow},
-};
-
-#[derive(Debug)]
-struct MyOwnDateTime(i64);
-
-impl SurrealValue for MyOwnDateTime {
-    fn kind_of() -> surrealdb_types::Kind {
-        Kind::Datetime
-    }
-
-    fn into_value(self) -> surrealdb_types::Value {
-        Value::Datetime(Datetime::from_timestamp(self.0, 0).unwrap())
-    }
-
-    fn from_value(value: surrealdb_types::Value) -> anyhow::Result<Self>
-    where
-        Self: Sized,
-    {
-        match value {
-            Value::Datetime(n) => Ok(MyOwnDateTime(n.timestamp_millis())),
-            other => Err(anyhow!("Couldn't convert {other:?} to MyOwnDateTime")),
-        }
-    }
-}
-
 #[tokio::main]
 async fn main() {
     let db = connect("memory").await.unwrap();
@@ -155,6 +126,8 @@ Err(InternalError("Couldn't convert Object(Object({\"id\": RecordId(RecordId { t
 
 Importing the `SurrealValue` trait gives access to a lot of convenience methods.
 
+One example is the `.into_value()` method which converts a large number of Rust standard library types into a SurrealQL `Value`.
+
 ```rust
 use surrealdb_types::{SurrealValue, Value};
 
@@ -165,7 +138,7 @@ fn main() {
 }
 ```
 
-These convenience methods exist for most types, including collection types:
+One more example of `.into_value()` to convert a `HashMap<String, &'str>` into a `Value`:
 
 ```rust
 use std::collections::HashMap;

--- a/src/content/doc-sdk-rust/concepts/vector-embeddings.mdx
+++ b/src/content/doc-sdk-rust/concepts/vector-embeddings.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 8
 sidebar_label: Vector embeddings
 title: Vector embeddings in Rust | Rust SDK | SurrealDB
 description: Many crates are available to work with vector embeddings via the SurrealDB Rust SDK.


### PR DESCRIPTION
(Some at least) documentation for https://github.com/surrealdb/surrealdb/pull/6402 for the Rust SDK.