### PR TITLE
Document Rust SDK missing methods, update transactions concept page

### DIFF
--- a/src/content/index/languages/rust/concepts/transaction.mdx
+++ b/src/content/index/languages/rust/concepts/transaction.mdx
@@ -1,7 +1,7 @@
 ---
 position: 3
 title: Manual transactions
-description: Manual transactions can be used via the Rust SDK in the same manner as regular SurrealQL queries
+description: Use SurrealQL BEGIN and COMMIT in queries, or the Rust SDK `begin` / `commit` / `cancel` transaction handle, and check per-statement results before committing
 ---
 
 
@@ -13,8 +13,6 @@ description: Manual transactions can be used via the Rust SDK in the same manner
 
 While every query in SurrealDB is run [inside its own transaction](/docs/reference/query-language/language-primitives/transactions), manual transactions made up of multiple statements can be used via the [BEGIN](/docs/reference/query-language/statements/begin) and [COMMIT](/docs/reference/query-language/statements/commit) keywords.
 
-The [`.query()`](https://docs.rs/surrealdb/latest/surrealdb/struct.Surreal.html#method.query) method can take any number of statements, returning a [`Response`](https://docs.rs/surrealdb/latest/surrealdb/struct.Response.html) that contains the results of each of them. In addition, the same method before being called returns [a struct](https://docs.rs/surrealdb/latest/surrealdb/method/struct.Query.html) that also allows [the same `.query()` method](https://docs.rs/surrealdb/latest/surrealdb/method/struct.Query.html#method.query) to be called on it, chaining the new query onto the existing query. This can help greatly with readability, as the example code below shows.
-
 ## Getting started
 
 Start a running database using the following command:
@@ -23,7 +21,7 @@ Start a running database using the following command:
 surreal start --user root --pass secret 
 ```
 
-To follow along interactively, connect [using Surrealist](/docs/explore/surrealist/getting-started#creating-a-connection) or the following command to open up the CLI:
+To follow along interactively, connect [using Surrealist](/docs/explore/surrealist/getting-started#creating-a-connection) or the following command to open a connection in the CLI:
 
 ```
 surreal sql --user root --pass secret --pretty
@@ -33,11 +31,68 @@ Then use the `cargo add` command to add the `surrealdb` and `tokio` crates. The 
 
 ```toml
 [dependencies]
-surrealdb = "2.4.1"
-tokio = "1.49.0"
+surrealdb = "3.0.5"
+tokio = "1.52.1"
 ```
 
-Once this is done, copy and paste the following code to run a manual transaction that creates two `account` records and then transfers 300 units from one account to the other.
+### Using a client-side transaction
+
+Once this is done, you can use [`.begin()`](https://docs.rs/surrealdb/3.0.5/surrealdb/struct.Surreal.html#method.begin) to get a client-side [`Transaction`](https://docs.rs/surrealdb/3.0.5/surrealdb/method/struct.Transaction.html). Run your statements with [`.query()`](https://docs.rs/surrealdb/3.0.5/surrealdb/method/struct.Transaction.html#method.query) or other methods such as `.select()`,` `.create()` and so on, then end the transaction in one of two ways:
+
+* [`commit()`](https://docs.rs/surrealdb/3.0.5/surrealdb/method/struct.Transaction.html#method.commit) — apply the changes. The future resolves to a [`Surreal`](https://docs.rs/surrealdb/3.0.5/surrealdb/struct.Surreal.html) client again.
+* [`cancel()`](https://docs.rs/surrealdb/3.0.5/surrealdb/method/struct.Transaction.html#method.cancel) — roll back. This also returns the `Surreal` client when it completes.
+
+Note that the outer `Result` from `await`ing a query only shows that the statements have succeeded, but a response can still include per-statement failures (the request succeeded, but one of the SQL statements did not). Collect those with [`take_errors()`](https://docs.rs/surrealdb/3.0.5/surrealdb/struct.IndexedResults.html#method.take_errors) on the query response, or use [`check()`](https://docs.rs/surrealdb/3.0.5/surrealdb/struct.IndexedResults.html#method.check) to fail on the first error. If the outer `Result` is `Err`, the transaction is not usable as intended.
+
+The following example uses an in-memory database, runs every query in its own short transaction, and cancels (or would skip a commit) when a statement error shows up.
+
+```rust
+use surrealdb::Surreal;
+use surrealdb::engine::any::{connect, Any};
+
+#[tokio::main]
+async fn main() -> surrealdb::Result<()> {
+    let db = connect("memory").await?;
+    db.use_ns("ns").use_db("db").await?;
+
+    let db = run_in_transaction(db, "LET $x: int = 'not a number';").await?;
+    let db = run_in_transaction(db, "SELECT SELECT SELECT").await?;
+    run_in_transaction(db, "9").await?;
+
+    Ok(())
+}
+
+// Runs a single query inside a new transaction.
+// `commit` only runs when there
+// are no per-statement errors;
+// otherwise the transaction is cancelled.
+async fn run_in_transaction(
+    db: Surreal<Any>,
+    surql: &str,
+) -> surrealdb::Result<Surreal<Any>> {
+    let tx = db.begin().await?;
+
+    match tx.query(surql).await {
+        Ok(mut response) => {
+            let errors = response.take_errors();
+            if !errors.is_empty() {
+                eprintln!("Errors from statements: {errors:#?}\n");
+                return tx.cancel().await;
+            }
+            println!("Ok: {response:#?}\n");
+            return tx.commit().await;
+        }
+        Err(e) => {
+            eprintln!("Error from query request: {e}\n");
+            return tx.cancel().await;
+        }
+    }
+}
+```
+
+### Using SurrealQL transaction statements
+
+A manual transaction can also be performed by sending in a `BEGIN` and other statements into the `.query()` method manually. This will result in the same behaviour as the previous method, but will not return a `Transaction` on the SDK side.
 
 ```rust
 use surrealdb::Surreal;
@@ -47,7 +102,7 @@ use surrealdb_types::{SurrealValue, ToSql, Value};
 
 #[tokio::main]
 async fn main() -> surrealdb::Result<()> {
-    let db = Surreal::new::<Ws>("localhost:8000").await?;
+    let db = connect("memory").await?;
 
     db.signin(Root {
         username: "root".to_string(),
@@ -141,10 +196,10 @@ async fn main() -> surrealdb::Result<()> {
 
     println!("{response:#?}");
 
-    // See if any errors were returned
-    response.check()?;
+	// See if any errors were returned
+	response.check()?;
 
-    Ok(())
+	Ok(())
 }
 ```
 
@@ -166,7 +221,7 @@ Start a running database using the following command:
 surreal start --user root --pass secret 
 ```
 
-To follow along interactively, connect [using Surrealist](/docs/explore/surrealist/getting-started#creating-a-connection) or the following command to open up the CLI:
+To follow along interactively, connect [using Surrealist](/docs/explore/surrealist/getting-started#creating-a-connection) or the following command to open a connection in the CLI:
 
 ```
 surreal sql --user root --pass secret --ns main --db main --pretty
@@ -268,6 +323,8 @@ async fn main() -> surrealdb::Result<()> {
 	Ok(())
 }
 ```
+
+`Surreal::begin()` and the `Transaction` handle (with [`commit()`](https://docs.rs/surrealdb/3.0.5/surrealdb/method/struct.Transaction.html#method.commit) / [`cancel()`](https://docs.rs/surrealdb/3.0.5/surrealdb/method/struct.Transaction.html#method.cancel)) are only in the `surrealdb` **Rust crate 3.0.0+**. The first tab (**3.x**) shows the full example, including per-statement errors and `commit` or `cancel`. In this 2.x tab, use `BEGIN` / `COMMIT` in SurrealQL, or [upgrade the crate to 3.0 or newer](https://crates.io/crates/surrealdb) and add `surrealdb = "3.0.5"` (or similar) in `Cargo.toml` to use that API.
 
 </TabItem>
 

--- a/src/content/index/languages/rust/methods/begin.mdx
+++ b/src/content/index/languages/rust/methods/begin.mdx
@@ -1,0 +1,27 @@
+---
+position: 3
+title: begin
+description: The .begin() method on the SurrealDB Rust SDK client starts a multi-statement transaction and returns a handle for running queries, commits, and rollbacks.
+---
+
+# `begin()`
+
+Starts a transaction. The connection is taken into a [`Transaction`](https://docs.rs/surrealdb/latest/surrealdb/method/struct.Transaction.html) that exposes the same query and CRUD entry points as `Surreal` (scoped to the transaction) plus [`commit()`](https://docs.rs/surrealdb/latest/surrealdb/method/struct.Transaction.html#method.commit) and [`cancel()`](https://docs.rs/surrealdb/latest/surrealdb/method/struct.Transaction.html#method.cancel).
+
+Note that this method takes by value (taking a `self`), which is then passed on to the `Transaction`. The `.commit()` and `.cancel()` methods are used to finalise the transaction and return the `Surreal` client for reuse.
+
+```rust title="Method Syntax"
+let tx = db.begin().await?;
+// tx.query(...), .select(), .create(), .insert(), .upsert(), .update(), .delete()
+
+// Get the connection back
+// let db = tx.commit().await?;
+// let db = tx.cancel().await?;
+```
+
+For a broader discussion and more detailed examples, see the concept page on [Manual transactions](/docs/languages/rust/concepts/transaction).
+
+### See also
+
+* [`.begin()` on Docs.rs](https://docs.rs/surrealdb/latest/surrealdb/struct.Surreal.html#method.begin)
+* [`Transaction` in the Rust API](https://docs.rs/surrealdb/latest/surrealdb/method/struct.Transaction.html)

--- a/src/content/index/languages/rust/methods/connect.mdx
+++ b/src/content/index/languages/rust/methods/connect.mdx
@@ -1,5 +1,5 @@
 ---
-position: 3
+position: 4
 title: connect
 description: The .connect() method for the SurrealDB Rust SDK connects to a local or remote database endpoint.
 ---

--- a/src/content/index/languages/rust/methods/create.mdx
+++ b/src/content/index/languages/rust/methods/create.mdx
@@ -1,5 +1,5 @@
 ---
-position: 4
+position: 5
 title: create
 description: The .create() method for the SurrealDB Rust SDK creates one or more records in the database.
 ---

--- a/src/content/index/languages/rust/methods/delete.mdx
+++ b/src/content/index/languages/rust/methods/delete.mdx
@@ -1,5 +1,5 @@
 ---
-position: 5
+position: 6
 title: delete
 description: The .delete() method for the SurrealDB Rust SDK deletes all or specific records from the database.
 ---

--- a/src/content/index/languages/rust/methods/export.mdx
+++ b/src/content/index/languages/rust/methods/export.mdx
@@ -1,5 +1,5 @@
 ---
-position: 6
+position: 7
 title: export
 description: The .export() method for the SurrealDB Rust SDK dumps the database contents to a file.
 ---

--- a/src/content/index/languages/rust/methods/get.mdx
+++ b/src/content/index/languages/rust/methods/get.mdx
@@ -1,5 +1,5 @@
 ---
-position: 7
+position: 8
 title: get
 description: The .get() method for the SurrealDB Rust SDK retrieves the value at a certain field or index.
 ---

--- a/src/content/index/languages/rust/methods/health.mdx
+++ b/src/content/index/languages/rust/methods/health.mdx
@@ -1,0 +1,19 @@
+---
+position: 9
+title: health
+description: The .health() method for the SurrealDB Rust SDK checks that the server-side connection is able to run a health command (useful for readiness and liveness checks).
+---
+
+# `health()`
+
+Runs a lightweight health check on the current session/connection. On success, the future resolves to `Ok(())`; otherwise you get a [`surrealdb::Error`](https://docs.rs/surrealdb/latest/surrealdb/enum.Error.html).
+
+```rust title="Method Syntax"
+db.health().await?
+```
+
+This is a simple way to assert the database is reachable and accepting commands after `connect` (or periodically in long-lived processes) without sending a full SurrealQL query.
+
+### See also
+
+* [`.health()` on Docs.rs](https://docs.rs/surrealdb/latest/surrealdb/struct.Surreal.html#method.health)

--- a/src/content/index/languages/rust/methods/import.mdx
+++ b/src/content/index/languages/rust/methods/import.mdx
@@ -1,5 +1,5 @@
 ---
-position: 8
+position: 10
 title: import
 description: The .import() method for the SurrealDB Rust SDK restores the database from a file.
 ---

--- a/src/content/index/languages/rust/methods/index.mdx
+++ b/src/content/index/languages/rust/methods/index.mdx
@@ -8,7 +8,9 @@ description: The SurrealDB SDK for Rust enables simple and advanced querying of 
 
 Most methods in the SurrealDB SDK involve either working with or creating an instance of the [`Surreal`](https://docs.rs/surrealdb/latest/surrealdb/struct.Surreal.html) struct, which serves as the database client instance for embedded or remote databases.
 
-## Initialization methods
+The table below lists documented methods **in alphabetical order** (by page name).
+
+## All methods
 
 <table>
 	<thead>
@@ -19,157 +21,112 @@ Most methods in the SurrealDB SDK involve either working with or creating an ins
 	</thead>
 	<tbody>
 		<tr>
+			<td scope="row" data-label="Function"><a href="/docs/languages/rust/methods/authenticate"> <code>db.authenticate()</code></a></td>
+			<td scope="row" data-label="Description">Authenticates the current connection with a JWT token</td>
+		</tr>
+		<tr>
+			<td scope="row" data-label="Function"><a href="/docs/languages/rust/methods/begin"> <code>db.begin()</code></a></td>
+			<td scope="row" data-label="Description">Start a session-scoped multi-statement transaction, returning a <code>Transaction</code> handle (commit, cancel, query, and CRUD)</td>
+		</tr>
+		<tr>
 			<td scope="row" data-label="Function"><a href="/docs/languages/rust/methods/connect"> <code>db.connect()</code></a></td>
 			<td scope="row" data-label="Description">Connects to a local or remote database endpoint</td>
+		</tr>
+		<tr>
+			<td scope="row" data-label="Function"><a href="/docs/languages/rust/methods/create"> <code>db.create()</code></a></td>
+			<td scope="row" data-label="Description">Creates a record in the database</td>
+		</tr>
+		<tr>
+			<td scope="row" data-label="Function"><a href="/docs/languages/rust/methods/delete"> <code>db.delete()</code></a></td>
+			<td scope="row" data-label="Description">Deletes all records, or a specific record</td>
+		</tr>
+		<tr>
+			<td scope="row" data-label="Function"><a href="/docs/languages/rust/methods/export"> <code>db.export()</code></a></td>
+			<td scope="row" data-label="Description">Exports the database to a file or a live stream of bytes</td>
+		</tr>
+		<tr>
+			<td scope="row" data-label="Function"><a href="/docs/languages/rust/methods/get"> <code>value.get()</code></a></td>
+			<td scope="row" data-label="Description">On <code>Value</code> (and query results), reads a field on an object or an index in an array</td>
+		</tr>
+		<tr>
+			<td scope="row" data-label="Function"><a href="/docs/languages/rust/methods/health"> <code>db.health()</code></a></td>
+			<td scope="row" data-label="Description">Runs a health check to verify the server accepts commands</td>
+		</tr>
+		<tr>
+			<td scope="row" data-label="Function"><a href="/docs/languages/rust/methods/import"> <code>db.import()</code></a></td>
+			<td scope="row" data-label="Description">Imports the contents of another database from a file</td>
 		</tr>
 		<tr>
 			<td scope="row" data-label="Function"><a href="/docs/languages/rust/methods/init"> <code>Surreal::init()</code></a></td>
 			<td scope="row" data-label="Description">Initializes a non-connected instance of the database client</td>
 		</tr>
 		<tr>
+			<td scope="row" data-label="Function"><a href="/docs/languages/rust/methods/insert"> <code>db.insert()</code></a></td>
+			<td scope="row" data-label="Description">Inserts one or multiple records or relations in the database</td>
+		</tr>
+		<tr>
+			<td scope="row" data-label="Function"><a href="/docs/languages/rust/methods/invalidate"> <code>db.invalidate()</code></a></td>
+			<td scope="row" data-label="Description">Invalidates the authentication for the current connection</td>
+		</tr>
+		<tr>
 			<td scope="row" data-label="Function"><a href="/docs/languages/rust/methods/new"> <code>Surreal::new()</code></a></td>
 			<td scope="row" data-label="Description">Initializes a connected instance of the database client</td>
 		</tr>
 		<tr>
-            <td scope="row" data-label="Function"><a href="/docs/languages/rust/methods/set"> <code>db.set()</code></a></td>
-            <td scope="row" data-label="Description">Assigns a value as a parameter for this connection</td>
-        </tr>
+			<td scope="row" data-label="Function"><a href="/docs/languages/rust/methods/query"> <code>db.query()</code></a></td>
+			<td scope="row" data-label="Description">Runs a set of [SurrealQL statements](/docs/reference/query-language) against the database</td>
+		</tr>
 		<tr>
-			<td scope="row" data-label="Function"><a href="/docs/languages/rust/methods/use"> <code> db.use_ns().use_db()</code></a></td>
+			<td scope="row" data-label="Function"><a href="/docs/languages/rust/methods/run"> <code>db.run()</code></a></td>
+			<td scope="row" data-label="Description">Runs a SurrealQL function</td>
+		</tr>
+		<tr>
+			<td scope="row" data-label="Function"><a href="/docs/languages/rust/methods/select"> <code>db.select()</code></a></td>
+			<td scope="row" data-label="Description">Selects all records in a table, or a specific record</td>
+		</tr>
+		<tr>
+			<td scope="row" data-label="Function"><a href="/docs/languages/rust/methods/select-live"> <code>db.select().live()</code></a></td>
+			<td scope="row" data-label="Description">Performs a LIVE SELECT query on the database</td>
+		</tr>
+		<tr>
+			<td scope="row" data-label="Function"><a href="/docs/languages/rust/methods/set"> <code>db.set()</code></a></td>
+			<td scope="row" data-label="Description">Assigns a value as a parameter for this connection</td>
+		</tr>
+		<tr>
+			<td scope="row" data-label="Function"><a href="/docs/languages/rust/methods/signin"> <code>db.signin()</code></a></td>
+			<td scope="row" data-label="Description">Signs this connection in to a specific authentication scope</td>
+		</tr>
+		<tr>
+			<td scope="row" data-label="Function"><a href="/docs/languages/rust/methods/signup"> <code>db.signup()</code></a></td>
+			<td scope="row" data-label="Description">Signs this connection up to a specific authentication scope</td>
+		</tr>
+		<tr>
+			<td scope="row" data-label="Function"><a href="/docs/languages/rust/methods/unset"> <code>db.unset()</code></a></td>
+			<td scope="row" data-label="Description">Removes a parameter for this connection</td>
+		</tr>
+		<tr>
+			<td scope="row" data-label="Function"><a href="/docs/languages/rust/methods/update"> <code>db.update()</code></a></td>
+			<td scope="row" data-label="Description">Updates all records in a table, or a specific record</td>
+		</tr>
+		<tr>
+			<td scope="row" data-label="Function"><a href="/docs/languages/rust/methods/upsert"> <code>db.upsert()</code></a></td>
+			<td scope="row" data-label="Description">Upserts all records in a table, or a specific record</td>
+		</tr>
+		<tr>
+			<td scope="row" data-label="Function"><a href="/docs/languages/rust/methods/use"> <code>db.use_ns().use_db()</code></a></td>
 			<td scope="row" data-label="Description">Switch to a specific namespace and database</td>
 		</tr>
-        <tr>
-            <td scope="row" data-label="Function"><a href="/docs/languages/rust/methods/unset"> <code>db.unset()</code></a></td>
-            <td scope="row" data-label="Description">Removes a parameter for this connection</td>
-        </tr>
-	</tbody>
-</table>
-
-## Query methods
-
-<table>
-    <thead>
-        <tr>
-            <th scope="col">Function</th>
-            <th scope="col">Description</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td scope="row" data-label="Function"><a href="/docs/languages/rust/methods/query"> <code>db.query()</code></a></td>
-            <td scope="row" data-label="Description">Runs a set of [SurrealQL statements](/docs/reference/query-language) against the database</td>
-        </tr>
-        <tr>
-            <td scope="row" data-label="Function"><a href="/docs/languages/rust/methods/run"> <code>db.run()</code></a></td>
-            <td scope="row" data-label="Description">Runs a SurrealQL function</td>
-        </tr>
-        <tr>
-            <td scope="row" data-label="Function"><a href="/docs/languages/rust/methods/select"> <code>db.select()</code></a></td>
-            <td scope="row" data-label="Description">Selects all records in a table, or a specific record</td>
-        </tr>
-        <tr>
-            <td scope="row" data-label="Function"><a href="/docs/languages/rust/methods/select-live"> <code>db.select().live()</code></a></td>
-            <td scope="row" data-label="Description">Performs a LIVE SELECT query on the database</td>
-        </tr>
-    </tbody>
-</table>
-
-## Mutation methods
-
-<table>
-    <thead>
-        <tr>
-            <th scope="col">Function</th>
-            <th scope="col">Description</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td scope="row" data-label="Function"><a href="/docs/languages/rust/methods/create"> <code>db.create()</code></a></td>
-            <td scope="row" data-label="Description">Creates a record in the database</td>
-        </tr>
-        <tr>
-            <td scope="row" data-label="Function"><a href="/docs/languages/rust/methods/delete"> <code>db.delete()</code></a></td>
-            <td scope="row" data-label="Description">Deletes all records, or a specific record</td>
-        </tr>
-        <tr>
-            <td scope="row" data-label="Function"><a href="/docs/languages/rust/methods/insert"> <code>db.insert()</code></a></td>
-            <td scope="row" data-label="Description">Inserts one or multiple records or relations in the database</td>
-        </tr>
-        <tr>
-            <td scope="row" data-label="Function"><a href="/docs/languages/rust/methods/update"> <code>db.update()</code></a></td>
-            <td scope="row" data-label="Description">Updates all records in a table, or a specific record</td>
-        </tr>
-        <tr>
-            <td scope="row" data-label="Function"><a href="/docs/languages/rust/methods/upsert"> <code>db.upsert()</code></a></td>
-            <td scope="row" data-label="Description">Upserts all records in a table, or a specific record</td>
-        </tr>
-    </tbody>
-</table>
-
-## Authentication methods
-
-<table>
-    <thead>
-        <tr>
-            <th scope="col">Function</th>
-            <th scope="col">Description</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td scope="row" data-label="Function"><a href="/docs/languages/rust/methods/authenticate"> <code>db.authenticate()</code></a></td>
-            <td scope="row" data-label="Description">Authenticates the current connection with a JWT token</td>
-        </tr>
 		<tr>
-            <td scope="row" data-label="Function"><a href="/docs/languages/rust/methods/invalidate"> <code>db.invalidate()</code></a></td>
-            <td scope="row" data-label="Description">Invalidates the authentication for the current connection</td>
-        </tr>
-        <tr>
-            <td scope="row" data-label="Function"><a href="/docs/languages/rust/methods/signin"> <code>db.signin()</code></a></td>
-            <td scope="row" data-label="Description">Signs this connection in to a specific authentication scope</td>
-        </tr>
-        <tr>
-            <td scope="row" data-label="Function"><a href="/docs/languages/rust/methods/signup"> <code>db.signup()</code></a></td>
-            <td scope="row" data-label="Description">Signs this connection up to a specific authentication scope</td>
-        </tr>
-    </tbody>
-</table>
-
-## Data methods
-
-<table>
-    <thead>
-        <tr>
-            <th scope="col">Function</th>
-            <th scope="col">Description</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td scope="row" data-label="Function"><a href="/docs/languages/rust/methods/export"> <code>db.export()</code></a></td>
-            <td scope="row" data-label="Description">Exports the database to a file or a live stream of bytes</td>
-        </tr>
-        <tr>
-            <td scope="row" data-label="Function"><a href="/docs/languages/rust/methods/import"> <code>db.import()</code></a></td>
-            <td scope="row" data-label="Description">Imports the contents of another database from a file=</td>
-        </tr>
-    </tbody>
-</table>
-
-## Other methods
-
-<table>
-    <thead>
-        <tr>
-            <th scope="col">Function</th>
-            <th scope="col">Description</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td scope="row" data-label="Function"><a href="/docs/languages/rust/methods/version"> <code>db.version()</code></a></td>
-            <td scope="row" data-label="Description">Returns the current database version</td>
-        </tr>
-    </tbody>
+			<td scope="row" data-label="Function"><a href="/docs/languages/rust/methods/use-defaults"> <code>db.use_defaults()</code></a></td>
+			<td scope="row" data-label="Description">Select the default namespace and database for this connection</td>
+		</tr>
+		<tr>
+			<td scope="row" data-label="Function"><a href="/docs/languages/rust/methods/version"> <code>db.version()</code></a></td>
+			<td scope="row" data-label="Description">Returns the current database version</td>
+		</tr>
+		<tr>
+			<td scope="row" data-label="Function"><a href="/docs/languages/rust/methods/wait-for"> <code>db.wait_for()</code></a></td>
+			<td scope="row" data-label="Description">Blocks until a connection or database session event (such as <code>WaitFor::Connection</code>) is ready</td>
+		</tr>
+	</tbody>
 </table>

--- a/src/content/index/languages/rust/methods/init.mdx
+++ b/src/content/index/languages/rust/methods/init.mdx
@@ -1,5 +1,5 @@
 ---
-position: 9
+position: 11
 title: init
 description: The .init() method for the SurrealDB Rust SDK initializes a new unconnected instance.
 ---

--- a/src/content/index/languages/rust/methods/insert.mdx
+++ b/src/content/index/languages/rust/methods/insert.mdx
@@ -1,5 +1,5 @@
 ---
-position: 10
+position: 12
 title: insert
 description: The .insert() method for the SurrealDB Rust SDK inserts a record or records into a table.
 ---

--- a/src/content/index/languages/rust/methods/invalidate.mdx
+++ b/src/content/index/languages/rust/methods/invalidate.mdx
@@ -1,5 +1,5 @@
 ---
-position: 11
+position: 13
 title: invalidate
 description: The .invalidate() method for the SurrealDB Rust SDK invalidates the authentication for the current connection.
 ---

--- a/src/content/index/languages/rust/methods/new.mdx
+++ b/src/content/index/languages/rust/methods/new.mdx
@@ -1,5 +1,5 @@
 ---
-position: 12
+position: 14
 title: new
 description: The .new() method for the SurrealDB Rust SDK connects to a local or remote database endpoint.
 ---

--- a/src/content/index/languages/rust/methods/query.mdx
+++ b/src/content/index/languages/rust/methods/query.mdx
@@ -1,5 +1,5 @@
 ---
-position: 13
+position: 15
 title: query
 description: The .query() method for the SurrealDB Rust SDK runs one or more SurrealQL statements against the database.
 ---

--- a/src/content/index/languages/rust/methods/run.mdx
+++ b/src/content/index/languages/rust/methods/run.mdx
@@ -1,5 +1,5 @@
 ---
-position: 14
+position: 16
 title: run
 description: The .run() method for the SurrealDB Rust SDK runs a SurrealQL function.
 ---

--- a/src/content/index/languages/rust/methods/select-live.mdx
+++ b/src/content/index/languages/rust/methods/select-live.mdx
@@ -1,5 +1,5 @@
 ---
-position: 15
+position: 18
 title: select_live
 description: The .select().live() methods for the SurrealDB Rust SDK initiate live queries for a live stream of notifications.
 ---

--- a/src/content/index/languages/rust/methods/select.mdx
+++ b/src/content/index/languages/rust/methods/select.mdx
@@ -1,5 +1,5 @@
 ---
-position: 16
+position: 17
 title: select
 description: The .select() method for the SurrealDB Rust SDK selects all or specific records from the database.
 ---
@@ -139,7 +139,7 @@ let people: Vec<Person> = db.select("person").await?;
 let person: Option<Person> = db.select(("person", "h5wxrf2ewk8xjxosxtyc")).await?;
 ```
 
-### Example usage: Retrieve unique id of a record
+### Example usage: retrieve unique id of a record
 
 ```rust
 use serde::Deserialize;

--- a/src/content/index/languages/rust/methods/set.mdx
+++ b/src/content/index/languages/rust/methods/set.mdx
@@ -1,5 +1,5 @@
 ---
-position: 17
+position: 19
 title: set
 description: The .set() method for the SurrealDB Rust SDK assigns a value as a parameter for this connection.
 ---

--- a/src/content/index/languages/rust/methods/signin.mdx
+++ b/src/content/index/languages/rust/methods/signin.mdx
@@ -1,5 +1,5 @@
 ---
-position: 18
+position: 20
 title: signin
 description: The .signin() method for the SurrealDB Rust SDK signs in to a specific access method.
 ---

--- a/src/content/index/languages/rust/methods/signup.mdx
+++ b/src/content/index/languages/rust/methods/signup.mdx
@@ -1,5 +1,5 @@
 ---
-position: 19
+position: 21
 title: signup
 description: The .signup() method for the SurrealDB Rust SDK signs up to a specific access method.
 ---

--- a/src/content/index/languages/rust/methods/unset.mdx
+++ b/src/content/index/languages/rust/methods/unset.mdx
@@ -1,5 +1,5 @@
 ---
-position: 20
+position: 22
 title: unset
 description: The .unset() method for the SurrealDB Rust SDK removes a parameter from the connection.
 ---

--- a/src/content/index/languages/rust/methods/update.mdx
+++ b/src/content/index/languages/rust/methods/update.mdx
@@ -1,5 +1,5 @@
 ---
-position: 21
+position: 23
 title: update
 description: The .update() method for the SurrealDB Rust SDK updates all or specific records in the database.
 ---

--- a/src/content/index/languages/rust/methods/upsert.mdx
+++ b/src/content/index/languages/rust/methods/upsert.mdx
@@ -1,5 +1,5 @@
 ---
-position: 22
+position: 24
 title: upsert
 description: The .upsert() method for the SurrealDB Rust SDK upserts all or specific records in a table.
 ---

--- a/src/content/index/languages/rust/methods/use-defaults.mdx
+++ b/src/content/index/languages/rust/methods/use-defaults.mdx
@@ -1,0 +1,19 @@
+---
+position: 26
+title: use_defaults
+description: The .use_defaults() method for the SurrealDB Rust SDK selects the default namespace and database for this connection, if the server and client are configured to provide one.
+---
+
+# `use_defaults()`
+
+Clears the explicit `USE` state for namespace and database and **uses the default** values associated with the connection. The outcome depends on your endpoint and `DEFINE` configuration.
+
+```rust title="Method Syntax"
+db.use_defaults().await?
+```
+
+This complements [`use_ns()` and `use_db()`](/docs/languages/rust/methods/use) when you want to reset to defaults instead of a specific pair.
+
+### See also
+
+* [`.use_defaults()` on Docs.rs](https://docs.rs/surrealdb/latest/surrealdb/struct.Surreal.html#method.use_defaults)

--- a/src/content/index/languages/rust/methods/use.mdx
+++ b/src/content/index/languages/rust/methods/use.mdx
@@ -1,5 +1,5 @@
 ---
-position: 23
+position: 25
 title: use_ns and use_db
 description: The .use_ns() and .use_db() methods for the SurrealDB Rust SDK switch to a specific namespace and database.
 ---

--- a/src/content/index/languages/rust/methods/version.mdx
+++ b/src/content/index/languages/rust/methods/version.mdx
@@ -1,5 +1,5 @@
 ---
-position: 24
+position: 27
 title: version
 description: The .version() method for the SurrealDB Rust SDK returns the version of the server.
 ---

--- a/src/content/index/languages/rust/methods/wait-for.mdx
+++ b/src/content/index/languages/rust/methods/wait-for.mdx
@@ -1,5 +1,5 @@
 ---
-position: 25
+position: 28
 title: wait_for
 description: The .wait_for() method for the SurrealDB Rust SDK waits for the selected event to happen before proceeding.
 ---


### PR DESCRIPTION
Mostly focused on documenting client-side transactions after 3.0, including the concepts page with an example on how to best handle errors.

Also adds some missing methods like .health() and .use_defaults().