### PR TITLE
Restructure env vars

### DIFF
--- a/src/content/doc-surrealdb/cli/env.mdx
+++ b/src/content/doc-surrealdb/cli/env.mdx
@@ -22,7 +22,11 @@ Environment variables are divided into four types:
 
 Many environment variables have a maximum value equivalent to the greatest possible `usize`, which is an unsigned integer with a number of bytes depending on the target that the database runs on. For most systems this will be 64 bits, leading to a maximum size of 18_446_744_073_709_551_615 (2<sup>64</sup>), while for 32 bits the maximum will be 4_294_967_296 (2<sup>32</sup>).
 
-## Batch environment variables
+## SurrealDB environment variables
+
+These environment variables can be used to configure a SurrealDB server to configure areas such as the HTTP server and client, limits, telemetry, and so on.
+
+### Batch config
 
 <table>
   <thead>
@@ -37,7 +41,7 @@ Many environment variables have a maximum value equivalent to the greatest possi
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_NORMAL_FETCH_SIZE</code></td>
       <td scope="row" data-label="Default">500</td>
-      <td scope="row" data-label="Allowed values">A duration</td>
+      <td scope="row" data-label="Allowed values">A usize</td>
       <td scope="row" data-label="Notes">The maximum number of keys that should be scanned at once in general queries.</td>
     </tr>
         <tr>
@@ -61,7 +65,7 @@ Many environment variables have a maximum value equivalent to the greatest possi
   </tbody>
 </table>
 
-## Cache environment variables
+### Cache config
 
 <table>
   <thead>
@@ -100,7 +104,7 @@ Many environment variables have a maximum value equivalent to the greatest possi
   </tbody>
 </table>
 
-## File environment variables
+### File config
 
 <table>
   <thead>
@@ -139,7 +143,7 @@ Many environment variables have a maximum value equivalent to the greatest possi
   </tbody>
 </table>
 
-## HTTP client environment variables
+### HTTP client config
 
 <table>
   <thead>
@@ -191,7 +195,7 @@ Many environment variables have a maximum value equivalent to the greatest possi
   </tbody>
 </table>
 
-## HTTP server environment variables
+### HTTP server config
 
 <table>
   <thead>
@@ -261,7 +265,7 @@ Many environment variables have a maximum value equivalent to the greatest possi
   </tbody>
 </table>
 
-## Limits environment variables
+### Limits config
 
 <table>
   <thead>
@@ -282,14 +286,14 @@ Many environment variables have a maximum value equivalent to the greatest possi
     </tr>
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_STRING_SIMILARITY_LIMIT</code></td>
-      <td scope="row" data-label="Default">none</td>
-      <td scope="row" data-label="Allowed values">A string</td>
-      <td scope="row" data-label="Notes">Write stuff here</td>
+      <td scope="row" data-label="Default">16384</td>
+      <td scope="row" data-label="Allowed values">A usize</td>
+      <td scope="row" data-label="Notes">The maximum input string length for similarity/distance functions</td>
     </tr>
      <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_GENERATION_ALLOCATION_LIMIT</code></td>
-      <td scope="row" data-label="Default">20</td>
-      <td scope="row" data-label="Allowed values">An integer</td>
+      <td scope="row" data-label="Default">1,048,576</td>
+      <td scope="row" data-label="Allowed values">A usize</td>
       <td scope="row" data-label="Notes">Limits memory allocation for certain built-in functions (e.g., string::replace) to avoid uncontrolled memory usage. Default is 1,048,576 bytes (computed as 2<sup>20</sup>).</td>
     </tr>
     <tr>
@@ -343,7 +347,7 @@ Many environment variables have a maximum value equivalent to the greatest possi
   </tbody>
 </table>
 
-## Runtime environment variables
+### Runtime config
 
 <table>
   <thead>
@@ -376,7 +380,7 @@ Many environment variables have a maximum value equivalent to the greatest possi
   </tbody>
 </table>
 
-## Scripting environment variables
+### Scripting config
 
 <table>
   <thead>
@@ -402,14 +406,14 @@ Many environment variables have a maximum value equivalent to the greatest possi
     </tr>
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_SCRIPTING_MAX_TIME_LIMIT</code><Since v="v2.0.5" /></td>
-      <td scope="row" data-label="Default">5000 (5000 milliseconds or 5 seconds</td>
-      <td scope="row" data-label="Allowed values">A usize)</td>
+      <td scope="row" data-label="Default">5000 (5000 milliseconds or 5 seconds)</td>
+      <td scope="row" data-label="Allowed values">A usize</td>
       <td scope="row" data-label="Notes">Maximum allowed time in milliseconds that a JavaScript function is allowed to run for.</td>
     </tr>
   </tbody>
 </table>
 
-## Security environment variables
+### Security config
 
 <table>
   <thead>
@@ -430,7 +434,7 @@ Many environment variables have a maximum value equivalent to the greatest possi
   </tbody>
 </table>
 
-## Telemetry environment variables
+### Telemetry config
 
 <table>
   <thead>
@@ -480,14 +484,14 @@ Many environment variables have a maximum value equivalent to the greatest possi
     </tr>
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_TOKIO_CONSOLE_SOCKET_ADDR</code><Since v="v3.0.0" /></td>
-      <td scope="row" data-label="Default">false</td>
-      <td scope="row" data-label="Allowed values">A string to a socket address</td>
+      <td scope="row" data-label="Default">none</td>
+      <td scope="row" data-label="Allowed values">String to a socket address</td>
       <td scope="row" data-label="Notes">The socket address that Tokio Console will bind to.</td>
     </tr>
   </tbody>
 </table>
 
