### PR TITLE
Correct statements about no limit

### DIFF
--- a/src/content/doc-surrealql/datamodel/arrays.mdx
+++ b/src/content/doc-surrealql/datamodel/arrays.mdx
@@ -2,7 +2,7 @@
 sidebar_position: 2
 sidebar_label: Arrays
 title: Arrays | SurrealQL
-description: Records in SurrealDB can store arrays of values, with no limit to the depth of the arrays
+description: Records in SurrealDB can store arrays of values, including arrays within arrays
 
 ---
 
@@ -98,7 +98,7 @@ SELECT * FROM ONLY [1,9];
 'Expected a single result output when using the ONLY keyword'
 ```
 
-Similar to Object-based Record IDs, records in SurrealDB can store arrays of values, with no limit to the depth of the arrays. Arrays can store any value stored within them, and can store different value types within the same array.
+Similar to Object-based Record IDs, records in SurrealDB can store arrays of values, including arrays within arrays. Arrays can store any value stored within them, and can store different value types within the same array.
 
 ```surql
 /**[test]

--- a/src/content/doc-surrealql/datamodel/ids.mdx
+++ b/src/content/doc-surrealql/datamodel/ids.mdx
@@ -243,7 +243,7 @@ CREATE year:29878977097987987979232 SET
 
 Record IDs can be constructed out of arrays and even objects. This sort of record ID is most used when you have a field or two that will be used to look up records inside a [record range](/docs/surrealql/datamodel/ids#record-ranges), which is extremely performant. This is in contrast to using a `WHERE` clause to filter, which involves a table scan.
 
-Records in SurrealDB can store arrays of values, with no limit to the depth of the arrays. Arrays can store any value stored within them, and can store different value types within the same array.
+Records in SurrealDB can store arrays of values, including other nested arrays or objects within them. Different types of values can be stored within the same array, unless defined otherwise.
 
 ```surql
 /**[test]

--- a/src/content/doc-surrealql/datamodel/index.mdx
+++ b/src/content/doc-surrealql/datamodel/index.mdx
@@ -135,7 +135,7 @@ SurrealQL allows you to describe data with specific data types. These data types
                 <code>object</code>
             </td>
             <td scope="row" data-label="Description">
-                Store formatted objects containing values of any supported type with no limit to object depth or nesting.
+                Store formatted objects containing values of any supported type including nested objects or arrays.
             </td>
         </tr>
         <tr>


### PR DESCRIPTION
Corrects some statements saying that arrays and objects have unlimited depth. It turns out that the maximum depth is this:

```
[[[[[[[[[[[[[[[[[[[[[]]]]]]]]]]]]]]]]]]]]];
{{{{{{{{{{{{{{{{{{{{{}}}}}}}}}}}}}}}}}}}}};
```


(Interestingly, one statement about IF ELSE statements having unlimited length is true - those can go on forever)

