### PR TITLE
Example of closure only being read-only

### DIFF
--- a/src/content/doc-surrealql/datamodel/closures.mdx
+++ b/src/content/doc-surrealql/datamodel/closures.mdx
@@ -141,6 +141,44 @@ value = "'true'"
 'true'
 ```
 
+## Closure limitations
+
+Closures work inside a read-only context, and cannot be used to modify database resources.
+
+```surql
+-- 1. Create a test table and function
+DEFINE TABLE test_table SCHEMAFULL;
+DEFINE FIELD name ON test_table TYPE string;
+
+DEFINE FUNCTION fn::test_create($name: string) -> object {
+    CREATE test_table CONTENT { name: $name };
+    { created: true, name: $name };
+};
+
+-- 2. Call the function directly - works
+fn::test_create("direct_call");
+
+-- 3. Call the function inside .map() - fails
+LET $names = ["Alice", "Bob", "Charlie"];
+$names.map(|$n| fn::test_create($n));
+-- Error: "Couldn't write to a read only transaction"
+```
+
+In many cases, a closure can be substituted by another operation such as a `FOR` loop or a regular `SELECT` statement.
+
+```surql
+DEFINE TABLE test_table SCHEMAFULL;
+DEFINE FIELD name ON test_table TYPE string;
+
+DEFINE FUNCTION fn::test_create($name: string) -> object {
+    CREATE test_table CONTENT { name: $name };
+    { created: true, name: $name };
+};
+
+-- Function to create a record called for each name
+SELECT VALUE fn::test_create($this) FROM ["Alice", "Bob", "Charlie"];
+```
+
 ## Capturing parameters
 
 <Since v="v3.0.0-beta" />


### PR DESCRIPTION
Adds a section demonstrating that closures work in a read-only context as mentioned here:

https://github.com/surrealdb/surrealdb/issues/6674