### PR TITLE
Decimal clarification

### DIFF
--- a/src/content/doc-surrealql/datamodel/casting.mdx
+++ b/src/content/doc-surrealql/datamodel/casting.mdx
@@ -304,23 +304,31 @@ d'2025-06-07T00:00:00Z'
 
 ## `<decimal>`
 
-The `<decimal>` casting function converts a value into an infinite precision decimal number.
+The `<decimal>` casting function converts a value into a decimal which allows for 128 bits of precision.
+
+```surql
+RETURN <decimal> "13.5729484672938472938410938456";
+-- 13.572948467293847293841093846dec
+```
+
+Decimal casting should generally not be used to convert from floats with a large number of digits after the decimal point, because the input to the right will first be turned into a less precise float before the cast is performed.
 
 ```surql
 RETURN <decimal> 13.572948467293847293841093845679289;
+-- 13.57294846729385dec
 
-13.572948467293847293841093845679289
-```
-```surql
-RETURN <decimal> "13.572948467293847293841093845679289";
-
-"13.572948467293847293841093845679289"
-```
-
-```surql
 RETURN <decimal> 1.193847193847193847193487E11;
+-- 119384719384.7194dec
+```
 
-"119384719384.7193847193487"
+In this case, the `dec` suffix is preferable as it will instruct the database to treat the **input** as a decimal, rather than create a float to then cast into a decimal.
+
+```surql
+13.572948467293847293841093845679289dec;
+-- 13.572948467293847293841093846dec
+
+1.193847193847193847193487E11dec;
+-- 1.193847193847193847193487E11dec;
 ```
 
 ## `<duration>`


### PR DESCRIPTION
Clarifies that a decimal does not have infinite precision but 128 bits of precision, and adds the usual advice that generally you don't want to `<decimal>` a float when precision is needed.