### PR TITLE
Some improvements to rand/time functions

### DIFF
--- a/src/content/doc-surrealql/functions/database/rand.mdx
+++ b/src/content/doc-surrealql/functions/database/rand.mdx
@@ -63,10 +63,6 @@ These functions can be used when generating random data values.
       <td scope="row" data-label="Description">Generates and returns a random Version 4 UUID</td>
     </tr>
     <tr>
-      <td scope="row" data-label="Function"><a href="#randuuidv7"><code>rand::uuid::v7()</code></a></td>
-      <td scope="row" data-label="Description">Generates and returns a random Version 7 UUID</td>
-    </tr>
-    <tr>
       <td scope="row" data-label="Function"><a href="#randulid"><code>rand::ulid()</code></a></td>
       <td scope="row" data-label="Description">Generates and returns a random ULID</td>
     </tr>
@@ -382,10 +378,11 @@ As of this version, this function returns a datetime between 0000-01-01T00:00:00
 
 ## `rand::uuid`
 
-The `rand::uuid` function generates a random UUID. You can also generate uuids from datetime values.
+The `rand::uuid` function generates a random Version 7 UUID.
 
 ```surql title="API DEFINITION"
 rand::uuid() -> uuid
+rand::uuid(datetime) -> uuid
 ```
 
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
@@ -396,32 +393,26 @@ RETURN rand::uuid();
 [u"e20b2836-e689-4643-998d-b17a16800323"]
 ```
 
-### `rand::uuid` from timestamp
-
-<Since v="v2.0.0" />
-
-The `rand::uuid` function generates a random UUID from a datetime type.
-
-```surql title="API DEFINITION"
-rand::uuid(datetime) -> uuid
-```
-
-The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
+The `rand::uuid` function can also generate a random UUID from a datetime.
 
 ```surql
 RETURN rand::uuid(d"2021-09-07T04:27:53Z");
 ```
 
-```surql
-CREATE ONLY test:[rand::uuid()] SET created = time::now(), num = 1;
-SLEEP 100ms;
+Note that a UUID has a precision of one millisecond, and thus one converted back to a datetime will truncate nanosecond precision.
 
-LET $rec = CREATE ONLY test:[rand::uuid()] SET created = time::now(), num = 2;
-SLEEP 100ms;
-CREATE ONLY test:[rand::uuid()] SET created = time::now(), num = 3;
--- Select the value of the record created before the current record in the table
-SELECT VALUE num FROM test:[rand::uuid($rec.created - 100ms)]..;
-  ```
+```surql
+LET $now = time::now();
+[$now, time::from_uuid(rand::uuid($now))];
+
+-- Output:
+[
+	d'2026-01-29T02:14:10.057075Z',
+	d'2026-01-29T02:14:10.057Z'
+]
+```
+
+The `rand::uuid` function can also be called using its alias `rand::uuid::v7`.
 
 <br />
 
@@ -441,85 +432,6 @@ RETURN rand::uuid::v4();
 [u"4def23a5-a847-4934-8dad-c64ccc48921b"]
 ```
 
-### `rand::uuid::v4` from timestamp
-
-<Since v="v2.0.0" />
-
-The `rand::uuid::v4` function generates a random version 4 UUID from a datetime type.
-
-```surql title="API DEFINITION"
-rand::uuid::v4(datetime) -> uuid
-```
-
-The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
-
-```surql
-RETURN rand::uuid::v4(d"2021-09-07T04:27:53Z");
-```
-
-```surql
-CREATE ONLY test:[rand::uuid::v4()] SET created = time::now(), num = 1;
-SLEEP 100ms;
-
-LET $rec = CREATE ONLY test:[rand::uuid::v4()] SET created = time::now(), num = 2;
-SLEEP 100ms;
-CREATE ONLY test:[rand::uuid::v4()] SET created = time::now(), num = 3;
--- Select the value of the record created before the current record in the table
-SELECT VALUE num FROM test:[rand::uuid::v4($rec.created - 100ms)]..;
-  ```
-
-<br />
-
-## `rand::uuid::v7`
-
-The `rand::uuid::v7` function generates a random Version 7 UUID.
-
-```surql title="API DEFINITION"
-rand::uuid::v7() -> uuid
-```
-
-The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
-
-```surql
-RETURN rand::uuid::v7();
-
-[u'0190d9df-c6cd-7e8a-aae2-aa3a162507ed']
-```
-
-### `rand::uuid::v7` from timestamp
-
-<Since v="v2.0.0" />
-
-The `rand::uuid::v7` function generates a random  Version 7  UUID from a datetime type.
-
-```surql title="API DEFINITION"
-rand::uuid::v7(datetime) -> uuid
-```
-
-The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
-
-```surql
-RETURN rand::uuid::v7(d"2021-09-07T04:27:53Z");
-```
-
-```surql
-CREATE ONLY test:[rand::uuid::v7()] SET created = time::now(), num = 1;
-SLEEP 100ms;
-
-LET $rec = CREATE ONLY test:[rand::uuid::v7()] SET created = time::now(), num = 2;
-SLEEP 100ms;
-CREATE ONLY test:[rand::uuid::v7()] SET created = time::now(), num = 3;
--- Select the value of the record created before the current record in the table
-SELECT VALUE num FROM test:[rand::uuid::v7($rec.created - 100ms)]..;
-  ```
-
-To enable `rand::uuid::v7` in [embedded mode](/docs/surrealdb/embedding/rust) you need to add the following to your `.cargo/config.toml` file in your project
-
-```toml
-[build]
-rustflags = ["--cfg", "uuid_unstable"]
-```
-
 <br />
 
 ## `rand::ulid`
