### PR TITLE
Give duration own page, restructure section

### DIFF
--- a/src/content/doc-surrealql/datamodel/casting.mdx
+++ b/src/content/doc-surrealql/datamodel/casting.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 21
 sidebar_label: Casting
 title: Casting | SurrealQL
 description: In the SurrealDB type system, values can be converted to other values efficiently.

--- a/src/content/doc-surrealql/datamodel/closures.mdx
+++ b/src/content/doc-surrealql/datamodel/closures.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 5
 sidebar_label: Closures
 title: Closures | SurrealQL
 description: Anonymous functions in SurrealDB allow you to define small, reusable pieces of logic that can be used throughout your queries.

--- a/src/content/doc-surrealql/datamodel/datetimes.mdx
+++ b/src/content/doc-surrealql/datamodel/datetimes.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 6
 sidebar_label: Datetimes
 title: Datetimes | SurrealQL
 description: SurrealDB has native support for datetimes with nanosecond precision. SurrealDB is able to parse datetimes from strings.
@@ -10,9 +10,7 @@ description: SurrealDB has native support for datetimes with nanosecond precisio
 
 SurrealDB has native support for datetimes with nanosecond precision. SurrealDB automatically parses and understands datetimes which are written as strings in the SurrealQL language. Times must also be formatted in [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339) format.
 
