### PR TITLE
Change SHOW statement output

### DIFF
--- a/src/content/doc-sdk-java/concepts/live-queries.mdx
+++ b/src/content/doc-sdk-java/concepts/live-queries.mdx
@@ -88,4 +88,4 @@ try (LiveStream stream = db.selectLive("users")) {
 - [LiveStream API reference](/docs/sdk/java/api/core/live-stream) for stream and notification details
 - [Connecting to SurrealDB](/docs/sdk/java/concepts/connecting-to-surrealdb) for WebSocket connection setup
 - [SurrealQL LIVE SELECT](/docs/surrealql/statements/live) for the underlying query syntax
-- [DEFINE TABLE ... CHANGEFEED](/docs/surrealql/statements/define/table) for configuring change feeds on tables
+- [DEFINE TABLE ... CHANGEFEED](/docs/surrealql/statements/define/table) for configuring changefeeds on tables

--- a/src/content/doc-surrealql/statements/define/table.mdx
+++ b/src/content/doc-surrealql/statements/define/table.mdx
@@ -86,8 +86,10 @@ DEFINE TABLE reading DROP;
 
 The following expression shows how you can define a `CHANGEFEED` for a table. After creating, updating, and deleting records in the table as usual, using `SHOW CHANGES FOR` will show the changes that have taken place during this time.
 
+If an entry holds a change to an existing record, the diff will show the operation needed to modify the record to the state immediately preceding its current state. In other words, the diff included is a reverse diff.
+
 ```surql
--- Define the change feed and its duration
+-- Define the changefeed and its duration
 -- Optionally, append INCLUDE ORIGINAL to include info
 -- on the current record before a change took place
 DEFINE TABLE reading CHANGEFEED 3d;
@@ -95,10 +97,11 @@ DEFINE TABLE reading CHANGEFEED 3d;
 -- Create some records in the reading table
 CREATE reading SET story = "Once upon a time";
 CREATE reading SET story = "there was a database";
+UPDATE reading SET is_interesting = true;
 
 -- Replay changes to the reading table since a certain date
 -- Must be after the timestamp at which the changefeed began
-SHOW CHANGES FOR TABLE reading SINCE d"2023-09-07T01:23:52Z" LIMIT 10;
+SHOW CHANGES FOR TABLE reading SINCE d"2025-09-07T01:23:52Z" LIMIT 10;
 
 -- Alternatively, show the changes for the table since a version number
 SHOW CHANGES FOR TABLE reading SINCE 0 LIMIT 10;
@@ -106,89 +109,157 @@ SHOW CHANGES FOR TABLE reading SINCE 0 LIMIT 10;
 
 ```surql title="Response without INCLUDE ORIGINAL"
 [
-    {
-        "changes": [
-            {
-                "define_table": {
-                    "name": "reading"
-                }
-            }
-        ],
-        "versionstamp": 29
-    },
-    {
-        "changes": [
-            {
-                "update": {
-                    "id": "reading:h1gcbc7ykbpslellh2g2",
-                    "story": "Once upon a time"
-                }
-            }
-        ],
-        "versionstamp": 30
-    },
-    {
-        "changes": [
-            {
-                "update": {
-                    "id": "reading:l9qfcncklhnlklby1avf",
-                    "story": "there was a database"
-                }
-            }
-        ],
-        "versionstamp": 31
-    }
+	{
+		changes: [
+			{
+				define_table: {
+					changefeed: {
+						expiry: 3d,
+						original: false
+					},
+					drop: false,
+					id: 0,
+					kind: {
+						kind: 'ANY'
+					},
+					name: 'reading',
+					permissions: {
+						create: false,
+						delete: false,
+						select: false,
+						update: false
+					},
+					schemafull: false
+				}
+			}
+		],
+		versionstamp: 116395447100768256
+	},
+	{
+		changes: [
+			{
+				update: {
+					id: reading:bqlejs8fx4phgbo6g5ve,
+					story: 'Once upon a time'
+				}
+			}
+		],
+		versionstamp: 116395447100833792
+	},
+	{
+		changes: [
+			{
+				update: {
+					id: reading:fa8o65ccxykfxqqz91yo,
+					story: 'there was a database'
+				}
+			}
+		],
+		versionstamp: 116395447100833793
+	},
+	{
+		changes: [
+			{
+				update: {
+					id: reading:bqlejs8fx4phgbo6g5ve,
+					is_interesting: true,
+					story: 'Once upon a time'
+				}
+			},
+			{
+				update: {
+					id: reading:fa8o65ccxykfxqqz91yo,
+					is_interesting: true,
+					story: 'there was a database'
+				}
+			}
+		],
+		versionstamp: 116395447100833794
+	}
 ]
 ```
 
 ```surql title="Response with INCLUDE ORIGINAL"
 [
-    {
-        "changes": [
-            {
-                "define_table": {
-                    "name": "reading"
-                }
-            }
-        ],
-        "versionstamp": 29
-    },
-    {
-        "changes": [
-            {
-                "current": {
-                    "id": "reading:2j3rc2yw1jzspcuvfe9v",
-                    "story": "Once upon a time"
-                },
-                "update": [
-                    {
-                        "op": "replace",
-                        "path": "/",
-                        "value": null
-                    }
-                ]
-            }
-        ],
-        "versionstamp": 30
-    },
-    {
-        "changes": [
-            {
-                "current": {
-                    "id": "reading:iuiurhi0y2ka0by0skqi",
-                    "story": "there was a database"
-                },
-                "update": [
-                    {
-                        "op": "replace",
-                        "path": "/",
-                        "value": null
-                    }
-                ]
-            }
-        ],
-        "versionstamp": 31
-    }
+	{
+		changes: [
+			{
+				define_table: {
+					changefeed: {
+						expiry: 3d,
+						original: true
+					},
+					drop: false,
+					id: 0,
+					kind: {
+						kind: 'ANY'
+					},
+					name: 'reading',
+					permissions: {
+						create: false,
+						delete: false,
+						select: false,
+						update: false
+					},
+					schemafull: false
+				}
+			}
+		],
+		versionstamp: 116395448975818752
+	},
+	{
+		changes: [
+			{
+				update: {
+					id: reading:kypj876yubk4fnnja93b,
+					story: 'Once upon a time'
+				}
+			}
+		],
+		versionstamp: 116395448975818753
+	},
+	{
+		changes: [
+			{
+				update: {
+					id: reading:0i2qwoi053nmrl4k2wm2,
+					story: 'there was a database'
+				}
+			}
+		],
+		versionstamp: 116395448975818754
+	},
+	{
+		changes: [
+			{
+				current: {
+					id: reading:0i2qwoi053nmrl4k2wm2,
+					is_interesting: true,
+					story: 'there was a database'
+				},
+				update: [
+					{
+						op: 'remove',
+						path: '/is_interesting'
+					}
+				]
+			},
+			{
+				current: {
+					id: reading:kypj876yubk4fnnja93b,
+					is_interesting: true,
+					story: 'Once upon a time'
+				},
+				update: [
+					{
+						op: 'remove',
+						path: '/is_interesting'
+					}
+				]
+			}
+		],
+		versionstamp: 116395448975818755
+	}
 ]
 ```
 

--- a/src/content/doc-surrealql/statements/show.mdx
+++ b/src/content/doc-surrealql/statements/show.mdx
@@ -7,9 +7,9 @@ description: The SHOW statement can be used to replay changes made to a table.
 
 # `SHOW` statement
 
-changefeeds allows you to retrieve and sync changes from SurrealDB to external systems and platforms using the `SHOW` statement.
+Changefeeds allows you to retrieve and sync changes from SurrealDB to external systems and platforms using the `SHOW` statement.
 
-The `SHOW` statement can be used to replay changes made to a table.
+For updates to existing records, the shape of each mutation depends on how the changefeed was defined on the table. When you use `INCLUDE ORIGINAL` with `CHANGEFEED`, stored differences are **reverse diffs**: they describe the changes required to go from the record’s state after the write **back** to the state immediately before it.
 
 
 ## Requirements
@@ -47,11 +47,11 @@ The following expression shows usage of the SHOW statement.
 -- Optionally, append INCLUDE ORIGINAL to include info
 -- on the operation that would be needed to have the
 -- state at that point match the previous state
-DEFINE TABLE reading CHANGEFEED 3d;
+DEFINE TABLE reading CHANGEFEED 3d INCLUDE ORIGINAL;
 
 -- Create some records in the reading table
-CREATE reading SET story = "Once upon a time";
-CREATE reading SET story = "there was a database";
+CREATE reading SET story += ["Once upon a time"];
+UPDATE reading SET story += ["there was a database"];
 
 -- Replay changes to the reading table since a date
 SHOW CHANGES FOR TABLE reading SINCE d"2023-09-07T01:23:52Z" LIMIT 10;
@@ -67,33 +67,118 @@ Assuming the datetime above matches with the one when the changefeed was establi
 		changes: [
 			{
 				define_table: {
-					name: 'reading'
+					changefeed: {
+						expiry: 3d,
+						original: false
+					},
+					drop: false,
+					id: 0,
+					kind: {
+						kind: 'ANY'
+					},
+					name: 'reading',
+					permissions: {
+						create: false,
+						delete: false,
+						select: false,
+						update: false
+					},
+					schemafull: false
 				}
 			}
 		],
-		versionstamp: 65536
+		versionstamp: 116395873313095680
 	},
 	{
 		changes: [
 			{
 				update: {
-					id: reading:bavjgpnhkgvudfg4mg16,
-					story: 'Once upon a time'
+					id: reading:kpqxnt8h4me84zed9fgf,
+					story: [
+						'Once upon a time'
+					]
 				}
 			}
 		],
-		versionstamp: 131072
+		versionstamp: 116395873313161216
 	},
 	{
 		changes: [
 			{
 				update: {
-					id: reading:liq4e7hzjaw7bp5t4pn1,
-					story: 'there was a database'
+					id: reading:kpqxnt8h4me84zed9fgf,
+					story: [
+						'Once upon a time',
+						'there was a database'
+					]
 				}
 			}
 		],
-		versionstamp: 196608
+		versionstamp: 116395873313161217
+	}
+]
+```
+
+```surql title="Response if INCLUDE ORIGINAL set on changefeed"
+[
+	{
+		changes: [
+			{
+				define_table: {
+					changefeed: {
+						expiry: 3d,
+						original: true
+					},
+					drop: false,
+					id: 0,
+					kind: {
+						kind: 'ANY'
+					},
+					name: 'reading',
+					permissions: {
+						create: false,
+						delete: false,
+						select: false,
+						update: false
+					},
+					schemafull: false
+				}
+			}
+		],
+		versionstamp: 116395871166398464
+	},
+	{
+		changes: [
+			{
+				update: {
+					id: reading:q0lovlass9zgq19l1kfb,
+					story: [
+						'Once upon a time, '
+					]
+				}
+			}
+		],
+		versionstamp: 116395871166464000
+	},
+	{
+		changes: [
+			{
+				current: {
+					id: reading:q0lovlass9zgq19l1kfb,
+					story: [
+						'Once upon a time, ',
+						'there was a database'
+					]
+				},
+				update: [
+					{
+						op: 'remove',
+						path: '/story/1'
+					}
+				]
+			}
+		],
+		versionstamp: 116395871166529536
 	}
 ]
 ```

--- a/src/content/doc-surrealql/statements/show.mdx
+++ b/src/content/doc-surrealql/statements/show.mdx
@@ -7,7 +7,7 @@ description: The SHOW statement can be used to replay changes made to a table.
 
 # `SHOW` statement
 
-Change Feeds allows you to retrieve and sync changes from SurrealDB to external systems and platforms using the `SHOW` statement.
+changefeeds allows you to retrieve and sync changes from SurrealDB to external systems and platforms using the `SHOW` statement.
 
 The `SHOW` statement can be used to replay changes made to a table.
 
@@ -43,7 +43,10 @@ SHOW CHANGES FOR TABLE @tablename
 The following expression shows usage of the SHOW statement.
 
 ```surql
--- Define the change feed and its duration
+-- Define the changefeed and its duration
+-- Optionally, append INCLUDE ORIGINAL to include info
+-- on the operation that would be needed to have the
+-- state at that point match the previous state
 DEFINE TABLE reading CHANGEFEED 3d;
 
 -- Create some records in the reading table


### PR DESCRIPTION
The INCLUDE ORIGINAL part of a changefeed shows a negative diff, namely the diff needed to reach the previous point.

Relevant part of the code to show why this is the case:

```
	/// Push a mutation to the table mutations (record change)
	pub fn push_record_change(
		&mut self,
		id: RecordId,
		previous: CursorRecord,
		current: CursorRecord,
		store_difference: bool,
	) {
		// Check if this is a delete operation
		if current.as_ref().is_nullish() {
			// Push the delete mutation to the entry
			self.1.push(match store_difference {
				true => TableMutation::DelWithOriginal(id, previous.into_owned()),
				false => TableMutation::Del(id),
			});
		} else {
			// Push the set mutation to the entry
			self.1.push(match store_difference {
				true => {
					if previous.as_ref().is_none() {
						TableMutation::Set(id, current.into_owned())
					} else {
						// We intentionally record the patches in reverse (current -> previous)
						// because we cannot otherwise resolve operations such as "replace" and
						// "remove".
						let patches_to_create_previous = current.as_ref().diff(previous.as_ref());
						TableMutation::SetWithDiff(
							id,
							current.into_owned(),
							patches_to_create_previous,
						)
					}
				}
				false => TableMutation::Set(id, current.into_owned()),
			});
		}
	}
```