### PR TITLE
Python SDK: document v3.0 builder API, query() tuple results, run()

### DIFF
--- a/src/content/index/languages/python/api/core/surreal-session.mdx
+++ b/src/content/index/languages/python/api/core/surreal-session.mdx
@@ -59,7 +59,7 @@ A session exposes the same interface as the parent connection. All methods below
 | Method | Returns | Description |
 |---|---|---|
 | [`.use(namespace, database)`](/docs/languages/python/api/core/surreal#use) | `None` | Switch namespace and database for this session. |
-| [`.query(query, vars)`](/docs/languages/python/api/core/surreal#query) | [`Value`](/docs/languages/python/api/types/#value) | Execute a SurrealQL query. |
+| [`.query(query, vars)`](/docs/languages/python/api/core/surreal#query) | Awaitable / lazy `Value` or `tuple[Value, ...]` builder | Execute one or more SurrealQL statements. |
 | [`.signin(vars)`](/docs/languages/python/api/core/surreal#signin) | [`Tokens`](/docs/languages/python/api/types/#tokens) | Sign in within this session. |
 | [`.signup(vars)`](/docs/languages/python/api/core/surreal#signup) | [`Tokens`](/docs/languages/python/api/types/#tokens) | Sign up within this session. |
 | [`.authenticate(token)`](/docs/languages/python/api/core/surreal#authenticate) | `None` | Authenticate this session with a JWT. |
@@ -67,14 +67,12 @@ A session exposes the same interface as the parent connection. All methods below
 | [`.let(key, value)`](/docs/languages/python/api/core/surreal#let) | `None` | Define a session-scoped variable. |
 | [`.unset(key)`](/docs/languages/python/api/core/surreal#unset) | `None` | Remove a session-scoped variable. |
 | [`.select(record)`](/docs/languages/python/api/core/surreal#select) | [`Value`](/docs/languages/python/api/types/#value) | Select records. |
-| [`.create(record, data)`](/docs/languages/python/api/core/surreal#create) | [`Value`](/docs/languages/python/api/types/#value) | Create a record. |
-| [`.update(record, data)`](/docs/languages/python/api/core/surreal#update) | [`Value`](/docs/languages/python/api/types/#value) | Replace a record. |
-| [`.merge(record, data)`](/docs/languages/python/api/core/surreal#merge) | [`Value`](/docs/languages/python/api/types/#value) | Merge data into a record. |
-| [`.patch(record, data)`](/docs/languages/python/api/core/surreal#patch) | [`Value`](/docs/languages/python/api/types/#value) | Apply JSON Patch operations. |
-| [`.delete(record)`](/docs/languages/python/api/core/surreal#delete) | [`Value`](/docs/languages/python/api/types/#value) | Delete records. |
-| [`.insert(table, data)`](/docs/languages/python/api/core/surreal#insert) | [`Value`](/docs/languages/python/api/types/#value) | Insert records. |
-| [`.insert_relation(table, data)`](/docs/languages/python/api/core/surreal#insert-relation) | [`Value`](/docs/languages/python/api/types/#value) | Insert relation records. |
-| [`.upsert(record, data)`](/docs/languages/python/api/core/surreal#upsert) | [`Value`](/docs/languages/python/api/types/#value) | Upsert a record. |
+| [`.create(record, data)`](/docs/languages/python/api/core/surreal#create) | CRUD builder -> `dict[str, Value]` | Create a record (chain `.content/.replace/.merge/.patch`). |
+| [`.update(record, data)`](/docs/languages/python/api/core/surreal#update) | CRUD builder -> `dict` or `list` | Update records (chain `.content/.replace/.merge/.patch`). |
+| [`.upsert(record, data)`](/docs/languages/python/api/core/surreal#upsert) | CRUD builder -> `dict` or `list` | Upsert a record (chain `.content/.replace/.merge/.patch`). |
+| [`.delete(record)`](/docs/languages/python/api/core/surreal#delete) | CRUD builder -> `dict` or `list` | Delete records. |
+| [`.insert(table, data, relation=False)`](/docs/languages/python/api/core/surreal#insert) | Insert builder -> `list[Value]` | Insert records. Pass `relation=True` or chain `.relation()` for `INSERT RELATION`. |
+| [`.run(name, args, version)`](/docs/languages/python/api/core/surreal#run) | [`Value`](/docs/languages/python/api/types/#value) | Call a SurrealDB function. |
 | [`.live(table, diff)`](/docs/languages/python/api/core/surreal#live) | `UUID` | Start a live query. |
 | [`.kill(query_uuid)`](/docs/languages/python/api/core/surreal#kill) | `None` | Kill a live query. |
 

--- a/src/content/index/languages/python/api/core/surreal-transaction.mdx
+++ b/src/content/index/languages/python/api/core/surreal-transaction.mdx
@@ -68,16 +68,16 @@ A transaction exposes query and CRUD methods that mirror the parent connection's
 
 | Method | Returns | Description |
 |---|---|---|
-| [`.query(query, vars)`](/docs/languages/python/api/core/surreal#query) | [`Value`](/docs/languages/python/api/types/#value) | Execute a SurrealQL query within the transaction. |
+| [`.query(query, vars)`](/docs/languages/python/api/core/surreal#query) | Awaitable / lazy `Value` or `tuple[Value, ...]` builder | Execute one or more SurrealQL statements within the transaction. |
 | [`.select(record)`](/docs/languages/python/api/core/surreal#select) | [`Value`](/docs/languages/python/api/types/#value) | Select records. |
-| [`.create(record, data)`](/docs/languages/python/api/core/surreal#create) | [`Value`](/docs/languages/python/api/types/#value) | Create a record. |
-| [`.update(record, data)`](/docs/languages/python/api/core/surreal#update) | [`Value`](/docs/languages/python/api/types/#value) | Replace a record. |
-| [`.merge(record, data)`](/docs/languages/python/api/core/surreal#merge) | [`Value`](/docs/languages/python/api/types/#value) | Merge data into a record. |
-| [`.patch(record, data)`](/docs/languages/python/api/core/surreal#patch) | [`Value`](/docs/languages/python/api/types/#value) | Apply JSON Patch operations. |
-| [`.delete(record)`](/docs/languages/python/api/core/surreal#delete) | [`Value`](/docs/languages/python/api/types/#value) | Delete records. |
-| [`.insert(table, data)`](/docs/languages/python/api/core/surreal#insert) | [`Value`](/docs/languages/python/api/types/#value) | Insert records. |
-| [`.insert_relation(table, data)`](/docs/languages/python/api/core/surreal#insert-relation) | [`Value`](/docs/languages/python/api/types/#value) | Insert relation records. |
-| [`.upsert(record, data)`](/docs/languages/python/api/core/surreal#upsert) | [`Value`](/docs/languages/python/api/types/#value) | Upsert a record. |
+| [`.create(record, data)`](/docs/languages/python/api/core/surreal#create) | CRUD builder -> `dict[str, Value]` | Create a record (chain `.content/.replace/.merge/.patch`). |
+| [`.update(record, data)`](/docs/languages/python/api/core/surreal#update) | CRUD builder -> `dict` or `list` | Update records (chain `.content/.replace/.merge/.patch`). |
+| [`.upsert(record, data)`](/docs/languages/python/api/core/surreal#upsert) | CRUD builder -> `dict` or `list` | Upsert a record (chain `.content/.replace/.merge/.patch`). |
+| [`.delete(record)`](/docs/languages/python/api/core/surreal#delete) | CRUD builder -> `dict` or `list` | Delete records. |
+| [`.insert(table, data, relation=False)`](/docs/languages/python/api/core/surreal#insert) | Insert builder -> `list[Value]` | Insert records. Pass `relation=True` or chain `.relation()` for `INSERT RELATION`. |
+| [`.run(name, args, version)`](/docs/languages/python/api/core/surreal#run) | [`Value`](/docs/languages/python/api/types/#value) | Call a SurrealDB function within the transaction. |
+| [`.let(key, value)`](/docs/languages/python/api/core/surreal#let) | `None` | Set a transaction-scoped variable. |
+| [`.unset(key)`](/docs/languages/python/api/core/surreal#unset) | `None` | Unset a transaction-scoped variable. |
 
 ---
 

--- a/src/content/index/languages/python/api/core/surreal.mdx
+++ b/src/content/index/languages/python/api/core/surreal.mdx
@@ -524,14 +524,14 @@ await db.unset("user_id")
 
 ### `.query()` {#query}
 
-Runs a set of [SurrealQL](/docs/reference/query-language) statements against the database.
+Runs a set of [SurrealQL](/docs/reference/query-language) statements against the database. Returns an awaitable (async) or lazy (sync) builder.
 
 ```python title="Method Syntax"
 db.query(query, vars)
 ```
 
 > [!IMPORTANT]
-> When multiple statements are provided, `.query()` returns only the first statement's result. If you need results from all statements, use [`.query_raw()`](#query-raw) instead.
+> **Behaviour change in v3.0.** `.query()` now surfaces every statement result. When the server returns a single statement result it returns the result directly; when it returns multiple results it returns a `tuple[Value, ...]`. This fixes the silent-discard behaviour reported in [issue #232](https://github.com/surrealdb/surrealdb.py/issues/232).
 
 <table>
     <thead>
@@ -555,26 +555,44 @@ db.query(query, vars)
     </tbody>
 </table>
 
-**Returns:** [`Value`](/docs/languages/python/api/types/#value)
+**Returns:** [`Value`](/docs/languages/python/api/types/#value) for a single-statement query, otherwise `tuple[Value, ...]` of statement results.
+
+The returned object also exposes `.into(cls)` which maps the N statement results positionally onto the fields of a dataclass (or any class accepting keyword arguments).
 
 #### Examples
 
-```python title="Synchronous"
-result = db.query(
-    "SELECT * FROM users WHERE age > $min_age",
-    {"min_age": 18},
-)
-```
-
-```python title="Asynchronous"
+```python title="Single statement (async)"
 result = await db.query(
     "SELECT * FROM users WHERE age > $min_age",
     {"min_age": 18},
 )
 ```
 
-```python title="Without variables"
-result = db.query("SELECT * FROM users")
+```python title="Multi-statement returns tuple"
+people, count = await db.query(
+    "SELECT * FROM person; SELECT count() FROM person GROUP ALL"
+)
+```
+
+```python title="Map results onto a dataclass"
+from dataclasses import dataclass
+
+@dataclass
+class Stats:
+    people: list
+    count: list
+
+stats = await db.query(
+    "SELECT * FROM person; SELECT count() FROM person GROUP ALL"
+).into(Stats)
+```
+
+```python title="Synchronous lazy builder"
+# The sync builder auto-executes when consumed (indexed, iterated, compared, etc.).
+# For fire-and-forget statements call .execute() explicitly.
+people = db.query("SELECT * FROM users")
+print(len(people))
+db.query("DELETE temp_data;").execute()
 ```
 
 ### `.query_raw()` {#query-raw}
@@ -631,6 +649,16 @@ raw = await db.query_raw(
 ---
 
 ## CRUD methods
+
+> [!IMPORTANT]
+> **v3.0 builder pattern.** `.create()`, `.update()`, `.upsert()`, `.delete()`, and `.insert()` return an awaitable (async) or lazy (sync) builder. The builder exposes chainable clause methods that map directly to SurrealQL clauses:
+>
+> - `.content(data)` -> `... CONTENT $data`
+> - `.replace(data)` -> `... REPLACE $data`
+> - `.merge(data)`   -> `... MERGE $data`
+> - `.patch(data)`   -> `... PATCH $data`
+>
+> Calling `.create(record, data)` is sugar for `.create(record).content(data)`. The standalone `.merge()`, `.patch()`, and `.insert_relation()` methods from v2.x have been removed.
 
 ### `.select()` {#select}
 
@@ -822,95 +850,31 @@ await db.upsert(RecordID("users", "john"), {
 })
 ```
 
-### `.merge()` {#merge}
+### `.merge` clause {#merge}
 
-Merges the given data into an existing record. Existing fields not present in `data` are preserved.
-
-```python title="Method Syntax"
-db.merge(record, data)
-```
-
-<table>
-    <thead>
-        <tr>
-            <th>Parameter</th>
-            <th>Type</th>
-            <th>Description</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td><code>record</code> <Label label="required" /></td>
-            <td><code><a href="/docs/languages/python/api/types/#recordidtype">RecordIdType</a></code></td>
-            <td>The table name or <code>RecordID</code> to merge into.</td>
-        </tr>
-        <tr>
-            <td><code>data</code> <Label label="optional" /></td>
-            <td><code><a href="/docs/languages/python/api/types/#value">Value</a> | None</code></td>
-            <td>The data to merge. Defaults to <code>None</code>.</td>
-        </tr>
-    </tbody>
-</table>
-
-**Returns:** [`Value`](/docs/languages/python/api/types/#value)
-
-#### Examples
+`.merge(data)` is a builder clause method - chain it on `.update()`, `.upsert()`, or `.create()`. It compiles to `... MERGE $data` and preserves any existing fields not present in `data`.
 
 ```python title="Synchronous"
-db.merge(RecordID("users", "john"), {
-    "age": 32,
-})
+db.update(RecordID("users", "john")).merge({"age": 32})
 ```
 
 ```python title="Asynchronous"
-await db.merge(RecordID("users", "john"), {
-    "age": 32,
-})
+await db.update(RecordID("users", "john")).merge({"age": 32})
 ```
 
-### `.patch()` {#patch}
+### `.patch` clause {#patch}
 
-Applies JSON Patch operations to a record.
-
-```python title="Method Syntax"
-db.patch(record, data)
-```
-
-<table>
-    <thead>
-        <tr>
-            <th>Parameter</th>
-            <th>Type</th>
-            <th>Description</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td><code>record</code> <Label label="required" /></td>
-            <td><code><a href="/docs/languages/python/api/types/#recordidtype">RecordIdType</a></code></td>
-            <td>The table name or <code>RecordID</code> to patch.</td>
-        </tr>
-        <tr>
-            <td><code>data</code> <Label label="optional" /></td>
-            <td><code><a href="/docs/languages/python/api/types/#value">Value</a> | None</code></td>
-            <td>A list of JSON Patch operations. Defaults to <code>None</code>.</td>
-        </tr>
-    </tbody>
-</table>
-
-**Returns:** [`Value`](/docs/languages/python/api/types/#value)
-
-#### Examples
+`.patch(data)` is a builder clause method - chain it on `.update()`, `.upsert()`, or `.create()`. It compiles to `... PATCH $data` and applies JSON Patch operations.
 
 ```python title="Synchronous"
-db.patch(RecordID("users", "john"), [
+db.update(RecordID("users", "john")).patch([
     {"op": "replace", "path": "/email", "value": "new@example.com"},
     {"op": "add", "path": "/verified", "value": True},
 ])
 ```
 
 ```python title="Asynchronous"
-await db.patch(RecordID("users", "john"), [
+await db.update(RecordID("users", "john")).patch([
     {"op": "replace", "path": "/email", "value": "new@example.com"},
 ])
 ```
@@ -1005,12 +969,40 @@ db.insert("users", [
 await db.insert("users", {"name": "Alice", "email": "alice@example.com"})
 ```
 
-### `.insert_relation()` {#insert-relation}
+### Inserting relations {#insert-relation}
 
-Inserts one or more relation records into a relation table.
+The standalone `.insert_relation()` method from v2.x has been removed. Use `.insert(table, data, relation=True)` or chain `.relation()` on the insert builder to issue an `INSERT RELATION INTO` statement.
+
+```python title="Synchronous"
+db.insert("likes", {
+    "in": RecordID("users", "alice"),
+    "out": RecordID("posts", "post1"),
+}, relation=True)
+
+# Or via the builder:
+db.insert("likes").relation().content({
+    "in": RecordID("users", "alice"),
+    "out": RecordID("posts", "post1"),
+})
+```
+
+```python title="Asynchronous"
+await db.insert("likes", {
+    "in": RecordID("users", "alice"),
+    "out": RecordID("posts", "post1"),
+}, relation=True)
+```
+
+---
+
+## Calling functions
+
+### `.run()` {#run}
+
+Calls a SurrealDB function and returns its result. The function name typically uses the `fn::` prefix for user-defined functions or namespace prefixes for built-ins.
 
 ```python title="Method Syntax"
-db.insert_relation(table, data)
+db.run(name, args, version)
 ```
 
 <table>
@@ -1023,14 +1015,19 @@ db.insert_relation(table, data)
     </thead>
     <tbody>
         <tr>
-            <td><code>table</code> <Label label="required" /></td>
-            <td><code>str | Table</code></td>
-            <td>The relation table to insert into.</td>
+            <td><code>name</code> <Label label="required" /></td>
+            <td><code>str</code></td>
+            <td>The fully-qualified function name, e.g. <code>"fn::increment"</code>.</td>
         </tr>
         <tr>
-            <td><code>data</code> <Label label="required" /></td>
-            <td><code><a href="/docs/languages/python/api/types/#value">Value</a></code></td>
-            <td>A single relation dict or a list of relation dicts. Each must include <code>in</code> and <code>out</code> fields.</td>
+            <td><code>args</code> <Label label="optional" /></td>
+            <td><code>list[<a href="/docs/languages/python/api/types/#value">Value</a>] | None</code></td>
+            <td>Positional arguments forwarded to the function.</td>
+        </tr>
+        <tr>
+            <td><code>version</code> <Label label="optional" /></td>
+            <td><code>str | None</code></td>
+            <td>Optional function version selector.</td>
         </tr>
     </tbody>
 </table>
@@ -1040,18 +1037,11 @@ db.insert_relation(table, data)
 #### Examples
 
 ```python title="Synchronous"
-db.insert_relation("likes", {
-    "in": RecordID("users", "alice"),
-    "out": RecordID("posts", "post1"),
-    "created_at": "2025-01-01T00:00:00Z",
-})
+result = db.run("fn::increment", [1])
 ```
 
 ```python title="Asynchronous"
-await db.insert_relation("likes", {
-    "in": RecordID("users", "alice"),
-    "out": RecordID("posts", "post1"),
-})
+greeting = await db.run("fn::greet", ["world"])
 ```
 
 ---
@@ -1471,7 +1461,7 @@ with Surreal("ws://localhost:8000") as db:
     )
     print("Affordable:", cheap)
 
-    db.merge(RecordID("products", products[0]["id"].id), {"stock": 50})
+    db.update(RecordID("products", products[0]["id"].id)).merge({"stock": 50})
 
     db.delete(RecordID("products", products[1]["id"].id))
 ```


### PR DESCRIPTION
## Summary

Updates the Python SDK reference for the v3.0 release, mirroring [surrealdb/surrealdb.py#252](https://github.com/surrealdb/surrealdb.py/pull/252).

- Document the awaitable / lazy CRUD builder pattern with the chainable \`.content\` / \`.replace\` / \`.merge\` / \`.patch\` clauses.
- Document \`insert(table, data, relation=True)\` (and the \`.relation()\` chained form) replacing the standalone \`insert_relation\` method.
- Update \`query()\` to describe the new return shape (single \`Value\` for one statement, \`tuple[Value, ...]\` for multi-statement queries) and the \`.into(cls)\` dataclass-mapping helper. Calls out the fix for [surrealdb/surrealdb.py#232](https://github.com/surrealdb/surrealdb.py/issues/232).
- Add a \`.run(name, args, version)\` section.
- Update the SurrealSession and SurrealTransaction inherited-methods tables to reflect the builder return types and the removal of \`merge\`, \`patch\`, and \`insert_relation\`.

## Files changed

- \`src/content/index/languages/python/api/core/surreal.mdx\` — main reference (query, builder pattern, run, into, removed methods)
- \`src/content/index/languages/python/api/core/surreal-session.mdx\` — inherited methods table updated
- \`src/content/index/languages/python/api/core/surreal-transaction.mdx\` — inherited methods table updated

## Related

- Companion SDK PR: [surrealdb/surrealdb.py#252](https://github.com/surrealdb/surrealdb.py/pull/252)
- Fixed by SDK PR: [surrealdb/surrealdb.py#232](https://github.com/surrealdb/surrealdb.py/issues/232)