### PR TITLE
Update + add more content to HTTP endpoints

### DIFF
--- a/src/content/doc-surrealdb/cli/start.mdx
+++ b/src/content/doc-surrealdb/cli/start.mdx
@@ -20,83 +20,7 @@ The start command starts a SurrealDB server in memory, on disk, or in a distribu
 
 <Tabs groupId="surreal-start">
 
-<TabItem value="V1" label="V1.x" >
-<table>
-    <thead>
-        <tr>
-            <th colspan="2">Arguments</th>
-            <th>Description</th>
-        </tr>
-    </thead>  
-    <tbody>
-        <tr>
-            <td colspan="2">
-                `-b` / `--bind`
-               <Label label="optional" />
-            </td>
-            <td>
-            Sets the hostname or IP address to listen for connections on
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2">
-                `-l` / `--log`
-               <Label label="optional" />
-            </td>
-            <td>
-                Sets the logging level for the database server
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2">
-                `-u` / `--user`
-               <Label label="optional" />
-            </td>
-            <td>
-                Sets master username for the database
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2">
-                `-p` / `--pass`
-               <Label label="optional" />
-            </td>
-            <td>
-                Sets master password for the database
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2">
-                `--allow-experimental`
-               <Label label="optional" />
-            </td>
-            <td>
-                Enable experimental capabilities
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2">
-                `--auth`
-               <Label label="optional" />
-            </td>
-            <td>
-                Sets authentication to enabled
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2">
-                `--no-identification-headers`
-               <Label label="optional" />
-            </td>
-            <td>
-                Whether to suppress the server name and version headers
-            </td>
-        </tr>
-    </tbody>
-</table>
-</TabItem>
-
-<TabItem value="V2" label="V2.x" >
+<TabItem value="V2" label="V2.x+" >
 <table>
     <thead>
         <tr>
@@ -184,6 +108,82 @@ The start command starts a SurrealDB server in memory, on disk, or in a distribu
             </td>
             <td>
                 Sets the experimental capabilities to the experimental capabilities you want to allow.
+            </td>
+        </tr>
+    </tbody>
+</table>
+</TabItem>
+
+<TabItem value="V1" label="V1.x" >
+<table>
+    <thead>
+        <tr>
+            <th colspan="2">Arguments</th>
+            <th>Description</th>
+        </tr>
+    </thead>  
+    <tbody>
+        <tr>
+            <td colspan="2">
+                `-b` / `--bind`
+               <Label label="optional" />
+            </td>
+            <td>
+            Sets the hostname or IP address to listen for connections on
+            </td>
+        </tr>
+        <tr>
+            <td colspan="2">
+                `-l` / `--log`
+               <Label label="optional" />
+            </td>
+            <td>
+                Sets the logging level for the database server
+            </td>
+        </tr>
+        <tr>
+            <td colspan="2">
+                `-u` / `--user`
+               <Label label="optional" />
+            </td>
+            <td>
+                Sets master username for the database
+            </td>
+        </tr>
+        <tr>
+            <td colspan="2">
+                `-p` / `--pass`
+               <Label label="optional" />
+            </td>
+            <td>
+                Sets master password for the database
+            </td>
+        </tr>
+        <tr>
+            <td colspan="2">
+                `--allow-experimental`
+               <Label label="optional" />
+            </td>
+            <td>
+                Enable experimental capabilities
+            </td>
+        </tr>
+        <tr>
+            <td colspan="2">
+                `--auth`
+               <Label label="optional" />
+            </td>
+            <td>
+                Sets authentication to enabled
+            </td>
+        </tr>
+        <tr>
+            <td colspan="2">
+                `--no-identification-headers`
+               <Label label="optional" />
+            </td>
+            <td>
+                Whether to suppress the server name and version headers
             </td>
         </tr>
     </tbody>

--- a/src/content/doc-surrealdb/integration/http.mdx
+++ b/src/content/doc-surrealdb/integration/http.mdx
@@ -12,23 +12,25 @@ import Label from "@components/shared/Label.astro";
 
 # HTTP & Rest
 
-The HTTP endpoints exposed by SurrealDB instances provide a simple way to interact with the database over a traditional RESTful interface. This includes selecting and modifying one or more records, executing custom SurrealQL queries, and managing SurrealML models. 
+The HTTP endpoints exposed by SurrealDB instances provide a simple way to interact with the database over a traditional RESTful interface. This includes selecting and modifying one or more records, executing custom SurrealQL queries, and importing and exporting data.
 
 The endpoints are designed to be simple and easy to use in stateless environments, making them ideal for lightweight applications where a persistent database connection is not required.
 
+## Setup
+
+The [`surreal start`](/docs/surrealdb/cli/start) command without any arguments is all that is needed to start a server at the default `http://localhost:8000` URL. Many examples below assume the flags `--user root` and `--pass secret` to create a root user with the name `root` and password `secret`. The `--unauthenticated` flag can be used when experimenting to turn off authentication, effectively allowing root access by any and all connections.
+
+Surrealist's [local database serving](/docs/surrealist/concepts/local-database-serving) functionality can also be used to start a server.
+
 ## Querying via Postman
 
