### PR TITLE
Rewrite performance tip, rv some version mentions

### DIFF
--- a/src/content/doc-surrealdb/reference-guide/performance-best-practices.mdx
+++ b/src/content/doc-surrealdb/reference-guide/performance-best-practices.mdx
@@ -7,7 +7,7 @@ description: This guide outlines some key performance best practices for using S
 
 # Performance Best Practices
 
-This guide outlines some key performance best practices for using SurrealDB `v2.x.x`. While SurrealDB offers powerful and flexible features to help you meet your desired performance standards, your use of those features will ultimately determine whether or not you meet them.
+This guide outlines some key performance best practices for using SurrealDB. While SurrealDB offers powerful and flexible features to help you meet your desired performance standards, your use of those features will ultimately determine whether or not you meet them.
 
 To achieve the best performance from SurrealDB, there are a number of configuration options and runtime design choices to be considered which can improve and affect the performance of the database.
 
@@ -61,20 +61,18 @@ Read more about running SurrealDB as a [single-node server](/docs/surrealdb/inst
 
 ### Running SurrealDB embedded in Rust
 
-When running SurrealDB as an embedded database within Rust, using the correct release profile and memory allocator can
-greatly improve the performance of the database core engine. In addition using an optimised asynchronous runtime
-configuration can help speed up concurrent queries and increase database throughput.
-
-In your project's `Cargo.toml` file, ensure that the release profile uses the following configuration:
+It is common knowledge among Rust developers that the `--release` flag is used to ensure that a build is optimized for performance as opposed to compilation speed. However, the SurrealDB source code also contains a few additional flags when the `--release` flag is passed in as seen below. As this configuration will not be present by default inside the `Cargo.toml` for your own project when adding the `surrealdb` dependency, be sure to add it if performance is crucial.
 
 ```toml
 [profile.release]
+codegen-units = 1
 lto = true
-strip = true
 opt-level = 3
 panic = 'abort'
-codegen-units = 1
+strip = true
 ```
+
+In addition, using the correct memory allocator can greatly improve the performance of the database core engine when running SurrealDB as an embedded database within Rust. Using an optimised asynchronous runtime configuration can also help speed up concurrent queries and increase database throughput.
 
 In your project's `Cargo.toml` file, ensure that the `allocator` feature is enabled on the `surrealdb` dependency:
 

--- a/src/content/doc-surrealql/datamodel/bytes.mdx
+++ b/src/content/doc-surrealql/datamodel/bytes.mdx
@@ -29,7 +29,7 @@ b"4920616D20736F6D65206279746573"
 
 ## Conversion from other types
 
-<Since v="v3.0.0-beta" />
+<Since v="v2.3.0" />
 
 Since SurrealDB 2.3.0, conversions can be performed between bytes, strings, and arrays.
 

--- a/src/content/doc-surrealql/datamodel/records.mdx
+++ b/src/content/doc-surrealql/datamodel/records.mdx
@@ -65,7 +65,7 @@ CREATE person:tobie SET name = 'Tobie', email = 'tobie@surrealdb.com', opts.enab
 -- Select the whole record
 person:tobie.*;
 
--- Select specific fields (since 2.0.0)
+-- Select specific fields
 person:tobie.{ name, email };
 ```
 

--- a/src/content/doc-surrealql/datamodel/strings.mdx
+++ b/src/content/doc-surrealql/datamodel/strings.mdx
@@ -135,7 +135,7 @@ true
 The `r` prefix tells the parser that the contents of the string represent a [`record ID`](/docs/surrealql/datamodel/ids). The parser expects record IDs to have the following format: `table_name:record ID`.
 
 > [!NOTE]
-> As of SurrealDB 2.0, without the `r` prefix the type of the value will be `string`.
+> All strings since SurrealDB 2.0 without the `r` prefix are of type `string` and are not parsed as records unless the prefix is present.
 
 Here is an example of a record ID literal value, specified using a string with the `r` prefix.
 

--- a/src/content/doc-surrealql/functions/database/string.mdx
+++ b/src/content/doc-surrealql/functions/database/string.mdx
@@ -488,7 +488,7 @@ RETURN string::repeat('test', 3);
 
 ## `string::replace`
 
-The `string::replace`  function replaces an occurrence of a string with another string.
+The `string::replace` function replaces an occurrence of a string with another string.
 
 <Tabs>
   <TabItem label="Before 2.3" default>

--- a/src/content/doc-surrealql/functions/database/value.mdx
+++ b/src/content/doc-surrealql/functions/database/value.mdx
@@ -50,12 +50,12 @@ Any value can be followed with the `.chain()` syntax, after which an anonymous f
 /**[test]
 
 [[test.results]]
-value = "'SurrealDB 2.0'"
+value = "'SurrealDB 3.0'"
 
 */
 
-'SurrealDB'.chain(|$n| $n + ' 2.0');
--- 'SurrealDB 2.0'
+'SurrealDB'.chain(|$n| $n + ' 3.0');
+-- 'SurrealDB 3.0'
 ```
 
 The function is only called using the `.` operator (method syntax) and, as the name implies, works well within a chain of methods.

--- a/src/content/doc-surrealql/statements/delete.mdx
+++ b/src/content/doc-surrealql/statements/delete.mdx
@@ -216,7 +216,7 @@ SELECT * FROM cat;
 ]
 ```
 
-This pattern is particularly useful when using SurrealDB's [literal types](/docs/surrealql/datamodel/literals) which were added in version 2.0. A literal type containing objects that contain a single top-level field can easily be matched on through the field name.
+This pattern is particularly useful when using SurrealDB's [literal types](/docs/surrealql/datamodel/literals). A literal type containing objects that contain a single top-level field can easily be matched on through the field name.
 
 ```surql
 /**[test]

--- a/src/content/doc-surrealql/statements/relate.mdx
+++ b/src/content/doc-surrealql/statements/relate.mdx
@@ -1119,7 +1119,7 @@ FROM person;
 ]
 ```
 
-As of SurrealDB 2.0, [destructuring](/docs/surrealql/datamodel/idioms#destructuring) can also be used to pick and choose which fields to access inside a graph query. The following query will return the same output as above, except that `original_name: 'Πολιτεία'` will no longer show up.
+[Destructuring](/docs/surrealql/datamodel/idioms#destructuring) can also be used to pick and choose which fields to access inside a graph query. The following query will return the same output as above, except that `original_name: 'Πολιτεία'` will no longer show up.
 
 ```surql
 SELECT 
@@ -1430,7 +1430,7 @@ SELECT
 FROM country:usa;
 ```
 
-If using SurrealDB versions 2.0 and above, [destructuring syntax](/docs/surrealql/datamodel/idioms#destructuring) can be used to reduce some typing. Here is the same query as the last using destructuring syntax instead of one line for each field.
+The [destructuring syntax](/docs/surrealql/datamodel/idioms#destructuring) can be used to reduce some typing. Here is the same query as the last using destructuring syntax instead of one line for each field.
 
 ```surql
 SELECT

--- a/src/content/doc-surrealql/statements/select.mdx
+++ b/src/content/doc-surrealql/statements/select.mdx
@@ -257,7 +257,7 @@ SELECT ->likes->friend.name AS friends FROM person:tobie;
 -- Use the result of a subquery as a returned field
 SELECT *, (SELECT * FROM events WHERE type = 'activity' LIMIT 5) AS history FROM user;
 
--- Restructure objects in a select expression after `.` operator (since version 2.0.0)
+-- Restructure objects in a select expression after `.` operator
 SELECT address.{city, country} FROM person;
 ```
 
@@ -380,7 +380,7 @@ SELECT * FROM person;
 -- Omit the password field and security field in the options object
 SELECT * OMIT password, opts.security FROM person;
 
--- Using destructuring syntax (since 2.0.0)
+-- Using destructuring syntax
 SELECT * OMIT password, opts.{ security, enabled } FROM person;
 ```
 


### PR DESCRIPTION

* Explains in performance best practices page why the release profile is recommended (it's the profile drawn from when building from source but surrealdb as a dependency won't have this show up by default)
* Changes a few 2.x mentions including removing a few places where something from 2.0 is now by no means a new feature.