### PR TITLE
Add const tables

### DIFF
--- a/src/content/reference/query-language/functions/database-functions/duration.mdx
+++ b/src/content/reference/query-language/functions/database-functions/duration.mdx
@@ -1,16 +1,17 @@
 ---
 position: 7
 title: Duration
-description: These functions can be used when converting between numeric and duration data.
+description: Functions and constants for working with duration-related data.
 ---
 
+# Duration functions and consts
 
-# Duration functions
+This page contains built-in functions and constants for converting between numeric and [duration](/docs/reference/query-language/language-primitives/data-types/durations) data.
 
 > [!NOTE]
 > Since version 3.0.0-beta, the `::from::` functions (e.g. `duration::from::millis()`) now use underscores (e.g. `duration::from_millis()`) to better match the intent of the function and method syntax.
 
-These functions can be used when converting between numeric and duration data.
+## Duration functions
 
 <table>
   <thead>
@@ -27,10 +28,6 @@ These functions can be used when converting between numeric and duration data.
     <tr>
       <td scope="row" data-label="Function"><a href="#durationhours"><code>duration::hours()</code></a></td>
       <td scope="row" data-label="Description">Counts how many hours fit in a duration</td>
-    </tr>
-    <tr>
-      <td scope="row" data-label="Function"><a href="#durationmax"><code>duration::max</code></a></td>
-      <td scope="row" data-label="Description">Constant representing the greatest possible duration</td>
     </tr>
     <tr>
       <td scope="row" data-label="Function"><a href="#durationmicros"><code>duration::micros()</code></a></td>
@@ -91,6 +88,23 @@ These functions can be used when converting between numeric and duration data.
     <tr>
       <td scope="row" data-label="Function"><a href="#durationfrom_weeks"><code>duration::from_weeks()</code></a></td>
       <td scope="row" data-label="Description">Converts a numeric amount of weeks into a duration that represents weeks</td>
+    </tr>
+  </tbody>
+</table>
+
+## Duration constants
+
+<table>
+  <thead>
+    <tr>
+      <th scope="col">Constant</th>
+      <th scope="col">Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td scope="row" data-label="Constant"><a href="#durationmax"><code>duration::max</code></a></td>
+      <td scope="row" data-label="Description">Constant representing the greatest possible duration</td>
     </tr>
   </tbody>
 </table>

--- a/src/content/reference/query-language/functions/database-functions/index.mdx
+++ b/src/content/reference/query-language/functions/database-functions/index.mdx
@@ -91,7 +91,7 @@ SurrealDB has many built-in functions designed to handle many common database ta
 				</a>
 			</td>
 			<td scope="row" data-label="Description and Example">
-				These functions can be used when converting between numeric
+				Funcions and constants for converting between numeric values
 				and duration data.
 				
 				Example: <code>duration::days(90h30m)</code>
@@ -154,8 +154,8 @@ SurrealDB has many built-in functions designed to handle many common database ta
 				</a>
 			</td>
 			<td scope="row" data-label="Description and Example">
-				These functions can be used when analysing numeric data and
-				numeric collections.
+				Functions and constants for
+				analysing numeric data and numeric collections.
 				
 				Example:{' '}
 				<code>
@@ -341,8 +341,8 @@ SurrealDB has many built-in functions designed to handle many common database ta
 				</a>
 			</td>
 			<td scope="row" data-label="Description and Example">
-				These functions can be used when working with and
-				manipulating datetime values.
+				Functions and constants for
+				working with and manipulating datetime values.
 				
 				Example: <code>time::timezone()</code>
 			</td>
@@ -443,7 +443,7 @@ The following functions will produce the same output as the classic syntax above
 10.is_number();
 ```
 
-The method syntax is particular useful when calling a number of functions inside a single query.
+The method syntax is particularly useful when calling a number of functions inside a single query.
 
 ```surql
 array::len(array::windows(array::distinct(array::flatten([[1,2,3],[1,4,6],[4,2,4]])), 2));