-The most convenient way to access these endpoints is via SurrealDB's Postman Collection. To do so, follow these steps:
+One convenient way to access these endpoints is via SurrealDB's Postman Collection. To do so, follow these steps:
 
 1. Open Postman
 2. Clone the [SurrealDB Postman Collection](https://postman.com/surrealdb/workspace/surrealdb/collection/19100500-3da237f3-588b-4252-8882-6d487c11116a)
 2. Select the appropriate HTTP method (`GET /health`, `DEL /key/:table`, etc.).
 3. Enter the endpoint URL.
 4. If the endpoint requires any parameters or a body, make sure to include those in your request.
-
-> [!IMPORTANT]
-> Ensure that your URL is set correctly, if running locally, the URL should be `http://localhost:8000`.By default, the URL is set to local. Start your server using the [`surreal start`](/docs/surrealdb/cli/start) command in the CLI or through Surrealist's [local database serving](/docs/surrealist/concepts/local-database-serving) functionality, before querying the endpoints.
-
 
 ## Supported methods
 
@@ -149,13 +151,13 @@ curl -I http://localhost:8000/status
 
 ```bash title="Sample output"
 HTTP/1.1 200 OK
-content-length: 0
 vary: origin, access-control-request-method, access-control-request-headers
 access-control-allow-origin: *
-surreal-version: surrealdb-2.0.0+20240910.8f30ee08
+surreal-version: surrealdb/3.0.0-beta
 server: SurrealDB
-x-request-id: 3dedcc96-4d8a-451e-b60d-4eaac14fa3f8
-date: Wed, 11 Sep 2024 00:52:49 GMT
+x-request-id: fdb9bcdb-b085-4da0-80ef-a61105c432f9
+content-length: 0
+date: Tue, 03 Feb 2026 02:10:33 GMT
 ```
 
 <br />
@@ -172,13 +174,13 @@ curl -I http://localhost:8000/health
 
 ```bash title="Sample output"
 HTTP/1.1 200 OK
-content-length: 0
 vary: origin, access-control-request-method, access-control-request-headers
 access-control-allow-origin: *
-surreal-version: surrealdb-2.0.0+20240910.8f30ee08
+surreal-version: surrealdb/3.0.0-beta
 server: SurrealDB
-x-request-id: 24a1e675-af50-4676-b8ff-6eee18e9a077
-date: Wed, 11 Sep 2024 00:53:22 GMT
+x-request-id: 66938ec2-ad7c-4afb-928d-683e7a75433a
+content-length: 0
+date: Tue, 03 Feb 2026 02:15:08 GMT
 ```
 
 <br />
@@ -194,7 +196,7 @@ curl http://localhost:8000/version
 ```
 
 ```bash title="Sample output"
-surrealdb-2.0.0+20240910.8f30ee08
+surrealdb-3.0.0-beta
 ```
 
 
@@ -202,11 +204,60 @@ surrealdb-2.0.0+20240910.8f30ee08
 
 ## `POST /import` {#import}
 
-This HTTP RESTful endpoint imports a set of SurrealQL queries into a specific Namespace and Database.
+This HTTP RESTful endpoint imports a set of SurrealQL queries into a specific namespace and database.
 
 ### Headers
 
 <Tabs groupId="http-sql">
+
+<TabItem value="V2" label="V2.x+" >
+<table>
+    <thead>
+        <tr>
+            <th colspan="2">Header</th>
+            <th colspan="2">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td colspan="2" scope="row" data-label="Header">
+                <code>Authorization</code>
+                <Label label="optional" >OPTIONAL</Label>
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+                Sets the root, namespace, or database authentication data
+            </td>
+        </tr>
+        <tr>
+            <td colspan="2" scope="row" data-label="Header">
+                <code>Accept</code>
+                <Label label="required" />
+            </td>
+            <td colspan="2" scope="row" data-label="Header">
+                Sets the desired content-type of the response
+            </td>
+        </tr>
+        <tr>
+            <td colspan="2" scope="row" data-label="Header">
+                <code>Surreal-NS</code>
+                <Label label="required" />
+            </td>
+            <td colspan="2" scope="row" data-label="Header">
+                Sets the selected Namespace for queries.
+            </td>
+        </tr>
+        <tr>
+            <td colspan="2" scope="row" data-label="Header">
+                <code>Surreal-DB</code>
+                <Label label="required" />
+            </td>
+            <td colspan="2" scope="row" data-label="Header">
+                Sets the selected Database for queries.
+            </td>
+        </tr>
+    </tbody>
+</table>
+</TabItem>
 
 <TabItem value="V1" label="V1.x" >
 <table>
@@ -257,81 +308,34 @@ This HTTP RESTful endpoint imports a set of SurrealQL queries into a specific Na
 </table>
 </TabItem>
 
-<TabItem value="V2" label="V2.x" >
-<table>
-    <thead>
-        <tr>
-            <th colspan="2">Header</th>
-            <th colspan="2">Description</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td colspan="2" scope="row" data-label="Header">
-                <code>Authorization</code>
-                <Label label="optional" >OPTIONAL</Label>
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-                Sets the root, namespace, or database authentication data
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" scope="row" data-label="Header">
-                <code>Accept</code>
-                <Label label="required" />
-            </td>
-            <td colspan="2" scope="row" data-label="Header">
-                Sets the desired content-type of the response
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" scope="row" data-label="Header">
-                <code>Surreal-NS</code>
-                <Label label="required" />
-            </td>
-            <td colspan="2" scope="row" data-label="Header">
-                Sets the selected Namespace for queries.
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" scope="row" data-label="Header">
-                <code>Surreal-DB</code>
-                <Label label="required" />
-            </td>
-            <td colspan="2" scope="row" data-label="Header">
-                Sets the selected Database for queries.
-            </td>
-        </tr>
-    </tbody>
-</table>
-
-</TabItem>
 </Tabs>
 
 ### Example usage
 
 > [!NOTE]
-> The `-u` in the example below is a shorthand used by curl to send an Authorization header.
+> The `-u` in the example below is a shorthand used by curl to send an Authorization header (name and password), in this case assuming the username `root` and password `secret`.
 
 
 <Tabs groupId="http-sql">
-<TabItem value="V1" label="V1.x">
+
+<TabItem value="V2" label="V2.x+" default>
 ```bash title="Request"
-curl -X POST -u "root:root" \
-  -H "ns: mynamespace" \
-  -H "db: mydatabase" \
+curl -X POST -u "root:secret" \
+  -H "Surreal-NS: main" \
+  -H "Surreal-DB: main" \
   -H "Accept: application/json" \
-  -d path/to/file.surql \
+  -d file.surql \
   http://localhost:8000/import
 ```
 </TabItem>
-<TabItem value="V2" label="V2.x" default>
+
+<TabItem value="V1" label="V1.x">
 ```bash title="Request"
-curl -X POST -u "root:root" \
-  -H "Surreal-NS: mynamespace" \
-  -H "Surreal-DB: mydatabase" \
+curl -X POST -u "root:secret" \
+  -H "ns: main" \
+  -H "db: main" \
   -H "Accept: application/json" \
-  -d path/to/file.surql \
+  -d file.surql \
   http://localhost:8000/import
 ```
 </TabItem>
@@ -349,6 +353,46 @@ This HTTP RESTful endpoint exports all data for a specific Namespace and Databas
 
 <Tabs groupId="http-sql">
 
+<TabItem value="V2" label="V2.x+" >
+<table>
+    <thead>
+        <tr>
+            <th colspan="2">Header</th>
+            <th colspan="2">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td colspan="2" scope="row" data-label="Header">
+                <code>Authorization</code>
+                <Label label="optional" >OPTIONAL</Label>
+            </td>
+            <td colspan="2" scope="row" data-label="Header">
+                Sets the root, namespace, or database authentication data
+            </td>
+        </tr>
+        <tr>
+            <td colspan="2" scope="row" data-label="Header">
+                <code>Surreal-NS</code>
+                <Label label="required" />
+            </td>
+            <td colspan="2" scope="row" data-label="Header">
+                Sets the selected Namespace for queries.
+            </td>
+        </tr>
+        <tr>
+            <td colspan="2" scope="row" data-label="Header">
+                <code>Surreal-DB</code>
+                <Label label="required" />
+            </td>
+            <td colspan="2" scope="row" data-label="Header">
+                Sets the selected Database for queries.
+            </td>
+        </tr>
+    </tbody>
+</table>
+</TabItem>
+
 <TabItem value="V1" label="V1.x" >
 <table>
     <thead>
@@ -388,45 +432,6 @@ This HTTP RESTful endpoint exports all data for a specific Namespace and Databas
     </tbody>
 </table>
 </TabItem>
-
-<TabItem value="V2" label="V2.x" >
-<table>
-    <thead>
-        <tr>
-            <th colspan="2">Header</th>
-            <th colspan="2">Description</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td colspan="2" scope="row" data-label="Header">
-                <code>Authorization</code>
-                <Label label="optional" >OPTIONAL</Label>
-            </td>
-            <td colspan="2" scope="row" data-label="Header">
-                Sets the root, namespace, or database authentication data
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" scope="row" data-label="Header">
-                <code>Surreal-NS</code>
-                <Label label="required" />
-            </td>
-            <td colspan="2" scope="row" data-label="Header">
-                Sets the selected Namespace for queries.
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" scope="row" data-label="Header">
-                <code>Surreal-DB</code>
-                <Label label="required" />
-            </td>
-            <td colspan="2" scope="row" data-label="Header">
-                Sets the selected Database for queries.
-            </td>
-        </tr>
-    </tbody>
-</table>
 
 #### Export options 
 
@@ -522,8 +527,6 @@ This HTTP RESTful endpoint exports all data for a specific Namespace and Databas
     </tbody>
 </table>
 
-</TabItem>
-
 </Tabs>
 
 
@@ -531,41 +534,44 @@ This HTTP RESTful endpoint exports all data for a specific Namespace and Databas
 ### Example usage
 
 > [!NOTE]
-> The `-u` in the example below is a shorthand used by curl to send an Authorization header, while `-o` allows the output to be written to a file.
+> The `-u` in the example below is a shorthand used by curl to send an Authorization header (name and password), in this case assuming the username `root` and password `secret`. The `-o` allows the output to be written to a file.
 
 <Tabs groupId="http-sql">
+
+<TabItem value="V2" label="V2.x+" default>
+```bash title="Request"
+curl -X GET \
+  -u "root:secret" \
+  -H "Surreal-NS: main" \
+  -H "Surreal-DB: main" \
+  -H "Accept: application/json" \
+  -o file.surql \
+  http://localhost:8000/export
+```
+
+</TabItem>
 
 <TabItem value="V1" label="V1.x">
 ```bash title="Request"
 curl -X GET \
-  -u "root:root" \
-  -H "ns: mynamespace" \
-  -H "db: mydatabase" \
+  -u "root:secret" \
+  -H "ns: main" \
+  -H "db: main" \
   -H "Accept: application/json" \
-  -o path/to/file.surql \
+  -o file.surql \
   http://localhost:8000/export
 ```
 </TabItem>
-
-<TabItem value="V2" label="V2.x" default>
-```bash title="Request"
-curl -X GET \
-  -u "root:root" \
-  -H "Surreal-NS: mynamespace" \
-  -H "Surreal-DB: mydatabase" \
-  -H "Accept: application/json" \
-  -o path/to/file.surql \
-  http://localhost:8000/export
-```
+</Tabs>
 
 ```bash title="Exporting specific parameters"
 curl -X POST \
-  -u "root:root" \
-  -H "Surreal-NS: mynamespace" \
-  -H "Surreal-DB: mydatabase" \
+  -u "root:secret" \
+  -H "Surreal-NS: main" \
+  -H "Surreal-DB: main" \
   -H "Content-Type: application/json" \
   -H "Accept: application/json" \
-  -o path/to/file.surql \
+  -o file.surql \
   -d '{
         "users": true,
         "accesses": false,
@@ -578,9 +584,6 @@ curl -X POST \
       }' \
   http://localhost:8000/export
 ```
-</TabItem>
-
-</Tabs>
 
 <br />
 
@@ -678,22 +681,10 @@ This HTTP RESTful endpoint is used to access an existing account inside the Surr
 
 ### Example with a Record user
 
-```bash title="Request"
-curl -X POST -H "Accept: application/json" -d '{"ns":"test","db":"test","ac":"users","user":"john.doe","pass":"123456"}' http://localhost:8000/signin
-```
-
-```json title="Response"
-{
-	"code": 200,
-	"details": "Authentication succeeded",
-	"token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
-}
-```
-
-### Example with Namespace user
+The following example will work as long as as an access method has been defined and a record user has been signed up using the [`/signup`](/docs/surrealdb/integration/http#signup) endpoint.
 
 ```bash title="Request"
-curl -X POST -H "Accept: application/json" -d '{"ns":"test","user":"john.doe","pass":"123456"}' http://localhost:8000/signin
+curl -X POST -H "Accept: application/json" -d '{"ns":"main","db":"main","ac":"users","user":"johndoe","pass":"123456"}' http://localhost:8000/signin
 ```
 
 ```json title="Response"
@@ -707,7 +698,7 @@ curl -X POST -H "Accept: application/json" -d '{"ns":"test","user":"john.doe","p
 ### Example with Root user
 
 ```bash title="Request"
-curl -X POST -H "Accept: application/json" -d '{"user":"john.doe","pass":"123456"}' http://localhost:8000/signin
+curl -X POST -H "Accept: application/json" -d '{"user":"root","pass":"secret"}' http://localhost:8000/signin
 ```
 
 ```json title="Response"
@@ -718,6 +709,31 @@ curl -X POST -H "Accept: application/json" -d '{"user":"john.doe","pass":"123456
 }
 ```
 
+### Example with Namespace user
+
+To create the namespace user needed for the following query, use the following command.
+
+```bash
+curl -X POST -u "root:secret" -H "Surreal-NS: main" -H "Surreal-DB: main" -H "Accept: application/json" \
+  -d 'DEFINE USER johndoe ON NAMESPACE PASSWORD "123456" ROLES EDITOR' http://localhost:8000/sql
+```
+
+Once the user has been created, use this command to sign in.
+
+```bash title="Request"
+curl -X POST -H "Accept: application/json" -d '{"ns":"main","user":"johndoe","pass":"123456"}' http://localhost:8000/signin
+```
+
+```json title="Response"
+{
+	"code": 200,
+	"details": "Authentication succeeded",
+	"token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+}
+```
+
+
+
 ### Example usage via Postman
 
 After you have defined the users permissions for the record user, you can use the `POST /signin` endpoint to sign in as a user.