-## Websocket environment variables
+### Websocket config
 
 <table>
   <thead>
@@ -544,7 +548,7 @@ Many environment variables have a maximum value equivalent to the greatest possi
   </tbody>
 </table>
 
-## Other environment variables
+### Other environment variables
 
 <table>
   <thead>
@@ -607,7 +611,7 @@ Many environment variables have a maximum value equivalent to the greatest possi
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_REGEX_CACHE_SIZE</code></td>
       <td scope="row" data-label="Default">1000</td>
-      <td scope="row" data-label="Allowed values">A duration</td>
+      <td scope="row" data-label="Allowed values">A usize</td>
       <td scope="row" data-label="Notes">The number of computed regexes which can be cached in the engine.</td>
     </tr>
   </tbody>
@@ -689,7 +693,7 @@ surreal start --allow-all true
       <td scope="row" data-label="Command">`start`</td>
       <td scope="row" data-label="Default">5s</td>
       <td scope="row" data-label="Allowed values">A duration</td>
-      <td scope="row" data-label="Details">The interval at which to process async events.</td>
+      <td scope="row" data-label="Notes">The interval at which to process async events.</td>
     </tr>
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_AUTH_LEVEL</code></td>
@@ -697,15 +701,15 @@ surreal start --allow-all true
       <td scope="row" data-label="Command">`export`, `import`, `sql`</td>
       <td scope="row" data-label="Default">root</td>
       <td scope="row" data-label="Allowed values">root, namespace, ns, database, db</td>
-      <td scope="row" data-label="Details">Authentication level to use when connecting.</td>
+      <td scope="row" data-label="Notes">Authentication level to use when connecting.</td>
     </tr>
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_BIND</code></td>
       <td scope="row" data-label="Command arg"><code>bind</code></td>
       <td scope="row" data-label="Command">`start`</td>
       <td scope="row" data-label="Default">127.0.0.1:8000</td>
-      <td scope="row" data-label="Allowed values">A string to an address</td>
-      <td scope="row" data-label="Details">The hostname or IP address(es) to listen for connections on.</td>
+      <td scope="row" data-label="Allowed values">String to an address</td>
+      <td scope="row" data-label="Notes">The hostname or IP address(es) to listen for connections on.</td>
     </tr>
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_CAPS_ALLOW_ALL</code></td>
@@ -713,7 +717,7 @@ surreal start --allow-all true
       <td scope="row" data-label="Command">`start`</td>
       <td scope="row" data-label="Default">false</td>
       <td scope="row" data-label="Allowed values">true, false</td>
-      <td scope="row" data-label="Details">Allow all capabilities.</td>
+      <td scope="row" data-label="Notes">Allow all capabilities.</td>
     </tr>
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_CAPS_ALLOW_ARBITRARY_QUERY</code></td>
@@ -721,7 +725,7 @@ surreal start --allow-all true
       <td scope="row" data-label="Command">`start`</td>
       <td scope="row" data-label="Default">none</td>
       <td scope="row" data-label="Allowed values">guest, record, system (comma-separated)</td>
-      <td scope="row" data-label="Details">Allows arbitrary queries to be used by user groups except when specifically denied. Alternatively, you can provide a comma-separated list of user groups to allow specifically denied user groups to prevail over any other allowed user group.</td>
+      <td scope="row" data-label="Notes">Allows arbitrary queries to be used by user groups except when specifically denied. Alternatively, you can provide a comma-separated list of user groups to allow specifically denied user groups to prevail over any other allowed user group.</td>
     </tr>
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_CAPS_ALLOW_EXPERIMENTAL</code></td>
@@ -729,7 +733,7 @@ surreal start --allow-all true
       <td scope="row" data-label="Command">`start`</td>
       <td scope="row" data-label="Default">none</td>
       <td scope="row" data-label="Allowed values">files, surrealism (comma-separated)</td>
-      <td scope="row" data-label="Details">Allow execution of experimental features.</td>
+      <td scope="row" data-label="Notes">Allow execution of experimental features.</td>
     </tr>
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_CAPS_ALLOW_FUNC</code></td>
@@ -737,7 +741,7 @@ surreal start --allow-all true
       <td scope="row" data-label="Command">`start`</td>
       <td scope="row" data-label="Default">false</td>
       <td scope="row" data-label="Allowed values">true, false, comma-separated strings to function paths</td>
-      <td scope="row" data-label="Details">Allow execution of all functions except for functions that are specifically denied.</td>
+      <td scope="row" data-label="Notes">Allow execution of all functions except for functions that are specifically denied.</td>
     </tr>
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_CAPS_ALLOW_GUESTS</code></td>
@@ -745,15 +749,15 @@ surreal start --allow-all true
       <td scope="row" data-label="Command">`start`</td>
       <td scope="row" data-label="Default">true</td>
       <td scope="row" data-label="Allowed values">true, false</td>
-      <td scope="row" data-label="Details">Allow guest users to execute queries.</td>
+      <td scope="row" data-label="Notes">Allow guest users to execute queries.</td>
     </tr>
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_CAPS_ALLOW_NET</code></td>
-      <td scope="row" data-label="Command arg"><code>-allow-net</code></td>
+      <td scope="row" data-label="Command arg"><code>allow-net</code></td>
       <td scope="row" data-label="Command">`start`</td>
       <td scope="row" data-label="Default">none</td>
       <td scope="row" data-label="Allowed values">Comma-separated list of paths</td>
