### PR TITLE
Update search to match new docs

### DIFF
--- a/search/README.md
+++ b/search/README.md
@@ -8,16 +8,16 @@ SurrealDB.
 
 ### Indexing (build-time)
 
-1. **Crawler** (`search/crawler.ts`) walks every markdown file in
+1. **Crawler** (`search/scripts/crawler.ts`) walks every markdown file in
    `src/content/`, parses frontmatter and body, then yields two kinds of
    records:
    - **Page** — one per document (title, description, breadcrumb, full plain
      text).
    - **Section** — one per H2 heading within a page (title, breadcrumb, plain
      text until the next H2). Links to the parent page via `#anchor`.
-2. **Embedder** (`search/embed.ts`) sends each record's text to OpenAI
+2. **Embedder** (`search/src/embed.ts`) sends each record's text to OpenAI
    `text-embedding-3-small` and receives a 1536-dimensional vector.
-3. **Indexer** (`search/indexer.ts`) connects to SurrealDB, compares content
+3. **Indexer** (`search/scripts/indexer.ts`) connects to SurrealDB, compares content
    hashes to skip unchanged records, upserts new/changed records with their
    embeddings, and deletes stale records.
 
@@ -116,11 +116,11 @@ production search endpoint at `https://surrealdb.com/docs/api/search`.
 
 ### Commands
 
-| Command                  | Description                                    |
-| ------------------------ | ---------------------------------------------- |
-| `bun run search:schema`  | Apply `search/schema.surql` to local SurrealDB |
-| `bun run search:index`   | Crawl content and upsert into SurrealDB        |
-| `bun run search:serve`   | Start local search API on port 4322            |
+| Command                 | Description                                    |
+| ----------------------- | ---------------------------------------------- |
+| `bun run search:schema` | Apply `search/schema.surql` to local SurrealDB |
+| `bun run search:index`  | Crawl content and upsert into SurrealDB        |
+| `bun run search:serve`  | Start local search API on port 4322            |
 
 ### Re-indexing
 
@@ -137,14 +137,14 @@ the production search API.
 
 ### Environment variables (Vercel project settings)
 
-| Variable              | Description                             |
-| --------------------- | --------------------------------------- |
-| `SURREAL_ENDPOINT`    | SurrealDB WebSocket URL                 |
-| `SURREAL_NAMESPACE`   | SurrealDB namespace                     |
-| `SURREAL_DATABASE`    | SurrealDB database                      |
-| `SURREAL_USERNAME`    | SurrealDB username (root or scoped)     |
-| `SURREAL_PASSWORD`    | SurrealDB password                      |
-| `OPENAI_API_KEY`      | OpenAI API key for embeddings           |
+| Variable            | Description                         |
+| ------------------- | ----------------------------------- |
+| `SURREAL_ENDPOINT`  | SurrealDB WebSocket URL             |
+| `SURREAL_NAMESPACE` | SurrealDB namespace                 |
+| `SURREAL_DATABASE`  | SurrealDB database                  |
+| `SURREAL_USERNAME`  | SurrealDB username (root or scoped) |
+| `SURREAL_PASSWORD`  | SurrealDB password                  |
+| `OPENAI_API_KEY`    | OpenAI API key for embeddings       |
 
 ## File structure
 

--- a/search/schema.surql
+++ b/search/schema.surql
@@ -36,7 +36,7 @@ DEFINE ANALYZER OVERWRITE simple
 DEFINE TABLE OVERWRITE page SCHEMAFULL;
 
 DEFINE FIELD OVERWRITE path         ON page TYPE string;
-DEFINE FIELD OVERWRITE collection   ON page TYPE string;  -- e.g. "doc-surrealql", "doc-sdk-javascript"
+DEFINE FIELD OVERWRITE collection   ON page TYPE string;  -- e.g. "reference/query-language", "index"
 DEFINE FIELD OVERWRITE title        ON page TYPE string;
 DEFINE FIELD OVERWRITE description  ON page TYPE string;
 DEFINE FIELD OVERWRITE breadcrumb   ON page TYPE string;  -- "SurrealQL > Statements > SELECT"

