### PR TITLE
Show that table can't be removed if a view is using it

### DIFF
--- a/src/content/doc-surrealql/statements/remove.mdx
+++ b/src/content/doc-surrealql/statements/remove.mdx
@@ -177,3 +177,45 @@ REMOVE PARAM IF EXISTS $author;
 
 REMOVE TABLE IF EXISTS article;
 ```
+
+### Usage in table views
+
+<Since v="v3.0.0-alpha.14" />
+
+A table used as a source for a table view cannot be removed until the table view itself has been removed.
+
+```surql
+DEFINE TABLE pc;
+DEFINE TABLE pc_agg AS SELECT count(), class FROM pc GROUP BY class;
+CREATE |pc:3| SET class = "Wizard";
+CREATE |pc:10| SET class = "Warrior";
+SELECT * FROM pc_agg;
+-- Error: pc_agg requires pc to work
+REMOVE TABLE pc;
+REMOVE TABLE pc_agg;
+-- pc_agg is now gone, pc can be removed too
+REMOVE TABLE pc;
+```
+
+The `SELECT * FROM pc_agg` query shows that the table view is pulling data from the `pc` table. As long as the `pc` table exists, `pc_agg` cannot be removed.
+
+```surql
+-------- Query --------
+
+[
+  { 
+    class: 'Warrior', 
+    count: 10, 
+    id: pc_agg:['Warrior'] 
+  }, 
+  { 
+    class: 'Wizard', 
+    count: 3, 
+    id: pc_agg:['Wizard'] 
+  }
+]
+
+-------- Query --------
+
+'Invalid query: Cannot delete table `pc` on which a view is defined, table(s) `pc_agg` are defined as a view on this table.'
+```


### PR DESCRIPTION
Adds an example to show that a table can't be removed since 3.0.0-alpha.14 if a table view is defined on it.