-      <td scope="row" data-label="Details">Allow all or certain outbound network access.</td>
+      <td scope="row" data-label="Notes">Allow all or certain outbound network access.</td>
     </tr>
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_CAPS_ALLOW_SCRIPT</code></td>
@@ -761,7 +765,7 @@ surreal start --allow-all true
       <td scope="row" data-label="Command">`start`</td>
       <td scope="row" data-label="Default">true</td>
       <td scope="row" data-label="Allowed values">true, false</td>
-      <td scope="row" data-label="Details">Allow execution of embedded scripting functions.</td>
+      <td scope="row" data-label="Notes">Allow execution of embedded scripting functions.</td>
     </tr>
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_CAPS_ALLOW_INSECURE_STORABLE_CLOSURES</code><Since v="v2.5.0" /></td>
@@ -769,7 +773,7 @@ surreal start --allow-all true
       <td scope="row" data-label="Command">`start`</td>
       <td scope="row" data-label="Default">false</td>
       <td scope="row" data-label="Allowed values">true, false</td>
-      <td scope="row" data-label="Details">Takes a boolean. Prevents closures from being stored, which eliminates a potential attack surface. For version 2.5.0, this can still be allowed by using this capability.</td>
+      <td scope="row" data-label="Notes">Takes a boolean. Prevents closures from being stored, which eliminates a potential attack surface. For version 2.5.0, this can still be allowed by using this capability.</td>
     </tr>
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_CAPS_DENY_ALL</code></td>
@@ -777,7 +781,7 @@ surreal start --allow-all true
       <td scope="row" data-label="Command">`start`</td>
       <td scope="row" data-label="Default">false</td>
       <td scope="row" data-label="Allowed values">true, false</td>
-      <td scope="row" data-label="Details">Deny all capabilities.</td>
+      <td scope="row" data-label="Notes">Deny all capabilities.</td>
     </tr>
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_CAPS_DENY_FUNC</code></td>
@@ -785,7 +789,7 @@ surreal start --allow-all true
       <td scope="row" data-label="Command">`start`</td>
       <td scope="row" data-label="Default">false</td>
       <td scope="row" data-label="Allowed values">true, false, comma-separated list</td>
-      <td scope="row" data-label="Details">Deny execution of all or certain functions.</td>
+      <td scope="row" data-label="Notes">Deny execution of all or certain functions.</td>
     </tr>
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_CAPS_DENY_GUESTS</code></td>
@@ -793,7 +797,7 @@ surreal start --allow-all true
       <td scope="row" data-label="Command">`start`</td>
       <td scope="row" data-label="Default">true</td>
       <td scope="row" data-label="Allowed values">true, false</td>
-      <td scope="row" data-label="Details">Deny guest users from executing queries.</td>
+      <td scope="row" data-label="Notes">Deny guest users from executing queries.</td>
     </tr>
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_CAPS_DENY_NET</code></td>
@@ -801,7 +805,7 @@ surreal start --allow-all true
       <td scope="row" data-label="Command">`start`</td>
       <td scope="row" data-label="Default">true</td>
       <td scope="row" data-label="Allowed values">true, false, comma-separated list</td>
-      <td scope="row" data-label="Details">Deny all or certain outbound access paths.</td>
+      <td scope="row" data-label="Notes">Deny all or certain outbound access paths.</td>
     </tr>
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_CAPS_DENY_SCRIPT</code></td>
@@ -809,7 +813,7 @@ surreal start --allow-all true
       <td scope="row" data-label="Command">`start`</td>
       <td scope="row" data-label="Default">true</td>
       <td scope="row" data-label="Allowed values">true, false</td>
-      <td scope="row" data-label="Details">Deny execution of embedded scripting functions.</td>
+      <td scope="row" data-label="Notes">Deny execution of embedded scripting functions.</td>
     </tr>
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_CHANGEFEED_GC_INTERVAL</code></td>
@@ -817,7 +821,7 @@ surreal start --allow-all true
       <td scope="row" data-label="Command">`start`</td>
       <td scope="row" data-label="Default">30s</td>
       <td scope="row" data-label="Allowed values">A duration</td>
-      <td scope="row" data-label="Details">The interval at which to perform changefeed garbage collection.</td>
+      <td scope="row" data-label="Notes">The interval at which to perform changefeed garbage collection.</td>
     </tr>
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_CLIENT_IP</code></td>
@@ -825,7 +829,7 @@ surreal start --allow-all true
       <td scope="row" data-label="Command">`start`</td>
       <td scope="row" data-label="Default">none</td>
       <td scope="row" data-label="Allowed values">none, socket, CF-Connecting-IP, Fly-Client-IP, True-Client-IP, X-Real-IP, X-Forwarded-For</td>
-      <td scope="row" data-label="Details">The method of detecting the client's IP address.</td>
+      <td scope="row" data-label="Notes">The method of detecting the client's IP address.</td>
     </tr>
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_DATABASE</code></td>
@@ -833,7 +837,7 @@ surreal start --allow-all true
       <td scope="row" data-label="Command">`sql`</td>
       <td scope="row" data-label="Default">main</td>
       <td scope="row" data-label="Allowed values">A string</td>
-      <td scope="row" data-label="Details">The database selected when starting the REPL.</td>
+      <td scope="row" data-label="Notes">The database selected when starting the REPL.</td>
     </tr>
 <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_DATABASE</code></td>
