### PR TITLE
Rename surrealdbNodeEngines to createNodeEngines

### DIFF
--- a/src/content/doc-sdk-javascript/engines/node.mdx
+++ b/src/content/doc-sdk-javascript/engines/node.mdx
@@ -65,14 +65,14 @@ To use the Node.js engine, you need to import the `surrealdbNodeEngines` functio
 
 ```js
 import { Surreal } from 'surrealdb';
-import { surrealdbNodeEngines } from '@surrealdb/node';
+import { createNodeEngines } from '@surrealdb/node';
 ```
 
 After importing the `surrealdbNodeEngines` function, you can pass it as an option to the `Surreal` constructor. 
 
 ```js
 const db = new Surreal({
-    engines: surrealdbNodeEngines(),
+    engines: createNodeEngines(),
 });
 ```
 
@@ -84,11 +84,11 @@ Using the [`.connect()`](/docs/sdk/javascript/methods/connect) method, you can c
 
 ```js
 import { Surreal } from 'surrealdb';
-import { surrealdbNodeEngines } from '@surrealdb/node';
+import { createNodeEngines } from '@surrealdb/node';
 
 // Enable the WebAssembly engines
 const db = new Surreal({
-    engines: surrealdbNodeEngines(),
+    engines: createNodeEngines(),
 });
 
 // Now we can start SurrealDB as an in-memory database


### PR DESCRIPTION
Upgrade export name to the 2.4.0 version of @surrealdb/node.