### PR TITLE
Add note on underscores

### DIFF
--- a/src/content/doc-surrealql/datamodel/numbers.mdx
+++ b/src/content/doc-surrealql/datamodel/numbers.mdx
@@ -141,6 +141,21 @@ RETURN 0.3dec + 0.3dec + 0.3dec + 0.1dec;
 -- 1.0dec
 ```
 
+## Underscores
+
+As a convenience, underscores are ignored when using a number. This allows input to be more readable than it would otherwise. Because underscores are ignored, they will not display in the output.
+
+```surql
+RELATE dr:evil->bribes->other:character SET dollars = 1_000_000.99;
+-- [{ dollars: 1000000.99, id: bribes:4bfld2ukwnja24dzrpw9, in: dr:evil, out: other:character }]
+
+-- Input Korean currency counted in units of 10000, not 1000
+RELATE korean:purchaser->buys_house_from->korean:seller
+              -- 10억 4천만 5천
+    SET amount = 10_4000_5000;
+-- [{ amount: 1040005000, id: buys_house_from:9070t2ctgwwg202cpw1z, in: korean:purchaser, out: korean:seller }]
+```
+
 ## Mathematical constants
 A set of floating point numeric constants are available in SurrealDB. Constant names are case insensitive, and can be specified with either lowercase or capital letters, or a mixture of both.
 


### PR DESCRIPTION
Looks like numbers can take underscores, after which they are ignored. (Since 2.0 apparently)