### PR TITLE
Fix bucket path env var name

### DIFF
--- a/src/content/doc-surrealql/statements/define/bucket.mdx
+++ b/src/content/doc-surrealql/statements/define/bucket.mdx
@@ -98,7 +98,7 @@ DEFINE BUCKET my_bucket BACKEND "file:/some_directory";
 DEFINE BUCKET my_bucket BACKEND "file:/some_directory";
 ```
 
-A check will then be made to see if the `SURREAL_FILE_ALLOWLIST` environment variable contains the path, without which the following error will be generated.
+A check will then be made to see if the `SURREAL_BUCKET_FOLDER_ALLOWLIST` environment variable contains the path, without which the following error will be generated.
 
 ```surql
 'Bucket backend not supported: Path not allowed'
@@ -108,10 +108,10 @@ The following command can be used to start running an instance in which a bucket
 
 ```bash
 # Unix
-SURREAL_FILE_ALLOWLIST="/" surreal start --user root --pass secret --allow-experimental files
+SURREAL_BUCKET_FOLDER_ALLOWLIST="/" surreal start --user root --pass secret --allow-experimental files
 
 # Windows (PowerShell)
-$env:SURREAL_FILE_ALLOWLIST = "/" 
+$env:SURREAL_BUCKET_FOLDER_ALLOWLIST = "/" 
 surreal start --user root --pass secret --allow-experimental files
 ```
 


### PR DESCRIPTION
The current docs states that the bucket path is validated against the `SURREAL_FILE_ALLOWLIST` env var when defining a new bucket.
I think this is not right and the correct env var is `SURREAL_BUCKET_FOLDER_ALLOWLIST`. Only the latter one worked for me, I am not sure what the first one is used for.

This PR simply replaces it in the docs.