@@ -725,8 +741,8 @@ After you have defined the users permissions for the record user, you can use th
 Using the [user credentials](/docs/surrealdb/security/authentication#record-users) created add the following to the request body:
 ```json
 {
-    "ns": "test",
-    "db": "test",
+    "ns": "main",
+    "db": "main",
     "ac": "account",
     "email": "",
     "pass": "123456"
@@ -824,7 +840,7 @@ This HTTP RESTful endpoint is used to create an account inside the SurrealDB dat
 ### Example usage
 
 ```bash title="Request"
-curl -X POST -H "Accept: application/json" -d '{"ns":"test","db":"test","ac":"users","user":"john.doe","pass":"123456"}' http://localhost:8000/signup
+curl -X POST -H "Accept: application/json" -d '{"ns":"main","db":"main","ac":"users","user":"johndoe","pass":"123456"}' http://localhost:8000/signup
 ```
 
 ```json title="Response"
@@ -834,33 +850,45 @@ curl -X POST -H "Accept: application/json" -d '{"ns":"test","db":"test","ac":"us
 	"token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
 }
 ```
-### Example usage via Postman
 
-Before you sign up a new [record user](/docs/surrealdb/security/authentication#record-users), you must first [define a record access method](/docs/surrealql/statements/define/access/record) for the user. To do so, follow these steps:
+The above example will only work if a record access method has already been set up.
 
-> [!NOTE]
-> You can also define [system users](/docs/surrealdb/security/authentication#system-users) and [user](/docs/surrealql/statements/define/user) credentials using the [`POST /sql`](/docs/surrealdb/integration/http#sql) endpoint.
+### Setting up a record access method
+
+Before you sign up a new [record user](/docs/surrealdb/security/authentication#record-users), you must first [define a record access method](/docs/surrealql/statements/define/access/record) for the user. The following curl command will do so on the command line using the [`POST /sql`](/docs/surrealdb/integration/http#sql) endpoint.
+
+```bash
+curl -X POST -u "root:secret" -H "Surreal-NS: main" -H "Surreal-DB: main" -H "Accept: application/json" \
+  -d 'DEFINE ACCESS users ON DATABASE TYPE RECORD
+    SIGNUP ( CREATE user SET email = $email, pass = crypto::argon2::generate($pass) )
+    SIGNIN ( SELECT * FROM user WHERE email = $email AND crypto::argon2::compare(pass, $pass) )
+    DURATION FOR SESSION 24h' http://localhost:8000/sql
+```
+
+To do the same using Postman, use the following steps:
 
 1. Navigate to the `POST /sql` endpoint in Postman.
 2. Enter the following query in the body of the request:
 ```surql
 -- Enable authentication directly against a SurrealDB record
-DEFINE ACCESS account ON DATABASE TYPE RECORD
+DEFINE ACCESS users ON DATABASE TYPE RECORD
     SIGNUP ( CREATE user SET email = $email, pass = crypto::argon2::generate($pass) )
     SIGNIN ( SELECT * FROM user WHERE email = $email AND crypto::argon2::compare(pass, $pass) )
     DURATION FOR SESSION 24h
 ;
 ```
+
 The above query defines a record access method called `account` that allows users to sign up and sign in. The access method also defines the session duration to be 24 hours.
 
 3. Click `Send` to send the request to the SurrealDB database server.
 4. Navigate to the `POST /signup` endpoint in Postman.
 5. Enter the following query in the body of the request:
+
 ```json
 {
-    "ns": "test",
-    "db": "test",
-    "ac": "account",
+    "ns": "main",
+    "db": "main",
+    "ac": "users",
     "email": "",
     "pass": "123456"
 }
@@ -870,7 +898,7 @@ The above query defines a record access method called `account` that allows user
     - namespace: `test`
     - database: `test`
     - access: `account`
-6. Click `Send` to send the request to the SurrealDB database server. You will get back a
+6. Click `Send` to send the request to the SurrealDB database server. You will receive the following response.
 
 ```json
 {
@@ -879,7 +907,6 @@ The above query defines a record access method called `account` that allows user
     "token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJpYXQiOjE3MDY2MTA4MDMsIm5iZiI6MTcwNjYxMDgwMywiZXhwIjoxNzA2Njk3MjAzLCJpc3MiOiJTdXJyZWFsREIiLCJOUyI6InRlc3QiLCJEQiI6InRlc3QiLCJBQyI6Imh1bWFuIiwiSUQiOiJ1c2VyOjZsOTl1OWI0bzVoa3h0NnY3c3NzIn0.3jR8PHgS8iLefZDuPHBFcdUFNfuB3OBNqQtqxLVVzxAIxVj1RAkD5rCEZHH2QaPV-D2zNwYO5Fh_a8jD1l_cqQ"
 }
 ```
-
 
 <br />
 
@@ -890,6 +917,55 @@ This HTTP RESTful endpoint selects all records in a specific table in the databa
 ### Headers
 
 <Tabs groupId="http-sql">
+
+<TabItem value="V2" label="V2.x+" >
+<table>
+    <thead>
+        <tr>
+            <th colspan="2">Header</th>
+            <th colspan="2">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td colspan="2" scope="row" data-label="Header">
+                <code>Authorization</code>
+                <Label label="optional" >OPTIONAL</Label>
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+            Sets the root, namespace, database, or record authentication data
+            </td>
+        </tr>
+        <tr>
+            <td colspan="2" scope="row" data-label="Header">
+                <code>Accept</code>
+                <Label label="required" />
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+                Sets the desired content-type of the response
+            </td>
+        </tr>
+        <tr>
+            <td colspan="2" scope="row" data-label="Header">
+                <code>Surreal-NS</code>
+                <Label label="required" />
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+                Sets the selected Namespace for queries.
+            </td>
+        </tr>
+        <tr>
+            <td colspan="2" scope="row" data-label="Header">
+                <code>Surreal-DB</code>
+                <Label label="required" />
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+                Sets the selected Database for queries.
+            </td>
+        </tr>
+    </tbody>
+</table>
+</TabItem>
 
 <TabItem value="V1" label="V1.x" >
 <table>
@@ -930,55 +1006,6 @@ This HTTP RESTful endpoint selects all records in a specific table in the databa
         <tr>
             <td colspan="2" scope="row" data-label="Header">
                 <code>db</code>
-                <Label label="required" />
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-                Sets the selected Database for queries.
-            </td>
-        </tr>
-    </tbody>
-</table>
-</TabItem>
-
-<TabItem value="V2" label="V2.x" >
-<table>
-    <thead>
-        <tr>
-            <th colspan="2">Header</th>
-            <th colspan="2">Description</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td colspan="2" scope="row" data-label="Header">
-                <code>Authorization</code>
-                <Label label="optional" >OPTIONAL</Label>
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-            Sets the root, namespace, database, or record authentication data
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" scope="row" data-label="Header">
-                <code>Accept</code>
-                <Label label="required" />
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-                Sets the desired content-type of the response
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" scope="row" data-label="Header">
-                <code>Surreal-NS</code>
-                <Label label="required" />
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-                Sets the selected Namespace for queries.
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" scope="row" data-label="Header">
-                <code>Surreal-DB</code>
                 <Label label="required" />
             </td>
             <td colspan="2" scope="row" data-label="Description">
@@ -996,7 +1023,14 @@ This HTTP RESTful endpoint selects all records in a specific table in the databa
 ```surql
 SELECT * FROM type::table($table);
 ```
-<br />
+
+### Example usage
+
+```bash
+curl -X GET -u "root:secret" -H "Surreal-NS: main" -H "Surreal-DB: main" -H "Accept: application/json" http://localhost:8000/key/person
+```
+
+<br/>
 
 ## `POST /key/:table` {#post-table}
 
@@ -1008,6 +1042,55 @@ This HTTP RESTful endpoint creates a record in a specific table in the database.
 ### Headers
 
 <Tabs groupId="http-sql">
+
+<TabItem value="V2" label="V2.x+" >
+<table>
+    <thead>
+        <tr>
+            <th colspan="2">Header</th>
+            <th colspan="2">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td colspan="2" scope="row" data-label="Header">
+                <code>Authorization</code>
+                <Label label="optional" >OPTIONAL</Label>
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+            Sets the root, namespace, database, or record authentication data
+            </td>
+        </tr>
+        <tr>
+            <td colspan="2" scope="row" data-label="Header">
+                <code>Accept</code>
+                <Label label="required" />
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+                Sets the desired content-type of the response
+            </td>
+        </tr>
+        <tr>
+            <td colspan="2" scope="row" data-label="Header">
+                <code>Surreal-NS</code>
+                <Label label="required" />
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+                Sets the selected Namespace for queries.
+            </td>
+        </tr>
+        <tr>
+            <td colspan="2" scope="row" data-label="Header">
+                <code>Surreal-DB</code>
+                <Label label="required" />
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+                Sets the selected Database for queries.
+            </td>
+        </tr>
+    </tbody>
+</table>
+</TabItem>
 
 <TabItem value="V1" label="V1.x" >
 <table>
@@ -1048,55 +1131,6 @@ This HTTP RESTful endpoint creates a record in a specific table in the database.
         <tr>
             <td colspan="2" scope="row" data-label="Header">
                 <code>db</code>