@@ -492,9 +492,13 @@ person:one.is_record();
 type::is_record(person:one);
 ```
 
-### Mathematical constants
+### Built-in constants
 
-The page on mathematical functions also contains a number of mathematical constants. They are used in a similar way to functions except that their paths point to hard-coded values instead of a function pointer and thus do not need parentheses.
+Some modules expose constants (fixed values) as well as functions. Consts use the same `module::name` path syntax as for functions, but omit parentheses because they access direct values instead of a function to be called.
+
+- **[Math](/docs/reference/query-language/functions/database-functions/math#math-constants)** — numeric constants (π, e, τ, infinities, and related values).
+- **[Time](/docs/reference/query-language/functions/database-functions/time#time-constants)** — `time::epoch`, `time::minimum`, and `time::maximum`.
+- **[Duration](/docs/reference/query-language/functions/database-functions/duration#duration-constants)** — `duration::max`.
 
 ```surql
 RETURN [math::pi, math::tau, math::e];

--- a/src/content/reference/query-language/functions/database-functions/math.mdx
+++ b/src/content/reference/query-language/functions/database-functions/math.mdx
@@ -1,13 +1,15 @@
 ---
 position: 12
 title: Math
-description: These functions can be used when analysing numeric data and numeric collections.
+description: Built-in math functions and consts for analysing numeric data and collections.
 ---
 
 
-# Math functions
+# Math functions and consts
 
-These functions can be used when analysing numeric data and numeric collections.
+This page contains built-in functions and constants on the `math` module for analysing numeric data and numeric collections.
+
+## Math functions
 
 <table>
   <thead>
@@ -62,56 +64,12 @@ These functions can be used when analysing numeric data and numeric collections.
       <td scope="row" data-label="Description">Converts an angle from degrees to radians</td>
     </tr>
     <tr>
