### PR TITLE
Update experimental targets

### DIFF
--- a/src/content/doc-surrealdb/cli/env.mdx
+++ b/src/content/doc-surrealdb/cli/env.mdx
@@ -55,11 +55,6 @@ Environment variables can be used to tailor the behaviour of a running SurrealDB
       <td scope="row" data-label="Notes"><Since v="v2.1.0" /> The number of definitions which can be cached across transactions.</td>
     </tr>
     <tr>
-      <td scope="row" data-label="Env var"><code>SURREAL_EXPERIMENTAL_BEARER_ACCESS</code></td>
-      <td scope="row" data-label="Default">false</td>
-      <td scope="row" data-label="Notes">Enable experimental bearer access and stateful access grant management. Still under active development. Using this experimental feature may introduce risks related to breaking changes and security issues.</td>
-    </tr>
-    <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_EXPERIMENTAL_GRAPHQL</code></td>
       <td scope="row" data-label="Default">false</td>
       <td scope="row" data-label="Notes">Enables experimental graphql integration. Still under active development. Using this experimental feature may introduce risks related to breaking changes and security issues.</td>

--- a/src/content/doc-surrealdb/cli/sql.mdx
+++ b/src/content/doc-surrealdb/cli/sql.mdx
@@ -180,8 +180,6 @@ To use experimental capabilities, set the `SURREAL_CAPS_ALLOW_EXPERIMENTAL` [env
 
 For example, to use record references, set the `SURREAL_CAPS_ALLOW_EXPERIMENTAL` environment variable to `record_references`.
 
-For [graphql](/docs/surrealdb/querying/graphql/surrealist), use `graphql` and for [bearer access](/docs/surrealql/statements/define/access/bearer), use `bearer_access`.
-
 ```bash
 SURREAL_CAPS_ALLOW_EXPERIMENTAL="record_references" surreal sql ... 
 ```
@@ -201,6 +199,8 @@ SURREAL_CAPS_ALLOW_EXPERIMENTAL="record_references, graphql" surreal sql ...
 
 surreal sql -e [CONNECTION_STRING] --allow-experimental record_references,graphql
 ```
+
+The current experimental targets are `record_references`, `graphql`, `define_api`, `files`, and `surrealism`.
 
 > [!NOTE]
 > The experimental capability is completely hidden in the CLI help command, and `--allow-all` will not enable the experimental capabilities by default.

--- a/src/content/doc-surrealdb/cli/start.mdx
+++ b/src/content/doc-surrealdb/cli/start.mdx
@@ -397,10 +397,6 @@ For example, to use record references, set the `SURREAL_CAPS_ALLOW_EXPERIMENTAL`
             <td><code>graphql</code></td>
         </tr>
         <tr>
-            <td><a href="/docs/surrealql/statements/define/access/bearer">DEFINE ACCESS ... TYPE BEARER</a></td>
-            <td><code>bearer_access</code></td>
-        </tr>
-        <tr>
             <td><a href="/docs/surrealql/statements/define/config">DEFINE CONFIG API</a> and <a href="/docs/surrealql/statements/define/api">DEFINE API</a></td>
             <td><code>define_api</code></td>
         </tr>

--- a/src/content/doc-surrealql/statements/access.mdx
+++ b/src/content/doc-surrealql/statements/access.mdx
@@ -15,7 +15,7 @@ import TabItem from '@components/Tabs/TabItem.astro'
 <Since v="v2.2.0" />
 
 > [!CAUTION]
-> Currently, the `ACCESS` statement is an experimental feature intended to be used for validating its suitability and security. As such, it may be subject to breaking changes and may present unidentified security issues. Do not rely on this feature in production applications. To enable this and other experimental features related to bearer access, set the `SURREAL_EXPERIMENTAL_BEARER_ACCESS` [environment variable](/docs/surrealdb/cli/env) to `true`.
+> Currently, the `ACCESS` statement is an experimental feature intended to be used for validating its suitability and security. As such, it may be subject to breaking changes and may present unidentified security issues. Do not rely on this feature in production applications.
 
 The `ACCESS` statement can be used to manage access grants. It provides the ability to generate access grants using certain access methods, such as bearer keys defined with the [`DEFINE ACCESS ... TYPE BEARER`](/docs/surrealql/statements/define/access/bearer) statement, as well as the ability to show, revoke and purge such grants.
 

--- a/src/content/doc-surrealql/statements/define/access/bearer.mdx
+++ b/src/content/doc-surrealql/statements/define/access/bearer.mdx
@@ -9,10 +9,6 @@ import Since from '@components/shared/Since.astro'
 
 # `DEFINE ACCESS ... TYPE BEARER`
 
-
-> [!CAUTION]
-> Currently, the `BEARER` access method is an experimental feature intended to be used for validating its suitability and security. As such, it may be subject to breaking changes and may present unidentified security issues. Do not rely on this feature in production applications. To enable this and other experimental features related to bearer access, set the `SURREAL_CAPS_ALLOW_EXPERIMENTAL` [environment variable](/docs/surrealdb/cli/env) to `"bearer_access"`.
-
 A bearer access method allows generating bearer grants with an associated key that can be used to access SurrealDB as a specific [system user](/docs/surrealdb/security/authentication#system-users) or [record user](/docs/surrealdb/security/authentication#record-users). Bearer grants allow other systems and software to authenticate with SurrealDB using a secure and unique credential that can be [audited](/docs/surrealql/statements/access#show) and [revoked](/docs/surrealql/statements/access#revoke) at any time.
 
 Allowing access to SurrealDB using a bearer access method requires creating grants associated with that access method. This can be done using the [`GRANT`](/docs/surrealql/statements/access#grant) clause of the [`ACCESS`](/docs/surrealql/statements/access) statement.

--- a/src/content/doc-surrealql/statements/define/access/record.mdx
+++ b/src/content/doc-surrealql/statements/define/access/record.mdx
@@ -174,7 +174,7 @@ ALGORITHM HS512 KEY "secret";
 ### With refresh token
 
 > [!CAUTION]
-> Currently, the `WITH REFRESH` clause is an experimental feature intended to be used for validating its suitability and security. As such, it may be subject to breaking changes and may present unidentified security issues. Do not rely on this feature in production applications. To enable this and other experimental features related to bearer access, set the `SURREAL_EXPERIMENTAL_BEARER_ACCESS` [environment variable](/docs/surrealdb/cli/env) to `true`.
+> Currently, the `WITH REFRESH` clause is an experimental feature intended to be used for validating its suitability and security. As such, it may be subject to breaking changes and may present unidentified security issues. Do not rely on this feature in production applications.
 
 > [!NOTE]
 > Due to changes required in the RPC API and the SDKs, refresh tokens are currently only available when signing up and in through the [HTTP REST API](/docs/surrealdb/integration/http).


### PR DESCRIPTION
Some updates to experimental targets (more coming soon): bearer access is no longer experimental, while surrealism has been added.