### PR TITLE
Add DISKANN

### DIFF
--- a/src/content/learn/data-models/vector-search/embedding-pipelines.mdx
+++ b/src/content/learn/data-models/vector-search/embedding-pipelines.mdx
@@ -25,4 +25,4 @@ There are no strict rules or limitations regarding the length of the embeddings,
 
 In fact, embeddings retrieved from a model can be cut down to any length you prefer if the accuracy is still acceptable for your use case.
 
-For end-to-end similarity examples, see [Similarity search](/docs/learn/data-models/vector-search/similarity-search). For HNSW and brute-force trade-offs, see [Vector indexes](/docs/learn/data-models/vector-search/vector-indexes).
+For end-to-end similarity examples, see [Similarity search](/docs/learn/data-models/vector-search/similarity-search). For HNSW, DISKANN, and brute-force trade-offs, see [Vector indexes](/docs/learn/data-models/vector-search/vector-indexes).

--- a/src/content/learn/data-models/vector-search/hybrid-search.mdx
+++ b/src/content/learn/data-models/vector-search/hybrid-search.mdx
@@ -45,10 +45,36 @@ DEFINE ANALYZER simple TOKENIZERS class, punct FILTERS lowercase, ascii;
 
 -- Full‑text index
 DEFINE INDEX idx_text ON TABLE test FIELDS text FULLTEXT ANALYZER simple BM25;
+```
 
--- Vector index (HNSW) on a 3‑dimensional embedding, using cosine distance
-DEFINE INDEX idx_embedding ON TABLE test FIELDS embedding HNSW DIMENSION 3 DIST COSINE;
+<Tabs synckey="hybrid-vector-index">
+<TabItem label="HNSW (in-memory)">
 
+```surql
+DEFINE INDEX idx_embedding
+    ON TABLE test 
+    FIELDS embedding 
+    HNSW DIMENSION 3 DIST COSINE;
+```
+
+</TabItem>
+<TabItem label="DISKANN (on-disk)">
+
+<Since v="v3.1.0" />
+
+```surql
+DEFINE INDEX idx_embedding
+    ON TABLE test 
+    FIELDS embedding 
+    DISKANN DIMENSION 3 DIST COSINE TYPE F32;
+```
+
+For very large embedding sets that do not fit comfortably in RAM, prefer DISKANN. It is **not available on WASM** builds.
+
+</TabItem>
+</Tabs>
+
+```surql
 -- Query vector (whatever your embedding model produced for "graph databases")
 LET $qvec = [0.12, 0.18, 0.27];
 

--- a/src/content/learn/data-models/vector-search/overview.mdx
+++ b/src/content/learn/data-models/vector-search/overview.mdx
@@ -68,7 +68,7 @@ The guides in this section break down how to store embeddings and query them in 
 
 - [Embedding pipelines](/docs/learn/data-models/vector-search/embedding-pipelines): defining vector fields, record shapes, and dimension trade-offs.
 - [Similarity search](/docs/learn/data-models/vector-search/similarity-search): worked examples, the `vector::` function family, and KNN-style filtering.
-- [Vector indexes](/docs/learn/data-models/vector-search/vector-indexes): brute force vs HNSW, parameters, and the query cheat sheet.
+- [Vector indexes](/docs/learn/data-models/vector-search/vector-indexes): brute force vs HNSW vs DISKANN, parameters, and the query cheat sheet.
 - [Hybrid search](/docs/learn/data-models/vector-search/hybrid-search): combining lexical full-text search with vector retrieval, including `search::rrf()`.
 - [RAG architecture patterns](/docs/learn/data-models/vector-search/rag-architecture-patterns): retrieval-oriented conclusions and further reading.
 

