### PR TITLE
chore: fix typo in DEFINE EVENT doc

### DIFF
--- a/src/content/doc-surrealql/statements/define/event.mdx
+++ b/src/content/doc-surrealql/statements/define/event.mdx
@@ -194,7 +194,7 @@ value = "NONE"
 -- CREATE event is triggered when a new record is inserted into the table.
 -- Here we are updating the status of the post to PUBLISHED
 -- when a new record is inserted into the publish_post table.
-DEFINE EVENT publish_post ON TABLE post
+DEFINE EVENT publish_post ON TABLE publish_post
     WHEN $event = "CREATE"
     THEN (
         UPDATE post SET status = "PUBLISHED" WHERE id = $after.post_id


### PR DESCRIPTION
The idea is to create a post when an `publish_post` is created.

Reference https://discord.com/channels/902568124350599239/902568124350599242/1492470400276238398