### PR TITLE
Remove legacy IF ELSE

### DIFF
--- a/src/content/doc-surrealql/statements/ifelse.mdx
+++ b/src/content/doc-surrealql/statements/ifelse.mdx
@@ -12,26 +12,15 @@ The `IF ELSE` statement can be used as a main statement, or within a parent stat
 > [!NOTE]
 > As [THROW](/docs/surrealql/statements/throw), [CONTINUE](/docs/surrealql/statements/continue), and [BREAK](/docs/surrealql/statements/break) do not return an expression, they must be inside a separate code block inside an `IF ELSE` statement.
 
-The original `IF ELSE` syntax involves one or more conditions, `THEN`, an expression if the condition evaluates to true, and the `END` keyword to finalize it. A separate code block can also be used, in which case multiple statements can be run.
+An `IF ELSE` syntax uses `{}` to open up a code block on each condition check which will be run when it evaluates as [truthy](/docs/surrealql/datamodel/values#values-and-truthiness).
 
 import RailroadDiagram from '@components/RailroadDiagram.astro'
 import Tabs from '@components/Tabs/Tabs.astro'
 import TabItem from '@components/Tabs/TabItem.astro'
 
 <Tabs syncKey="ifelse-statement">
-  <TabItem label="Legacy Syntax">
 
-```surql title="SurrealQL legacy syntax"
-IF @condition THEN @expression | { @expression; .. }
-   [ ELSE IF @condition THEN @expression | { @expression; .. } ] ...
-   [ ELSE @expression | { @expression; .. } ]
-END;
-```
-
-The modern `IF ELSE` syntax does not require `THEN` or `END`, instead using `{}` to open up a code block on each condition check which will be run when it evaluates to true.
-
-  </TabItem>
-  <TabItem label="Modern Syntax">
+  <TabItem label="Syntax">
 
 ```surql title="Modern syntax"
 IF @condition { @expression; .. }
@@ -40,7 +29,7 @@ IF @condition { @expression; .. }
 ```
 
   </TabItem>
-  <TabItem label="Railroad Diagram (Modern)">
+  <TabItem label="Railroad Diagram">
 
 export const ifElseAst = {
   type: "Diagram",
@@ -85,11 +74,7 @@ The following queries show example usage of this statement.
 The smallest possible `IF THEN` statement simply does something when a condition is true, and nothing otherwise.
 
 ```surql
-// Original syntax
-IF 9 = 9 THEN RETURN "Nine is indeed nine" END;
-
-// New scope syntax
-IF 9 = 9 { RETURN 'Nine is indeed nine' };
+IF 9 = 9 { 'Nine is indeed nine' };
 ```
 
 As the last line of a scope is its return value, the `RETURN` keyword can also be placed before the entire `IF THEN` statement. This is particularly convenient in long `IF ELSE` chains to avoid using the `RETURN` keyword at the end of every check for a condition.
@@ -106,18 +91,29 @@ RETURN IF $num < 0 {
 } ELSE {
     "Positive uninteresting number"
 };
-````
+```
+
+The `RETURN` keyword can even be omitted, as the output at each point is the output of the entire expression if evaluated as truthy.
+
+```surql
+LET $num = 100;
+
+IF $num < 0 {
+    "Negative"
+} ELSE IF $num = 0 {
+    "Zero"
+} ELSE IF $num = 13 {
+    "Thirteen"
+} ELSE {
+    "Positive uninteresting number"
+};
+```
 
 The `THROW` keyword inside `{}` braces can be used to break out of an `IF LET` statement early.
 
 ```surql
 LET $badly_formatted_datetime = "2024-04TT08:08:08Z";
-// Original syntax
-IF !type::is_datetime($badly_formatted_datetime) THEN {
-    THROW "Whoops, that isn't a real datetime"
-} END;
 
-// New scope syntax
 IF !type::is_datetime($badly_formatted_datetime) {
     THROW "Whoops, that isn't a real datetime"
 };
@@ -130,17 +126,6 @@ IF !type::is_datetime($badly_formatted_datetime) {
 `ELSE IF` branches and a final `ELSE` can be added into an `IF ELSE` statement:
 
 ```surql
-// Original syntax
-IF $access = "admin" THEN
-	SELECT * FROM account
-ELSE IF $access = "user" THEN
-	SELECT * FROM $auth.account
-ELSE {
-    THROW "Access method hasn't been defined!"
-}
-END;
-
-// New scope syntax
 RETURN
     IF $access = "admin" { (SELECT * FROM account) }
     ELSE IF $access = "user"  { (SELECT * FROM $auth.account) }
@@ -154,15 +139,6 @@ The output of an `IF ELSE` statement can be assigned to a parameter:
 ```surql
 LET $num = 9;
 
-// Original syntax
-LET $odd_even =
-  IF $num % 2 = 0 THEN
-    "even"
-  ELSE
-    "odd"
-  END;
-
-// New scope syntax
 LET $odd_even = 
     IF $num % 2 = 0 { "even" } 
     ELSE { "odd" };
@@ -172,23 +148,6 @@ If-else statements can also be used as subqueries within other statements.
 
 ```surql
 UPSERT person SET railcard =
-	(IF age <= 10 THEN)
-		'junior'
-	ELSE IF age <= 21 THEN
-		'student'
-	ELSE IF age >= 65 THEN
-		'senior'
-	ELSE
-		NULL
-	END
-;
-
-```
-Alternatively: 
-
-```surql
-
-UPSERT person SET railcard =
     (IF age <= 10 { 'junior' })
     ELSE IF age <= 21 { 'student' }
     ELSE IF age >= 65 { 'senior' }
@@ -196,32 +155,6 @@ UPSERT person SET railcard =
 ```
 
 You can also have nested conditions:
-
-```surql
-IF $access = "admin" THEN
-    SELECT * FROM admin_data WHERE access_level = 'full'
-ELSE IF $access = "user" THEN
-    IF $auth.role = "premium" THEN
-        IF $auth.subscription_status = "active" THEN
-            SELECT * FROM premium_user_data WHERE active = 1
-        ELSE IF $auth.subscription_status = "trial" THEN
-            SELECT * FROM trial_user_data
-        ELSE
-            SELECT * FROM basic_user_data
-        END
-    ELSE IF $auth.role = "standard" THEN
-        SELECT * FROM standard_user_data WHERE region = 'US'
-    ELSE IF $auth.role = "standard" AND $auth.subscription_status = "active" THEN
-        SELECT * FROM standard_user_data WHERE region = 'EU'
-    ELSE
-        SELECT * FROM unauthorized_user_data
-    END
-ELSE
-    SELECT * FROM unknown_access_data
-END;
-```
-
-The new scope syntax makes it easy to carry out multiple statements even inside nested conditions.
 
 ```surql
 IF $access = 'admin'


### PR DESCRIPTION
The "new" IF ELSE syntax was introduced way back in SurrealDB 1.0 and there is no longer a need for documentation that shows the legacy syntax.