--- a/src/content/learn/data-models/vector-search/similarity-search.mdx
+++ b/src/content/learn/data-models/vector-search/similarity-search.mdx
@@ -60,7 +60,7 @@ The [`vector::distance::knn()`](/docs/reference/query-language/functions/databas
 
 Consider a scenario where you’re searching for actors who look like you but they should have won an Oscar. You set a flag, which is true for actors who’ve won the golden trophy.
 
-Let’s create a dataset of actors and define an HNSW index on the embeddings field.
+Let’s create a dataset of actors and define an approximate vector index on the embeddings field. This walkthrough uses **HNSW**; from SurrealDB 3.1 you can instead use **DISKANN** when your vectors no longer fit comfortably in memory. See the page on [vector indexes](/docs/learn/data-models/vector-search/vector-indexes) for trade-offs and supported `TYPE` / `DIST` combinations.
 
 ```surql
 -- Create a dataset of actors with embeddings and flags
@@ -98,4 +98,4 @@ SELECT id, flag, vector::distance::knn() AS distance FROM actor WHERE flag = tru
 
 `actor:1` and `actor:4` have the closest resemblance with your query vector among those who have also won an Oscar.
 
-For HNSW configuration and the KNN cheat sheet, see [Vector indexes](/docs/learn/data-models/vector-search/vector-indexes).
+For HNSW and DISKANN configuration and the KNN cheat sheet, see [Vector indexes](/docs/learn/data-models/vector-search/vector-indexes).

--- a/src/content/learn/data-models/vector-search/vector-indexes.mdx
+++ b/src/content/learn/data-models/vector-search/vector-indexes.mdx
@@ -1,7 +1,7 @@
 ---
 position: 4
 title: Vector indexes
-description: Choose brute force or HNSW vector indexes, tune DIMENSION and distance metrics, and use the query cheat sheet with vector::distance::knn().
+description: "Choose brute force, HNSW, or DISKANN vector indexes, tune DIMENSION and distance metrics, and use the query cheat sheet with vector::distance::knn()."
 ---
 
 # Vector indexes
@@ -16,20 +16,30 @@ The brute force approach for finding the nearest neighbour is generally preferre
 
 - Small datasets / limited query vectors: For applications with small datasets, the overhead of building and maintaining an index might outweigh its benefits. In such cases, the brute force approach is optimal.
 - Guaranteed accuracy: Since the brute force method compares the query vector against every vector in the dataset, it guarantees finding the exact nearest vectors based on the chosen distance metric (like Euclidean, Manhattan, etc.).
-- Benchmarking models: The brute force approach can be used as a reference to help benchmark the performance of other approximate alternatives like HNSW.
+- Benchmarking models: The brute force approach can be used as a reference to help benchmark the performance of other approximate alternatives like HNSW or DISKANN.
 
 While brute force can give you exact results, it's computationally expensive for large datasets.
 
 In most cases, you do not need a 100% exact match, and you can give it up for faster, high-dimensional searches to find the approximate nearest neighbour to a query vector.
 
-This is where Vector indexes come in.
+This is where vector indexes come in.
 
-In SurrealDB, you can perform a vector search using a [Hierarchical Navigable Small World](https://en.wikipedia.org/wiki/Hierarchical_navigable_small_world) (HNSW) index, a state-of-the-art algorithm for approximate nearest neighbour search in high-dimensional spaces. It is a [proximity graph-based index](/docs/reference/query-language/statements/define/indexes#hnsw-hierarchical-navigable-small-world) that offers a balance between search efficiency and accuracy.
+## HNSW and DISKANN
+
+SurrealDB offers two **approximate** graph indexes for k-nearest-neighbour search:
+
+| Index | Best for | Storage |
+| --- | --- | --- |
+| [HNSW](https://en.wikipedia.org/wiki/Hierarchical_navigable_small_world) ([`DEFINE INDEX … HNSW`](/docs/reference/query-language/statements/define/indexes#hnsw-hierarchical-navigable-small-world)) | Low-latency ANN when the graph fits comfortably in memory with headroom for the bounded vector cache | In-memory hot graph + persistence |
+| [DISKANN](https://arxiv.org/abs/1907.01668) ([`DEFINE INDEX … DISKANN`](/docs/reference/query-language/statements/define/indexes#diskann-disk-based-approximate-nearest-neighbours)) *(SurrealDB 3.1+)* | Very large corpora where RAM cannot hold the full graph — optimises for **disk-resident** graphs and quantisation-friendly types | On-disk graph with caching (not on **WASM** targets) |
+
+Both are [proximity graph](/docs/reference/query-language/statements/define/indexes#hnsw-hierarchical-navigable-small-world)-style indexes. Queries use the same [`<|K, …|>` KNN operator shapes](/docs/reference/query-language/language-primitives/operators#knn); the optimiser picks the index when distances and types line up.
 
 ## Vector search cheat sheet
 
-- HNSW: efficient approximation for high dimensions or large datasets
-- Brute force: when you don’t define an index, or you want exact nearest neighbours, or when you provide a distance function to the query
+- **HNSW** — efficient in-memory approximation for high dimensions or large in-RAM datasets.
+- **DISKANN** — disk-oriented approximation for embeddings that exceed practical memory for a pure HNSW graph.
+- **Brute force** — when you do not define an index, when you want exact nearest neighbours, or when you pass an explicit distance function to the query that does not route to your index.
 
 ### HNSW index
 
@@ -57,6 +67,26 @@ DEFINE INDEX hnsw_idx ON pts FIELDS point HNSW DIMENSION 4 DIST EUCLIDEAN TYPE F
 
 For more details, see the [`DEFINE INDEX` statement](/docs/reference/query-language/statements/define/indexes#hnsw-hierarchical-navigable-small-world) documentation.
 
+### DISKANN index
+
+<Since v="v3.1.0" />
+
+| Parameter  | Default   | Options | Description |
+| ---------- | --------- | ------- | ----------- |
+| DIMENSION  |           |         | Vector dimension |
+| DIST       | EUCLIDEAN | EUCLIDEAN, COSINE, INNER_PRODUCT, COSINE_NORMALIZED | Distance (narrower set than HNSW) |
+| TYPE       | F32       | F32, F16, I8, U8 | Element encoding (`COSINE_NORMALIZED` requires `F32` or `F16`) |
+| DEGREE     | 64        | > 0     | Target maximum graph degree |
+| L_BUILD    | 100       | > 0     | Construction search-list size |
+| ALPHA      | 1.2       |         | DiskANN pruning parameter |
+| HASHED_VECTOR | off    |         | Optional hash-stabilised vector keys |
+
+```surql
+DEFINE INDEX diskann_idx ON pts FIELDS point DISKANN DIMENSION 4 DIST COSINE TYPE F32;
+```
+
+See [`DEFINE INDEX` → DISKANN](/docs/reference/query-language/statements/define/indexes#diskann-disk-based-approximate-nearest-neighbours) for platform notes (including **no WASM support**).
+
 ### Querying
 
 ```surql
@@ -76,6 +106,8 @@ WHERE point
     $vector;
 ```
 
+With a DISKANN index defined on `point`, the same `<|K, EF|>` approximate form applies; the second number bounds the dynamic candidate list for search (see the [KNN operator](/docs/reference/query-language/language-primitives/operators#knn)).
+
 | Functions                                 |     |
 | ------------------------------------------------ | --- |
 | `vector::distance::knn()`                        | reuses the value computed during the query
@@ -90,22 +122,22 @@ WHERE point
 
 **WHERE statement**
 
-| Query                   | HNSW index |
-| ----------------------- | ---------- |
-| `<\|2\|>`               | uses distance function defined in index
-| `<\|2, EUCLIDEAN\|>`    | brute force method
-| `<\|2, COSINE\|>`       | brute force method
-| `<\|2, MANHATTAN\|>`    | brute force method
-| `<\|2, MINKOWSKI, 3\|>` | brute force method (third param is [𝑝](#notes))
-| `<\|2, CHEBYSHEV\|>`    | brute force method
-| `<\|2, HAMMING\|>`      | brute force method
-| `<\|2, 10\|>`           | second param is effort*
+| Query                   | HNSW index | DISKANN index |
+| ----------------------- | ---------- | --------------- |
+| `<\|2\|>`               | uses distance function defined in index | same when the index distance matches |
+| `<\|2, EUCLIDEAN\|>`    | brute force method | brute force method |
+| `<\|2, COSINE\|>`       | brute force method | brute force method |
+| `<\|2, MANHATTAN\|>`    | brute force method | brute force method |
+| `<\|2, MINKOWSKI, 3\|>` | brute force method (third param is [𝑝](#notes)) | brute force method |
+| `<\|2, CHEBYSHEV\|>`    | brute force method | brute force method |
+| `<\|2, HAMMING\|>`      | brute force method | brute force method |
+| `<\|2, 10\|>`           | second param is effort* | same approximate form — second value bounds the candidate list |
 
-*effort: Tells HNSW how far to go in trying to find the exact response. HNSW is approximate, and may miss some vectors.
+\* **effort** — for HNSW and DISKANN, the second number in `<|K, N|>` tells the engine how far to search along the graph. Both algorithms are approximate and may miss some vectors.
 
 ### Notes
 
-- Verify index utilization in queries using the [`EXPLAIN FULL` clause](/docs/reference/query-language/statements/select#the-explain-clause). E.g: `SELECT id FROM pts WHERE point <|10|> [2,3,4,5] EXPLAIN FULL;`
+- Verify index utilisation in queries using the [`EXPLAIN FULL` clause](/docs/reference/query-language/statements/select#the-explain-clause). E.g: `SELECT id FROM pts WHERE point <|10|> [2,3,4,5] EXPLAIN FULL;`
 - 𝑝 values: (more about 𝑝 in [Minkowski distance](https://en.wikipedia.org/wiki/Minkowski_distance))
   - 2<sup>0</sup> = 1 → manhattan/diamond ◇
   - 2<sup>1</sup> = 2 → euclidean/circle ○

--- a/src/content/reference/query-language/language-primitives/operators.mdx
+++ b/src/content/reference/query-language/language-primitives/operators.mdx
@@ -1576,10 +1576,14 @@ CREATE pts:3 SET point = [8,9,10,11];
 SELECT id FROM pts WHERE point <|2,EUCLIDEAN|> [2,3,4,5];
 ```
 
-### HNSW method
+### Approximate graph indexes
 
+<Tabs synckey="knn-approximate-indexes">
+<TabItem label="HNSW">
 
-Recommended for very large datasets where speed is essential and some loss of accuracy is acceptable.
+#### HNSW
+
+Recommended for very large datasets where speed is essential and some loss of accuracy is acceptable, **while the graph fits in memory**.
 
 ```syntax title="SurrealQL Syntax"
 <|K,EF|>
@@ -1606,6 +1610,31 @@ CREATE pts:3 SET point = [8,9,10,11];
 DEFINE INDEX mt_pts ON pts FIELDS point HNSW DIMENSION 4 DIST EUCLIDEAN EFC 150 M 12;
 SELECT id FROM pts WHERE point <|10,40|> [2,3,4,5];
 ```
+
+</TabItem>
+<TabItem label="DISKANN">
+
+#### DISKANN
+
+<Since v="v3.1.0" />
+
+Recommended when embeddings are too large to keep an HNSW graph resident in RAM as the graph lives on disk with caching. Note that WASM targets do not support DISKANN, so use HNSW or brute force there.
+
+The query syntax matches HNSW: use the approximate form `<|K, L|>` where the second value bounds the search candidate list (see [`DEFINE INDEX … DISKANN`](/docs/reference/query-language/statements/define/indexes#diskann-disk-based-approximate-nearest-neighbours) for defaults and supported `TYPE` / `DIST` combinations).
+
+```syntax title="SurrealQL Syntax"
+<|K,L|>
+```
+
+```surql
+CREATE pts:3 SET point = [8,9,10,11];
+DEFINE INDEX diskann_pts ON pts FIELDS point DISKANN DIMENSION 4 DIST EUCLIDEAN TYPE F32 DEGREE 8 L_BUILD 20;
+SELECT id FROM pts WHERE point <|10,40|> [2,3,4,5];
+```
+
+</TabItem>
+</Tabs>
+
 <br /><br />
 
 ## Using the `ANY`/`ALL` operators for string indexes

--- a/src/content/reference/query-language/statements/define/indexes.mdx
+++ b/src/content/reference/query-language/statements/define/indexes.mdx
@@ -1,7 +1,7 @@
 ---
 position: 11
 title: DEFINE INDEX
-description: "SurrealDB uses indexes to help optimize query performance. An index can consist of one or more fields in a table and can enforce a uniqueness constraint."
+description: "SurrealDB uses indexes to help optimize query performance. An index can consist of one or more fields in a table and can enforce a uniqueness constraint — including HNSW and DISKANN vector indexes."
 ---
 
 > [!NOTE]
@@ -37,7 +37,8 @@ The `@special_clause` part of the statement is an optional part in which an inde
 UNIQUE
 | COUNT
 | FULLTEXT ANALYZER @analyzer [ BM25 [(@k1, @b)] ] [ HIGHLIGHTS ]
-| HNSW DIMENSION @dimension [ TYPE @type ] [DIST @distance] [ EFC @efc ] [ M @m ]
+| HNSW DIMENSION @dimension [ TYPE @type ] [ DIST @distance ] [ EFC @efc ] [ M @m ]
+| DISKANN DIMENSION @dimension [ TYPE @type ] [ DIST @distance ] [ DEGREE @degree ] [ L_BUILD @l_build ] [ ALPHA @alpha ] [ HASHED_VECTOR ]
 ```
 
   </TabItem>
@@ -260,6 +261,10 @@ When defining a vector index with [HNSW](#hnsw-hierarchical-navigable-small-worl
 > [!NOTE]
 > In SurrealDB the default type for vectors is `F64`.
 
+<Since v="v3.1.0" />
+
+[DISKANN](#diskann-disk-based-approximate-nearest-neighbours) indexes accept a **narrower** set of element types: `F32`, `F16`, `I8`, and `U8` only, and only a subset of distance metrics — see the [DISKANN](#diskann-disk-based-approximate-nearest-neighbours) section below.
+
 For example, to define a vector index with 64-bit signed integers, you can use the following query:
 
 ```surql
@@ -302,6 +307,45 @@ Used to determine the maximum level ll for a new element during its insertion in
 <Since v="v3.0.0" />
 
 HNSW vector search uses a bounded memory cache by default, reducing memory spikes and improving stability under load. The default size for the cache is 256 MiB, and can be modified via the `SURREAL_HNSW_CACHE_SIZE` [environment variable](/docs/reference/cli/surrealdb-cli/environment-variables).
+
+### DISKANN (disk-based approximate nearest neighbours)
+
+<Since v="v3.1.0" />
+
+[DiskANN](https://arxiv.org/abs/1907.01668)-style indexes provide **on-disk** approximate nearest-neighbour graphs. They are aimed at **very large** embedding sets where keeping the full graph in RAM (as with HNSW) is impractical: vectors and graph structure are persisted in the key-value store and paged through a bounded cache, trading some latency for a much larger working set.
+
+> [!NOTE]
+> DISKANN indexes are **not supported on WASM** targets. Use HNSW or brute-force KNN for browser / embedded WASM builds.
+
+#### Syntax and defaults
+
+The clause mirrors HNSW: `DISKANN DIMENSION …` followed by optional `TYPE`, `DIST`, tuning knobs, and `HASHED_VECTOR`.
+
+```surql
+DEFINE INDEX diskann_pts ON pts FIELDS point DISKANN DIMENSION 4 DIST EUCLIDEAN TYPE F32;
+-- Same index with defaults written out explicitly:
+-- DEFINE INDEX diskann_pts ON pts FIELDS point DISKANN DIMENSION 4 DIST EUCLIDEAN TYPE F32 DEGREE 64 L_BUILD 100 ALPHA 1.2;
+```
+
+| Clause | Default | Notes |
+| --- | --- | --- |
+| `DIST` | `EUCLIDEAN` | Only `EUCLIDEAN`, `COSINE`, `INNER_PRODUCT`, and `COSINE_NORMALIZED` are valid for DISKANN. |
+| `TYPE` | `F32` | Must be one of `F32`, `F16`, `I8`, `U8`. `COSINE_NORMALIZED` further requires `F32` or `F16`. |
+| `DEGREE` | `64` | Target maximum graph degree (`> 0`). |
+| `L_BUILD` | `100` | Construction search-list size (`> 0`). |
+| `ALPHA` | `1.2` | DiskANN pruning parameter. |
+| `HASHED_VECTOR` | off | Same semantics as for HNSW — hash-stabilised vector–document keys. |
+
+Queries use the **same** KNN operator shape as HNSW: `<|K, EF|>` (approximate) or `<|K, DIST|>` when the distance matches the index, letting the optimiser pick the DISKANN graph. The second number in the approximate form bounds the dynamic candidate list during search (analogous to HNSW `EF`).
+
+#### Choosing HNSW or DISKANN
+
+| Concern | Prefer HNSW | Prefer DISKANN |
+| --- | --- | --- |
+| Working set size | Fits comfortably in memory with headroom for the HNSW cache | Much larger than RAM; cold data should stay on disk |
+| Latency profile | Lowest latency when the graph is hot in cache | Extra I/O; better for throughput to cost on huge corpora |
+| Vector element types | Full set (`F64` … `I16` in docs above) | Quantised-friendly types (`F32`, `F16`, `I8`, `U8`) |
+| Deployment target | Includes WASM | Server / native binaries only |
 
 ### Brute Force method
 


### PR DESCRIPTION
Adds docs for DISKANN which makes for three choices for vector search in addition to the existing brute force and HNSW.