@@ -841,7 +845,7 @@ surreal start --allow-all true
       <td scope="row" data-label="Command">`export`, `import`</td>
       <td scope="row" data-label="Default">none</td>
       <td scope="row" data-label="Allowed values">A string</td>
-      <td scope="row" data-label="Details">The database selected for the import or export.</td>
+      <td scope="row" data-label="Notes">The database selected for the import or export.</td>
     </tr>
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_DEFAULT_DATABASE</code><Since v="v3.0.0" /></td>
@@ -849,7 +853,7 @@ surreal start --allow-all true
       <td scope="row" data-label="Command">`start`</td>
       <td scope="row" data-label="Default">main</td>
       <td scope="row" data-label="Allowed values">A string</td>
-      <td scope="row" data-label="Details">The default database to use when starting a SurrealDB instance.</td>
+      <td scope="row" data-label="Notes">The default database to use when starting a SurrealDB instance.</td>
     </tr>
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_DEFAULT_NAMESPACE</code><Since v="v3.0.0" /></td>
@@ -857,7 +861,7 @@ surreal start --allow-all true
       <td scope="row" data-label="Command">`start`</td>
       <td scope="row" data-label="Default">main</td>
       <td scope="row" data-label="Allowed values">A string</td>
-      <td scope="row" data-label="Details">The default namespace to use when starting a SurrealDB instance.</td>
+      <td scope="row" data-label="Notes">The default namespace to use when starting a SurrealDB instance.</td>
     </tr>
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_HIDE_WELCOME</code></td>
@@ -865,7 +869,7 @@ surreal start --allow-all true
       <td scope="row" data-label="Command">`sql`</td>
       <td scope="row" data-label="Default">false</td>
       <td scope="row" data-label="Allowed values">true, false</td>
-      <td scope="row" data-label="Details">Whether to show the welcome message when starting the REPL.</td>
+      <td scope="row" data-label="Notes">Whether to show the welcome message when starting the REPL.</td>
     </tr>
 <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_IMPORT_FILE</code></td>
@@ -873,7 +877,7 @@ surreal start --allow-all true
       <td scope="row" data-label="Command">`start`</td>
       <td scope="row" data-label="Default">none</td>
       <td scope="row" data-label="Allowed values">A file path</td>
-      <td scope="row" data-label="Details">Path to a SurrealQL file that will be imported when starting the server.</td>
+      <td scope="row" data-label="Notes">Path to a SurrealQL file that will be imported when starting the server.</td>
     </tr>
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_INDEX_COMPACTION_INTERVAL</code><Since v="v3.0.0" /></td>
@@ -881,7 +885,7 @@ surreal start --allow-all true
       <td scope="row" data-label="Command">`start`</td>
       <td scope="row" data-label="Default">5s</td>
       <td scope="row" data-label="Allowed values">A duration</td>
-      <td scope="row" data-label="Details">The interval at which to perform changefeed garbage collection.</td>
+      <td scope="row" data-label="Notes">The interval at which to perform changefeed garbage collection.</td>
     </tr>
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_KEY</code></td>
@@ -889,31 +893,31 @@ surreal start --allow-all true
       <td scope="row" data-label="Command">`start`</td>
       <td scope="row" data-label="Default">none</td>
       <td scope="row" data-label="Allowed values">A string 16, 24, or 32 bytes long</td>
-      <td scope="row" data-label="Details">Encryption key to use for on-disk encryption. Not currently in use.</td>
+      <td scope="row" data-label="Notes">Encryption key to use for on-disk encryption. Not currently in use.</td>
     </tr>
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_KVS_CA</code></td>
       <td scope="row" data-label="Command arg"><code>kvs-ca</code></td>
       <td scope="row" data-label="Command">`start`</td>
       <td scope="row" data-label="Default">none</td>
-      <td scope="row" data-label="Allowed values">A string to a path</td>
-      <td scope="row" data-label="Details">Path to the CA file used when connecting to the remote KV store.</td>
+      <td scope="row" data-label="Allowed values">String to a path</td>
+      <td scope="row" data-label="Notes">Path to the CA file used when connecting to the remote KV store.</td>
     </tr>
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_KVS_CRT</code></td>
       <td scope="row" data-label="Command arg"><code>kvs-crt</code></td>
       <td scope="row" data-label="Command">`start`</td>
       <td scope="row" data-label="Default">none</td>
-      <td scope="row" data-label="Allowed values">A string to a path</td>
-      <td scope="row" data-label="Details">Path to the certificate file used when connecting to the remote KV store.</td>
+      <td scope="row" data-label="Allowed values">String to a path</td>
+      <td scope="row" data-label="Notes">Path to the certificate file used when connecting to the remote KV store.</td>
     </tr>
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_KVS_KEY</code></td>
       <td scope="row" data-label="Command arg"><code>kvs-key</code></td>
       <td scope="row" data-label="Command">`start`</td>
       <td scope="row" data-label="Default">none</td>
-      <td scope="row" data-label="Allowed values">A string to a path</td>
-      <td scope="row" data-label="Details">Path to the private key file used when connecting to the remote KV store.</td>
+      <td scope="row" data-label="Allowed values">String to a path</td>
+      <td scope="row" data-label="Notes">Path to the private key file used when connecting to the remote KV store.</td>
     </tr>
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_LOG</code></td>
@@ -921,15 +925,15 @@ surreal start --allow-all true
       <td scope="row" data-label="Command">`start`, `fix`</td>
       <td scope="row" data-label="Default">info</td>
       <td scope="row" data-label="Allowed values">none, full, error, warn, info, debug, trace</td>