-                <Label label="required" />
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-                Sets the selected Database for queries.
-            </td>
-        </tr>
-    </tbody>
-</table>
-</TabItem>
-
-<TabItem value="V2" label="V2.x" >
-<table>
-    <thead>
-        <tr>
-            <th colspan="2">Header</th>
-            <th colspan="2">Description</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td colspan="2" scope="row" data-label="Header">
-                <code>Authorization</code>
-                <Label label="optional" >OPTIONAL</Label>
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-            Sets the root, namespace, database, or record authentication data
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" scope="row" data-label="Header">
-                <code>Accept</code>
-                <Label label="required" />
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-                Sets the desired content-type of the response
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" scope="row" data-label="Header">
-                <code>Surreal-NS</code>
-                <Label label="required" />
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-                Sets the selected Namespace for queries.
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" scope="row" data-label="Header">
-                <code>Surreal-DB</code>
                 <Label label="required" />
             </td>
             <td colspan="2" scope="row" data-label="Description">
@@ -1114,6 +1148,28 @@ This HTTP RESTful endpoint creates a record in a specific table in the database.
 CREATE type::table($table) CONTENT $body;
 ```
 
+### Example usage
+
+```bash
+curl -X POST -u "root:secret" -H "Surreal-NS: main" -H "Surreal-DB: main" -H "Accept: application/json" -d '{ name: "Billy" }' http://localhost:8000/key/person
+```
+
+```json title="Response"
+[
+	{
+		"result": [
+			{
+				"id": "person:sf8l6ejkm6swdwoyx2mt",
+				"name": "Billy"
+			}
+		],
+		"status": "OK",
+		"time": "160.375µs",
+		"type": null
+	}
+]
+```
+
 <br />
 
 ## `PUT /key/:table` {#put-table}
@@ -1126,6 +1182,55 @@ This HTTP RESTful endpoint updates all records in a specific table in the databa
 ### Headers
 
 <Tabs groupId="http-sql">
+
+<TabItem value="V2" label="V2.x+" >
+<table>
+    <thead>
+        <tr>
+            <th colspan="2">Header</th>
+            <th colspan="2">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td colspan="2" scope="row" data-label="Header">
+                <code>Authorization</code>
+                <Label label="optional" >OPTIONAL</Label>
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+            Sets the root, namespace, database, or record authentication data
+            </td>
+        </tr>
+        <tr>
+            <td colspan="2" scope="row" data-label="Header">
+                <code>Accept</code>
+                <Label label="required" />
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+                Sets the desired content-type of the response
+            </td>
+        </tr>
+        <tr>
+            <td colspan="2" scope="row" data-label="Header">
+                <code>Surreal-NS</code>
+                <Label label="required" />
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+                Sets the selected Namespace for queries.
+            </td>
+        </tr>
+        <tr>
+            <td colspan="2" scope="row" data-label="Header">
+                <code>Surreal-DB</code>
+                <Label label="required" />
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+                Sets the selected Database for queries.
+            </td>
+        </tr>
+    </tbody>
+</table>
+</TabItem>
 
 <TabItem value="V1" label="V1.x" >
 <table>
@@ -1166,55 +1271,6 @@ This HTTP RESTful endpoint updates all records in a specific table in the databa
         <tr>
             <td colspan="2" scope="row" data-label="Header">
                 <code>db</code>
-                <Label label="required" />
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-                Sets the selected Database for queries.
-            </td>
-        </tr>
-    </tbody>
-</table>
-</TabItem>
-
-<TabItem value="V2" label="V2.x" >
-<table>
-    <thead>
-        <tr>
-            <th colspan="2">Header</th>
-            <th colspan="2">Description</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td colspan="2" scope="row" data-label="Header">
-                <code>Authorization</code>
-                <Label label="optional" >OPTIONAL</Label>
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-            Sets the root, namespace, database, or record authentication data
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" scope="row" data-label="Header">
-                <code>Accept</code>
-                <Label label="required" />
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-                Sets the desired content-type of the response
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" scope="row" data-label="Header">
-                <code>Surreal-NS</code>
-                <Label label="required" />
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-                Sets the selected Namespace for queries.
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" scope="row" data-label="Header">
-                <code>Surreal-DB</code>
                 <Label label="required" />
             </td>
             <td colspan="2" scope="row" data-label="Description">
@@ -1232,6 +1288,36 @@ This HTTP RESTful endpoint updates all records in a specific table in the databa
 UPDATE type::table($table) CONTENT $body;
 ```
 
+### Example usage
+
+To use this example, first create a record using the `POST` endpoint:
+
+```bash
+curl -X POST -u "root:secret" -H "Surreal-NS: main" -H "Surreal-DB: main" -H "Accept: application/json" -d '{ name: "Billy" }' http://localhost:8000/key/person
+```
+
+Then use this `PUT` endpoint to modify the existing record.
+
+```bash
+curl -X PUT -u "root:secret" -H "Surreal-NS: main" -H "Surreal-DB: main" -H "Accept: application/json" -d '{ name: "Not Billy anymore" }' http://localhost:8000/key/person
+```
+
+```json title="Response"
+[
+	{
+		"result": [
+			{
+				"id": "person:f8i2ej4xluh5dgw2lgko",
+				"name": "Not Billy anymore"
+			}
+		],
+		"status": "OK",
+		"time": "109.458µs",
+		"type": null
+	}
+]
+```
+
 <br />
 
 ## `PATCH /key/:table` {#patch-table}
@@ -1244,6 +1330,55 @@ This HTTP RESTful endpoint modifies all records in a specific table in the datab
 ### Headers
 
 <Tabs groupId="http-sql">
+
+<TabItem value="V2" label="V2.x+" >
+<table>
+    <thead>
+        <tr>
+            <th colspan="2">Header</th>
+            <th colspan="2">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td colspan="2" scope="row" data-label="Header">
+                <code>Authorization</code>
+                <Label label="optional" >OPTIONAL</Label>
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+            Sets the root, namespace, database, or record authentication data
+            </td>
+        </tr>
+        <tr>
+            <td colspan="2" scope="row" data-label="Header">
+                <code>Accept</code>
+                <Label label="required" />
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+                Sets the desired content-type of the response
+            </td>
+        </tr>
+        <tr>
+            <td colspan="2" scope="row" data-label="Header">
+                <code>Surreal-NS</code>
+                <Label label="required" />
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+                Sets the selected Namespace for queries.
+            </td>
+        </tr>
+        <tr>
+            <td colspan="2" scope="row" data-label="Header">
+                <code>Surreal-DB</code>
+                <Label label="required" />
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+                Sets the selected Database for queries.
+            </td>
+        </tr>
+    </tbody>
+</table>
+</TabItem>
 
 <TabItem value="V1" label="V1.x" >
 <table>
@@ -1284,55 +1419,6 @@ This HTTP RESTful endpoint modifies all records in a specific table in the datab
         <tr>
             <td colspan="2" scope="row" data-label="Header">
                 <code>db</code>
-                <Label label="required" />
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-                Sets the selected Database for queries.
-            </td>
-        </tr>
-    </tbody>
-</table>
-</TabItem>
-
-<TabItem value="V2" label="V2.x" >
-<table>
-    <thead>
-        <tr>
-            <th colspan="2">Header</th>
-            <th colspan="2">Description</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td colspan="2" scope="row" data-label="Header">
-                <code>Authorization</code>
-                <Label label="optional" >OPTIONAL</Label>
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-            Sets the root, namespace, database, or record authentication data
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" scope="row" data-label="Header">
-                <code>Accept</code>
-                <Label label="required" />
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-                Sets the desired content-type of the response
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" scope="row" data-label="Header">
-                <code>Surreal-NS</code>
-                <Label label="required" />
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-                Sets the selected Namespace for queries.
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" scope="row" data-label="Header">
-                <code>Surreal-DB</code>
                 <Label label="required" />
             </td>
             <td colspan="2" scope="row" data-label="Description">
@@ -1350,6 +1436,36 @@ This HTTP RESTful endpoint modifies all records in a specific table in the datab
 UPDATE type::table($table) MERGE $body;
 ```
 
+### Example usage
+
+To use this example, first create a record using the `POST` endpoint:
+
+```bash
+curl -X POST -u "root:secret" -H "Surreal-NS: main" -H "Surreal-DB: main" -H "Accept: application/json" -d '{ id: person:one, name: "Billy" }' http://localhost:8000/key/person
+```
+
+Then use this `PATCH` endpoint to modify the existing records.
+
+```bash
+curl -X PATCH -u "root:secret" -H "Surreal-NS: main" -H "Surreal-DB: main" -H "Accept: application/json" -d '{ "name": "Not Billy anymore" }' http://localhost:8000/key/person
+```
+
+```json title="Response"
+[
+	{
+		"result": [
+			{
+				"id": "person:one",
+				"name": "Not Billy anymore"
+			}
+		],
+		"status": "OK",
+		"time": "162.167µs",
+		"type": null
+	}
+]
+```
+
 <br />
 
 ## `DELETE /key/:table` {#delete-table}
@@ -1359,6 +1475,55 @@ This HTTP RESTful endpoint deletes all records from the specified table in the d
 ### Headers
 
 <Tabs groupId="http-sql">
+
+<TabItem value="V2" label="V2.x+" >
+<table>
+    <thead>
+        <tr>
+            <th colspan="2">Header</th>
+            <th colspan="2">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td colspan="2" scope="row" data-label="Header">
+                <code>Authorization</code>
+                <Label label="optional" >OPTIONAL</Label>
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+            Sets the root, namespace, database, or record authentication data
+            </td>
+        </tr>
+        <tr>
+            <td colspan="2" scope="row" data-label="Header">
+                <code>Accept</code>
+                <Label label="required" />
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+                Sets the desired content-type of the response
+            </td>
+        </tr>
+        <tr>
+            <td colspan="2" scope="row" data-label="Header">
+                <code>Surreal-NS</code>
+                <Label label="required" />
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+                Sets the selected Namespace for queries.
+            </td>
+        </tr>
+        <tr>
+            <td colspan="2" scope="row" data-label="Header">
+                <code>Surreal-DB</code>
+                <Label label="required" />
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+                Sets the selected Database for queries.
+            </td>
+        </tr>
+    </tbody>
+</table>
+</TabItem>
 
 <TabItem value="V1" label="V1.x" >
 <table>
@@ -1409,60 +1574,41 @@ This HTTP RESTful endpoint deletes all records from the specified table in the d
 </table>
 </TabItem>
 
-<TabItem value="V2" label="V2.x" >
-<table>
-    <thead>
-        <tr>
-            <th colspan="2">Header</th>
-            <th colspan="2">Description</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td colspan="2" scope="row" data-label="Header">
-                <code>Authorization</code>
-                <Label label="optional" >OPTIONAL</Label>
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-            Sets the root, namespace, database, or record authentication data
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" scope="row" data-label="Header">
-                <code>Accept</code>
-                <Label label="required" />
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-                Sets the desired content-type of the response
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" scope="row" data-label="Header">
-                <code>Surreal-NS</code>
-                <Label label="required" />
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-                Sets the selected Namespace for queries.
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" scope="row" data-label="Header">
-                <code>Surreal-DB</code>
-                <Label label="required" />
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-                Sets the selected Database for queries.
-            </td>
-        </tr>
-    </tbody>
-</table>
-</TabItem>
-
 </Tabs>
 
 ### Translated query
 ```surql