-      <td scope="row" data-label="Constant"><a href="#mathe"><code>math::e</code></a></td>
-      <td scope="row" data-label="Description">Constant representing the base of the natural logarithm (Euler's number)</td>
-    </tr>
-    <tr>
       <td scope="row" data-label="Function"><a href="#mathfixed"><code>math::fixed()</code></a></td>
       <td scope="row" data-label="Description">Returns a number with the specified number of decimal places</td>
     </tr>
     <tr>
       <td scope="row" data-label="Function"><a href="#mathfloor"><code>math::floor()</code></a></td>
       <td scope="row" data-label="Description">Rounds a number down to the nearest integer</td>
-    </tr>
-    <tr>
-      <td scope="row" data-label="Function"><a href="#mathfrac_1_pi"><code>math::frac_1_pi</code></a></td>
-      <td scope="row" data-label="Description">Constant representing the fraction 1/π</td>
-    </tr>
-    <tr>
-      <td scope="row" data-label="Function"><a href="#mathfrac_1_sqrt_2"><code>math::frac_1_sqrt_2</code></a></td>
-      <td scope="row" data-label="Description">Constant representing the fraction 1/sqrt(2)</td>
-    </tr>
-    <tr>
-      <td scope="row" data-label="Function"><a href="#mathfrac_2_pi"><code>math::frac_2_pi</code></a></td>
-      <td scope="row" data-label="Description">Constant representing the fraction 2/π</td>
-    </tr>
-    <tr>
-      <td scope="row" data-label="Function"><a href="#mathfrac_2_sqrt_pi"><code>math::frac_2_sqrt_pi</code></a></td>
-      <td scope="row" data-label="Description">Constant representing the fraction 2/sqrt(π)</td>
-    </tr>
-    <tr>
-      <td scope="row" data-label="Function"><a href="#mathfrac_pi_2"><code>math::frac_pi_2</code></a></td>
-      <td scope="row" data-label="Description">Constant representing the fraction π/2</td>
-    </tr>
-    <tr>
-      <td scope="row" data-label="Function"><a href="#mathfrac_pi_3"><code>math::frac_pi_3</code></a></td>
-      <td scope="row" data-label="Description">Constant representing the fraction π/3</td>
-    </tr>
-    <tr>
-      <td scope="row" data-label="Function"><a href="#mathfrac_pi_4"><code>math::frac_pi_4</code></a></td>
-      <td scope="row" data-label="Description">Constant representing the fraction π/4</td>
-    </tr>
-    <tr>
-      <td scope="row" data-label="Function"><a href="#mathfrac_pi_6"><code>math::frac_pi_6</code></a></td>
-      <td scope="row" data-label="Description">Constant representing the fraction π/6</td>
-    </tr>
-    <tr>
-      <td scope="row" data-label="Function"><a href="#mathfrac_pi_8"><code>math::frac_pi_8</code></a></td>
-      <td scope="row" data-label="Description">Constant representing the fraction π/8</td>
-    </tr>
-    <tr>
-      <td scope="row" data-label="Constant"><a href="#mathinf"><code>math::infinity</code></a></td>
-      <td scope="row" data-label="Description">Constant representing positive infinity</td>
     </tr>
     <tr>
       <td scope="row" data-label="Function"><a href="#mathinterquartile"><code>math::interquartile()</code></a></td>
@@ -130,14 +88,6 @@ These functions can be used when analysing numeric data and numeric collections.
       <td scope="row" data-label="Description">Computes the natural logarithm (base e) of a value</td>
     </tr>
     <tr>
-      <td scope="row" data-label="Function"><a href="#mathln_10"><code>math::ln_10</code></a></td>
-      <td scope="row" data-label="Description">Constant representing the natural logarithm (base e) of 10</td>
-    </tr>
-    <tr>
-      <td scope="row" data-label="Function"><a href="#mathln_2"><code>math::ln_2</code></a></td>
-      <td scope="row" data-label="Description">Constant representing the natural logarithm (base e) of 2</td>
-    </tr>
-    <tr>
       <td scope="row" data-label="Function"><a href="#mathlog"><code>math::log()</code></a></td>
       <td scope="row" data-label="Description">Computes the logarithm of a value with the specified base</td>
     </tr>
@@ -146,24 +96,8 @@ These functions can be used when analysing numeric data and numeric collections.
       <td scope="row" data-label="Description">Computes the base-10 logarithm of a value</td>
     </tr>
     <tr>
-      <td scope="row" data-label="Function"><a href="#mathlog10_2"><code>math::log10_2</code></a></td>
-      <td scope="row" data-label="Description">Constant representing the base-10 logarithm of 2</td>
-    </tr>
-    <tr>
-      <td scope="row" data-label="Function"><a href="#mathlog10_e"><code>math::log10_e</code></a></td>
-      <td scope="row" data-label="Description">Constant representing the base-10 logarithm of e, the base of the natural logarithm (Euler’s number)</td>
-    </tr>
-    <tr>
       <td scope="row" data-label="Function"><a href="#mathlog2"><code>math::log2()</code></a></td>
       <td scope="row" data-label="Description">Computes the base-2 logarithm of a value</td>
-    </tr>
-    <tr>
-      <td scope="row" data-label="Function"><a href="#mathlog2_10"><code>math::log2_10</code></a></td>
-      <td scope="row" data-label="Description">Constant representing the base-2 logarithm of 10</td>
-    </tr>
-    <tr>
-      <td scope="row" data-label="Function"><a href="#mathlog2_e"><code>math::log2_e</code></a></td>
-      <td scope="row" data-label="Description">Constant representing the base-2 logarithm of e, the base of the natural logarithm (Euler’s number)</td>
     </tr>
     <tr>
       <td scope="row" data-label="Function"><a href="#mathmax"><code>math::max()</code></a></td>
@@ -194,19 +128,11 @@ These functions can be used when analysing numeric data and numeric collections.
       <td scope="row" data-label="Description">Returns the nearest rank of an array of numbers</td>
     </tr>
     <tr>
-      <td scope="row" data-label="Constant"><a href="#mathneg_inf"><code>math::neg_infinity</code></a></td>
-      <td scope="row" data-label="Description">Constant representing negative infinity</td>
-    </tr>
-    <tr>
       <td scope="row" data-label="Function"><a href="#mathpercentile"><code>math::percentile()</code></a></td>
       <td scope="row" data-label="Description">Returns the value below which a percentage of data falls</td>
     </tr>
     <tr>
-      <td scope="row" data-label="Constant"><a href="#mathpi"><code>math::pi</code></a></td>
-      <td scope="row" data-label="Description">Constant representing the mathematical constant π.</td>
-    </tr>
-    <tr>
-      <td scope="row" data-label="Constant"><a href="#mathpow"><code>math::pow()</code></a></td>
+      <td scope="row" data-label="Function"><a href="#mathpow"><code>math::pow()</code></a></td>
       <td scope="row" data-label="Description">Returns a number raised to a power</td>
     </tr>
     <tr>
@@ -225,7 +151,7 @@ These functions can be used when analysing numeric data and numeric collections.
       <td scope="row" data-label="Function"><a href="#mathsign"><code>math::sign()</code></a></td>
       <td scope="row" data-label="Description">Returns the sign of a value (-1, 0, or 1)</td>
     </tr>
-     <tr>
+    <tr>
       <td scope="row" data-label="Function"><a href="#mathsin"><code>math::sin()</code></a></td>
       <td scope="row" data-label="Description">Computes the sine of an angle given in radians</td>
     </tr>
@@ -236,10 +162,6 @@ These functions can be used when analysing numeric data and numeric collections.
     <tr>
       <td scope="row" data-label="Function"><a href="#mathsqrt"><code>math::sqrt()</code></a></td>
       <td scope="row" data-label="Description">Returns the square root of a number</td>
-    </tr>
-    <tr>
-      <td scope="row" data-label="Function"><a href="#mathsqrt_2"><code>math::sqrt_2</code></a></td>
-      <td scope="row" data-label="Description">Constant representing the square root of 2</td>
     </tr>
     <tr>
       <td scope="row" data-label="Function"><a href="#mathstddev"><code>math::stddev()</code></a></td>
@@ -254,10 +176,6 @@ These functions can be used when analysing numeric data and numeric collections.
       <td scope="row" data-label="Description">Computes the tangent of an angle given in radians.</td>
     </tr>
     <tr>
-      <td scope="row" data-label="Constant"><a href="#mathtau"><code>math::tau()</code></a></td>
-      <td scope="row" data-label="Description">Represents the mathematical constant τ, which is equal to 2π</td>
-    </tr>
-    <tr>
       <td scope="row" data-label="Function"><a href="#mathtop"><code>math::top()</code></a></td>
       <td scope="row" data-label="Description">Returns the top X set of numbers in a set of numbers</td>
     </tr>
@@ -268,6 +186,103 @@ These functions can be used when analysing numeric data and numeric collections.
     <tr>
       <td scope="row" data-label="Function"><a href="#mathvariance"><code>math::variance()</code></a></td>
       <td scope="row" data-label="Description">Calculates how far a set of numbers are spread out from the mean</td>
+    </tr>
+  </tbody>
+</table>
+
+## Math constants
+
+<table>
+  <thead>
+    <tr>
+      <th scope="col">Constant</th>
+      <th scope="col">Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td scope="row" data-label="Constant"><a href="#mathe"><code>math::e</code></a></td>
+      <td scope="row" data-label="Description">Constant representing the base of the natural logarithm (Euler's number)</td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Constant"><a href="#mathfrac_1_pi"><code>math::frac_1_pi</code></a></td>
+      <td scope="row" data-label="Description">Constant representing the fraction 1/π</td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Constant"><a href="#mathfrac_1_sqrt_2"><code>math::frac_1_sqrt_2</code></a></td>
+      <td scope="row" data-label="Description">Constant representing the fraction 1/sqrt(2)</td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Constant"><a href="#mathfrac_2_pi"><code>math::frac_2_pi</code></a></td>
+      <td scope="row" data-label="Description">Constant representing the fraction 2/π</td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Constant"><a href="#mathfrac_2_sqrt_pi"><code>math::frac_2_sqrt_pi</code></a></td>
+      <td scope="row" data-label="Description">Constant representing the fraction 2/sqrt(π)</td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Constant"><a href="#mathfrac_pi_2"><code>math::frac_pi_2</code></a></td>
+      <td scope="row" data-label="Description">Constant representing the fraction π/2</td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Constant"><a href="#mathfrac_pi_3"><code>math::frac_pi_3</code></a></td>
+      <td scope="row" data-label="Description">Constant representing the fraction π/3</td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Constant"><a href="#mathfrac_pi_4"><code>math::frac_pi_4</code></a></td>
+      <td scope="row" data-label="Description">Constant representing the fraction π/4</td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Constant"><a href="#mathfrac_pi_6"><code>math::frac_pi_6</code></a></td>
+      <td scope="row" data-label="Description">Constant representing the fraction π/6</td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Constant"><a href="#mathfrac_pi_8"><code>math::frac_pi_8</code></a></td>
+      <td scope="row" data-label="Description">Constant representing the fraction π/8</td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Constant"><a href="#mathinf"><code>math::infinity</code></a></td>
+      <td scope="row" data-label="Description">Constant representing positive infinity</td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Constant"><a href="#mathln_10"><code>math::ln_10</code></a></td>
+      <td scope="row" data-label="Description">Constant representing the natural logarithm (base e) of 10</td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Constant"><a href="#mathln_2"><code>math::ln_2</code></a></td>
+      <td scope="row" data-label="Description">Constant representing the natural logarithm (base e) of 2</td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Constant"><a href="#mathlog10_2"><code>math::log10_2</code></a></td>
+      <td scope="row" data-label="Description">Constant representing the base-10 logarithm of 2</td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Constant"><a href="#mathlog10_e"><code>math::log10_e</code></a></td>
+      <td scope="row" data-label="Description">Constant representing the base-10 logarithm of e, the base of the natural logarithm (Euler’s number)</td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Constant"><a href="#mathlog2_10"><code>math::log2_10</code></a></td>
+      <td scope="row" data-label="Description">Constant representing the base-2 logarithm of 10</td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Constant"><a href="#mathlog2_e"><code>math::log2_e</code></a></td>
+      <td scope="row" data-label="Description">Constant representing the base-2 logarithm of e, the base of the natural logarithm (Euler’s number)</td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Constant"><a href="#mathneg_inf"><code>math::neg_infinity</code></a></td>
+      <td scope="row" data-label="Description">Constant representing negative infinity</td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Constant"><a href="#mathpi"><code>math::pi</code></a></td>
+      <td scope="row" data-label="Description">Constant representing the mathematical constant π.</td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Constant"><a href="#mathsqrt_2"><code>math::sqrt_2</code></a></td>
+      <td scope="row" data-label="Description">Constant representing the square root of 2</td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Constant"><a href="#mathtau"><code>math::tau</code></a></td>
+      <td scope="row" data-label="Description">Represents the mathematical constant τ, which is equal to 2π</td>
     </tr>
   </tbody>
 </table>

--- a/src/content/reference/query-language/functions/database-functions/overview.mdx
+++ b/src/content/reference/query-language/functions/database-functions/overview.mdx
@@ -1,13 +1,28 @@
 ---
-position: 1
-title: Database functions overview
-description: SurrealDB allows for advanced functions with complicated logic, by allowing embedded functions to be written in JavaScript.
+position: 0
+title: Overview
+description: Built-in SurrealQL database functions and constants, along with JavaScript and SurrealML functions.
 ---
 
-# Functions
+# Database functions overview
 
-SurrealDB offers a number of functions that can be used to perform complex logic. These functions are grouped into the following categories:
+Database functions are SurrealQL’s built-in, namespaced helpers (`string::split()`, `math::mean()`, `time::now()`, and so on). They run inside the database engine, are documented module-by-module in this section, and are the usual choice for everyday querying and data shaping.
 
-- [Database functions](/docs/reference/query-language/functions/database-functions)
-- [JavaScript functions](/docs/reference/query-language/scripting/overview)
-- [SurrealML functions](/docs/explore/ml-models)
+SurrealQL also supports other kinds of callable logic:
+
+- [JavaScript functions](/docs/reference/query-language/scripting/overview) — embedded scripts when the JavaScript runtime is enabled; see the scripting docs for definitions, context, and limits.
+- [SurrealML functions](/docs/explore/ml-models) — helpers used with SurrealML.
+
+For the full module list, short examples per module, and calling conventions (classic `::` paths, method chaining, and v3 underscore paths), open the [database functions catalogue](/docs/reference/query-language/functions/database-functions).
+
+## Constants
+
+Several modules expose constants: fixed values referenced like `math::pi` or `time::minimum` (without parentheses) alongside callable functions on the same pages:
+
+- [Math constants](/docs/reference/query-language/functions/database-functions/math#math-constants) — numeric values such as `math::e`, `math::pi`, τ, infinities, and common fractions.
+- [Time constants](/docs/reference/query-language/functions/database-functions/time#time-constants) — `time::epoch`, `time::minimum`, and `time::maximum`.
+- [Duration constants](/docs/reference/query-language/functions/database-functions/duration#duration-constants) — `duration::max` as the greatest representable duration.
+
+## Extensions
+
+You can also write your own functions in Rust that can be compiled to WASM modules, linked to and called from the database. For more on how extensions are built and run, see [this page](/docs/learn/extensions).

--- a/src/content/reference/query-language/functions/database-functions/time.mdx
+++ b/src/content/reference/query-language/functions/database-functions/time.mdx
@@ -1,15 +1,15 @@
 ---
 position: 24
 title: Time
-description: These functions can be used when working with and manipulating datetime values.
+description: Datetime functions and constants for working with and manipulating datetime values.
 ---
 
-# Time functions
+# Time functions and consts
+
+This page contains built-in functions and constants for working with and manipulating [datetime](/docs/reference/query-language/language-primitives/data-types/datetimes) values.
 
 > [!NOTE]
 > Since version 3.0.0-beta, the `::from::` functions (e.g. `time::from::millis()`) now use underscores (e.g. `time::from_millis()`) to better match the intent of the function and method syntax.
-
-These functions can be used when working with and manipulating [datetime](/docs/reference/query-language/language-primitives/data-types/datetimes) values.
 
 Many time functions take an `option<datetime>` in order to return certain values from a datetime such as its hours, minutes, day of the year, and so in. If no argument is present, the current datetime will be extracted and used. As such, all of the following function calls are valid and will not return an error.
 
@@ -23,6 +23,8 @@ time::minute();
 time::yday(d'2024-09-04T00:32:44.107Z');
 time::yday();
 ```
+
+## Time functions
 
 <table>
   <thead>
@@ -39,10 +41,6 @@ time::yday();
     <tr>
       <td scope="row" data-label="Function"><a href="#timeday"><code>time::day()</code></a></td>
       <td scope="row" data-label="Description">Extracts the day as a number from a datetime or current datetime</td>
-    </tr>
-    <tr>
-      <td scope="row" data-label="Function"><a href="#timeepoch"><code>time::epoch</code></a></td>
-      <td scope="row" data-label="Description">Constant datetime representing the UNIX epoch</td>
     </tr>
     <tr>
       <td scope="row" data-label="Function"><a href="#timefloor"><code>time::floor()</code></a></td>
@@ -65,10 +63,6 @@ time::yday();
       <td scope="row" data-label="Description">Returns the greatest datetime from an array</td>
     </tr>
     <tr>
-      <td scope="row" data-label="Function"><a href="#timemaximum"><code>time::maximum</code></a></td>
-      <td scope="row" data-label="Description">Constant representing the greatest possible datetime</td>
-    </tr>
-    <tr>
       <td scope="row" data-label="Function"><a href="#timemicros"><code>time::micros()</code></a></td>
       <td scope="row" data-label="Description">Extracts the microseconds as a number from a datetime or current datetime</td>
     </tr>
@@ -79,10 +73,6 @@ time::yday();
     <tr>
       <td scope="row" data-label="Function"><a href="#timemin"><code>time::min()</code></a></td>
       <td scope="row" data-label="Description">Returns the least datetime from an array</td>
-    </tr>
-    <tr>
-      <td scope="row" data-label="Function"><a href="#timeminimum"><code>time::minimum</code></a></td>
-      <td scope="row" data-label="Description">Constant representing the least possible datetime</td>
     </tr>
     <tr>
       <td scope="row" data-label="Function"><a href="#timeminute"><code>time::minute()</code></a></td>
@@ -194,6 +184,32 @@ time::yday();
     </tr>
   </tbody>
 </table>
+
+## Time constants
+
+<table>
+  <thead>
+    <tr>
+      <th scope="col">Constant</th>
+      <th scope="col">Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td scope="row" data-label="Constant"><a href="#timeepoch"><code>time::epoch</code></a></td>
+      <td scope="row" data-label="Description">Constant datetime representing the UNIX epoch</td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Constant"><a href="#timemaximum"><code>time::maximum</code></a></td>
+      <td scope="row" data-label="Description">Constant representing the greatest possible datetime</td>
+    </tr>
+    <tr>
+      <td scope="row" data-label="Constant"><a href="#timeminimum"><code>time::minimum</code></a></td>
+      <td scope="row" data-label="Description">Constant representing the least possible datetime</td>
+    </tr>
+  </tbody>
+</table>
+
 
 ## `time::ceil`
 


### PR DESCRIPTION
Constants are documented in the same area as database functions but don't have much visibility. This adds a table for consts where they are present (math, time, duration) and updates the overview pages to note that the section includes them as well.