### PR TITLE
More rust sdk

### DIFF
--- a/src/content/index/languages/rust/methods/authenticate.mdx
+++ b/src/content/index/languages/rust/methods/authenticate.mdx
@@ -118,6 +118,24 @@ async fn main() -> surrealdb::Result<()> {
 }
 ```
 
+### Refreshing a session (`.refresh()`)
+
+When the server issues a token that includes a **refresh** component, you can obtain a new access token without signing in again. Build the usual [`db.authenticate(token)`](https://docs.rs/surrealdb/latest/surrealdb/struct.Surreal.html#method.authenticate) future, then call [`.refresh()`](https://docs.rs/surrealdb/latest/surrealdb/method/struct.Authenticate.html#method.refresh). The inner future runs the refresh command and returns a new [`Token`](https://docs.rs/surrealdb/latest/surrealdb/opt/auth/struct.Token.html). If the token has no refresh material, the SDK returns an error (`Missing refresh token`).
+
+```rust
+// Get a token from signin
+let token = db.signin(credentials).await?;
+
+// Later, refresh the token
+let new_token = db.authenticate(token).refresh().await?;
+```
+
+This pairs with the access and refresh model configured via [`DEFINE ACCESS`](/docs/reference/query-language/statements/define/access/record) (token duration, refresh behaviour, and scope depend on your statement).
+
+### See also
+
+* [`Authenticate::refresh` on Docs.rs](https://docs.rs/surrealdb/latest/surrealdb/method/struct.Authenticate.html#method.refresh)
+
 </TabItem>
 
 <TabItem label="2.x">

--- a/src/content/index/languages/rust/methods/begin.mdx
+++ b/src/content/index/languages/rust/methods/begin.mdx
@@ -13,9 +13,21 @@ Note that this method takes by value (taking a `self`), which is then passed on 
 ```rust title="Method Syntax"
 let tx = db.begin().await?;
 // tx.query(...), .select(), .create(), .insert(), .upsert(), .update(), .delete()
+```
 
-// Get the connection back
+## `.commit()`
+
+[`tx.commit().await?`](https://docs.rs/surrealdb/latest/surrealdb/method/struct.Transaction.html#method.commit) applies every statement run on the handle and returns ownership of the underlying `Surreal` client so the connection can run further work outside the transaction.
+
+```rust
 // let db = tx.commit().await?;
+```
+
+## `.cancel()`
+
+[`tx.cancel().await?`](https://docs.rs/surrealdb/latest/surrealdb/method/struct.Transaction.html#method.cancel) rolls back the transaction and **also** returns the `Surreal` client for reuse.
+
+```rust
 // let db = tx.cancel().await?;
 ```
 

--- a/src/content/index/languages/rust/methods/delete.mdx
+++ b/src/content/index/languages/rust/methods/delete.mdx
@@ -73,6 +73,36 @@ async fn main() -> surrealdb::Result<()> {
 }
 ```
 
