### PR TITLE
Add details on how time::floor and time::ceil work

### DIFF
--- a/src/content/reference/query-language/functions/database-functions/time.mdx
+++ b/src/content/reference/query-language/functions/database-functions/time.mdx
@@ -213,7 +213,7 @@ time::yday();
 
 ## `time::ceil`
 
-The `time::ceil` function rounds a datetime up to the next largest duration.
+The `time::floor` function raises a datetime to the next multiple of duration from the Unix epoch (January 1, 1970).
 
 ```surql title="API DEFINITION"
 time::ceil(datetime, $ceiling: duration) -> datetime
@@ -244,6 +244,41 @@ RETURN [
 	d'2024-08-30T03:00:00Z',
 	d'2024-09-05T00:00:00Z'
 ]
+```
+
+### Implementation details
+
+Since this function raises a datetime to the next multiple of duration from the Unix epoch, this means for example that:
+
+* time::ceil(now, 18d) rounds up from the nearest multiple of 18 days since epoch
+* time::ceil(now, 17d) rounds up from the nearest multiple of 17 days since epoch
+
+Each call uses a different modular base, so the truncation points land at different offsets that may not be sequential. For example, for October 23, 2023 (day ~19,653 since epoch):
+
+* 19653 / 18 = 1091.83… → 1092 × 18 = day 19,656 → Oct 26
+* 19653 / 17 = 1156.05… → 1157 × 17 = day 19,669 → Nov 08
+* 19653 / 16 = 1228.31… → 1229 × 16 = day 19,664 → Nov 03
+* 19653 / 15 = 1310.20… → 1311 × 15 = day 19,665 → Nov 04
+
+
+```surql
+LET $now = d'2023-10-23T09:12:53Z';
+
+time::ceil($now, 18d); -- d'2023-10-26T00:00:00Z'
+time::ceil($now, 17d); -- d'2023-11-08T00:00:00Z'
+time::ceil($now, 16d); -- d'2023-11-03T00:00:00Z'
+time::ceil($now, 15d); -- d'2023-11-04T00:00:00Z'
+```
+
+To use this function to raise to midnight of the next day, the duration values above can be subtracted from the datetime first, followed by `1d` for the ceiling.
+
+```surql
+LET $now = d'2023-10-23T09:12:53Z';
+
+time::ceil($now - 18d, 1d); -- d'2023-10-06T00:00:00Z'
+time::ceil($now - 17d, 1d); -- d'2023-10-07T00:00:00Z'
+time::ceil($now - 16d, 1d); -- d'2023-10-08T00:00:00Z'
+time::ceil($now - 15d, 1d); -- d'2023-10-09T00:00:00Z'
 ```
 
 ## `time::day`
@@ -290,7 +325,7 @@ CREATE ONLY event:one SET information = "Something happened";
 
 ## `time::floor`
 
-The `time::floor` function rounds a datetime down by a specific duration.
+The `time::floor` function truncates a datetime to the nearest lower multiple of duration from the Unix epoch (January 1, 1970).
 
 ```surql title="API DEFINITION"
 time::floor(datetime, $floor: duration) -> datetime
@@ -309,6 +344,41 @@ value = "d'2021-10-28T00:00:00Z'"
 RETURN time::floor(d"2021-11-01T08:30:17+00:00", 1w);
 
 -- d'2021-10-28T00:00:00Z'
+```
+
+### Implementation details
+
+Since this function truncates a datetime to the nearest lower multiple of duration from the Unix epoch, this means for example that:
+
+* time::floor(now, 18d) rounds down to the nearest multiple of 18 days since epoch
+* time::floor(now, 17d) rounds down to the nearest multiple of 17 days since epoch
+
+Each call uses a different modular base, so the truncation points land at different offsets that may not be sequential. For example, for October 23, 2023 (day ~19,653 since epoch):
+
+* 19653 / 18 = 1091.83… → 1091 × 18 = day 19,638 → Oct 8
+* 19653 / 17 = 1156.05… → 1156 × 17 = day 19,652 → Oct 22
+* 19653 / 16 = 1228.31… → 1228 × 16 = day 19,648 → Oct 18
+* 19653 / 15 = 1310.20… → 1310 × 15 = day 19,650 → Oct 20
+
+
+```surql
+LET $now = d'2023-10-23T09:12:53Z';
+
+time::floor($now, 18d); -- d'2023-10-08T00:00:00Z'
+time::floor($now, 17d); -- d'2023-10-22T00:00:00Z'
+time::floor($now, 16d); -- d'2023-10-18T00:00:00Z'
+time::floor($now, 15d); -- d'2023-10-20T00:00:00Z'
+```
+
+To use this function to truncate to the day, the duration values above can be subtracted from the datetime first, followed by `1d` for the floor.
+
+```surql
+LET $now = d'2023-10-23T09:12:53Z';
+
+time::floor($now - 18d, 1d); -- d'2023-10-05T00:00:00Z'
+time::floor($now - 17d, 1d); -- d'2023-10-06T00:00:00Z'
+time::floor($now - 16d, 1d); -- d'2023-10-07T00:00:00Z'
+time::floor($now - 15d, 1d); -- d'2023-10-08T00:00:00Z'
 ```
 
 <br />

--- a/src/content/reference/query-language/functions/database-functions/time.mdx
+++ b/src/content/reference/query-language/functions/database-functions/time.mdx
@@ -36,7 +36,7 @@ time::yday();
   <tbody>
     <tr>
       <td scope="row" data-label="Function"><a href="#timeceil"><code>time::ceil()</code></a></td>
-      <td scope="row" data-label="Description">Rounds a datetime up to the next largest duration</td>
+      <td scope="row" data-label="Description">Raises a datetime to the nearest multiple of duration from the Unix epoch</td>
     </tr>
     <tr>
       <td scope="row" data-label="Function"><a href="#timeday"><code>time::day()</code></a></td>
@@ -44,7 +44,7 @@ time::yday();
     </tr>
     <tr>
       <td scope="row" data-label="Function"><a href="#timefloor"><code>time::floor()</code></a></td>
-      <td scope="row" data-label="Description">Rounds a datetime down by a specific duration</td>
+      <td scope="row" data-label="Description">Truncates a datetime to the nearest lower multiple of duration from the Unix epoch</td>
     </tr>
     <tr>
       <td scope="row" data-label="Function"><a href="#timeformat"><code>time::format()</code></a></td>
@@ -213,7 +213,7 @@ time::yday();
 
 ## `time::ceil`
 
-The `time::floor` function raises a datetime to the next multiple of duration from the Unix epoch (January 1, 1970).
+The `time::floor` function raises a datetime to the nearest multiple of duration from the Unix epoch (January 1, 1970).
 
 ```surql title="API DEFINITION"
 time::ceil(datetime, $ceiling: duration) -> datetime


### PR DESCRIPTION
The time::floor and time::ceil functions seemed to be working oddly until some [investigation was done](https://github.com/surrealdb/surrealdb/issues/2877#issuecomment-4231017106) to determine how they actually work. Another recent issue on the same: https://github.com/surrealdb/surrealdb/issues/7306

This PR adds these details as well as sample queries for when a user actually wants to truncate or raise to a single date after adding or subtracting a certain length of time (usually days).