@@ -527,7 +439,8 @@ rustflags = ["--cfg", "uuid_unstable"]
 The `rand::ulid` function generates a random ULID.
 
 ```surql title="API DEFINITION"
-rand::ulid() -> ulid
+rand::ulid() -> uuid
+rand::ulid(datetime) -> uuid
 ```
 
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
@@ -538,15 +451,7 @@ RETURN rand::ulid();
 [u"01H9QDG81Q7SB33RXB7BEZBK7G"]
 ```
 
-### `rand::ulid` from timestamp
-
-<Since v="v2.0.0" />
-
-The `rand::ulid` function generates a random ULID from a datetime type.
-
-```surql title="API DEFINITION"
-rand::ulid(datetime) -> ulid
-```
+The `rand::ulid` function can also generate a random ULID from a datetime type.
 
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/surrealql/statements/return) statement:
 
@@ -554,16 +459,15 @@ The following example shows this function, and its output, when used in a [`RETU
 RETURN rand::ulid(d"2021-09-07T04:27:53Z");
 ```
 
+Note that a ULID has a precision of one millisecond, and thus one converted back to a datetime will truncate nanosecond precision.
+
 ```surql
-CREATE ONLY test:[rand::ulid()] SET created = time::now(), num = 1;
-SLEEP 100ms;
+LET $now = time::now();
+[$now, time::from_ulid(rand::ulid($now))];
 
-LET $rec = CREATE ONLY test:[rand::ulid()] SET created = time::now(), num = 2;
-SLEEP 100ms;
-CREATE ONLY test:[rand::ulid()] SET created = time::now(), num = 3;
--- Select the value of the record created before the current record in the table
-SELECT VALUE num FROM test:[rand::ulid($rec.created - 100ms)]..;
-  ```
-
-
-<br /><br />
+-- Output:
+[
+	d'2026-01-29T02:14:10.057075Z',
+	d'2026-01-29T02:14:10.057Z'
+]
+```

--- a/src/content/doc-surrealql/functions/database/time.mdx
+++ b/src/content/doc-surrealql/functions/database/time.mdx
@@ -996,6 +996,19 @@ RETURN time::from_ulid("01JH5BBTK9FKTGSDXHWP5YP9TQ");
 -- d'2025-01-09T10:57:03.593Z'
 ```
 
+As a ULID is only precise up to the millisecond, a conversion from a ULID to a timestamp will truncate nanosecond precision.
+
+```surql
+LET $now = time::now();
+[$now, time::from_ulid(rand::ulid($now))];
+
+-- Output:
+[
+	d'2026-01-29T02:07:06.494218Z',
+	d'2026-01-29T02:07:06.494Z'
+]
+```
+
 <br />
 
 ## `time::from_uuid`
@@ -1019,6 +1032,19 @@ value = "d'2025-01-09T10:57:58.757Z'"
 RETURN time::from_uuid(u'01944ab6-c1e5-7760-ab6a-127d37eb1b94');
 
 -- d'2025-01-09T10:57:58.757Z'
+```
+
+As a UUID is only precise up to the millisecond, a conversion from a UUID to a timestamp will truncate nanosecond precision.
+
+```surql
+LET $now = time::now();
+[$now, time::from_uuid(rand::uuid($now))];
+
+-- Output:
+[
+	d'2026-01-29T02:12:13.848476Z',
+	d'2026-01-29T02:12:13.848Z'
+]
 ```
 
 <br />


### PR DESCRIPTION
Improvements:

* While a datetime has nanosecond precision, ULID and UUID do not. Gives an example of how the truncation happens when doing a round trip.
* Removes rand::uuid::v7 aside from a brief mention as it is effectively an alias for rand::uuid.
* Removes the Since part of the rand:: functions mentioning that they can also take a datetime, as it has been a long time since the release of 2.0.