-      <td scope="row" data-label="Details">The logging level for the database server.</td>
+      <td scope="row" data-label="Notes">The logging level for the database server.</td>
     </tr>
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_LOG_FILE_ENABLED</code><Since v="v2.4.0" /></td>
       <td scope="row" data-label="Command arg"><code>log-file-enabled</code></td>
       <td scope="row" data-label="Command">`start`</td>
-      <td scope="row" data-label="Default">true</td>
+      <td scope="row" data-label="Default">false</td>
       <td scope="row" data-label="Allowed values">true, false</td>
-      <td scope="row" data-label="Details">Toggles file output (default: false)</td>
+      <td scope="row" data-label="Notes">Toggles file output.</td>
     </tr>
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_LOG_FILE_FORMAT</code><Since v="v2.4.0" /></td>
@@ -937,7 +941,7 @@ surreal start --allow-all true
       <td scope="row" data-label="Command">`start`</td>
       <td scope="row" data-label="Default">none</td>
       <td scope="row" data-label="Allowed values">text, json</td>
-      <td scope="row" data-label="Details">The format for log file output.</td>
+      <td scope="row" data-label="Notes">The format for log file output.</td>
     </tr>
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_LOG_FILE_LEVEL</code><Since v="v2.4.0" /></td>
@@ -945,7 +949,7 @@ surreal start --allow-all true
       <td scope="row" data-label="Command">`start`</td>
       <td scope="row" data-label="Default">none</td>
       <td scope="row" data-label="Allowed values">none, full, error, warn, info, debug, trace</td>
-      <td scope="row" data-label="Details">Override the logging level for file output</td>
+      <td scope="row" data-label="Notes">Override the logging level for file output</td>
     </tr>
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_LOG_FILE_NAME</code><Since v="v2.4.0" /></td>
@@ -953,7 +957,7 @@ surreal start --allow-all true
       <td scope="row" data-label="Command">`start`</td>
       <td scope="row" data-label="Default">surrealdb.log</td>
       <td scope="row" data-label="Allowed values">String to a file</td>
-      <td scope="row" data-label="Details">Filename for logs (default: `surrealdb.log`)</td>
+      <td scope="row" data-label="Notes">Filename for logs (default: `surrealdb.log`)</td>
     </tr>
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_LOG_FILE_PATH</code><Since v="v2.4.0" /></td>
@@ -961,7 +965,7 @@ surreal start --allow-all true
       <td scope="row" data-label="Command">`start`</td>
       <td scope="row" data-label="Default">logs</td>
       <td scope="row" data-label="Allowed values">String to a path</td>
-      <td scope="row" data-label="Details">Sets the directory for logs</td>
+      <td scope="row" data-label="Notes">Sets the directory for logs</td>
     </tr>
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_LOG_FILE_ROTATION</code><Since v="v2.4.0" /></td>
@@ -969,7 +973,7 @@ surreal start --allow-all true
       <td scope="row" data-label="Command">`start`</td>
       <td scope="row" data-label="Default">daily</td>
       <td scope="row" data-label="Allowed values">daily, hourly, never</td>
-      <td scope="row" data-label="Details">Sets the rotation duration for logs.</td>
+      <td scope="row" data-label="Notes">Sets the rotation duration for logs.</td>
     </tr>
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_LOG_FORMAT</code><Since v="v2.4.0" /></td>
@@ -977,7 +981,7 @@ surreal start --allow-all true
       <td scope="row" data-label="Command">`start`</td>
       <td scope="row" data-label="Default">text</td>
       <td scope="row" data-label="Allowed values">text, json</td>
-      <td scope="row" data-label="Details">Sets the format for logs.</td>
+      <td scope="row" data-label="Notes">Sets the format for logs.</td>
     </tr>
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_LOG_OTEL_LEVEL</code><br /><Since v="v2.4.0" /></td>
@@ -985,7 +989,7 @@ surreal start --allow-all true
       <td scope="row" data-label="Command">`start`</td>
       <td scope="row" data-label="Default">SURREAL_LOG logging level</td>
       <td scope="row" data-label="Allowed values">none, full, error, warn, info, debug, trace</td>
-      <td scope="row" data-label="Details">Override the logging level for OpenTelemetry</td>
+      <td scope="row" data-label="Notes">Override the logging level for OpenTelemetry</td>
     </tr>
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_LOG_SOCKET</code><Since v="v3.0.0" /></td>
@@ -993,7 +997,7 @@ surreal start --allow-all true
       <td scope="row" data-label="Command">`start`</td>
       <td scope="row" data-label="Default">none</td>
       <td scope="row" data-label="Allowed values">String to a host:port</td>
-      <td scope="row" data-label="Details">Send logs to the specified host:port</td>
+      <td scope="row" data-label="Notes">Send logs to the specified host:port</td>
     </tr>
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_LOG_SOCKET_FORMAT</code><Since v="v3.0.0" /></td>
@@ -1001,7 +1005,7 @@ surreal start --allow-all true
       <td scope="row" data-label="Command">`start`</td>
       <td scope="row" data-label="Default">text</td>
       <td scope="row" data-label="Allowed values">text, json</td>
-      <td scope="row" data-label="Details">  Set the format of the logs to the socket.</td>
+      <td scope="row" data-label="Notes">  Set the format of the logs to the socket.</td>
     </tr>
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_LOG_SOCKET_LEVEL</code><Since v="v3.0.0" /></td>
@@ -1009,7 +1013,7 @@ surreal start --allow-all true
       <td scope="row" data-label="Command">`start`</td>
       <td scope="row" data-label="Default">SURREAL_LOG logging level</td>
       <td scope="row" data-label="Allowed values">none, full, error, warn, info, debug, trace</td>
