### PR TITLE
Fix JVM SDK versions to v2

### DIFF
--- a/src/content/doc-sdk-java/installation.mdx
+++ b/src/content/doc-sdk-java/installation.mdx
@@ -21,7 +21,7 @@ Install the [SurrealDB SDK](https://mvnrepository.com/artifact/com.surrealdb/sur
   <TabItem label="Gradle (Groovy)">
 ```groovy
 ext {
-    surrealdbVersion = "3.0.0-ALPHA.1"
+    surrealdbVersion = "2.0.0"
 }
 
 dependencies {
@@ -33,7 +33,7 @@ dependencies {
   <TabItem value="gradle-kotlin" label="Gradle (Kotlin)">
 
 ```kotlin
-val surrealdbVersion by extra("3.0.0-ALPHA.1")
+val surrealdbVersion by extra("2.0.0")
 
 dependencies {
     implementation("com.surrealdb:surrealdb:${surrealdbVersion}")
@@ -45,7 +45,7 @@ dependencies {
 <dependency>
     <groupId>com.surrealdb</groupId>
     <artifactId>surrealdb</artifactId>
-    <version>3.0.0-ALPHA.1</version>
+    <version>2.0.0</version>
 </dependency>
 ```
   </TabItem>


### PR DESCRIPTION
Currently the Java SDK only ships v2 (same goes for the rest of the JVM ecosystem) as such the docs need to reflect this properly.

Closes #1711 