### PR TITLE
Add old function signature and examples for type::record

### DIFF
--- a/src/content/doc-surrealql/functions/database/type.mdx
+++ b/src/content/doc-surrealql/functions/database/type.mdx
@@ -766,6 +766,9 @@ RETURN type::range([1,9,4]);
 
 ## `type::record`
 
+<Tabs>
+<TabItem label="3.x">
+
 > [!NOTE]
 > This function was known as `type::thing` in versions of SurrrealDB before 3.0.0-beta. The behaviour has not changed.
 
@@ -829,6 +832,40 @@ type::record("person", person:mat);
 ```
 
 The output of the above function call will thus be `person:mat`, not `person:person:mat`.
+
+</TabItem>
+<TabItem label="2.x">
+
+The `type::record` function returns a record from a record or a string, with an optional argument to confirm the table name.
+
+```surql title="API DEFINITION"
+type::record($record: record|string, $table_name: option<string>) -> record
+```
+
+The function will return a record as long as the argument passed in is already a record, or a string that can be parsed into one.
+
+```surql
+-- Both return person:tobie
+type::record(person:tobie);
+type::record('person:tobie');
+```
+
+The optional second argument allows an assertation that the record passed in is of this table name.
+
+```surql
+type::record('person:tobie', 'person'); -- person:tobie
+type::record('person:tobie', 'cat'); -- "Expected a record<cat> but cannot convert 'person:tobie' into a record<cat>"
+```
+
+This second argument is mostly useful when involving a parameter that may or may not be a certain value. In the code below, the function may or may not err depending on whether the `$record` parameter is a `person` or a `cat` record.
+
+```surql
+LET $record = rand::enum(person:tobie, cat:tobie);
+type::record($record, 'person');
+```
+
+</TabItem>
+</Tabs>
 
 <br/>
 


### PR DESCRIPTION
type::record() is a bit unique in that its 3.x version is not just modified but directly renamed from the previous type::thing(). Its 2.x version was very uncommonly used but still needs to be documented to avoid confusion.