-      <td scope="row" data-label="Details">  Override the logging level for socket logs. Possible values: none, full, error, warn, info, debug, trace</td>
+      <td scope="row" data-label="Notes">  Override the logging level for socket logs. Possible values: none, full, error, warn, info, debug, trace</td>
     </tr>
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_NAME</code></td>
@@ -1017,7 +1021,7 @@ surreal start --allow-all true
       <td scope="row" data-label="Command">`ml export`</td>
       <td scope="row" data-label="Default">none</td>
       <td scope="row" data-label="Allowed values">A string</td>
-      <td scope="row" data-label="Details">The name of the model.</td>
+      <td scope="row" data-label="Notes">The name of the model.</td>
     </tr>
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_NAMESPACE</code></td>
@@ -1025,7 +1029,7 @@ surreal start --allow-all true
       <td scope="row" data-label="Command">`sql`</td>
       <td scope="row" data-label="Default">main</td>
       <td scope="row" data-label="Allowed values">A string</td>
-      <td scope="row" data-label="Details">The namespace to connect to via the REPL.</td>
+      <td scope="row" data-label="Notes">The namespace to connect to via the REPL.</td>
     </tr>
 <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_NAMESPACE</code></td>
@@ -1033,7 +1037,7 @@ surreal start --allow-all true
       <td scope="row" data-label="Command">`export`, `import`</td>
       <td scope="row" data-label="Default">none</td>
       <td scope="row" data-label="Allowed values">A string</td>
-      <td scope="row" data-label="Details">The namespace selected for the import/export operation.</td>
+      <td scope="row" data-label="Notes">The namespace selected for the import/export operation.</td>
     </tr>
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_NO_BANNER</code></td>
@@ -1041,7 +1045,7 @@ surreal start --allow-all true
       <td scope="row" data-label="Command">`start`</td>
       <td scope="row" data-label="Default">false</td>
       <td scope="row" data-label="Allowed values">true, false</td>
-      <td scope="row" data-label="Details">Whether to hide the startup banner.</td>
+      <td scope="row" data-label="Notes">Whether to hide the startup banner.</td>
     </tr>
 <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_NO_DEFAULTS</code><Since v="v3.0.0" /></td>
@@ -1049,7 +1053,7 @@ surreal start --allow-all true
       <td scope="row" data-label="Command"><code>`start`</code></td>
       <td scope="row" data-label="Default">false</td>
       <td scope="row" data-label="Allowed values">true, false</td>
-      <td scope="row" data-label="Details">Whether to disable default namespace and database creation. Conflicts with SURREAL_DEFAULT_DATABASE and SURREAL_DEFAULT_NAMESPACE, which set a default value for namespace and database for a new instance.</td>
+      <td scope="row" data-label="Notes">Whether to disable default namespace and database creation. Conflicts with SURREAL_DEFAULT_DATABASE and SURREAL_DEFAULT_NAMESPACE, which set a default value for namespace and database for a new instance.</td>
     </tr>
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_NO_IDENTIFICATION_HEADERS</code></td>
@@ -1057,7 +1061,7 @@ surreal start --allow-all true
       <td scope="row" data-label="Command">`start`</td>
       <td scope="row" data-label="Default">false</td>
       <td scope="row" data-label="Allowed values">true, false</td>
-      <td scope="row" data-label="Details">Whether to suppress the server name and version headers.</td>
+      <td scope="row" data-label="Notes">Whether to suppress the server name and version headers.</td>
     </tr>
 <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_NODE_MEMBERSHIP_CHECK_INTERVAL</code></td>
@@ -1089,15 +1093,15 @@ surreal start --allow-all true
       <td scope="row" data-label="Command">`export`, `import`, `sql`, `start`</td>
       <td scope="row" data-label="Default">none</td>
       <td scope="row" data-label="Allowed values">A string</td>
-      <td scope="row" data-label="Details">Database authentication password to use when connecting.</td>
+      <td scope="row" data-label="Notes">Database authentication password to use when connecting.</td>
     </tr>
     <tr>
-      <td scope="row" data-label="Env var">`SURREAL_PATH`</td>
+      <td scope="row" data-label="Env var">SURREAL_PATH</td>
       <td scope="row" data-label="Command arg"><code>path</code></td>
       <td scope="row" data-label="Command">`fix`, `start`</td>
       <td scope="row" data-label="Default">memory</td>
       <td scope="row" data-label="Allowed values">A string</td>
-      <td scope="row" data-label="Details">Database path used for storing data. As a required argument (albeit with a default), it is not passed in via `--path`.</td>
+      <td scope="row" data-label="Notes">Database path used for storing data. As a required argument (albeit with a default), it is not passed in via `--path`.</td>
     </tr>
 <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_PLANNER_STRATEGY</code><Since v="v3.0.0" /></td>
@@ -1113,31 +1117,31 @@ surreal start --allow-all true
       <td scope="row" data-label="Command">`start`</td>
       <td scope="row" data-label="Default">none</td>
       <td scope="row" data-label="Allowed values">A duration</td>
-      <td scope="row" data-label="Details">The maximum duration that a set of statements can run for.</td>
+      <td scope="row" data-label="Notes">The maximum duration that a set of statements can run for.</td>
     </tr>
     <tr>
