### PR TITLE
Add docs on file bucket permissions

### DIFF
--- a/src/content/doc-surrealql/statements/define/bucket.mdx
+++ b/src/content/doc-surrealql/statements/define/bucket.mdx
@@ -129,3 +129,42 @@ DEFINE BUCKET my_bucket;
 -- Writes to e.g. `my_global_bucket:/test_ns/test_db/my_bucket/my_book.txt`
 f"my_bucket:/my_book.txt".put("Once there were four children whose names were Peter, Susan, Edmund, and Lucy.");
 ```
+
+## Setting permissions on buckets
+
+By default, the permissions on a bucket will be set to FULL unless otherwise specified.
+
+```surql
+DEFINE BUCKET my_bucket BACKEND "memory";
+INFO FOR DB;
+```
+
+```surql title="Response"
+{
+  accesses: {},
+  analyzers: {},
+  apis: {},
+  buckets: {
+    my_bucket: "DEFINE BUCKET my_bucket BACKEND 'memory' PERMISSIONS FULL"
+  },
+  configs: {},
+  functions: {},
+  models: {},
+  modules: {},
+  params: {},
+  sequences: {},
+  tables: {},
+  users: {}
+}
+```
+
+You can set permissions on buckets to control who can perform operations on the files stored in them using the `PERMISSIONS` clause. In the clause three additional variables are available:
+- `$action`: The action to be executed (`put`, `get`, `head`, `delete`, `copy`, `rename`, `exists`, `list`)
+- `$file`: The [file pointer](/docs/surrealql/datamodel/files) of the file to be accessed
+- `$target`: The target [file pointer](/docs/surrealql/datamodel/files) in copy/rename operations
+
+```surql
+-- Set permissions for the bucket
+DEFINE BUCKET admin_bucket BACKEND "memory"
+  PERMISSIONS WHERE $auth.admin = true
+```


### PR DESCRIPTION
The current docs does not contain info on how the `PERMISSIONS` clause works on file buckets.
This PR adds a section to the `BUCKET` docs similar to the ones in the `TABLE` and `FIELD` docs.