### PR TITLE
Enhance data type descriptions in index.mdx

### DIFF
--- a/src/content/doc-surrealql/datamodel/index.mdx
+++ b/src/content/doc-surrealql/datamodel/index.mdx
@@ -75,7 +75,7 @@ SurrealQL allows you to describe data with specific data types. These data types
                 <code>decimal</code>
             </td>
             <td scope="row" data-label="Description">
-                Uses BigDecimal for storing any real number with arbitrary precision. <a href="https://docs.rs/rust_decimal/latest/rust_decimal/">BigDecimal specifications</a>.
+               Data type for storing [decimal floating point](https://en.wikipedia.org/wiki/Decimal128_floating-point_format) numbers. 
             </td>
         </tr>
         <tr>
@@ -91,7 +91,7 @@ SurrealQL allows you to describe data with specific data types. These data types
                 <code>float</code>
             </td>
             <td scope="row" data-label="Description">
-                <a href="https://standards.ieee.org/ieee/754/6210/" target="_blank" title="Link to IEEE 754">IEEE 754</a>(64-bit) compliant data type for storing floating point numbers. 
+                Data type for storing [floating point](https://en.wikipedia.org/wiki/Double-precision_floating-point_format) numbers. 
             </td>
         </tr>
         <tr>
@@ -117,7 +117,7 @@ SurrealQL allows you to describe data with specific data types. These data types
                 <code>int</code>
             </td>
             <td scope="row" data-label="Description">
-                Store a value in a 64 bit signed integer. Values can range between `-9223372036854775808` and `9223372036854775808` (inclusive). Larger values should be stored as a float or a double.
+                Store a value in a 64 bit signed integer. Values can range between `-9223372036854775808` and `9223372036854775807` (inclusive). Larger values should be stored as a float or a decimal.
             </td>
         </tr>
         <tr>


### PR DESCRIPTION
Updated descriptions for decimal, float, int, and number types to include additional specifications and clarifications.


Additional request: don't sort the entries in this table alphabetically, that makes it hard to see all of the number datatypes together -- they should be sorted by useage.