-DELETE FROM type::table($table);
+DELETE FROM type::table($table) RETURN BEFORE;
+```
+
+### Example usage
+
+To use this example, first create a record using the `POST` endpoint:
+
+```bash
+curl -X POST -u "root:secret" -H "Surreal-NS: main" -H "Surreal-DB: main" -H "Accept: application/json" -d '{ id: person:one, name: "Billy" }' http://localhost:8000/key/person
+```
+
+Then use this `DELETE` endpoint to delete and return the records that were just removed.
+
+```bash
+curl -X DELETE -u "root:secret" -H "Surreal-NS: main" -H "Surreal-DB: main" -H "Accept: application/json" http://localhost:8000/key/person
+```
+
+```json title="Response"
+[
+	{
+		"result": [
+			{
+				"id": "person:one",
+				"name": "Billy"
+			}
+		],
+		"status": "OK",
+		"time": "234.75µs",
+		"type": null
+	}
+]
 ```
 
 <br />
@@ -1475,6 +1621,55 @@ This HTTP RESTful endpoint selects a specific record from the database.
 
 <Tabs groupId="http-sql">
 
+<TabItem value="V2" label="V2.x+" >
+<table>
+    <thead>
+        <tr>
+            <th colspan="2">Header</th>
+            <th colspan="2">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td colspan="2" scope="row" data-label="Header">
+                <code>Authorization</code>
+                <Label label="optional" >OPTIONAL</Label>
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+            Sets the root, namespace, database, or record authentication data
+            </td>
+        </tr>
+        <tr>
+            <td colspan="2" scope="row" data-label="Header">
+                <code>Accept</code>
+                <Label label="required" />
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+                Sets the desired content-type of the response
+            </td>
+        </tr>
+        <tr>
+            <td colspan="2" scope="row" data-label="Header">
+                <code>Surreal-NS</code>
+                <Label label="required" />
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+                Sets the selected Namespace for queries.
+            </td>
+        </tr>
+        <tr>
+            <td colspan="2" scope="row" data-label="Header">
+                <code>Surreal-DB</code>
+                <Label label="required" />
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+                Sets the selected Database for queries.
+            </td>
+        </tr>
+    </tbody>
+</table>
+</TabItem>
+
 <TabItem value="V1" label="V1.x" >
 <table>
     <thead>
@@ -1524,54 +1719,6 @@ This HTTP RESTful endpoint selects a specific record from the database.
 </table>
 </TabItem>
 
-<TabItem value="V2" label="V2.x" >
-<table>
-    <thead>
-        <tr>
-            <th colspan="2">Header</th>
-            <th colspan="2">Description</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td colspan="2" scope="row" data-label="Header">
-                <code>Authorization</code>
-                <Label label="optional" >OPTIONAL</Label>
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-            Sets the root, namespace, database, or record authentication data
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" scope="row" data-label="Header">
-                <code>Accept</code>
-                <Label label="required" />
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-                Sets the desired content-type of the response
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" scope="row" data-label="Header">
-                <code>Surreal-NS</code>
-                <Label label="required" />
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-                Sets the selected Namespace for queries.
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" scope="row" data-label="Header">
-                <code>Surreal-DB</code>
-                <Label label="required" />
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-                Sets the selected Database for queries.
-            </td>
-        </tr>
-    </tbody>
-</table>
-</TabItem>
 </Tabs>
 
 ### Translated query
@@ -1582,6 +1729,14 @@ SELECT * FROM type::record($table, $id);
 
 <br />
 
+### Example usage
+
+```bash
+curl -X GET -u "root:secret" -H "Surreal-NS: main" -H "Surreal-DB: main" -H "Accept: application/json" http://localhost:8000/key/person/1
+```
+
+<br/>
+
 ## `POST /key/:table/:id` {#post-record}
 
 This HTTP RESTful endpoint creates a specific record in a table in the database.
@@ -1589,6 +1744,55 @@ This HTTP RESTful endpoint creates a specific record in a table in the database.
 ### Headers
 
 <Tabs groupId="http-sql">
+
+<TabItem value="V2" label="V2.x+" >
+<table>
+    <thead>
+        <tr>
+            <th colspan="2">Header</th>
+            <th colspan="2">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td colspan="2" scope="row" data-label="Header">
+                <code>Authorization</code>
+                <Label label="optional" >OPTIONAL</Label>
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+            Sets the root, namespace, database, or record authentication data
+            </td>
+        </tr>
+        <tr>
+            <td colspan="2" scope="row" data-label="Header">
+                <code>Accept</code>
+                <Label label="required" />
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+                Sets the desired content-type of the response
+            </td>
+        </tr>
+        <tr>
+            <td colspan="2" scope="row" data-label="Header">
+                <code>Surreal-NS</code>
+                <Label label="required" />
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+                Sets the selected Namespace for queries.
+            </td>
+        </tr>
+        <tr>
+            <td colspan="2" scope="row" data-label="Header">
+                <code>Surreal-DB</code>
+                <Label label="required" />
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+                Sets the selected Database for queries.
+            </td>
+        </tr>
+    </tbody>
+</table>
+</TabItem>
 
 <TabItem value="V1" label="V1.x" >
 <table>
@@ -1629,55 +1833,6 @@ This HTTP RESTful endpoint creates a specific record in a table in the database.
         <tr>
             <td colspan="2" scope="row" data-label="Header">
                 <code>db</code>
-                <Label label="required" />
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-                Sets the selected Database for queries.
-            </td>
-        </tr>
-    </tbody>
-</table>
-</TabItem>
-
-<TabItem value="V2" label="V2.x" >
-<table>
-    <thead>
-        <tr>
-            <th colspan="2">Header</th>
-            <th colspan="2">Description</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td colspan="2" scope="row" data-label="Header">
-                <code>Authorization</code>
-                <Label label="optional" >OPTIONAL</Label>
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-            Sets the root, namespace, database, or record authentication data
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" scope="row" data-label="Header">
-                <code>Accept</code>
-                <Label label="required" />
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-                Sets the desired content-type of the response
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" scope="row" data-label="Header">
-                <code>Surreal-NS</code>
-                <Label label="required" />
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-                Sets the selected Namespace for queries.
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" scope="row" data-label="Header">
-                <code>Surreal-DB</code>
                 <Label label="required" />
             </td>
             <td colspan="2" scope="row" data-label="Description">
@@ -1698,6 +1853,28 @@ CREATE type::record($table, $id) CONTENT $body;
 
 <br />
 
+### Example usage
+
+```bash
+curl -X POST -u "root:secret" -H "Surreal-NS: main" -H "Surreal-DB: main" -H "Accept: application/json" -d '{ name: "Billy" }' http://localhost:8000/key/person/1
+```
+
+```json title="Response"
+[
+	{
+		"result": [
+			{
+				"id": "person:1",
+				"name": "Billy"
+			}
+		],
+		"status": "OK",
+		"time": "103.542µs",
+		"type": null
+	}
+]
+```
+
 ## `PUT /key/:table/:id` {#put-record}
 
 This HTTP RESTful endpoint updates a specific record in a table in the database.
@@ -1708,6 +1885,55 @@ This HTTP RESTful endpoint updates a specific record in a table in the database.
 ### Headers
 
 <Tabs groupId="http-sql">
+
+<TabItem value="V2" label="V2.x+" >
+<table>
+    <thead>
+        <tr>
+            <th colspan="2">Header</th>
+            <th colspan="2">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td colspan="2" scope="row" data-label="Header">
+                <code>Authorization</code>
+                <Label label="optional" >OPTIONAL</Label>
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+            Sets the root, namespace, database, or record authentication data
+            </td>
+        </tr>
+        <tr>
+            <td colspan="2" scope="row" data-label="Header">
+                <code>Accept</code>
+                <Label label="required" />
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+                Sets the desired content-type of the response
+            </td>
+        </tr>
+        <tr>
+            <td colspan="2" scope="row" data-label="Header">
+                <code>Surreal-NS</code>
+                <Label label="required" />
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+                Sets the selected Namespace for queries.
+            </td>
+        </tr>
+        <tr>
+            <td colspan="2" scope="row" data-label="Header">
+                <code>Surreal-DB</code>
+                <Label label="required" />
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+                Sets the selected Database for queries.
+            </td>
+        </tr>
+    </tbody>
+</table>
+</TabItem>
 
 <TabItem value="V1" label="V1.x" >
 <table>
@@ -1748,55 +1974,6 @@ This HTTP RESTful endpoint updates a specific record in a table in the database.
         <tr>
             <td colspan="2" scope="row" data-label="Header">
                 <code>db</code>
-                <Label label="required" />
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-                Sets the selected Database for queries.
-            </td>
-        </tr>
-    </tbody>
-</table>
-</TabItem>
-
-<TabItem value="V2" label="V2.x" >
-<table>
-    <thead>
-        <tr>
-            <th colspan="2">Header</th>
-            <th colspan="2">Description</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td colspan="2" scope="row" data-label="Header">
-                <code>Authorization</code>
-                <Label label="optional" >OPTIONAL</Label>
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-            Sets the root, namespace, database, or record authentication data
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" scope="row" data-label="Header">
-                <code>Accept</code>
-                <Label label="required" />
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-                Sets the desired content-type of the response
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" scope="row" data-label="Header">
-                <code>Surreal-NS</code>
-                <Label label="required" />
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-                Sets the selected Namespace for queries.
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" scope="row" data-label="Header">
-                <code>Surreal-DB</code>
                 <Label label="required" />
             </td>
             <td colspan="2" scope="row" data-label="Description">
@@ -1828,6 +2005,55 @@ This HTTP RESTful endpoint modifies a specific record in a table in the database
 
 <Tabs groupId="http-sql">
 
+<TabItem value="V2" label="V2.x+" >
+<table>
+    <thead>
+        <tr>
+            <th colspan="2">Header</th>
+            <th colspan="2">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td colspan="2" scope="row" data-label="Header">
+                <code>Authorization</code>
+                <Label label="optional" >OPTIONAL</Label>
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+            Sets the root, namespace, database, or record authentication data
+            </td>
+        </tr>
+        <tr>
+            <td colspan="2" scope="row" data-label="Header">
+                <code>Accept</code>
+                <Label label="required" />
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+                Sets the desired content-type of the response
+            </td>
+        </tr>
+        <tr>
+            <td colspan="2" scope="row" data-label="Header">
+                <code>Surreal-NS</code>
+                <Label label="required" />
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+                Sets the selected Namespace for queries.
+            </td>
+        </tr>
+        <tr>
+            <td colspan="2" scope="row" data-label="Header">
+                <code>Surreal-DB</code>
+                <Label label="required" />
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+                Sets the selected Database for queries.
+            </td>
+        </tr>
+    </tbody>
+</table>
+</TabItem>
+
 <TabItem value="V1" label="V1.x" >
 <table>
     <thead>
@@ -1867,55 +2093,6 @@ This HTTP RESTful endpoint modifies a specific record in a table in the database
         <tr>
             <td colspan="2" scope="row" data-label="Header">
                 <code>db</code>
-                <Label label="required" />
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-                Sets the selected Database for queries.
-            </td>
-        </tr>
-    </tbody>
-</table>
-</TabItem>
-
-<TabItem value="V2" label="V2.x" >
-<table>
-    <thead>
-        <tr>
-            <th colspan="2">Header</th>
-            <th colspan="2">Description</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td colspan="2" scope="row" data-label="Header">
-                <code>Authorization</code>
-                <Label label="optional" >OPTIONAL</Label>
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-            Sets the root, namespace, database, or record authentication data
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" scope="row" data-label="Header">
-                <code>Accept</code>
-                <Label label="required" />
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-                Sets the desired content-type of the response
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" scope="row" data-label="Header">
-                <code>Surreal-NS</code>
-                <Label label="required" />
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-                Sets the selected Namespace for queries.
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" scope="row" data-label="Header">
-                <code>Surreal-DB</code>
                 <Label label="required" />
             </td>
             <td colspan="2" scope="row" data-label="Description">
@@ -1936,6 +2113,46 @@ UPDATE type::record($table, $id) MERGE $body;
 
 <br />
 
+### Example usage
+
+To use this example, first create a record using the `POST` endpoint:
+
+```bash
+curl -X POST -u "root:secret" -H "Surreal-NS: main" -H "Surreal-DB: main" -H "Accept: application/json" -d '{ name: "Billy" }' http://localhost:8000/key/person/1
+```
+
+### Example usage
+
+To use this example, first create a record using the `POST` endpoint:
+
+```bash
+curl -X POST -u "root:secret" -H "Surreal-NS: main" -H "Surreal-DB: main" -H "Accept: application/json" -d '{ id: person:one, name: "Billy" }' http://localhost:8000/key/person
+```
+
+Then use this `PATCH` endpoint to modify the existing record.
+
+```bash
+curl -X PATCH -u "root:secret" -H "Surreal-NS: main" -H "Surreal-DB: main" -H "Accept: application/json" -d '{ "name": "Not Billy anymore" }' http://localhost:8000/key/person/1
+```
+
+```json title="Response"
+[
+	{
+		"result": [
+			{
+				"id": "person:one",
+				"name": "Not Billy anymore"
+			}
+		],
+		"status": "OK",
+		"time": "162.167µs",
+		"type": null
+	}
+]
+```
+
+<br/>
+
 ## `DELETE /key/:table/:id` {#delete-record}
 
 This HTTP RESTful endpoint deletes a single specific record from the database.
@@ -1943,6 +2160,55 @@ This HTTP RESTful endpoint deletes a single specific record from the database.
 ### Headers
 
 <Tabs groupId="http-sql">
+
+<TabItem value="V2" label="V2.x+" >
+<table>
+    <thead>
+        <tr>
+            <th colspan="2">Header</th>
+            <th colspan="2">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td colspan="2" scope="row" data-label="Header">
+                <code>Authorization</code>
+                <Label label="optional" >OPTIONAL</Label>
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+            Sets the root, namespace, database, or record authentication data
+            </td>
+        </tr>
+        <tr>
+            <td colspan="2" scope="row" data-label="Header">
+                <code>Accept</code>
+                <Label label="required" />
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+                Sets the desired content-type of the response
+            </td>
+        </tr>
+        <tr>
+            <td colspan="2" scope="row" data-label="Header">
+                <code>Surreal-NS</code>
+                <Label label="required" />
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+                Sets the selected Namespace for queries.
+            </td>
+        </tr>
+        <tr>
+            <td colspan="2" scope="row" data-label="Header">
+                <code>Surreal-DB</code>
+                <Label label="required" />
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+                Sets the selected Database for queries.
+            </td>
+        </tr>
+    </tbody>
+</table>
+</TabItem>
 
 <TabItem value="V1" label="V1.x" >
 <table>
@@ -1983,55 +2249,6 @@ This HTTP RESTful endpoint deletes a single specific record from the database.
         <tr>
             <td colspan="2" scope="row" data-label="Header">
                 <code>db</code>
-                <Label label="required" />
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-                Sets the selected Database for queries.
-            </td>
-        </tr>
-    </tbody>
-</table>
-</TabItem>
-
-<TabItem value="V2" label="V2.x" >
-<table>
-    <thead>
-        <tr>
-            <th colspan="2">Header</th>
-            <th colspan="2">Description</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td colspan="2" scope="row" data-label="Header">
-                <code>Authorization</code>
-                <Label label="optional" >OPTIONAL</Label>
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-            Sets the root, namespace, database, or record authentication data
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" scope="row" data-label="Header">
-                <code>Accept</code>
-                <Label label="required" />
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-                Sets the desired content-type of the response
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" scope="row" data-label="Header">
-                <code>Surreal-NS</code>
-                <Label label="required" />
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-                Sets the selected Namespace for queries.
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" scope="row" data-label="Header">
-                <code>Surreal-DB</code>
                 <Label label="required" />
             </td>
             <td colspan="2" scope="row" data-label="Description">
@@ -2047,10 +2264,42 @@ This HTTP RESTful endpoint deletes a single specific record from the database.
 ### Translated query
 
 ```surql
