### PR TITLE
fix(search): canonical redirect uses /docs/api/search

### DIFF
--- a/api/search.ts
+++ b/api/search.ts
@@ -56,10 +56,14 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     // Redirect to the canonical query so every spelling variant
     // ("How to SELECT?", "how to select", "select") resolves to
     // a single CDN cache entry.
+    //
+    // Location must be `/docs/api/search`, not `/api/search`: the browser
+    // resolves relative URLs against `surrealdb.com`, and `/api/search` is
+    // not served by the docs app on that host (only `/docs/...` is proxied).
     if (query !== raw) {
         res.writeHead(302, {
             ...CORS_HEADERS,
-            Location: `/api/search?q=${encodeURIComponent(query)}`,
+            Location: `/docs/api/search?q=${encodeURIComponent(query)}`,
             "Cache-Control": CACHE_CONTROL,
         });
         return res.end();


### PR DESCRIPTION
## Problem

The search handler returns **302** to a canonical `q` after `normaliseQuery` (e.g. casing). The `Location` was `/api/search?...`. Browsers resolve that on `surrealdb.com` as `https://surrealdb.com/api/search`, which the main site does **not** proxy to the docs serverless function, so search failed after normalisation.

## Fix

Emit `Location: /docs/api/search?q=...` so the follow-up request matches the public docs search URL (`surrealdb.com/docs/api/search`) and is proxied to this app as before.

No change to the main website routing.

## Note

On the standalone docs deployment, `/docs/api/search` is already normalised to `/api/search` via existing Vercel redirects in `vercel.ts`.

Made with [Cursor](https://cursor.com)