### PR TITLE
Update the source of truth for latest SurrealDB versions

### DIFF
--- a/src/lib/versions/fetchers.ts
+++ b/src/lib/versions/fetchers.ts
@@ -1,10 +1,15 @@
 import type { VersionFetcher } from "./types";
 
-export function createGitHubFetcher(owner: string, repo: string): VersionFetcher {
+export function createSurrealDbVersionFetcher(): VersionFetcher {
     return async () => {
-        const res = await fetch(`https://api.github.com/repos/${owner}/${repo}/releases/latest`);
-        const data = await res.json();
-        return data?.tag_name ?? "unknown";
+        const res = await fetch("https://version.surrealdb.com");
+
+        if (!res.ok) {
+            return "unknown";
+        }
+
+        const version = (await res.text()).trim();
+        return version || "unknown";
     };
 }
 

--- a/src/lib/versions/registry.ts
+++ b/src/lib/versions/registry.ts
@@ -1,17 +1,17 @@
 import {
     createCratesIoFetcher,
-    createGitHubFetcher,
     createGoProxyFetcher,
     createMavenFetcher,
     createNpmFetcher,
     createNuGetFetcher,
     createPackagistFetcher,
     createPyPiFetcher,
+    createSurrealDbVersionFetcher,
 } from "./fetchers";
 import type { VersionFetcher } from "./types";
 
 export const sdkFetcherRegistry: Record<string, VersionFetcher> = {
-    surrealdb: createGitHubFetcher("surrealdb", "surrealdb"),
+    surrealdb: createSurrealDbVersionFetcher(),
     ".net": createNuGetFetcher("SurrealDb.Net"),
     php: createPackagistFetcher("surrealdb", "surrealdb.php"),
     javascript: createNpmFetcher("surrealdb"),


### PR DESCRIPTION
https://surrealdb.com/docs/running/installation currently shows the latest SurrealDB version as `v3.0.5` instead of `v3.1.2`. This is because it still uses `surrealdb/surrealdb` as the source of truth for latest SurrealDB releases. Since development has moved to a private repository, it's no longer current. This PR changes it to fetch the version from https://version.surrealdb.com instead.