### PR TITLE
Update + add new array size examples

### DIFF
--- a/src/content/doc-surrealdb/installation/upgrading/migrating-data-to-3.x.mdx
+++ b/src/content/doc-surrealdb/installation/upgrading/migrating-data-to-3.x.mdx
@@ -1002,3 +1002,20 @@ The statements which had this change from an identifier to allowing a general ex
 - The `ident` after `REMOVE ANALYZER ident ...`
 - The `ident` after `REMOVE BUCKET ident ...`
 - The `ident` after `REMOVE SEQUENCE ident ...`
+
+### 29. `DEFINE FIELD` number of items for arrays and sets
+
+A `DEFINE FIELD` statement for arrays and sets in SurrealDB 2.x allowed a maximum number of items to be indicated. This number now refers to the *required* number of items.
+
+As such, a schema with an `ASSERT $value().len()` is equal to a certain number can now have the required number in the type definition itself. Additionally, definitions that indicate a maximum number of items must be changed to `ASSERT $value.len() <=` followed by the maximum number.
+
+```surql
+-- Assert exact length of 640 bytes in SurrealDB 2.x
+DEFINE FIELD bytes ON data TYPE array<int> ASSERT $value.all(|$val| $val IN 0..=255) AND $value.len() = 640;
+
+-- Assert the same in SurrealDB 3.x
+DEFINE FIELD bytes ON data TYPE array<int, 640> ASSERT $value.all(|$val| $val IN 0..=255);
+
+-- Assert a maximum array size in SurrealDB 3.x
+DEFINE FIELD latest ON observation TYPE array<object> ASSERT $value.len() <= 1000;
+```

--- a/src/content/doc-surrealdb/reference-guide/schema-creation-best-practices.mdx
+++ b/src/content/doc-surrealdb/reference-guide/schema-creation-best-practices.mdx
@@ -11,7 +11,7 @@ With SurrealDB, you can create a schema that is as simple or as complex as you n
 
 ### Define arrays and sets with a type and maximum size
 
-In addition to a type, both arrays and sets can have a maximum number of items built into the type definition itself. The definition below pairs this with an assertion using the [`array::all()`](/docs/surrealql/functions/database/array#arrayall) function to also ensure that every item in the `small_bytes` field is between 0 and 255.
+In addition to a type, both arrays and sets can have a required number of items built into the type definition itself. The definition below pairs this with an assertion using the [`array::all()`](/docs/surrealql/functions/database/array#arrayall) function to also ensure that every item in the `small_bytes` field is between 0 and 255.
 
 ```surql
 DEFINE FIELD small_bytes ON data TYPE array<int, 8> ASSERT $value.all(|$int| $int IN 0..=255);

--- a/src/content/doc-surrealql/statements/define/field.mdx
+++ b/src/content/doc-surrealql/statements/define/field.mdx
@@ -263,10 +263,13 @@ DEFINE FIELD user_id ON TABLE user TYPE uuid|int;
 
 ### Array type
 
-You can also set a field to have the array data type. The array data type can be used to store a list of values. You can also set the data type of the array's contents, as well as the maximum number of items that it can hold.
+You can also set a field to have the array data type. The array data type can be used to store a list of values. You can also set the data type of the array's contents, as well as the required number of items that it must hold.
 
 ```surql
 /**[test]
+
+[[test.results]]
+value = "NONE"
 
 [[test.results]]
 value = "NONE"
@@ -291,9 +294,15 @@ DEFINE FIELD posts ON TABLE user TYPE array;
 -- Set a field to have the array object data type
 DEFINE FIELD emails ON TABLE user TYPE array<object>;
 
--- Field for a block in a game showing the possible directions a character can move next.
+-- Set a field that holds exactly 640 bytes
+DEFINE FIELD bytes ON TABLE data TYPE array<int, 640> ASSERT $value.all(|$val| $val IN 0..=255);
+
+-- Field for a block in a game showing the possible distinct directions a character can move next.
 -- The array can contain no more than four directions
-DEFINE FIELD next_paths ON TABLE block TYPE array<"north" | "east" | "south" | "west", 4>;
+DEFINE FIELD next_paths ON TABLE block 
+  TYPE array<"north" | "east" | "south" | "west"> 
+  VALUE $value.distinct() 
+  ASSERT $value.len() <= 4;
 ```
 
 ### Making a field optional


### PR DESCRIPTION
The number in a type definitions for arrays and sets refers to the required number of items as opposed to the maximum number. This info is present in the docs but more examples and indications are required.