### PR TITLE
Add notes on backticks in fields

### DIFF
--- a/src/content/reference/query-language/language-primitives/data-types/objects.mdx
+++ b/src/content/reference/query-language/language-primitives/data-types/objects.mdx
@@ -46,6 +46,8 @@ CREATE person SET metadata = {
 
 Similar to record IDs, field names can be constructed from ASCII characters, underscores, and numbers. To create a field name with complex characters, backticks can be used.
 
+When you combine backticks with dotted paths for nested fields, keep any periods used to denote a nested path **outside** the backticks. Anything inside backticks is treated as a single literal field name, including a `.` inside the backticks. For definitions and concrete examples (including non-ASCII identifiers), see [`DEFINE FIELD`](/docs/reference/query-language/statements/define/field#example-usage).
+
 ```surql
 /**[test]
 

--- a/src/content/reference/query-language/statements/define/field.mdx
+++ b/src/content/reference/query-language/statements/define/field.mdx
@@ -1,7 +1,7 @@
 ---
 position: 9
 title: DEFINE FIELD
-description: "The DEFINE FIELD statement allows you to instantiate a named field on a table, enabling you to set the field's achema and configuration."
+description: "The DEFINE FIELD statement allows you to instantiate a named field on a table, enabling you to set the field's schema and configuration."
 ---
 
 # `DEFINE FIELD` statement
@@ -123,6 +123,39 @@ DEFINE FIELD emails.primary ON TABLE user TYPE bool;
 -- Define individual fields on an array
 DEFINE FIELD metadata[0] ON person TYPE datetime;
 DEFINE FIELD metadata[1] ON person TYPE int;
+```
+
+Non-unicode fields can be defined and set using backticks where necessary. Be sure that any periods to indicate nested fields are not inside the backticks, as anything enclosed in backticks will be treated as a literal string.
+
+```surql
+DEFINE FIELD name.first    ON user TYPE string;
+DEFINE FIELD `nómine`.prim ON user TYPE string;
+DEFINE FIELD `nómine.prim` ON user TYPE string;
+
+CREATE user:one SET 
+	// Nested field
+    name.first = "Billy",
+	// Also nested
+    `nómine`.prim = "Billy",
+	// Not nested
+    `nómine.prim` = "Billy";
+```
+
+As the output shows, the `.` enclosed inside backticks in the last field results in a single non-nested field name that includes the period, while the one immediately preceding it is nested.
+
+```surql
+[
+	{
+		id: user:one,
+		name: {
+			first: 'Billy'
+		},
+		"nómine": {
+			prim: 'Billy'
+		},
+		"nómine.prim": 'Billy'
+	}
+]
 ```
 
 ## Defining data types


### PR DESCRIPTION
Adds some notes to ensure users don't use e.g. `söme.fiëld` and are surprised to see that `field` isn't a nested field. (Must be `söme`.`fiëld`)