### PR TITLE
fix(kreuzberg): remove HWPX MIME workaround, use native hwpx feature

### DIFF
--- a/src/content/build/integrations/ai-frameworks/kreuzberg.mdx
+++ b/src/content/build/integrations/ai-frameworks/kreuzberg.mdx
@@ -93,7 +93,7 @@ For more ideas on how to redo this example to suit your own needs, see the [API 
 
 ```rust
 // Required features to run:
-// kreuzberg = { version = "4.9.4", default-features = true, features = ["archives", "language-detection", "xml"] }
+// kreuzberg = { version = "4.9.4", default-features = true, features = ["hwpx", "language-detection"] }
 // surrealdb = { version = "3.1.0-beta.1", default-features = true, features = ["protocol-ws", "kv-mem"] }
 use anyhow::{Context, Result};
 use kreuzberg::{extract_file, ExtractionConfig, LanguageDetectionConfig};
@@ -216,11 +216,6 @@ pub fn document_record_from_json_entry(
 
 const TABLE: &str = "documents";
 
-/// HWPX is a ZIP package; Kreuzberg maps `.hwpx`to `application/haansofthwpx`, which is only
-/// handled when the `hwp` feature is enabled (legacy CFB `.hwp` path is wrong for HWPX, which is essentially a .zip of .xml files).
-/// Force ZIP so `archives` + `xml` handle the package.
-const HWPX_ZIP_MIME: &str = "application/zip";
-
 fn sha256_hex(content: &str) -> String {
     let mut h = Sha256::new();
     h.update(content.as_bytes());
@@ -293,10 +288,7 @@ async fn ingest_path(
         }
         Ok(records)
     } else {
-        // `demo.md` / `.markdown`: Kreuzberg resolves `text/markdown` from the extension.
-        // Other non-JSON types: same path. `.hwpx` only: force `application/zip` (see `HWPX_ZIP_MIME`).
-        let mime_hint = (ext == "hwpx").then_some(HWPX_ZIP_MIME);
-        let extracted = extract_file(&path, mime_hint, config)
+        let extracted = extract_file(&path, None, config)
             .await
             .with_context(|| format!("Kreuzberg extract {}", path.display()))?;
         if !extracted.processing_warnings.is_empty() {


### PR DESCRIPTION
The Rust example in #1755 used a forced `application/zip` MIME hint to work around a Kreuzberg bug where `.hwpx` files were misrouted through the legacy HWP (CFB) extractor.

This has since been fixed upstream in kreuzberg-dev/kreuzberg#872 and kreuzberg-dev/kreuzberg#875, which removed the false MIME claim and added a dedicated `HwpxExtractor` backed by the `unhwp` crate. This PR drops the workaround and updates the required features from `["archives", "language-detection", "xml"]` to `["hwpx", "language-detection"]`.