### PR TITLE
Move clauses down

### DIFF
--- a/src/content/doc-surrealql/clauses/_category_.json
+++ b/src/content/doc-surrealql/clauses/_category_.json
@@ -1,4 +1,4 @@
 {
     "sidebar_label": "Clauses",
-    "sidebar_position": 5
+    "sidebar_position": 6
 }

--- a/src/content/doc-surrealql/functions/_category_.json
+++ b/src/content/doc-surrealql/functions/_category_.json
@@ -1,4 +1,4 @@
 {
     "sidebar_label": "Functions",
-    "sidebar_position": 6
+    "sidebar_position": 7
 }


### PR DESCRIPTION
Makes sure that the CLAUSES section comes after the statements in which they are used.