### PR TITLE
Fix missing installation command argument

### DIFF
--- a/src/content/doc-surrealdb/installation/linux.mdx
+++ b/src/content/doc-surrealdb/installation/linux.mdx
@@ -38,7 +38,7 @@ curl -sSf https://install.surrealdb.com | sh
 To install a specific version of SurrealDB, a version argument (`-v` or `--version`) can be passed to the install script.
 
 ```bash
-curl -sSf https://install.surrealdb.com | sh -- -v <version>
+curl -sSf https://install.surrealdb.com | sh -s -- -v <version>
 ```
 
 ### Updating SurrealDB

--- a/src/content/doc-surrealdb/installation/macos.mdx
+++ b/src/content/doc-surrealdb/installation/macos.mdx
@@ -38,7 +38,7 @@ curl -sSf https://install.surrealdb.com | sh
 To install a specific version of SurrealDB, a version argument (`-v` or `--version`) can be passed to the install script.
 
 ```bash
-curl -sSf https://install.surrealdb.com | sh -- -v <version>
+curl -sSf https://install.surrealdb.com | sh -s -- -v <version>
 ```
 
 ### Updating SurrealDB


### PR DESCRIPTION
The installation command I added previously was missing the -s argument.