-DELETE FROM type::record($table, $id);
+DELETE FROM type::record($table, $id) RETURN BEFORE;
 ```
 
 <br />
+
+### Example usage
+
+To use this example, first create a record using the `POST` endpoint:
+
+```bash
+curl -X POST -u "root:secret" -H "Surreal-NS: main" -H "Surreal-DB: main" -H "Accept: application/json" -d '{ id: person:one, name: "Billy" }' http://localhost:8000/key/person/1
+```
+
+Then use this `DELETE` endpoint to delete and return the record that was just removed.
+
+```bash
+curl -X DELETE -u "root:secret" -H "Surreal-NS: main" -H "Surreal-DB: main" -H "Accept: application/json" http://localhost:8000/key/person/1
+```
+
+```json title="Response"
+[
+	{
+		"result": [
+			{
+				"id": "person:one",
+				"name": "Billy"
+			}
+		],
+		"status": "OK",
+		"time": "145.042µs",
+		"type": null
+	}
+]
+```
+
+<br/>
 
 ## `POST /sql` {#sql}
 
@@ -2062,6 +2311,55 @@ The SQL endpoint enables use of SurrealQL queries.
 ### Headers
 
 <Tabs groupId="http-sql">
+
+<TabItem value="V2" label="V2.x+" >
+<table>
+    <thead>
+        <tr>
+            <th colspan="2">Header</th>
+            <th colspan="2">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td colspan="2" scope="row" data-label="Header">
+                <code>Authorization</code>
+                <Label label="optional" >OPTIONAL</Label>
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+            Sets the root, namespace, database, or record authentication data
+            </td>
+        </tr>
+        <tr>
+            <td colspan="2" scope="row" data-label="Header">
+                <code>Accept</code>
+                <Label label="required" />
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+                Sets the desired content-type of the response
+            </td>
+        </tr>
+        <tr>
+            <td colspan="2" scope="row" data-label="Header">
+                <code>Surreal-NS</code>
+                <Label label="required" />
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+                Sets the selected Namespace for queries.
+            </td>
+        </tr>
+        <tr>
+            <td colspan="2" scope="row" data-label="Header">
+                <code>Surreal-DB</code>
+                <Label label="required" />
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+                Sets the selected Database for queries.
+            </td>
+        </tr>
+    </tbody>
+</table>
+</TabItem>
 
 <TabItem value="V1" label="V1.x" >
 <table>
@@ -2102,55 +2400,6 @@ The SQL endpoint enables use of SurrealQL queries.
         <tr>
             <td colspan="2" scope="row" data-label="Header">
                 <code>db</code>
-                <Label label="required" />
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-                Sets the selected Database for queries.
-            </td>
-        </tr>
-    </tbody>
-</table>
-</TabItem>
-
-<TabItem value="V2" label="V2.x" >
-<table>
-    <thead>
-        <tr>
-            <th colspan="2">Header</th>
-            <th colspan="2">Description</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td colspan="2" scope="row" data-label="Header">
-                <code>Authorization</code>
-                <Label label="optional" >OPTIONAL</Label>
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-            Sets the root, namespace, database, or record authentication data
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" scope="row" data-label="Header">
-                <code>Accept</code>
-                <Label label="required" />
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-                Sets the desired content-type of the response
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" scope="row" data-label="Header">
-                <code>Surreal-NS</code>
-                <Label label="required" />
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-                Sets the selected Namespace for queries.
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" scope="row" data-label="Header">
-                <code>Surreal-DB</code>
                 <Label label="required" />
             </td>
             <td colspan="2" scope="row" data-label="Description">
@@ -2171,27 +2420,27 @@ Query parameters can be provided via URL query parameters. These parameters will
 ### Example usage
 
 > [!NOTE]
-> The `-u` in the example below is a shorthand used by curl to send an Authorization header.
+> The `-u` in the example below is a shorthand used by curl to send an Authorization header (name and password), in this case assuming the username `root` and password `secret`.
 
 <Tabs groupId="http-sql">
 
-<TabItem value="V1" label="V1.x">
+<TabItem value="V2" label="V2.x+" default>
 ```bash title="Request"