-
-> [!NOTE]
-> As of `v2.0.0`, SurrealDB no longer eagerly converts a string into a datetime. An implicit `d` prefix or cast using `<datetime>` is required instead.
+Datetimes are represented and created by a `d` prefex in front of a string.
 
 ```surql
 /**[test]
@@ -209,57 +207,6 @@ CREATE event SET time = d"2025-07-03T07:18:52.841147Z" + 1h30m20s1350ms;
 ```surql title="Response"
 [{ id: event:5uuzy32t48yutxyszi7p, time: d'2025-07-03T08:49:14.191147Z' }]
 ```
-
-### Duration units
-
-Durations can be specified in any of the following units:
-
-<table>
-    <thead>
-    <tr>
-        <th scope="col">Unit</th>
-        <th scope="col">Description</th>
-    </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td scope="row" data-label="Type">ns</td>
-            <td scope="row" data-label="Description">Nanoseconds</td>
-        </tr>
-        <tr>
-            <td scope="row" data-label="Type">us</td>
-            <td scope="row" data-label="Description">Microseconds, alternative: µs</td>
-        </tr>
-        <tr>
-            <td scope="row" data-label="Type">ms</td>
-            <td scope="row" data-label="Description">Milliseconds</td>
-        </tr>
-        <tr>
-            <td scope="row" data-label="Type">s</td>
-            <td scope="row" data-label="Description">Seconds</td>
-        </tr>
-        <tr>
-            <td scope="row" data-label="Type">m</td>
-            <td scope="row" data-label="Description">Minutes</td>
-        </tr>
-        <tr>
-            <td scope="row" data-label="Type">h</td>
-            <td scope="row" data-label="Description">Hours</td>
-        </tr>
-        <tr>
-            <td scope="row" data-label="Type">d</td>
-            <td scope="row" data-label="Description">Days</td>
-        </tr>
-        <tr>
-            <td scope="row" data-label="Type">w</td>
-            <td scope="row" data-label="Description">Weeks</td>
-        </tr>
-        <tr>
-            <td scope="row" data-label="Type">y</td>
-            <td scope="row" data-label="Description">Years</td>
-        </tr>
-    </tbody>
-</table>
 
 ## Next steps
 You've now seen how to store, modify, and handle dates and times in SurrealDB. For more advanced functionality, take a look at the [time](/docs/surrealql/functions/database/time) functions, which enable extracting, altering, rounding, and grouping datetimes into specific time intervals.

--- a/src/content/doc-surrealql/datamodel/durations.mdx
+++ b/src/content/doc-surrealql/datamodel/durations.mdx
@@ -1,0 +1,129 @@
+---
+sidebar_position: 7
+sidebar_label: Durations
+title: Durations | SurrealQL
+description: SurrealDB has native support for durations with nanosecond precision. SurrealDB is able to parse durations from strings.
+
+---
+
+import Since from '@components/shared/Since.astro'
+
+# Durations
+
+A `duration` represents a non-negative period of time.
+
+## Duration units
+
+Durations can be specified in any of the following units:
+
+<table>
+    <thead>
+    <tr>
+        <th scope="col">Unit</th>
+        <th scope="col">Description</th>
+    </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td scope="row" data-label="Type">ns</td>
+            <td scope="row" data-label="Description">Nanoseconds</td>
+        </tr>
+        <tr>
+            <td scope="row" data-label="Type">us</td>
+            <td scope="row" data-label="Description">Microseconds, alternative: µs</td>
+        </tr>
+        <tr>
+            <td scope="row" data-label="Type">ms</td>
+            <td scope="row" data-label="Description">Milliseconds</td>
+        </tr>
+        <tr>
+            <td scope="row" data-label="Type">s</td>
+            <td scope="row" data-label="Description">Seconds</td>
+        </tr>
+        <tr>
+            <td scope="row" data-label="Type">m</td>
+            <td scope="row" data-label="Description">Minutes</td>
+        </tr>
+        <tr>
+            <td scope="row" data-label="Type">h</td>
+            <td scope="row" data-label="Description">Hours</td>
+        </tr>
+        <tr>
+            <td scope="row" data-label="Type">d</td>
+            <td scope="row" data-label="Description">Days</td>
+        </tr>
+        <tr>
+            <td scope="row" data-label="Type">w</td>
+            <td scope="row" data-label="Description">Weeks</td>
+        </tr>
+        <tr>
+            <td scope="row" data-label="Type">y</td>
+            <td scope="row" data-label="Description">Years</td>
+        </tr>
+    </tbody>
+</table>
+
+## Creating and using durations
+
+A duration can be composed of any number of duration units.
+
+```surql
+1y40w20h;
+```
+
+A duration that contains multiple instances of the same unit type will parse as well, combining lesser units into greater units when a maximum value is reached.
+
+For example, a duration that includes `12h` two times will be evaluated as `1d`.
+
+```surql
+1d1d12h12h;
+-- 3d
+```
+
+A duration can also be created by casting a string.
+
+```surql
+<duration>"1d1d12h12h";
+-- 3d
+```
+
+A duration can be zero, but cannot be negative.
+
+```surql
+0ns;
+0d; -- Evaluates to 0ns
+```
+
+The maximum possible duration can be accessed via the const [`duration::max`](/docs/surrealql/functions/database/duration#durationmax), above which a duration cannot be formed.
+
+```surql
+duration::max;
+-- 584942417355y3w5d7h15s999ms999µs999ns
+
+duration::max + 1ns
+-- 'Failed to compute: "584942417355y3w5d7h15s999ms999µs999ns + 1ns", as the operation results in an arithmetic overflow.'
+```
+
+Durations can be added to and subtracted from other durations as well as datetimes.
+
+```surql
+d'1970-01-01' + 1d;
+-- d'1970-01-02T00:00:00Z'
+
+1y - 6w;
+46w1d;
+```
+
+## Multiplying and dividing durations
+
+<Since v="v3.0.1" />
+
+A duration can be multiplied and divided by a number.
+
+```surql
+1d / 24;
+-- 1h
+
+1d * 5.5;
+-- 5d12h
+```

--- a/src/content/doc-surrealql/datamodel/files.mdx
+++ b/src/content/doc-surrealql/datamodel/files.mdx
@@ -72,9 +72,14 @@ A combination of files and SurrealDB's [encoding functions](/docs/surrealql/func
 
 The following example shows how this pattern might be used for temporary storage such as a user's shopping cart during a single session.
 
+```bash
+# Set the allowlist env var to allow the directory to be accesses
+SURREAL_BUCKET_FOLDER_ALLOWLIST="/users/your_user_name" surreal start --allow-experimental files
+```
+
 ```surql
 -- Set up the in-memory backend
-DEFINE BUCKET shopping_carts BACKEND "memory";
+DEFINE BUCKET my_bucket BACKEND "file:/users/your_user_name";
 
 -- Convenience functions to save, decode back into
 -- SurrealQL type, and delete

--- a/src/content/doc-surrealql/datamodel/formatters.mdx
+++ b/src/content/doc-surrealql/datamodel/formatters.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 9
+sidebar_position: 22
 sidebar_label: Formatters
 title: Formatters | SurrealQL
 description: Formatting functions in SurrealQL accept certain text formats for date/time formatting.

--- a/src/content/doc-surrealql/datamodel/futures.mdx
+++ b/src/content/doc-surrealql/datamodel/futures.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 10
+sidebar_position: 9
 sidebar_label: Futures
 title: Futures | SurrealQL
 description: Futures are values which are only computed when the data is selected and returned to the client.

--- a/src/content/doc-surrealql/datamodel/geometries.mdx
+++ b/src/content/doc-surrealql/datamodel/geometries.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 11
+sidebar_position: 10
 sidebar_label: Geometries
 title: Geometries | SurrealQL
 description: SurrealDB makes working with GeoJSON easy, with support for Point, LineString, Polygon, MultiPoint, MultiLineString, MultiPolygon, and Collection values.