+### Restrict records with `.range()`
+
+For deletes targeting every record in a table, chain [`.range(...)`](https://docs.rs/surrealdb/latest/surrealdb/method/struct.Delete.html#method.range-1) so only record IDs inside the [`RecordIdKeyRange`](https://docs.rs/surrealdb/latest/surrealdb/types/struct.RecordIdKeyRange.html) are removed.
+
+```rust
+use surrealdb::{
+    engine::any::connect,
+    opt::Resource,
+    types::{ToSql, Value},
+};
+
+#[tokio::main]
+async fn main() {
+    let db = connect("memory").await.unwrap();
+    db.use_ns("ns").use_db("db").await.unwrap();
+
+    db.query("CREATE person:alucard, person:plato, person:vlad")
+        .await
+        .unwrap();
+
+    let res = db
+        .delete::<Value>(Resource::from("person"))
+        .range("n"..="z")
+        .await
+        .unwrap()
+        .to_sql();
+    println!("{res:?}");
+}
+```
+
 </TabItem>
 
 <TabItem label="2.x">

--- a/src/content/index/languages/rust/methods/export.mdx
+++ b/src/content/index/languages/rust/methods/export.mdx
@@ -140,6 +140,10 @@ The [`Export`](https://docs.rs/surrealdb/2/surrealdb/method/struct.Export.html) 
 * `.accesses()`: whether to include [`DEFINE ACCESS` statements](/docs/reference/query-language/statements/define/access/record)
 * `.analyzers()`: whether to include [`DEFINE ANALYZER` statements](/docs/reference/query-language/statements/define/analyzer)
 * `.functions()`: whether to include [`DEFINE FUNCTION` statements](/docs/reference/query-language/statements/define/function)
+* `.apis()`: whether to include API definitions in the export
+* `.buckets()`: whether to include bucket definitions
+* `.modules()`: whether to include [`DEFINE MODULE`](/docs/reference/query-language/statements/define/module) statements
+* `.configs()`: whether to include stored configuration definitions
 * `.records()`: whether to include the existing records in the database
 * `.params()`: whether to include [`DEFINE PARAM` statements](/docs/reference/query-language/statements/define/param)
 * `.users()`: whether to include [`DEFINE USER` statements](/docs/reference/query-language/statements/define/user)
@@ -322,10 +326,14 @@ INSERT [ { id: person:bgq0b0rblnozrufizdjm } ];
 
 The [`Export`](https://docs.rs/surrealdb/2/surrealdb/method/struct.Export.html) struct has a method called `.with_config()` that gives access to the configuration parameters for the export. These can be chained one after another inside a single line of code. The majority of these functions take a single `bool`:
 
-* `.versions()`: whether to include [version information](/docs/reference/query-language/statements/select#the-version-clause) for the SurrealKV storage backend
+* `.versions()`: whether to include [version information](/docs/reference/query-language/statements/select#the-version-clause) for backends with versioning enabled
 * `.accesses()`: whether to include [`DEFINE ACCESS` statements](/docs/reference/query-language/statements/define/access/record)
 * `.analyzers()`: whether to include [`DEFINE ANALYZER` statements](/docs/reference/query-language/statements/define/analyzer)
 * `.functions()`: whether to include [`DEFINE FUNCTION` statements](/docs/reference/query-language/statements/define/function)
+* `.apis()`: whether to include [defined APIs](/docs/reference/query-language/statements/define/api) in the export
+* `.buckets()`: whether to include [defined buckets](/docs/reference/query-language/statements/define/bucket)
+* `.modules()`: whether to include [`DEFINE MODULE`](/docs/reference/query-language/statements/define/module) statements
+* `.configs()`: whether to include stored configuration definitions
 * `.records()`: whether to include the existing records in the database
 * `.params()`: whether to include [`DEFINE PARAM` statements](/docs/reference/query-language/statements/define/param)
 * `.users()`: whether to include [`DEFINE USER` statements](/docs/reference/query-language/statements/define/user)

--- a/src/content/index/languages/rust/methods/invalidate.mdx
+++ b/src/content/index/languages/rust/methods/invalidate.mdx
@@ -99,16 +99,31 @@ async fn main() -> surrealdb::Result<()> {
 }
 ```
 
-The output for both `println!` statements should look liike this.
+The output for both `println!` statements should look like this.
 
 ```
 IndexedResults { results: {0: (DbResultStats { execution_time: Some(26.458µs), query_type: Some(Other) }, Ok(RecordId(RecordId { table: Table("user"), key: String("ajdvh7uwk0sc79j48liw") })))}, live_queries: {} }
 Error: Error { code: -32002, message: "Anonymous access not allowed: Not enough permissions to perform this action", details: NotAllowed(Some(Auth(NotAllowed { actor: "anonymous", action: "process", resource: "query" }))) }
 ```
 
+### Revoking a refresh token (`.refresh(token)`)
+
+[`db.invalidate()`](https://docs.rs/surrealdb/latest/surrealdb/struct.Surreal.html#method.invalidate) normally clears the whole session. To revoke only the refresh token carried inside a [`Token`](https://docs.rs/surrealdb/latest/surrealdb/opt/auth/struct.Token.html) (without invalidating the entire session), call [`.refresh(token)`](https://docs.rs/surrealdb/latest/surrealdb/method/struct.Invalidate.html#method.refresh) on the invalidate builder, then await:
+
+```rust
+// Get a token from signin
+let token = db.signin(credentials).await?;
+
+// Later, explicitly revoke the refresh token
+db.invalidate().refresh(token).await?;
+```
+
+Use this when you need to drop refresh capability for a specific token pair while leaving other session state intact.
+
 ### See also
 
 * [.invalidate() method on Docs.rs](https://docs.rs/surrealdb/latest/surrealdb/struct.Surreal.html#method.invalidate)
+* [`Invalidate::refresh` on Docs.rs](https://docs.rs/surrealdb/latest/surrealdb/method/struct.Invalidate.html#method.refresh)
 
 </TabItem>
 

--- a/src/content/index/languages/rust/methods/query.mdx
+++ b/src/content/index/languages/rust/methods/query.mdx
@@ -201,6 +201,75 @@ Errors: {2: InternalError("Tried to set `$x`, but couldn't coerce value: Expecte
 Successes: IndexedResults { results: {0: (DbResultStats { execution_time: Some(301.375µs), query_type: Some(Other) }, Ok(None)), 3: (DbResultStats { execution_time: Some(2.278083ms), query_type: Some(Other) }, Ok(Array(Array([Object(Object({"id": RecordId(RecordId { table: Table("person"), key: String("yq7gxgm3ffkr4kibumeb") })}))]))))}, live_queries: {} }
 ```
 
+### Per-statement stats (`.with_stats()`)
+
+The [`.with_stats()`](https://docs.rs/surrealdb/latest/surrealdb/method/struct.Query.html#method.with_stats) method can be used on the query builder before awaiting the future. The awaited value is [`WithStats<IndexedResults>`](https://docs.rs/surrealdb/latest/surrealdb/method/query/struct.WithStats.html), which wraps the usual [`IndexedResults`](https://docs.rs/surrealdb/latest/surrealdb/method/query/struct.IndexedResults.html) so each `.take(...)` can return both [`Stats`](https://docs.rs/surrealdb/latest/surrealdb/method/struct.Stats.html) (including execution time) and the deserialized statement result.
+
+```rust
+use surrealdb::engine::any::connect;
+use surrealdb::types::Value;
+
+#[tokio::main]
+async fn main() -> surrealdb::Result<()> {
+    let db = connect("memory").await?;
+    db.use_ns("ns").use_db("db").await?;
+
+    let mut response = db
+        .query("CREATE person:ada SET name = 'Ada'; SELECT * FROM person;")
+        .with_stats()
+        .await?;
+
+    if let Some((stats, res)) = response.take(1) {
+        let records: Vec<Value> = res?;
+        println!("time = {:?}, records = {:?}", stats.execution_time, records);
+    }
+    Ok(())
+}
+```
+
+See [`WithStats::take`](https://docs.rs/surrealdb/latest/surrealdb/method/query/struct.WithStats.html#method.take) on Docs.rs for the supported `.take` shapes (statement index, nested paths, and tuples).
+
+### Stream `LIVE SELECT` output (`.stream()`)
+
+After awaiting `.query(...)`, [`IndexedResults::stream`](https://docs.rs/surrealdb/latest/surrealdb/method/query/struct.IndexedResults.html#method.stream) turns the live-query slot at a given statement index into a [`QueryStream`](https://docs.rs/surrealdb/latest/surrealdb/method/query/struct.QueryStream.html). Pass a statement index (`0`, `1`, …), or pass `()` to merge every `LIVE SELECT` in that response. The stream yields [`Notification`](https://docs.rs/surrealdb/latest/surrealdb/struct.Notification.html) values (or raw [`Value`](https://docs.rs/surrealdb/latest/surrealdb/types/enum.Value.html)) and implements [`futures::Stream`](https://docs.rs/futures/latest/futures/stream/trait.Stream.html). This can be polled with the [`StreamExt`](https://docs.rs/futures/latest/futures/stream/trait.StreamExt.html) trait from the `futures` crate.
+
+```rust
+use futures::StreamExt;
+use surrealdb::engine::any::connect;
+use surrealdb::opt::auth::Root;
+use surrealdb::types::Value;
+
+#[tokio::main]
+async fn main() -> surrealdb::Result<()> {
+    let db = connect("ws://localhost:8000").await?;
+    db.use_ns("main").use_db("main").await?;
+    db.signin(Root {
+        username: "root".into(),
+        password: "secret".into(),
+    })
+    .await?;
+
+    // Use 2 or 3 instead of () to only LIVE SELECT
+    // either person or cat
+    let mut response = db
+        .query(
+            "DEFINE TABLE IF NOT EXISTS person SCHEMALESS;
+            DEFINE TABLE IF NOT EXISTS cat SCHEMALESS;
+             LIVE SELECT * FROM person;
+             LIVE SELECT * FROM cat;",
+        )
+        .await?;
+    let mut stream = response.stream::<Value>(())?;
+
+    while let Some(item) = stream.next().await {
+        let notification = item?;
+        println!("{:?}", notification);
+    }
+    Ok(())
+}
+
+```
+
 ### Security when using the .query() method
 
 As the `.query()` method can be used to pass any SurrealQL query on to the database, it is an easy go-to when using complex queries. However, be sure to keep [the following best practices in mind](/docs/learn/security/best-practices/security-best-practices#query-safety) when doing so.
@@ -268,6 +337,7 @@ async fn main() -> surrealdb::Result<()> {
 ### See also
 
 * [.query() method on Docs.rs](https://docs.rs/surrealdb/latest/surrealdb/struct.Surreal.html#method.query)
+* [`Query::with_stats`](https://docs.rs/surrealdb/latest/surrealdb/method/struct.Query.html#method.with_stats), [`WithStats`](https://docs.rs/surrealdb/latest/surrealdb/method/query/struct.WithStats.html), [`IndexedResults::stream`](https://docs.rs/surrealdb/latest/surrealdb/method/query/struct.IndexedResults.html#method.stream)
 
 </TabItem>
 

--- a/src/content/index/languages/rust/methods/query.mdx
+++ b/src/content/index/languages/rust/methods/query.mdx
@@ -229,9 +229,11 @@ async fn main() -> surrealdb::Result<()> {
 
 See [`WithStats::take`](https://docs.rs/surrealdb/latest/surrealdb/method/query/struct.WithStats.html#method.take) on Docs.rs for the supported `.take` shapes (statement index, nested paths, and tuples).
 
-### Stream `LIVE SELECT` output (`.stream()`)
+### Stream `LIVE SELECT` output (`.stream()`) {#live-select-stream}
 
 After awaiting `.query(...)`, [`IndexedResults::stream`](https://docs.rs/surrealdb/latest/surrealdb/method/query/struct.IndexedResults.html#method.stream) turns the live-query slot at a given statement index into a [`QueryStream`](https://docs.rs/surrealdb/latest/surrealdb/method/query/struct.QueryStream.html). Pass a statement index (`0`, `1`, …), or pass `()` to merge every `LIVE SELECT` in that response. The stream yields [`Notification`](https://docs.rs/surrealdb/latest/surrealdb/struct.Notification.html) values (or raw [`Value`](https://docs.rs/surrealdb/latest/surrealdb/types/enum.Value.html)) and implements [`futures::Stream`](https://docs.rs/futures/latest/futures/stream/trait.Stream.html). This can be polled with the [`StreamExt`](https://docs.rs/futures/latest/futures/stream/trait.StreamExt.html) trait from the `futures` crate.
+
+If you prefer not to embed `LIVE SELECT` in SurrealQL, the same live subscription can be started with [`db.select(resource).live()`](/docs/languages/rust/methods/select-live) on top of [`select()`](/docs/languages/rust/methods/select); both approaches yield a stream of notifications.
 
 ```rust
 use futures::StreamExt;
@@ -338,6 +340,7 @@ async fn main() -> surrealdb::Result<()> {
 
 * [.query() method on Docs.rs](https://docs.rs/surrealdb/latest/surrealdb/struct.Surreal.html#method.query)
 * [`Query::with_stats`](https://docs.rs/surrealdb/latest/surrealdb/method/struct.Query.html#method.with_stats), [`WithStats`](https://docs.rs/surrealdb/latest/surrealdb/method/query/struct.WithStats.html), [`IndexedResults::stream`](https://docs.rs/surrealdb/latest/surrealdb/method/query/struct.IndexedResults.html#method.stream)
+* [Live queries via `select().live()`](/docs/languages/rust/methods/select-live) (alternative to [`LIVE SELECT`](#live-select-stream) in this page)
 
 </TabItem>
 

--- a/src/content/index/languages/rust/methods/query.mdx
+++ b/src/content/index/languages/rust/methods/query.mdx
@@ -269,7 +269,13 @@ async fn main() -> surrealdb::Result<()> {
     }
     Ok(())
 }
+```
 
+To test the live stream, either log in using Surrealist or the CLI using the `surreal sql --user root --pass secret` command in another terminal window. You should see notifications similar to the following whenever a new record is created from the `person` or `cat` table, but not for others.
+
+```bash
+Notification { query_id: Uuid(3bad02bb-fd1e-402b-9a43-5b3eae88f279), action: Create, data: Object(Object({"id": RecordId(RecordId { table: Table("person"), key: String("zhby5ibqh8b2hfyyao30") })})) }
+Notification { query_id: Uuid(829d7ec7-d67c-47ef-bd7c-8b3e10b8d149), action: Create, data: Object(Object({"id": RecordId(RecordId { table: Table("cat"), key: String("cgu921pkfco7uk7ajeym") })})) }
 ```
 
 ### Security when using the .query() method

--- a/src/content/index/languages/rust/methods/select-live.mdx
+++ b/src/content/index/languages/rust/methods/select-live.mdx
@@ -13,6 +13,8 @@ description: The .select().live() methods for the SurrealDB Rust SDK initiate li
 
 Initiate live queries for a live stream of notifications.
 
+You can achieve the same live subscription by running `LIVE SELECT` inside [`query()`](/docs/languages/rust/methods/query#live-select-stream) and consuming results with [`IndexedResults::stream`](https://docs.rs/surrealdb/latest/surrealdb/method/query/struct.IndexedResults.html#method.stream). This can be useful when one or more live statements are part of a larger batch or if you prefer to use raw SurrealQL.
+
 ```rust title="Method Syntax"
 db.select(resource).live()
 ```
@@ -109,6 +111,7 @@ Received notification: Ok(Notification { query_id: Uuid(ab57b7f9-00b1-47e8-8f29-
 ### See also
 
 * [.live() method on Docs.rs](https://docs.rs/surrealdb/latest/surrealdb/method/struct.Select.html#method.live)
+* [`query()` with streaming `LIVE SELECT`](/docs/languages/rust/methods/query#live-select-stream)
 
 </TabItem>
 

--- a/src/content/index/languages/rust/methods/select.mdx
+++ b/src/content/index/languages/rust/methods/select.mdx
@@ -130,6 +130,7 @@ SELECT * FROM $resource;
 
 * [.select() method on Docs.rs](https://docs.rs/surrealdb/latest/surrealdb/struct.Surreal.html#method.select)
 * [`Select::range`](https://docs.rs/surrealdb/latest/surrealdb/method/struct.Select.html#method.range-1)
+* [Live queries (`select().live()`)](/docs/languages/rust/methods/select-live); alternatively [`query()`](/docs/languages/rust/methods/query#live-select-stream) with `LIVE SELECT` and [`.stream()`](https://docs.rs/surrealdb/latest/surrealdb/method/query/struct.IndexedResults.html#method.stream)
 
 </TabItem>
 

--- a/src/content/index/languages/rust/methods/select.mdx
+++ b/src/content/index/languages/rust/methods/select.mdx
@@ -89,6 +89,36 @@ async fn main() -> surrealdb::Result<()> {
 }
 ```
 
+### Restrict records with `.range()`
+
+When selecting all records in a table (not a single record id), you can restrict results to a record-id range by chaining [`.range(...)`](https://docs.rs/surrealdb/latest/surrealdb/method/struct.Select.html#method.range-1). The argument implements [`Into<RecordIdKeyRange>`](https://docs.rs/surrealdb/latest/surrealdb/types/struct.RecordIdKeyRange.html): strings and tuples such as `"a"..="z"` or `(Bound::Included(x), Bound::Excluded(y))` express inclusive or exclusive bounds on the table’s record keys.
+
+```rust
+use surrealdb::{
+    engine::any::connect,
+    opt::Resource,
+    types::{ToSql, Value},
+};
+
+#[tokio::main]
+async fn main() {
+    let db = connect("memory").await.unwrap();
+    db.use_ns("ns").use_db("db").await.unwrap();
+
+    db.query("CREATE person:alucard, person:plato, person:vlad")
+        .await
+        .unwrap();
+
+    let res = db
+        .select::<Value>(Resource::from("person"))
+        .range("n"..="z")
+        .await
+        .unwrap()
+        .to_sql();
+    println!("{res:?}");
+}
+```
+
 ### Translated query
 This function will run the following query in the database:
 
@@ -99,6 +129,7 @@ SELECT * FROM $resource;
 ### See also
 
 * [.select() method on Docs.rs](https://docs.rs/surrealdb/latest/surrealdb/struct.Surreal.html#method.select)
+* [`Select::range`](https://docs.rs/surrealdb/latest/surrealdb/method/struct.Select.html#method.range-1)
 
 </TabItem>
 

--- a/src/content/index/languages/rust/methods/update.mdx
+++ b/src/content/index/languages/rust/methods/update.mdx
@@ -118,6 +118,44 @@ This function will run the following query in the database:
 UPDATE $resource CONTENT $data;
 ```
 
+### Restrict records with `.range()`
+
+Table-scoped updates accept [`.range(...)`](https://docs.rs/surrealdb/latest/surrealdb/method/struct.Update.html#method.range-1) before `.content`, `.merge`, or `.patch`, limiting which record IDs are affected:
+
+```rust
+use surrealdb::{
+    engine::any::connect,
+    opt::Resource,
+    types::{SurrealValue, ToSql, Value},
+};
+
+#[derive(SurrealValue)]
+struct Content {
+    second_half_of_alphabet: bool,
+}
+
+#[tokio::main]
+async fn main() {
+    let db = connect("memory").await.unwrap();
+    db.use_ns("ns").use_db("db").await.unwrap();
+
+    db.query("CREATE person:alucard, person:plato, person:vlad")
+        .await
+        .unwrap();
+
+    let res = db
+        .update::<Value>(Resource::from("person"))
+        .range("n"..="z")
+        .content(Content {
+            second_half_of_alphabet: true,
+        })
+        .await
+        .unwrap()
+        .to_sql();
+    println!("{res:?}");
+}
+```
+
 ## `.update().merge()`
 
 Modifies all records in a table, or a specific record, in the database.

--- a/src/content/index/languages/rust/methods/upsert.mdx
+++ b/src/content/index/languages/rust/methods/upsert.mdx
@@ -117,6 +117,44 @@ This function will run the following query in the database:
 upsert $resource CONTENT $data;
 ```
 
+### Restrict records with `.range()`
+
+For upserts against a **whole table**, use [`.range(...)`](https://docs.rs/surrealdb/latest/surrealdb/method/struct.Upsert.html#method.range-1) together with `.content`, `.merge`, or `.patch` if only keys inside the range should be considered:
+
+```rust
+use surrealdb::{
+    engine::any::connect,
+    opt::Resource,
+    types::{SurrealValue, ToSql, Value},
+};
+
+#[derive(SurrealValue)]
+struct Content {
+    second_half_of_alphabet: bool,
+}
+
+#[tokio::main]
+async fn main() {
+    let db = connect("memory").await.unwrap();
+    db.use_ns("ns").use_db("db").await.unwrap();
+
+    db.query("CREATE person:alucard, person:plato, person:vlad")
+        .await
+        .unwrap();
+
+    let res = db
+        .upsert::<Value>(Resource::from("person"))
+        .range("n"..="z")
+        .content(Content {
+            second_half_of_alphabet: true,
+        })
+        .await
+        .unwrap()
+        .to_sql();
+    println!("{res:?}");
+}
+```
+
 ## `.upsert().merge()`
 
 Modifies all records in a table, or a specific record, in the database.


### PR DESCRIPTION
Adds a number of other bits that weren't documented in the Rust SDK yet. The main points are:

* Using refresh tokens
* Adding .range() to queries
* More export configs that weren't present before
* Adding .with_stats() to queries
* How to do live selects using regular old .query()