-      <td scope="row" data-label="Env var"><code>SURREAL_SLOW_QUERY_LOG_THRESHOLD</code><br /><code>slow-log-threshold</code> <Since v="v2.3.8" /></td>
-      <td scope="row" data-label="Command arg"><code>slow-query-log-threshold</code></td>
+      <td scope="row" data-label="Env var"><code>SURREAL_SLOW_QUERY_LOG_THRESHOLD</code><br /><Since v="v2.3.8" /></td>
+      <td scope="row" data-label="Command arg"><code>slow-log-threshold</code></td>
       <td scope="row" data-label="Command">`start`</td>
       <td scope="row" data-label="Default">none</td>
       <td scope="row" data-label="Allowed values">A duration</td>
-      <td scope="row" data-label="Details">A duration specifying the minimum execution time after which a log is made to indicate a slow query</td>
+      <td scope="row" data-label="Notes">A duration specifying the minimum execution time after which a log is made to indicate a slow query</td>
     </tr>
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_SLOW_QUERY_LOG_PARAM_ALLOW</code><br /><code>slow-log-param-allow</code> <Since v="v2.3.9" /></td>
-      <td scope="row" data-label="Command arg"><code>slow-query-log-param-allow</code></td>
+      <td scope="row" data-label="Command arg"><code>slow-log-param-allow</code></td>
       <td scope="row" data-label="Command">`start`</td>
       <td scope="row" data-label="Default">none</td>
       <td scope="row" data-label="Allowed values">Comma-separated strings</td>
-      <td scope="row" data-label="Details">A comma-separated list of parameter names to include in slow query logs.</td>
+      <td scope="row" data-label="Notes">A comma-separated list of parameter names to include in slow query logs.</td>
     </tr>
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_SLOW_QUERY_LOG_PARAM_DENY</code><Since v="v2.3.9" /></td>
-      <td scope="row" data-label="Command arg"><code>slow-query-log-param-deny</code></td>
+      <td scope="row" data-label="Command arg"><code>slow-log-param-deny</code></td>
       <td scope="row" data-label="Command">`start`</td>
       <td scope="row" data-label="Default">none</td>
       <td scope="row" data-label="Allowed values">Comma-separated strings</td>
-      <td scope="row" data-label="Details">A comma-separated list of parameter names to omit from slow query logs.</td>
+      <td scope="row" data-label="Notes">A comma-separated list of parameter names to omit from slow query logs.</td>
     </tr>
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_STRICT</code></td>
@@ -1145,7 +1149,7 @@ surreal start --allow-all true
       <td scope="row" data-label="Command">`start`</td>
       <td scope="row" data-label="Default">false</td>
       <td scope="row" data-label="Allowed values">true, false</td>
-      <td scope="row" data-label="Details">Whether strict mode is enabled on this database instance.</td>
+      <td scope="row" data-label="Notes">Whether strict mode is enabled on this database instance.</td>
     </tr>
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_TEMPORARY_DIRECTORY</code></td>
@@ -1153,7 +1157,7 @@ surreal start --allow-all true
       <td scope="row" data-label="Command">`start`</td>
       <td scope="row" data-label="Default">none</td>
       <td scope="row" data-label="Allowed values">String to a directory</td>
-      <td scope="row" data-label="Details">Sets the directory for storing temporary database files</td>
+      <td scope="row" data-label="Notes">Sets the directory for storing temporary database files</td>
     </tr>
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_TOKEN</code></td>
@@ -1161,7 +1165,7 @@ surreal start --allow-all true
       <td scope="row" data-label="Command">`export`, `import`, `sql`</td>
       <td scope="row" data-label="Default">none</td>
       <td scope="row" data-label="Allowed values">A string</td>
-      <td scope="row" data-label="Details">Authentication token in JWT format to use when connecting.</td>
+      <td scope="row" data-label="Notes">Authentication token in JWT format to use when connecting.</td>
     </tr>
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_TRANSACTION_TIMEOUT</code></td>
@@ -1169,7 +1173,7 @@ surreal start --allow-all true
       <td scope="row" data-label="Command">`start`</td>
       <td scope="row" data-label="Default">none</td>
       <td scope="row" data-label="Allowed values">A duration</td>
-      <td scope="row" data-label="Details">The maximum duration that any single transaction can run for.</td>
+      <td scope="row" data-label="Notes">The maximum duration that any single transaction can run for.</td>
     </tr>
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_UNAUTHENTICATED</code></td>
@@ -1177,7 +1181,7 @@ surreal start --allow-all true
       <td scope="row" data-label="Command">`start`</td>
       <td scope="row" data-label="Default">false</td>
       <td scope="row" data-label="Allowed values">true, false</td>
-      <td scope="row" data-label="Details">Whether to allow unauthenticated access.</td>
+      <td scope="row" data-label="Notes">Whether to allow unauthenticated access.</td>
     </tr>
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_USER</code></td>
@@ -1185,7 +1189,7 @@ surreal start --allow-all true
       <td scope="row" data-label="Command">`export`, `import`, `sql`, start</td>
       <td scope="row" data-label="Default">none</td>
       <td scope="row" data-label="Allowed values">A string</td>
-      <td scope="row" data-label="Details">Database authentication username to use when connecting.</td>
+      <td scope="row" data-label="Notes">Database authentication username to use when connecting.</td>
     </tr>
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_VERSION</code></td>
@@ -1193,7 +1197,7 @@ surreal start --allow-all true
       <td scope="row" data-label="Command">`ml export`</td>
       <td scope="row" data-label="Default">none</td>
       <td scope="row" data-label="Allowed values">A string</td>