--- a/src/content/doc-surrealql/datamodel/idioms.mdx
+++ b/src/content/doc-surrealql/datamodel/idioms.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 12
+sidebar_position: 24
 sidebar_label: Idioms
 title: Idioms | SurrealQL
 description: Accessing and manipulating data using idioms (paths) in SurrealQL.

--- a/src/content/doc-surrealql/datamodel/ids.mdx
+++ b/src/content/doc-surrealql/datamodel/ids.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 17
+sidebar_position: 15
 sidebar_label: Record IDs
 title: Record IDs | SurrealQL
 description: In SurrealDB, document record IDs store both the table name, and the record ID.

--- a/src/content/doc-surrealql/datamodel/literals.mdx
+++ b/src/content/doc-surrealql/datamodel/literals.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 12
+sidebar_position: 23
 sidebar_label: Literals
 title: Literals | SurrealQL
 description: A value that may have multiple representations or formats.

--- a/src/content/doc-surrealql/datamodel/none-and-null.mdx
+++ b/src/content/doc-surrealql/datamodel/none-and-null.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 13
+sidebar_position: 11
 sidebar_label: None and Null
 title: None and Null | SurrealQL
 description: SurrealDB uses two types called None and Null to represent two different ways in which data may not exist.

--- a/src/content/doc-surrealql/datamodel/numbers.mdx
+++ b/src/content/doc-surrealql/datamodel/numbers.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 14
+sidebar_position: 12
 sidebar_label: Numbers
 title: Numbers | SurrealQL
 description: In SurrealDB, numbers can be one of three types - 64-bit integers, 64-bit floating point numbers, or 128-bit decimal numbers.

--- a/src/content/doc-surrealql/datamodel/objects.mdx
+++ b/src/content/doc-surrealql/datamodel/objects.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 15
+sidebar_position: 13
 sidebar_label: Objects
 title: Objects | SurrealQL
 description: SurrealDB records can store objects with fields that can also hold other objects or arrays

--- a/src/content/doc-surrealql/datamodel/ranges.mdx
+++ b/src/content/doc-surrealql/datamodel/ranges.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 16
+sidebar_position: 14
 sidebar_label: Ranges
 title: Ranges | SurrealQL
 description: A range of possible values.

--- a/src/content/doc-surrealql/datamodel/records.mdx
+++ b/src/content/doc-surrealql/datamodel/records.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 18
+sidebar_position: 25
 sidebar_label: Record links
 title: Record links | SurrealQL
 description: One of the most powerful features of SurrealDB is the ability to traverse from record-to-record without the need for traditional SQL JOINs. Each record ID points directly to a specific record in the database.

--- a/src/content/doc-surrealql/datamodel/references.mdx
+++ b/src/content/doc-surrealql/datamodel/references.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 19
+sidebar_position: 26
 sidebar_label: Record references
 title: Record references | SurrealQL
 description: Record references allow you to link records together, enabling you to traverse from one record to another.

--- a/src/content/doc-surrealql/datamodel/regex.mdx
+++ b/src/content/doc-surrealql/datamodel/regex.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 20
+sidebar_position: 16
 sidebar_label: Regex
 title: Regex | SurrealQL
 description: The regex type can 

--- a/src/content/doc-surrealql/datamodel/sets.mdx
+++ b/src/content/doc-surrealql/datamodel/sets.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 21
+sidebar_position: 17
 sidebar_label: Sets
 title: Sets | SurrealQL
 description: A set is a collection type of deduplicated and ordered values that can have a maximum size limit.

--- a/src/content/doc-surrealql/datamodel/strings.mdx
+++ b/src/content/doc-surrealql/datamodel/strings.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 22
+sidebar_position: 18
 sidebar_label: Strings
 title: Strings | SurrealQL
 description: Strings can be used to store text values. All string values can include Unicode values, emojis, tab characters, and line breaks.

--- a/src/content/doc-surrealql/datamodel/uuid.mdx
+++ b/src/content/doc-surrealql/datamodel/uuid.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 23
+sidebar_position: 19
 sidebar_label: UUIDs
 title: UUIDs | SurrealQL
 description: UUID values in SurrealQL represent UUID values

--- a/src/content/doc-surrealql/datamodel/values.mdx
+++ b/src/content/doc-surrealql/datamodel/values.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 24
+sidebar_position: 20
 sidebar_label: Values
 title: Values | SurrealQL
 description: Every type in SurrealDB is a value


### PR DESCRIPTION
Documentation for https://github.com/surrealdb/surrealdb/pull/6933

Plus gives `duration` its own section in the data types section, and reorders the section so that all the actual data types come first, followed by all the rest (casting, etc.).