### PR TITLE
Add page to graphql section

### DIFF
--- a/src/content/learn/querying/graphql/overview.mdx
+++ b/src/content/learn/querying/graphql/overview.mdx
@@ -41,9 +41,14 @@ A query for `(INFO FOR DB).configs` will show that the above statement ends up h
 
 For more fine tuning of the configuration, the `TABLES` and `FUNCTIONS` clauses can be followed by [other clauses](/docs/reference/query-language/statements/define/config#tables-configuration).
 
-## Querying
+## Next steps
 
-- Using [`/graphql`](/docs/reference/rest-api/http-protocol#graphql) endpoint:
-  - [via HTTP](/docs/learn/querying/graphql/via-http)
-  - [via Bruno](/docs/learn/querying/graphql/via-bruno)
+The next page introduces some common GraphQL patterns and their SurrealQL equivalents or near equivalents.
+
+This is followed by the following pages that detail the various tools by which GraphQL queries can be run on a SurrealDB database:
+
+- Using the [`/graphql`](/docs/reference/rest-api/http-protocol#graphql) endpoint [via HTTP (cURL)](/docs/learn/querying/graphql/via-http)
+- Using the [`/graphql`](/docs/reference/rest-api/http-protocol#graphql) endpoint [via Bruno](/docs/learn/querying/graphql/via-bruno)
 - Using [Surrealist](https://app.surrealdb.com/), SurrealDB's interactive environment for experimenting with GraphQL queries and seeing results immediately in the UI.
+
+Other tools such as Postman and many others can be used against the `/graphql` endpoint.

--- a/src/content/learn/querying/graphql/sample-queries.mdx
+++ b/src/content/learn/querying/graphql/sample-queries.mdx
@@ -1,0 +1,321 @@
+---
+position: 2
+title: Sample queries
+description: "Compare common GraphQL queries against similar SurrealQL SELECT patterns"
+---
+
+# Sample GraphQL and SurrealQL queries
+
+SurrealDB’s GraphQL layer turns each table into **list** fields (for example `person`) and **`_get_<table>`** helpers for a single record by id. Under the hood these map to SurrealQL-style reads (typically `SELECT`). The SurrealQL here is a rough equivalent for the same or similar data shape.
+
+Before trying the examples, enable GraphQL and define data in the current namespace and database (see [GraphQL overview](/docs/learn/querying/graphql/overview) using [`DEFINE CONFIG GRAPHQL AUTO`](/docs/reference/query-language/statements/define/config)). The snippets below assume:
+
+- Namespace **`main`**, database **`main`**
+- Root authentication **`root`** / **`secret`**
+- A `person` table with `name` and `age`, and records `person:simon` and `person:marcus` as in [GraphQL via HTTP](/docs/learn/querying/graphql/via-http)
+
+```surql title="Schema and sample data"
+DEFINE TABLE person SCHEMAFULL;
+DEFINE FIELD name ON TABLE person TYPE string;
+DEFINE FIELD age ON TABLE person TYPE number;
+CREATE person:simon SET name = "Simon", age = 23;
+CREATE person:marcus SET name = "Marcus", age = 28;
+DEFINE CONFIG GRAPHQL AUTO;
+```
+
+## List records and choose fields
+
+GraphQL here returns a list of objects, similar to `SELECT` without `ONLY`.
+
+<Tabs syncKey="graphql-surrealql-curl">
+<TabItem label="GraphQL" default>
+
+```graphql title="Query"
+query {
+	person {
+		name
+		age
+	}
+}
+```
+
+```graphql title="Output"
+{
+	"data": {
+		"person": [
+			{
+				"age": 28,
+				"name": "Marcus"
+			},
+			{
+				"age": 23,
+				"name": "Simon"
+			}
+		]
+	}
+}
+```
+
+</TabItem>
+<TabItem label="SurrealQL">
+
+```surql title="Query"
+SELECT name, age FROM person;
+```
+
+```surql title="Output"
+[
+	{
+		age: 28,
+		name: 'Marcus'
+	},
+	{
+		age: 23,
+		name: 'Simon'
+	}
+]
+```
+
+</TabItem>
+<TabItem label="cURL (HTTP)">
+
+```bash
+curl -X POST -u "root:secret" -H "Surreal-NS: main" -H "Surreal-DB: main" -H "Accept: application/json" \
+  -d '{ "query": "query { person { name age } }" }' http://localhost:8000/graphql
+```
+
+</TabItem>
+</Tabs>
+
+## Fetch a single record by id
+
+Use **`_get_<table>`** with the **record key** (`simon`, not `person:simon` in the argument). The GraphQL `id` field on the result is the full record id.
+
+<Tabs syncKey="graphql-surrealql-curl">
+<TabItem label="GraphQL" default>
+
+```graphql title="Query"
+query {
+	_get_person(id: "simon") {
+		id
+		name
+		age
+	}
+}
+```
+
+```graphql title="Output"
+{
+	"data": {
+		"_get_person": {
+			"id": "person:simon",
+			"name": "Simon",
+			"age": 23
+		}
+	}
+}
+```
+
+</TabItem>
+<TabItem label="SurrealQL">
+
+```surql title="Query"
+SELECT * FROM ONLY person:simon;
+```
+
+```surql title="Output"
+{
+	age: 23,
+	id: person:simon,
+	name: 'Simon'
+}
+```
+
+</TabItem>
+<TabItem label="cURL (HTTP)">
+
+```bash
+curl -X POST -u "root:secret" -H "Surreal-NS: main" -H "Surreal-DB: main" -H "Accept: application/json" \
+  -d '{ "query": "query { _get_person(id: \"simon\") { id name age } }" }' http://localhost:8000/graphql
+```
+
+</TabItem>
+</Tabs>
+
+## Limit how many records are returned
+
+GraphQL uses **`limit`** (and optional **`start`** for offset). SurrealQL uses `LIMIT` / `START` and `ONLY` to return a single record as opposed to an array containing a single record.
+
+<Tabs syncKey="graphql-surrealql-curl">
+<TabItem label="GraphQL" default>
+
+```graphql title="Query"
+query {
+	person(limit: 1) {
+		name
+		age
+	}
+}
+```
+
+```graphql title="Output"
+{
+	"data": {
+		"person": [
+			{
+				"age": 28,
+				"name": "Marcus"
+			}
+		]
+	}
+}
+```
+
+</TabItem>
+<TabItem label="SurrealQL">
+
+```surql title="Query"
+SELECT name, age FROM ONLY person LIMIT 1;
+```
+
+```surql title="Output"
+{
+	age: 28,
+	name: 'Marcus'
+}
+```
+
+</TabItem>
+<TabItem label="cURL (HTTP)">
+
+```bash
+curl -X POST -u "root:secret" -H "Surreal-NS: main" -H "Surreal-DB: main" -H "Accept: application/json" \
+  -d '{ "query": "query { person(limit: 1) { name age } }" }' http://localhost:8000/graphql
+```
+
+</TabItem>
+</Tabs>
+
+## Filter records
+
+GraphQL accepts **`filter`** or **`where`** with the generated input type for the table (for example `_filter_person`). For a scalar field, use comparison keys such as **`eq`**, **`ne`**, **`gt`**, and **`lt`** where the schema allows them.
+
+<Tabs syncKey="graphql-surrealql-curl">
+<TabItem label="GraphQL" default>
+
+```graphql title="Query"
+query {
+	person(where: { age: { eq: 23 } }) {
+		name
+	}
+}
+```
+
+```graphql title="Output"
+{
+	"data": {
+		"person": [
+			{
+				"name": "Simon"
+			}
+		]
+	}
+}
+```
+
+</TabItem>
+<TabItem label="SurrealQL">
+
+```surql title="Query"
+SELECT name FROM person WHERE age = 23;
+```
+
+```surql title="Output"
+[
+	{
+		name: 'Simon'
+	}
+]
+```
+
+</TabItem>
+<TabItem label="cURL (HTTP)">
+
+```bash
+curl -X POST -u "root:secret" -H "Surreal-NS: main" -H "Surreal-DB: main" -H "Accept: application/json" \
+  -d '{ "query": "query { person(where: { age: { eq: 23 } }) { name } }" }' http://localhost:8000/graphql
+```
+
+</TabItem>
+</Tabs>
+
+## Order results
+
+Use an **`order`** argument with **`asc`** or **`desc`** and a field name.
+
+<Tabs syncKey="graphql-surrealql-curl">
+<TabItem label="GraphQL" default>
+
+```graphql title="Query"
+query {
+	person(order: { asc: age }) {
+		name
+		age
+	}
+}
+```
+
+```graphql title="Output"
+{
+	"data": {
+		"person": [
+			{
+				"age": 23,
+				"name": "Simon"
+			},
+			{
+				"age": 28,
+				"name": "Marcus"
+			}
+		]
+	}
+}
+```
+
+</TabItem>
+<TabItem label="SurrealQL">
+
+```surql title="Query"
+SELECT name, age FROM person ORDER BY name ASC;
+```
+
+```surql title="Output"
+[
+	{
+		age: 23,
+		name: 'Simon'
+	},
+	{
+		age: 28,
+		name: 'Marcus'
+	}
+]
+```
+
+</TabItem>
+<TabItem label="cURL (HTTP)">
+
+```bash
+curl -X POST -u "root:secret" -H "Surreal-NS: main" -H "Surreal-DB: main" -H "Accept: application/json" \
+  -d '{ "query": "query { person(order: { asc: age }) { name age } }" }' http://localhost:8000/graphql
+```
+
+</TabItem>
+</Tabs>
+
+## Next steps
+
+- Query the same endpoint from HTTP clients: [GraphQL via HTTP](/docs/learn/querying/graphql/via-http)
+- Optional: [Bruno](/docs/learn/querying/graphql/via-bruno) or [Surrealist](/docs/learn/querying/graphql/via-surrealist)
+
+For the full configuration surface (tables, functions, limits), see [`DEFINE CONFIG GRAPHQL`](/docs/reference/query-language/statements/define/config).

--- a/src/content/learn/querying/graphql/via-bruno.mdx
+++ b/src/content/learn/querying/graphql/via-bruno.mdx
@@ -1,5 +1,5 @@
 ---
-position: 3
+position: 4
 title: Via Bruno
 description: "In this section, you will explore querying SurrealDB using Bruno."
 ---

--- a/src/content/learn/querying/graphql/via-http.mdx
+++ b/src/content/learn/querying/graphql/via-http.mdx
@@ -1,5 +1,5 @@
 ---
-position: 2
+position: 3
 title: Via HTTP
 description: "In this section, you will explore querying SurrealDB using the GraphQL HTTP endpoint. The HTTP API is designed to be simple and intuitive, with any interface that provides a consistent way to interact with the database."
 ---
@@ -49,8 +49,6 @@ curl -X POST -u "root:secret" -H "Surreal-NS: main" -H "Surreal-DB: main" -H "Ac
 
 
 ## `POST /graphql`
-
-<Since v="v2.0.0" />
 
 To use the GraphQL API, you can send a `POST` request to the `/graphql` endpoint with a JSON body containing the GraphQL query via Postman or any other HTTP client. For example, to query the `person` table for all records, you can send the following request:
 

--- a/src/content/learn/querying/graphql/via-surrealist.mdx
+++ b/src/content/learn/querying/graphql/via-surrealist.mdx
@@ -1,5 +1,5 @@
 ---
-position: 4
+position: 5
 title: Via Surrealist
 description: "In this section, you will explore querying SurrealDB using Surrealist."
 ---


### PR DESCRIPTION
Adds a page to the GraphQL section showing sample queries and their expected output before moving on to the actual ways to execute a query.