### PR TITLE
Add note of crate-type to surrealism tutorial

### DIFF
--- a/src/content/doc-surrealdb/querying/surrealism/tutorial.mdx
+++ b/src/content/doc-surrealdb/querying/surrealism/tutorial.mdx
@@ -7,12 +7,14 @@ description: A quick tutorial showing the steps involved in turning regular Rust
 
 ## Getting started: regular Rust code
 
-To start, you need a Rust project that has a `crate-type` of `cdylib` set in its `Cargo.toml`, like:
+To start, depending on your platform you may need to add this line in your `Cargo.toml` to instruct cargo to generate a .wasm file instead of the standard .rlib file:
+
 ```toml
 [lib]
 crate-type = [ "cdylib" ]
 ```
-Lets assume you have a `lib.rs` file that has three functions that you would like to call using SurrealQL.
+
+With that scaffolding out of the way, lets assume you have a `lib.rs` file that has three functions that you would like to call using SurrealQL.
 
 One is a simple function that returns a bool.
 
@@ -190,7 +192,7 @@ SURREAL_CAPS_ALLOW_EXPERIMENTAL=files,surrealism SURREAL_BUCKET_FOLDER_ALLOWLIST
 You can then connect through [surrealist](/surrealist) or the CLI with the [surreal sql](/docs/surrealdb/cli/sql) command:
 
 ```
-SURREAL_CAPS_ALLOW_EXPERIMENTAL=files,surrealism SURREAL_BUCKET_FOLDER_ALLOWLIST="/Users/my_name/my_rust_code/" surreal sql --ns ns --db db --user root --pass strongpassword
+SURREAL_CAPS_ALLOW_EXPERIMENTAL=files,surrealism SURREAL_BUCKET_FOLDER_ALLOWLIST="/Users/mithr/random/" cargo run -- sql --ns ns --db db --user root --pass strongpassword
 ```
 
 We're almost there! Only two statements left and we can start accessing these functions.


### PR DESCRIPTION
The current tutorial is missing an important step, that when not done will result in an error when running `surrealism build` because no wasm file will be emitted by the compiler.
This PR adds a note about this at the start of the tutorial.