--- a/search/scripts/crawler.ts
+++ b/search/scripts/crawler.ts
@@ -34,11 +34,11 @@ import type { CrawledEntry, CrawledPage, CrawledSection } from "../src/types";
 const CONTENT_DIR = join(import.meta.dirname, "../../src/content");
 
 interface CategoryMeta {
-    sidebar_label: string;
-    sidebar_position: number;
+    title: string;
+    position: number;
 }
 
-// Versioned SDK collections (e.g. "doc-sdk-javascript-1x") are
+// Versioned SDK collections are
 // skipped because only the latest version should be indexed.
 const VERSIONED_COLLECTION_IDS = new Set(
     Object.entries(versionedSdks).flatMap(([sdk, config]) =>
@@ -66,8 +66,8 @@ async function* walkMarkdown(dir: string): AsyncGenerator<string> {
 }
 
 /**
- * Loads _category_.json files from a collection directory tree.
- * These provide sidebar labels used to build breadcrumbs
+ * Loads __category.json files from a collection directory tree.
+ * These provide category titles used to build breadcrumbs
  * (e.g. "SurrealQL > Statements > SELECT"). The root category
  * is keyed by "" and subdirectory categories by their relative
  * path (e.g. "statements", "statements/define").
@@ -76,10 +76,10 @@ async function loadCategoryMap(collectionDir: string): Promise<Map<string, Categ
     const categories = new Map<string, CategoryMeta>();
 
     try {
-        const raw = await readFile(join(collectionDir, "_category_.json"), "utf-8");
+        const raw = await readFile(join(collectionDir, "__category.json"), "utf-8");
         categories.set("", JSON.parse(raw) as CategoryMeta);
     } catch {
-        // no root _category_.json
+        // no root __category.json
     }
 
     async function scan(dir: string) {
@@ -89,7 +89,7 @@ async function loadCategoryMap(collectionDir: string): Promise<Map<string, Categ
             if (!entry.isDirectory()) continue;
 
             const subdir = join(dir, entry.name);
-            const catPath = join(subdir, "_category_.json");
+            const catPath = join(subdir, "__category.json");
 
             try {
                 const raw = await readFile(catPath, "utf-8");
@@ -97,7 +97,7 @@ async function loadCategoryMap(collectionDir: string): Promise<Map<string, Categ
                 const relPath = relative(collectionDir, subdir);
                 categories.set(relPath, meta);
             } catch {
-                // no _category_.json in this dir
+                // no __category.json in this dir
             }
 
             await scan(subdir);
@@ -224,14 +224,14 @@ function splitAtHeadings(
 // ──────────────────────────────────────────────────────────
 // Breadcrumb and URL construction
 //
-// Breadcrumbs are built from _category_.json sidebar labels
+// Breadcrumbs are built from __category.json titles
 // and the page title, producing strings like:
 //   "SurrealQL > Statements > DEFINE > TABLE"
 //
 // URLs are built from the collection's URL prefix (defined in
 // src/content/config.ts) and the file's slug:
-//   collection "doc-surrealql" + slug "statements/select"
-//   → "/docs/surrealql/statements/select"
+//   collection "reference/query-language" + slug "statements/select"
+//   → "/docs/reference/query-language/statements/select"
 // ──────────────────────────────────────────────────────────
 
 function buildBreadcrumb(
@@ -240,7 +240,7 @@ function buildBreadcrumb(
     categories: Map<string, CategoryMeta>,
     pageLabel: string,
 ): string {
-    const rootLabel = categories.get("")?.sidebar_label ?? collection;
+    const rootLabel = categories.get("")?.title ?? collection;
     const parts: string[] = [rootLabel];
 
     // Walk each segment of the slug to pick up intermediate
@@ -253,7 +253,7 @@ function buildBreadcrumb(
         const cat = categories.get(dirPath);
 
         if (cat) {
-            parts.push(cat.sidebar_label);
+            parts.push(cat.title);
         }
     }
 
@@ -362,7 +362,7 @@ export async function* crawl(): AsyncGenerator<CrawledEntry> {
             const slug = buildSlug(filePath, collectionDir);
             const ast = parseMarkdown(body);
             const pageUrl = buildUrl(collection, slug);
-            const pageLabel = parsed.sidebar_label ?? parsed.title ?? slug.split("/").pop() ?? "";
+            const pageLabel = parsed.title ?? slug.split("/").pop() ?? "";
             const breadcrumb = buildBreadcrumb(collection, slug, categories, pageLabel);
             const pageContent = astToPlainText(ast);
             const description = parsed.description ?? "";

--- a/search/src/handler.ts
+++ b/search/src/handler.ts
@@ -213,14 +213,27 @@ function isTokenPrefix(shorter: string[], longer: string[]): boolean {
  * happens to mention auth as one of many methods.
  */
 const CORE_COLLECTIONS = new Set([
-    "doc-surrealdb",
-    "doc-surrealql",
-    "doc-tutorials",
-    "doc-cloud",
-    "doc-surrealist",
-    "doc-surrealml",
-    "doc-surrealkv",
-    "doc-integrations",
+    "index",
+    "learn/security",
+    "learn/querying",
+    "learn/data-models",
+    "learn/schema-management",
+    "learn/extensions",
+    "learn/context",
+    "build/migrating",
+    "build/embedding",
+    "build/integrations",
+    "build/deployment",
+    "build/ai-agents",
+    "explore/tutorials",
+    "explore/surrealist",
+    "explore/ml-models",
+    "reference/cli",
+    "reference/query-language",
+    "reference/rest-api",
+    "manage/self-hosted",
+    "manage/cloud",
+    "manage/enterprise",
 ]);
 
 /**

--- a/search/src/types.ts
+++ b/search/src/types.ts
@@ -9,9 +9,9 @@
 
 export interface CrawledPage {
     kind: "page";
-    id: string; // e.g. "doc-surrealql:statements/select"
-    collection: string; // e.g. "doc-surrealql", "doc-sdk-javascript"
-    path: string; // URL path, e.g. "/docs/surrealql/statements/select"
+    id: string; // e.g. "reference/query-language:statements/select"
+    collection: string; // e.g. "reference/query-language", "index", "manage/cloud"
+    path: string; // URL path, e.g. "/docs/reference/query-language/statements/select"
     url: string; // same as path for pages
     title: string;
     description: string; // from frontmatter, used in search ranking
@@ -22,7 +22,7 @@ export interface CrawledPage {
 
 export interface CrawledSection {
     kind: "section";
-    id: string; // e.g. "doc-surrealql:statements/select#record-ranges"
+    id: string; // e.g. "reference/query-language:statements/select#record-ranges"
     pageId: string; // parent page id
     anchor: string; // URL fragment, e.g. "record-ranges"
     depth: number; // heading depth (always 2)

--- a/search/tsconfig.json
+++ b/search/tsconfig.json
@@ -1,8 +1,7 @@
 {
     "extends": "../tsconfig.json",
     "compilerOptions": {
-        "noEmit": true,
-        "paths": {}
+        "noEmit": true
     },
-    "include": ["src/**/*", "scripts/**/*"]
+    "include": ["src/**/*", "scripts/**/*", "../src/content/config.ts", "../src/utils/schema.ts"]
 }

--- a/src/content/build/ai-agents/agent-skills.mdx
+++ b/src/content/build/ai-agents/agent-skills.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+position: 4
 title: Agent Skills
 description: Official SurrealDB agent skills for use in agentic coding workflows.
 ---

--- a/src/content/build/integrations/ai-frameworks/kreuzberg.mdx
+++ b/src/content/build/integrations/ai-frameworks/kreuzberg.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1
+position: 1
 title: Kreuzberg
 description: Integrate Kreuzberg document intelligence extraction pipelines with SurrealDB.
 ---


### PR DESCRIPTION
Small updates to the docs search to match the new format. e.g.

* sidebar_label and sidebar_position now all replaced with title and position
* _category_.json now all __category.json
* New CORE_COLLECTIONS const used to boost search results for these parts of the docs over less prominent parts like SDKs.

(Also fixes two pages that still have a sidebar_position)