### PR TITLE
Change section title to 'SurrealML Overview'

### DIFF
--- a/src/content/doc-surrealml/index.mdx
+++ b/src/content/doc-surrealml/index.mdx
@@ -9,7 +9,7 @@ no_page_headings: true
 
 # SurrealML
 
-# SurrealML
+# SurrealML Overview
 
 SurrealML is an engine that seeks to do one thing, and one thing well: store and execute trained ML models. SurrealML does not intrude on the training frameworks that are already out there, instead works with them to ease the storage, loading, and execution of models. Someone using SurrealML will be able to train their model in a chosen framework in Python, save their model, and load and execute the model in either Python or Rust. The inference engine is composed of python bindings interacting with a core written in Rust. This means that the exact same code that the Python client calls will be running on a production node by itself, or in the database. While the SurrealML engine runs in the database, it is developed in a completely isolated Github repository, giving the user 100% freedom on how they deploy and interact with the SurrealML engine.
 


### PR DESCRIPTION
Updated the title of the SurrealML section to 'SurrealML Overview' for clarity.