### PR TITLE
docs(integrations): add Kreuzberg framework integration docs

### DIFF
--- a/src/content/doc-integrations/frameworks/index.mdx
+++ b/src/content/doc-integrations/frameworks/index.mdx
@@ -50,7 +50,7 @@ SurrealDB seamlessly integrates with popular AI and data frameworks, enabling yo
         </tr>
         <tr>
             <td><a href="/docs/integrations/frameworks/kreuzberg">Kreuzberg</a></td>
-            <td>A polyglot document intelligence framework with SurrealDB schema management, deduplication, and hybrid search support.</td>
+            <td>A polyglot document intelligence framework to extract text, metadata, images, and structured information from documents (PDFs,images, etc.).</td>
         </tr>
         <tr>
             <td><a href="/docs/integrations/frameworks/langchain">LangChain</a></td>

--- a/src/content/doc-integrations/frameworks/index.mdx
+++ b/src/content/doc-integrations/frameworks/index.mdx
@@ -49,6 +49,10 @@ SurrealDB seamlessly integrates with popular AI and data frameworks, enabling yo
             <td>A framework for building and deploying intelligent agents in Google Cloud with SurrealDB vector storage for RAG.</td>
         </tr>
         <tr>
+            <td><a href="/docs/integrations/frameworks/kreuzberg">Kreuzberg</a></td>
+            <td>A polyglot document intelligence framework with SurrealDB schema management, deduplication, and hybrid search support.</td>
+        </tr>
+        <tr>
             <td><a href="/docs/integrations/frameworks/langchain">LangChain</a></td>
             <td>A framework for building LLM based applications.</td>
         </tr>

--- a/src/content/doc-integrations/frameworks/kreuzberg.mdx
+++ b/src/content/doc-integrations/frameworks/kreuzberg.mdx
@@ -28,4 +28,4 @@ The `kreuzberg-surrealdb` package connects Kreuzberg's document extraction pipel
 
 ## Getting started
 
-To get started, visit SurrealDB in the Kreuzberg Docs. For the complete API reference, embedding model options, chunking configuration, and database schema details, see the `kreuzberg-surrealdb` README.
+To get started, visit [SurrealDB in the Kreuzberg Docs](https://docs.kreuzberg.dev/integrations/surrealdb). For the complete API reference, embedding model options, chunking configuration, and database schema details, see the [`kreuzberg-surrealdb` README](https://github.com/kreuzberg-dev/kreuzberg-surrealdb).

--- a/src/content/doc-integrations/frameworks/kreuzberg.mdx
+++ b/src/content/doc-integrations/frameworks/kreuzberg.mdx
@@ -1,0 +1,31 @@
+---
+sidebar_position: 1
+sidebar_label: Kreuzberg
+title: Kreuzberg | Integrations
+description: Integrate Kreuzberg document intelligence extraction pipelines with SurrealDB.
+---
+
+# Kreuzberg
+
+Kreuzberg is a polyglot document intelligence framework that allows you to extract text, metadata, images, and structured information from PDFs, Office documents, images, and 91+ formats.
+
+The `kreuzberg-surrealdb` package connects Kreuzberg's document extraction pipeline to SurrealDB. It handles schema creation, content deduplication, optional chunking and embedding, and index configuration.
+
+## How it works
+
+1. **Extract** — Kreuzberg parses the source documents and runs OCR where needed.
+2. **Connect** — The connector receives the extracted output and manages the SurrealDB connection.
+3. **Store** — Each document is hashed (SHA-256) for deduplication, optionally chunked and embedded, then written to SurrealDB under an auto-generated schema.
+4. **Search** — Full-text (BM25), vector (HNSW), and hybrid (RRF) search are available immediately after ingestion.
+
+## Key capabilities
+
+- **Schema management** — `setup_schema()` creates tables, indexes, and analyzers. No manual DDL required.
+- **Deduplication** — Deterministic record IDs derived from content hashes prevent duplicate rows across ingestion runs.
+- **Flexible ingestion** — Single files, file lists, directories (with glob), or raw bytes.
+- **Extraction control** — Pass Kreuzberg's `ExtractionConfig` to set OCR behavior, output format, and quality processing.
+- **Batch tuning** — Adjust `insert_batch_size` to balance throughput against memory usage.
+
+## Getting started
+
+To get started, visit SurrealDB in the Kreuzberg Docs. For the complete API reference, embedding model options, chunking configuration, and database schema details, see the `kreuzberg-surrealdb` README.

--- a/src/content/doc-integrations/index.mdx
+++ b/src/content/doc-integrations/index.mdx
@@ -81,6 +81,10 @@ SurrealDB seamlessly integrates with popular AI and ML frameworks, enabling you 
       <td><a href="/docs/integrations/frameworks/smolagents">SmolAgents</a></td>
       <td>Create lightweight AI agents</td>
     </tr>
+    <tr>
+      <td><a href="/docs/integrations/frameworks/kreuzberg">Kreuzberg</a></td>
+      <td>Polyglot document intelligence extraction with SurrealDB ingestion and hybrid search</td>
+    </tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
### Motivation
- Add documentation for a new Frameworks integration, Kreuzberg, so users can learn how Kreuzberg connects document extraction pipelines to SurrealDB.
- Surface the integration in the Integrations introduction and the Frameworks overview so it is discoverable from the docs index.

### Description
- Added a new integration page at `src/content/doc-integrations/frameworks/kreuzberg.mdx` containing the provided overview, workflow, key capabilities, and getting started information.
- Updated the Integrations introduction table in `src/content/doc-integrations/index.mdx` to include a row linking to the Kreuzberg page.
- Updated the Frameworks overview table in `src/content/doc-integrations/frameworks/index.mdx` to include Kreuzberg in the list of frameworks.

### Testing
- Ran `bun run qa` (Biome check/format); Biome ran across the repo, fixed 2 files, and reported one informational message about the configuration schema version mismatch.
- Ran `bunx biome check` targeting the changed `.mdx` files, which reported those paths are ignored by the Biome configuration (no files processed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69df5d938c308329a18e2cc0205a6b5f)