-curl -X POST -u "root:root" -H "ns: mynamespace" -H "db: mydatabase" -H "Accept: application/json" \
-  -d 'SELECT * FROM person WHERE age > $age' http://localhost:8000/sql?age=18
-```
-</TabItem>
-
-<TabItem value="V2" label="V2.x" default>
-```bash title="Request"
-curl -X POST -u "root:root" -H "Surreal-NS: mynamespace" -H "Surreal-DB: mydatabase" -H "Accept: application/json" \
+curl -X POST -u "root:secret" -H "Surreal-NS: main" -H "Surreal-DB: main" -H "Accept: application/json" \
   -d 'SELECT * FROM person WHERE age > $age' http://localhost:8000/sql?age=18
 ```
 </TabItem>
 
 <TabItem value="V2 - Token" label="V2.x with token" default>
 ```bash title="Request"
-curl -X POST -H "Bearer: YourToken" -H "Surreal-NS: mynamespace" -H "Surreal-DB: mydatabase" -H "Accept: application/json" \
+curl -X POST -H "Bearer: YourToken" -H "Surreal-NS: main" -H "Surreal-DB: main" -H "Accept: application/json" \
+  -d 'SELECT * FROM person WHERE age > $age' http://localhost:8000/sql?age=18
+```
+</TabItem>
+
+<TabItem value="V1" label="V1.x">
+```bash title="Request"
+curl -X POST -u "root:secret" -H "ns: main" -H "db: main" -H "Accept: application/json" \
   -d 'SELECT * FROM person WHERE age > $age' http://localhost:8000/sql?age=18
 ```
 </TabItem>
@@ -2282,16 +2531,16 @@ The GraphQL endpoint enables use of GraphQL queries to interact with your data.
 ### Example usage
 
 > [!NOTE]
-> The `-u` in the example below is a shorthand used by curl to send an Authorization header.
+> The `-u` in the example below is a shorthand used by curl to send an Authorization header (name and password), in this case assuming the username `root` and password `secret`.
 
 <Tabs groupId="http-sql">
 
-<TabItem value="V2" label="V2.x" default>
+<TabItem value="V2" label="V2.x+" default>
 ```bash title="Request"
 curl -X POST \
-  -u "root:root" \
-  -H "Surreal-NS: mynamespace" \
-  -H "Surreal-DB: mydatabase" \
+  -u "root:secret" \
+  -H "Surreal-NS: main" \
+  -H "Surreal-DB: main" \
   -H "Accept: application/json" \
   -d '{
     "query": "{ 
@@ -2339,6 +2588,46 @@ This HTTP RESTful endpoint imports a SurrealML machine learning model into a spe
 
 <Tabs groupId="http-sql">
 
+<TabItem value="V2" label="V2.x+" >
+<table>
+    <thead>
+        <tr>
+            <th colspan="2">Header</th>
+            <th colspan="2">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td colspan="2" scope="row" data-label="Header">
+                <code>Authorization</code>
+                <Label label="optional" >OPTIONAL</Label>
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+            Sets the root, namespace, database, or record authentication data
+            </td>
+        </tr>
+        <tr>
+            <td colspan="2" scope="row" data-label="Header">
+                <code>Surreal-NS</code>
+                <Label label="required" />
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+                Sets the selected Namespace for queries.
+            </td>
+        </tr>
+        <tr>
+            <td colspan="2" scope="row" data-label="Header">
+                <code>Surreal-DB</code>
+                <Label label="required" />
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+                Sets the selected Database for queries.
+            </td>
+        </tr>
+    </tbody>
+</table>
+</TabItem>
+
 <TabItem value="V1" label="V1.x" >
 <table>
     <thead>
@@ -2379,75 +2668,35 @@ This HTTP RESTful endpoint imports a SurrealML machine learning model into a spe
 </table>
 </TabItem>
 
-<TabItem value="V2" label="V2.x" >
-<table>
-    <thead>
-        <tr>
-            <th colspan="2">Header</th>
-            <th colspan="2">Description</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td colspan="2" scope="row" data-label="Header">
-                <code>Authorization</code>
-                <Label label="optional" >OPTIONAL</Label>
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-            Sets the root, namespace, database, or record authentication data
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" scope="row" data-label="Header">
-                <code>Surreal-NS</code>
-                <Label label="required" />
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-                Sets the selected Namespace for queries.
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" scope="row" data-label="Header">
-                <code>Surreal-DB</code>
-                <Label label="required" />
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-                Sets the selected Database for queries.
-            </td>
-        </tr>
-    </tbody>
-</table>
-</TabItem>
-
 </Tabs>
 
 ### Example usage
 
 > [!NOTE]
-> The `-u` in the example below is a shorthand used by curl to send an Authorization header.
+> The `-u` in the example below is a shorthand used by curl to send an Authorization header (name and password), in this case assuming the username `root` and password `secret`.
 
 <Tabs groupId="http-sql">
 
-<TabItem value="V1" label="V1.x">
+<TabItem value="V2" label="V2.x+" default>
 ```bash title="Request"
 curl -X POST \
-  -u "root:root" \
-  -H "ns: mynamespace" \
-  -H "db: mydatabase" \
+  -u "root:secret" \
+  -H "Surreal-NS: main" \
+  -H "Surreal-DB: main" \
   -H "Accept: application/json" \
-  -d path/to/file.surml \
+  -d file.surml \
   http://localhost:8000/ml/import
 ```
 </TabItem>
 
-<TabItem value="V2" label="V2.x" default>
+<TabItem value="V1" label="V1.x">
 ```bash title="Request"
 curl -X POST \
-  -u "root:root" \
-  -H "Surreal-NS: mynamespace" \
-  -H "Surreal-DB: mydatabase" \
+  -u "root:secret" \
+  -H "ns: main" \
+  -H "db: main" \
   -H "Accept: application/json" \
-  -d path/to/file.surml \
+  -d file.surml \
   http://localhost:8000/ml/import
 ```
 </TabItem>
@@ -2475,6 +2724,46 @@ This HTTP RESTful endpoint exports a SurrealML machine learning model from a spe
 
 <Tabs groupId="http-sql">
 
+<TabItem value="V2" label="V2.x+" >
+<table>
+    <thead>
+        <tr>
+            <th colspan="2">Header</th>
+            <th colspan="2">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td colspan="2" scope="row" data-label="Header">
+                <code>Authorization</code>
+                <Label label="optional" >OPTIONAL</Label>
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+                Sets the root, namespace, or database authentication data
+            </td>
+        </tr>
+        <tr>
+            <td colspan="2" scope="row" data-label="Header">
+                <code>Surreal-NS</code>
+                <Label label="required" />
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+                Sets the selected Namespace for queries.
+            </td>
+        </tr>
+        <tr>
+            <td colspan="2" scope="row" data-label="Header">
+                <code>Surreal-DB</code>
+                <Label label="required" />
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+                Sets the selected Database for queries.
+            </td>
+        </tr>
+    </tbody>
+</table>
+</TabItem>
+
 <TabItem value="V1" label="V1.x" >
 <table>
     <thead>
@@ -2515,76 +2804,36 @@ This HTTP RESTful endpoint exports a SurrealML machine learning model from a spe
 </table>
 </TabItem>
 