-      <td scope="row" data-label="Details">The version of the ML model.</td>
+      <td scope="row" data-label="Notes">The version of the ML model.</td>
     </tr>
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_WEB_CRT</code></td>
@@ -1201,7 +1205,7 @@ surreal start --allow-all true
       <td scope="row" data-label="Command">`start`</td>
       <td scope="row" data-label="Default">none</td>
       <td scope="row" data-label="Allowed values">String to a path</td>
-      <td scope="row" data-label="Details">Path to the certificate file for encrypted client connections.</td>
+      <td scope="row" data-label="Notes">Path to the certificate file for encrypted client connections.</td>
     </tr>
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_WEB_KEY</code></td>
@@ -1209,46 +1213,14 @@ surreal start --allow-all true
       <td scope="row" data-label="Command">`start`</td>
       <td scope="row" data-label="Default">none</td>
       <td scope="row" data-label="Allowed values">String to a path</td>
-      <td scope="row" data-label="Details">Path to the private key file for encrypted client connections.</td>
+      <td scope="row" data-label="Notes">Path to the private key file for encrypted client connections.</td>
     </tr>
   </tbody>
 </table>
 
-## Environment variables by storage backend
+## Storage backend environment variables
 
 These environment variables are used to configure the storage backend for SurrealDB.
-
-### FoundationDB environment variables
-
-> [!WARNING]
-> FoundationDB support is deprecated in SurrealDB `3.0`. Please plan to migrate to a supported storage backend.
-
-<table>
-  <thead>
-    <tr>
-      <th scope="col">Environment variable</th>
-      <th scope="col">Default value</th>
-      <th scope="col">Notes</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td scope="row" data-label="Env var"><code>SURREAL_FOUNDATIONDB_TRANSACTION_MAX_RETRY_DELAY</code></td>
-      <td scope="row" data-label="Default">500</td>
-      <td scope="row" data-label="Notes">The maximum delay between transaction retries in milliseconds.</td>
-    </tr>
-    <tr>
-      <td scope="row" data-label="Env var"><code>SURREAL_FOUNDATIONDB_TRANSACTION_RETRY_LIMIT</code></td>
-      <td scope="row" data-label="Default">5</td>
-      <td scope="row" data-label="Notes">The maximum number of times a transaction can be retried.</td>
-    </tr>
-    <tr>
-      <td scope="row" data-label="Env var"><code>SURREAL_FOUNDATIONDB_TRANSACTION_TIMEOUT</code></td>
-      <td scope="row" data-label="Default">5000</td>
-      <td scope="row" data-label="Notes">The maximum transaction timeout in milliseconds.</td>
-    </tr>
-  </tbody>
-</table>
 
 ### RocksDB environment variables
 
@@ -1393,8 +1365,8 @@ The available environment variables for configuring a RocksDB instance are:
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_ROCKSDB_GROUPED_COMMIT_TIMEOUT</code></td>
       <td scope="row" data-label="Default">5ms</td>
-      <td scope="row" data-label="Allowed values">A usize</td>
-      <td scope="row" data-label="Notes">The maximum wait time in microseconds before forcing a grouped commit. Used to ensure that transactions do not wait indefinitely when concurrency is low, and to balance between transaction latency and write throughput.</td>
+      <td scope="row" data-label="Allowed values">A duration</td>
+      <td scope="row" data-label="Notes">The maximum wait time in nanosecond before forcing a grouped commit. Used to ensure that transactions do not wait indefinitely when concurrency is low, and to balance between transaction latency and write throughput.</td>
     </tr>
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_ROCKSDB_GROUPED_COMMIT_WAIT_THRESHOLD</code></td>
@@ -1617,6 +1589,38 @@ The available environment variables for configuring a RocksDB instance are:
       <td scope="row" data-label="Default">10</td>
       <td scope="row" data-label="Allowed values">A usize</td>
       <td scope="row" data-label="Notes">The duration in seconds for requests before they time out.</td>
+    </tr>
+  </tbody>
+</table>
+
+### FoundationDB environment variables
+
+> [!WARNING]
+> FoundationDB support is deprecated in SurrealDB `3.0`. Please plan to migrate to a supported storage backend.
+
+<table>
+  <thead>
+    <tr>
+      <th scope="col">Environment variable</th>
+      <th scope="col">Default value</th>
+      <th scope="col">Notes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td scope="row" data-label="Env var"><code>SURREAL_FOUNDATIONDB_TRANSACTION_MAX_RETRY_DELAY</code></td>
+      <td scope="row" data-label="Default">500</td>
+      <td scope="row" data-label="Notes">The maximum delay between transaction retries in milliseconds.</td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Env var"><code>SURREAL_FOUNDATIONDB_TRANSACTION_RETRY_LIMIT</code></td>
+      <td scope="row" data-label="Default">5</td>
+      <td scope="row" data-label="Notes">The maximum number of times a transaction can be retried.</td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Env var"><code>SURREAL_FOUNDATIONDB_TRANSACTION_TIMEOUT</code></td>
+      <td scope="row" data-label="Default">5000</td>
+      <td scope="row" data-label="Notes">The maximum transaction timeout in milliseconds.</td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
https://github.com/surrealdb/surrealdb/pull/6974 restructures the env var config and uses a number of structs that represent configuration for parts of the database. This PR follows that layout to make the vast number of env vars easier to read and search through.