### PR TITLE
Reorder sections a bit

### DIFF
--- a/src/content/doc-surrealdb/cli/_category_.json
+++ b/src/content/doc-surrealdb/cli/_category_.json
@@ -1,4 +1,4 @@
 {
     "sidebar_label": "CLI and database serving",
-    "sidebar_position": 8
+    "sidebar_position": 7
 }

--- a/src/content/doc-surrealdb/extensions/_category_.json
+++ b/src/content/doc-surrealdb/extensions/_category_.json
@@ -1,4 +1,4 @@
 {
     "sidebar_label": "Extensions",
-    "sidebar_position": 7
+    "sidebar_position": 8
 }

--- a/src/content/doc-surrealdb/migrating/_category_.json
+++ b/src/content/doc-surrealdb/migrating/_category_.json
@@ -1,4 +1,4 @@
 {
     "sidebar_label": "Migrating",
-    "sidebar_position": 5
+    "sidebar_position": 4
 }

--- a/src/content/doc-surrealdb/models/_category_.json
+++ b/src/content/doc-surrealdb/models/_category_.json
@@ -1,4 +1,4 @@
 {
     "sidebar_label": "Data Models",
-    "sidebar_position": 4
+    "sidebar_position": 6
 }

--- a/src/content/doc-surrealdb/querying/_category_.json
+++ b/src/content/doc-surrealdb/querying/_category_.json
@@ -1,4 +1,4 @@
 {
     "sidebar_label": "Querying",
-    "sidebar_position": 6
+    "sidebar_position": 5
 }


### PR DESCRIPTION
Reorders a few sections (no structural changes).

Reasons:

* Surreal Sync continues to expand and this will likely be the section that users of other databases will want to see after installation (other users will just skip over this part)
* Once that's done then it's time to learn the basics of querying
* Follow up with data models which is effectively an expansion of the same
* CLI commands move up a step as they are more of a core item to know compared to Surrealism extensions.