-<TabItem value="V2" label="V2.x" >
-<table>
-    <thead>
-        <tr>
-            <th colspan="2">Header</th>
-            <th colspan="2">Description</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td colspan="2" scope="row" data-label="Header">
-                <code>Authorization</code>
-                <Label label="optional" >OPTIONAL</Label>
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-                Sets the root, namespace, or database authentication data
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" scope="row" data-label="Header">
-                <code>Surreal-NS</code>
-                <Label label="required" />
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-                Sets the selected Namespace for queries.
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" scope="row" data-label="Header">
-                <code>Surreal-DB</code>
-                <Label label="required" />
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-                Sets the selected Database for queries.
-            </td>
-        </tr>
-    </tbody>
-</table>
-</TabItem>
-
 </Tabs>
 
 ### Example usage
 
 > [!NOTE]
-<em> Note: </em> The `-u` in the example below is a shorthand used by curl to send an Authorization header, while `-o` allows the output to be written to a file.
+<em> Note: </em> The `-u` in the example below is a shorthand used by curl to send an Authorization header (name and password), in this case assuming the username `root` and password `secret`. The `-o` allows the output to be written to a file.
 
 
 <Tabs groupId="http-sql">
 
-<TabItem value="V1" label="V1.x">
+<TabItem value="V2" label="V2.x+" default>
 ```bash title="Request"
 curl -X GET \
-  -u "root:root" \
-  -H "ns: mynamespace" \
-  -H "db: mydatabase" \
+  -u "root:secret" \
+  -H "Surreal-NS: main" \
+  -H "Surreal-DB: main" \
   -H "Accept: application/json" \
-  -o path/to/file.surml \
+  -o file.surml \
   http://localhost:8000/ml/export/prediction/1.0.0
 ```
 </TabItem>
 
-<TabItem value="V2" label="V2.x" default>
+<TabItem value="V1" label="V1.x">
 ```bash title="Request"
 curl -X GET \
-  -u "root:root" \
-  -H "Surreal-NS: mynamespace" \
-  -H "Surreal-DB: mydatabase" \
+  -u "root:secret" \
+  -H "ns: main" \
+  -H "db: main" \
   -H "Accept: application/json" \
-  -o path/to/file.surml \
+  -o file.surml \
   http://localhost:8000/ml/export/prediction/1.0.0
 ```
 </TabItem>
@@ -2595,7 +2844,7 @@ curl -X GET \
 
 <Since v="v2.2.0" />
 > [!CAUTION]
-> Currently, this is an experimental feature as such, it may be subject to breaking changes and may present unidentified security issues. Do not rely on this feature in production applications. To enable this, set the `SURREAL_CAPS_ALLOW_EXPERIMENTAL` [environment variable](/docs/surrealdb/cli/start) to `define_api`.
+> Currently, this is an experimental feature as such, it may be subject to breaking changes and may present unidentified security issues. Do not rely on this feature in production applications. To enable this, add the `--allow-experimental define_api` flag on startup or set the `SURREAL_CAPS_ALLOW_EXPERIMENTAL` [environment variable](/docs/surrealdb/cli/start) to `define_api`.
 
 
 A custom endpoint can be set using a [`DEFINE API`](/docs/surrealql/statements/define/api) statement. The possible HTTP methods (GET, PUT, etc.) are set using the statement itself. The path begins with `/api`, continues with the namespace and database, and ends with a custom endpoint that can include both static and dynamic path segments.
@@ -2642,8 +2891,25 @@ A custom endpoint can be set using a [`DEFINE API`](/docs/surrealql/statements/d
 
 ### Example usage
 
+To begin, start a server with the `define_api` capabilities enabled.
+
+```bash
+surreal start --user root --pass secret --allow-experimental define_api
+```
+
+A custom endpoint can first be set up using a `DEFINE API` statement via the `/sql` endpoint.
+
+```bash
+curl -X POST -u "root:secret" -H "Surreal-NS: main" -H "Surreal-DB: main" -H "Accept: application/json" -d 'DEFINE API "/custom_response" FOR get MIDDLEWARE api::res::body("json") THEN { { status: 200, body: { some: "info" } } }' http://localhost:8000/sql
+```
+
+Once this is set up, a simple curl command to the endpoint will suffice to see the response.
+
+
 ```bash title="Request"
-curl http://localhost:8000/api/my_namespace/my_database/test_endpoint \
-  -H "Surreal-NS: ns" -H "Surreal-DB: db" \
-  -H "Accept: application/json"
+curl http://localhost:8000/api/main/main/custom_response -H "Surreal-NS: ns" -H "Surreal-DB: db" -H "Accept: application/json"
+```
+
+```json title="Response"
+{"some":"info"}
 ```

--- a/src/content/doc-surrealdb/querying/surrealql/http.mdx
+++ b/src/content/doc-surrealdb/querying/surrealql/http.mdx
@@ -30,6 +30,55 @@ The `/sql` endpoint enables use of SurrealQL queries.
 
 <Tabs groupId="http-sql">
 
+<TabItem value="V2" label="V2.x+" default>
+<table>
+    <thead>
+        <tr>
+            <th colspan="2">Header</th>
+            <th colspan="2">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td colspan="2" scope="row" data-label="Header">
+                <code>Authorization</code>
+               <Label label="optional" />
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+            Sets the root, namespace, database, or record authentication data
+            </td>
+        </tr>
+        <tr>
+            <td colspan="2" scope="row" data-label="Header">
+                <code>Accept</code>
+                <Label label="required" />
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+                Sets the desired content-type of the response
+            </td>
+        </tr>
+        <tr>
+            <td colspan="2" scope="row" data-label="Header">
+                <code>surreal-ns</code>
+                <Label label="required" />
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+                Sets the selected Namespace for queries.
+            </td>
+        </tr>
+        <tr>
+            <td colspan="2" scope="row" data-label="Header">
+                <code>surreal-db</code>
+                <Label label="required" />
+            </td>
+            <td colspan="2" scope="row" data-label="Description">
+                Sets the selected Database for queries.
+            </td>
+        </tr>
+    </tbody>
+</table>
+</TabItem>
+
 <TabItem value="V1" label="V1.x" >
 <table>
     <thead>
@@ -79,54 +128,6 @@ The `/sql` endpoint enables use of SurrealQL queries.
 </table>
 </TabItem>
 
-<TabItem value="V2" label="V2.x" default>
-<table>
-    <thead>
-        <tr>
-            <th colspan="2">Header</th>
-            <th colspan="2">Description</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td colspan="2" scope="row" data-label="Header">
-                <code>Authorization</code>
-               <Label label="optional" />
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-            Sets the root, namespace, database, or record authentication data
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" scope="row" data-label="Header">
-                <code>Accept</code>
-                <Label label="required" />
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-                Sets the desired content-type of the response
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" scope="row" data-label="Header">
-                <code>surreal-ns</code>
-                <Label label="required" />
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-                Sets the selected Namespace for queries.
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2" scope="row" data-label="Header">
-                <code>surreal-db</code>
-                <Label label="required" />
-            </td>
-            <td colspan="2" scope="row" data-label="Description">
-                Sets the selected Database for queries.
-            </td>
-        </tr>
-    </tbody>
-</table>
-</TabItem>
 </Tabs>
 
 
@@ -137,6 +138,12 @@ The `/sql` endpoint enables use of SurrealQL queries.
 > The `-u` in the example below is a shorthand used by curl to send an Authorization header.
 
 <Tabs groupId="http-sql">
+<TabItem value="V2" label="V2.x+" default>
+```bash title="Request"
+curl -X POST -u "root:root" -H "surreal-ns: mynamespace" -H "surreal-db: mydatabase" -H "Accept: application/json" -d "SELECT * FROM person WHERE age > 18" http://localhost:8000/sql
+```
+</TabItem>
+
   <TabItem value="V1" label="V1.x">
 
 ```bash title="Request"
@@ -144,11 +151,7 @@ curl -X POST -u "root:root" -H "NS: mynamespace" -H "DB: mydatabase" -H "Accept:
 ```
 
 </TabItem>
-<TabItem value="V2" label="V2.x" default>
-```bash title="Request"
-curl -X POST -u "root:root" -H "surreal-ns: mynamespace" -H "surreal-db: mydatabase" -H "Accept: application/json" -d "SELECT * FROM person WHERE age > 18" http://localhost:8000/sql
-```
-</TabItem>
+
 </Tabs>
 
 

--- a/src/content/doc-surrealdb/security/security-best-practices.mdx
+++ b/src/content/doc-surrealdb/security/security-best-practices.mdx
@@ -195,7 +195,7 @@ var result = await db.RawQuery($"CREATE person CONTENT name = "{name}";");
 ### Example: Bind parameters in the HTTP REST API
 
 <Tabs groupId="http-sql">
-<TabItem value="V2" label="V2.x" default>
+<TabItem value="V2" label="V2.x+" default>
 ```bash title="Request"
 curl -X POST -u "root:root" -H "surreal-ns: mynamespace" -H "surreal-db: mydatabase" -H "Accept: application/json" \
 -d 'SELECT * FROM person WHERE age > $age' http://localhost:8000/sql?age=18


### PR DESCRIPTION
This PR mainly goes through the [HTTP protocol](https://surrealdb.com/docs/surrealdb/integration/http) page.

* Main change: ensuring that each endpoint has at least one example of a curl command, also adding any setup needed to make it work in the first place. e.g. for /signup it begins with a /sql command to set up a record access method. Any reader should be able to use them all with nothing more than copy and paste.
* Makes the default user and password `root:secret`, and namespace and database names are now both `main` as this is the default since 3.0.
* Puts 2.x+ tabs first so that users see them before any 1.x tabs. Also changes "2.x" to "2.x+" because they all work in the same way for 3.x.