### PR TITLE
More GraphQL examples

### DIFF
--- a/src/content/doc-surrealdb/integration/http.mdx
+++ b/src/content/doc-surrealdb/integration/http.mdx
@@ -2533,49 +2533,51 @@ The GraphQL endpoint enables use of GraphQL queries to interact with your data.
 > [!NOTE]
 > The `-u` in the example below is a shorthand used by curl to send an Authorization header (name and password), in this case assuming the username `root` and password `secret`.
 
-<Tabs groupId="http-sql">
+First, use the `/sql` endpoint to send in a [`DEFINE CONFIG`](/docs/surrealql/statements/define/config#define-config-graphql) statement to set the database up to use GraphQL.
 
-<TabItem value="V2" label="V2.x+" default>
+```bash
+curl -X POST -u "root:secret" -H "Surreal-NS: main" -H "Surreal-DB: main" -H "Accept: application/json" \
+  -d 'DEFINE TABLE person SCHEMAFULL; DEFINE FIELD name ON TABLE person TYPE string; DEFINE FIELD age ON TABLE person TYPE number;' \
+  http://localhost:8000/sql
+
+curl -X POST -u "root:secret" -H "Surreal-NS: main" -H "Surreal-DB: main" -H "Accept: application/json" \
+  -d 'CREATE person:simon SET name = "Simon", age = 23; CREATE person:marcus SET name = "Marcus", age = 28;' \
+  http://localhost:8000/sql
+
+curl -X POST -u "root:secret" -H "Surreal-NS: main" -H "Surreal-DB: main" -H "Accept: application/json" \
+  -d 'DEFINE CONFIG GRAPHQL AUTO' \
+  http://localhost:8000/sql
+```
+
+With that done, a GraphQL query can now be performed.
+
 ```bash title="Request"
 curl -X POST \
   -u "root:secret" \
   -H "Surreal-NS: main" \
   -H "Surreal-DB: main" \
   -H "Accept: application/json" \
-  -d '{
-    "query": "{ 
-      person(filter: {age: {age_gt: 18}}) {
-        id
-        name
-        age
-      }
-    }"
-  }' \
+  -d '{"query": "query { person { id name age } }"}' \
   http://localhost:8000/graphql
 ```
-</TabItem>
-
-</Tabs>
 
 ```json title="Response"
-[
-	{
-		"time": "14.357166ms",
-		"status": "OK",
-		"result": [
+{
+	"data": {
+		"person": [
 			{
-				"age": "23",
-				"id": "person:6r7wif0uufrp22h0jr0o"
-				"name": "Simon",
+				"age": 28,
+				"id": "person:marcus",
+				"name": "Marcus"
 			},
 			{
-				"age": "28",
-				"id": "person:6r7wif0uufrp22h0jr0o"
-				"name": "Marcus",
-			},
+				"age": 23,
+				"id": "person:simon",
+				"name": "Simon"
+			}
 		]
 	}
-]
+}
 ```
 
 <br />

--- a/src/content/doc-surrealdb/querying/graphql/http.mdx
+++ b/src/content/doc-surrealdb/querying/graphql/http.mdx
@@ -5,8 +5,6 @@ title: GraphQL via HTTP | GraphQL
 description: In this section, you will explore querying SurrealDB using the GraphQL HTTP endpoint. The HTTP API is designed to be simple and intuitive, with any interface that provides a consistent way to interact with the database.
 ---
 
-import Tabs from "@components/Tabs/Tabs.astro";
-import TabItem from "@components/Tabs/TabItem.astro";
 import Since from '@components/shared/Since.astro';
 import Label from "@components/shared/Label.astro";
 
@@ -21,18 +19,9 @@ The HTTP API is designed to be simple and intuitive, with a RESTful interface th
 Before you can start making queries, you need to start SurrealDB with the GraphQL module enabled. You can do this by starting a new instance of SurrealDB with the [`surreal start` command](/docs/surrealdb/cli/start).
 
 
-<Tabs groupId="start-surreal">
-<TabItem value="macOS" label="MacOS">
 ```bash
-surreal start --log debug --user root --password root
+surreal start --log debug --user root --password secret
 ```
-</TabItem>
-<TabItem value="Windows" label="Windows">
-```bash
-surreal start --log debug --user root --password root
-```
-</TabItem>
-</Tabs>
 
 In order to allow querying the created table using GraphQL, you will need to explicitly enable GraphQL using the [`DEFINE CONFIG`](/docs/surrealql/statements/define/config) statement. This will allow you to query the table using GraphQL on a per-database basis.
 
@@ -47,9 +36,17 @@ To do this, you can send a `POST` request to the `/sql` endpoint with a RAW body
 DEFINE CONFIG GRAPHQL AUTO;
 ```
 
-Here is an example of how to accomplish this query via a curl command to a namespace and database both named `main`, assuming a root user with the password `secret`.
+Here are three commands to define this configuration, along with some table and field definitions and sample data. They also assume a root user with the name `root` and the password `secret`.
 
 ```bash
+curl -X POST -u "root:secret" -H "Surreal-NS: main" -H "Surreal-DB: main" -H "Accept: application/json" \
+  -d 'DEFINE TABLE person SCHEMAFULL; DEFINE FIELD name ON TABLE person TYPE string; DEFINE FIELD age ON TABLE person TYPE number;' \
+  http://localhost:8000/sql
+
+curl -X POST -u "root:secret" -H "Surreal-NS: main" -H "Surreal-DB: main" -H "Accept: application/json" \
+  -d 'CREATE person:simon SET name = "Simon", age = 23; CREATE person:marcus SET name = "Marcus", age = 28;' \
+  http://localhost:8000/sql
+
 curl -X POST -u "root:secret" -H "Surreal-NS: main" -H "Surreal-DB: main" -H "Accept: application/json" \
   -d 'DEFINE CONFIG GRAPHQL AUTO' http://localhost:8000/sql
 ```
@@ -59,17 +56,16 @@ curl -X POST -u "root:secret" -H "Surreal-NS: main" -H "Surreal-DB: main" -H "Ac
 
 <Since v="v2.0.0" />
 
-To use the GraphQL API, you can send a `POST` request to the `/graphql` endpoint with a JSON body containing the GraphQL query. For example, to query the `person` table for all records, you can send the following request:
+To use the GraphQL API, you can send a `POST` request to the `/graphql` endpoint with a JSON body containing the GraphQL query via Postman or any other HTTP client. For example, to query the `person` table for all records, you can send the following request:
 
 ```json
-{
-  "query": "{ person { name } }"
-}
+curl -X POST -u "root:secret" -H "Surreal-NS: main" -H "Surreal-DB: main" -H "Accept: application/json" \
+  -d '{ "query": "query { person { name } }" }' http://localhost:8000/graphql
 ```
 
-You can access this endpoint at `http://localhost:8000/graphql` via Postman or any other HTTP client.
-
-
+```json title="Response"
+{"data":{"person":[{"name":"Marcus"},{"name":"Simon"}]}}
+```
 
 The GraphQL endpoint enables use of GraphQL queries to interact with your data.
 
@@ -123,7 +119,13 @@ The GraphQL endpoint enables use of GraphQL queries to interact with your data.
 
 ### Example usage
 ```bash title="Request"
-curl -X POST -u "root:secret" -H "surreal-ns: main" -H "surreal-db: main" -H "Accept: application/json" -d '{"query": "{ person(filter: {age: {age_gt: 18}}) { id name age } }"}' http://localhost:8000/graphql
+curl -X POST \
+  -u "root:secret" \
+  -H "Surreal-NS: main" \
+  -H "Surreal-DB: main" \
+  -H "Accept: application/json" \
+  -d '{"query": "query { person(where: { age: { gt: 18 } }) { id name age } }"}' \
+  http://localhost:8000/graphql
 ```
 
 ```json title="Response"
@@ -134,12 +136,12 @@ curl -X POST -u "root:secret" -H "surreal-ns: main" -H "surreal-db: main" -H "Ac
 		"result": [
 			{
 				"age": "23",
-				"id": "person:6r7wif0uufrp22h0jr0o"
+				"id": "person:simon"
 				"name": "Simon",
 			},
 			{
 				"age": "28",
-				"id": "person:6r7wif0uufrp22h0jr0o"
+				"id": "person:marcus"
 				"name": "Marcus",
 			},
 		]


### PR DESCRIPTION
Fills out some GraphQL examples so that all the setup (DEFINE CONFIG, DEFINE TABLE/FIELD, some sample data) is done by copy and paste and ready for the /graphql endpoint.