### PR TITLE
Add STRICT clause to define database

### DIFF
--- a/src/content/doc-surrealql/statements/define/database.mdx
+++ b/src/content/doc-surrealql/statements/define/database.mdx
@@ -24,7 +24,7 @@ The `DEFINE DATABASE` statement allows you to instantiate a named database, enab
   <TabItem label="SurrealQL Syntax">
 
 ```syntax title="SurrealQL Syntax"
-DEFINE DATABASE [ OVERWRITE | IF NOT EXISTS ] @name [ COMMENT @string ]
+DEFINE DATABASE [ OVERWRITE | IF NOT EXISTS ] @name [ STRICT ] [ COMMENT @string ]
 ```
 
   </TabItem>
@@ -39,6 +39,7 @@ export const defineDatabaseAst = {
       { type: "Terminal", text: "DATABASE" },
       { type: "Optional", child: { type: "Choice", index: 1, children: [ { type: "Terminal", text: "OVERWRITE" }, { type: "Sequence", children: [ { type: "Terminal", text: "IF" }, { type: "Terminal", text: "NOT" }, { type: "Terminal", text: "EXISTS" } ] } ] } },
       { type: "NonTerminal", text: "@name" },
+      { type: "Optional", child: { type: "Sequence", children: [ { type: "Terminal", text: "STRICT" } ] } },
       { type: "Optional", child: { type: "Sequence", children: [ { type: "Terminal", text: "COMMENT" }, { type: "NonTerminal", text: "@string" } ] } }
     ]}
   ]
@@ -108,4 +109,35 @@ value = "NONE"
 
 -- Create a database and overwrite if it already exists
 DEFINE DATABASE OVERWRITE app_vitalsense;
+```
+
+## Defining a `STRICT` database
+
+<Since v="v3.0.0-alpha.14" />
+
+A strict database is one that does not allow a resource to be used unless it has already been defined. The default behaviour in SurrealDB works otherwise, by allowing statements like [CREATE](/docs/surrealql/statements/create), [INSERT](/docs/surrealql/statements/insert) and [UPSERT](/docs/surrealql/statements/create) to work.
+
+```surql
+CREATE some_new_table;
+INFO FOR DATABASE.tables;
+```
+
+The output of the [INFO](/docs/surrealql/statements/info) statement shows that a table called `some_new_table` has been created with a few default clauses.
+
+```surql
+{
+	some_new_table: 'DEFINE TABLE some_new_table TYPE ANY SCHEMALESS PERMISSIONS NONE'
+}
+```
+
+Such an operation within a strict database is simply not allowed.
+
+```surql
+DEFINE DATABASE new_db STRICT;
+USE DATABASE new_db;
+CREATE some_new_table;
+```
+
+```surql title="Output"
+"The table 'some_new_table' does not exist"
 ```


### PR DESCRIPTION
Added STRICT to the docs recently except in the statement where it is used! This PR rectifies that.