### PR TITLE
Add example of sequence in failed transaction

### DIFF
--- a/src/content/doc-surrealql/statements/define/sequence.mdx
+++ b/src/content/doc-surrealql/statements/define/sequence.mdx
@@ -86,6 +86,23 @@ sequence::nextval('mySeq3');
 -- Possible output: 'The query was not executed because it exceeded the timeout'
 ```
 
+Sequences are never rolled back, even in a failed transaction. This differs from an approach like a single record with a manually incrementing value.
+
+```surql
+DEFINE SEQUENCE seq;
+CREATE my:counter SET val = 0;
+sequence::nextval("seq");        -- 0
+my:counter.val;                  -- 0
+
+BEGIN TRANSACTION;
+sequence::nextval("seq");        -- 0
+UPDATE my:counter SET val += 1;  -- my:counter.val = 1
+CANCEL TRANSACTION;              -- my:counter.val now rolled back to 0
+
+sequence::nextval("seq");        -- 2
+UPDATE my:counter SET val += 1;  -- 1
+```
+
 ## See also
 
 * [Sequence functions](/docs/surrealql/functions/database/sequence)


### PR DESCRIPTION
Adds an example showing that sequences are not rolled back in a failed transaction, unlike other resources like records.