### PR TITLE
Add MCP walkthrough

### DIFF
--- a/src/content/build/ai-agents/agent-rules.mdx
+++ b/src/content/build/ai-agents/agent-rules.mdx
@@ -1,5 +1,5 @@
 ---
-position: 5
+position: 6
 title: Agent rules
 description: "Building AI agents and agent rules with SurrealDB."
 ---

--- a/src/content/build/ai-agents/agent-skills.mdx
+++ b/src/content/build/ai-agents/agent-skills.mdx
@@ -1,5 +1,5 @@
 ---
-position: 4
+position: 5
 title: Agent Skills
 description: Official SurrealDB agent skills for use in agentic coding workflows.
 ---

--- a/src/content/build/ai-agents/ai-frameworks.mdx
+++ b/src/content/build/ai-agents/ai-frameworks.mdx
@@ -1,5 +1,5 @@
 ---
-position: 3
+position: 4
 title: AI frameworks
 description: "Building AI agents and agent rules with SurrealDB."
 ---

--- a/src/content/build/ai-agents/connect-mcp-to-your-editor.mdx
+++ b/src/content/build/ai-agents/connect-mcp-to-your-editor.mdx
@@ -1,0 +1,214 @@
+---
+position: 3
+title: Connect MCP to your coding assistant
+description: "Step-by-step tutorial — wire Cursor, VS Code, or Claude Desktop to SurrealDB's built-in MCP server."
+---
+
+# Connect MCP to your coding assistant
+
+<Since v="v3.1.0" />
+
+This tutorial walks you through connecting a coding assistant to SurrealDB using the [Model Context Protocol (MCP)](https://modelcontextprotocol.io). If MCP is new to you: it is a standard way for a coding assistant to call **tools** exposed by a server. SurrealDB's built-in MCP server publishes tools such as `query`, `select`, and `use` so your assistant can run SurrealQL and inspect schema without you copying SQL into a separate client.
+
+For the full tool list, limits, and security model, see [Model Context Protocol (MCP)](/docs/build/ai-agents/mcp). This page focuses on getting a working setup you can verify in a few minutes.
+
+> [!NOTE]
+> SurrealDB 3.1+ includes MCP in the main binary. Third-party MCP servers listed on [Surreal Labs](/docs/labs) (for example [surrealdb-mcp-server on GitHub](https://github.com/nsxdavid/surrealdb-mcp-server)) are separate projects; this tutorial uses the **built-in** server only.
+
+## Choose your setup
+
+Both `surreal start` (to start a SurrealDB server) and `surreal mcp` (to start a SurrealDB MCP server) expose the same tools (`query`, `select`, `use`, …). Pick based on **who shares the database** and **how auth should work**. See [When to use `surreal mcp` vs `surreal start`](/docs/build/ai-agents/mcp#when-to-use-surreal-mcp-vs-surreal-start) for the full comparison.
+
+| Situation | Use | Editor config |
+| --- | --- | --- |
+| Learning MCP or solo local dev | **`surreal mcp`** (stdio) | `command` + `args` |
+| Agent should use the same DB as your app or team | **`surreal start`** → **`/mcp`** (HTTP) | `url` + auth headers |
+| Database runs on SurrealDB Cloud or a remote host | **`surreal start`** → **`/mcp`** (HTTP) | `url` + auth headers |
+
+**Stdio** launches an embedded database in the same process as the MCP server — no separate terminal, no port, owner-level access. **HTTP** connects to a server you already run, with normal login and the option of least-privilege users.
+
+> [!WARNING]
+> Stdio MCP runs every tool call with owner-level access. Use it only on a machine you trust. Do not expose `surreal mcp` to untrusted users. See the [security checklist](/docs/build/ai-agents/mcp#security-checklist) before production HTTP deployments.
+
+## Prerequisites
+
+1. [Install SurrealDB](/docs/running/installation) and confirm the binary is on your `PATH`.
+
+If `surreal` is not on your `PATH`, use the full path from `which surreal` (macOS/Linux) or `where surreal` (Windows) as `command`.
+
+2. **An MCP-capable editor** — Cursor, VS Code (1.99+ with Copilot agent mode or another MCP client), or Claude Desktop.
+
+3. **Optional smoke test** — run the server manually once to confirm it starts:
+
+```bash
+surreal mcp --user root --pass secret --ns main --db main memory
+```
+
+You should see a log line that the MCP server is starting over stdio. Press Ctrl+C to stop; your editor will launch this command for you.
+
+## Path A — Local stdio (Cursor)
+
+This is the fastest path: the editor spawns `surreal mcp` as a child process and talks to it over stdin/stdout.
+
+### Step 1 — Create or edit your MCP config
+
+**Cursor** reads `~/.cursor/mcp.json` (global) or `.cursor/mcp.json` (project). Add a `surrealdb` entry:
+
+```json
+{
+  "mcpServers": {
+    "surrealdb": {
+      "command": "surreal",
+      "args": ["mcp", "--user", "root", "--pass", "secret", "--ns", "main", "--db", "main", "memory"]
+    }
+  }
+}
+```
+
+> [!NOTE]
+> `--user` and `--pass` create the root user on a **new** datastore (same semantics as [`surreal start`](/docs/reference/cli/surrealdb-cli/commands/start)). Stdio MCP still runs every tool call as **owner** — these flags do not authenticate each MCP request. They are not needed for throwaway in-memory use if the `--unauthenticated` flag is passed in when starting up the server, but recommended when you persist to disk or may later open the same path with `surreal start` and HTTP `/mcp`. For project-level config, prefer an `env` block (`SURREAL_USER`, `SURREAL_PASS`) instead of literals in `args` so you do not commit passwords.
+
+**Persist data between sessions** by replacing `memory` with a [file-backed path](/docs/reference/cli/surrealdb-cli/commands/start#datastore-configuration):
+
+```json
+"args": ["mcp", "--user", "root", "--pass", "secret", "--ns", "main", "--db", "main", "rocksdb://tmp/surreal-mcp"]
+```
+
+Create the directory first, or pick a path under your project. See [`surreal mcp`](/docs/reference/cli/surrealdb-cli/commands/mcp) for other storage backends.
+
+### Step 2 — Restart Cursor and verify
+
+1. Open **Settings → Features → MCP** (or **Cursor Settings → MCP**).
+2. Confirm **surrealdb** appears with a green / connected indicator.
+3. Open chat and ask: **"What MCP tools do you have for SurrealDB?"**
+
+You should see tools including `query`, `select`, `create`, `insert`, `update`, `delete`, `list`, `use`, and `info`.
+
+### Step 3 — First end-to-end task
+
+Paste a prompt like this:
+
+> Using the SurrealDB MCP tools, create a `task` table with fields `title` (string) and `done` (bool). Insert two tasks — one done, one not. Then list tasks where `done` is false and show me the result.
+
+The assistant should call MCP tools (often `query` or the CRUD helpers) against namespace **`main`** and database **`main`** as configured in your `args`. If something fails, check [Troubleshooting](#troubleshooting) below.
+
+## Other editors (stdio)
+
+<Tabs>
+
+<TabItem label="Claude Desktop">
+
+Config file (macOS): `~/Library/Application Support/Claude/claude_desktop_config.json`
+
+```json
+{
+  "mcpServers": {
+    "surrealdb": {
+      "command": "surreal",
+      "args": ["mcp", "--user", "root", "--pass", "secret", "--ns", "main", "--db", "main", "memory"]
+    }
+  }
+}
+```
+
+Restart Claude Desktop completely after saving. In a new chat, ask what MCP tools are available.
+
+</TabItem>
+
+<TabItem label="VS Code">
+
+VS Code uses a `servers` object and a `type` field. Workspace config: `.vscode/mcp.json`
+
+```json
+{
+  "servers": {
+    "surrealdb": {
+      "type": "stdio",
+      "command": "surreal",
+      "args": ["mcp", "--user", "root", "--pass", "secret", "--ns", "main", "--db", "main", "memory"]
+    }
+  }
+}
+```
+
+Enable Copilot agent mode (`github.copilot.chat.agent.enabled`) or use another MCP-compatible extension. Reload the window after editing the config.
+
+</TabItem>
+
+</Tabs>
+
+## Path B — HTTP (`surreal start`)
+
+Use this when SurrealDB already runs as a service and you want authenticated, network-accessible MCP.
+
+### Step 1 — Start the server
+
+```bash
+surreal start --user root --pass secret --bind 127.0.0.1:8000 memory
+```
+
+MCP is available at **`http://127.0.0.1:8000/mcp`** on the same listener as the REST API.
+
+### Step 2 — Configure your editor
+
+**Cursor** example (global `~/.cursor/mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "surrealdb": {
+      "url": "http://127.0.0.1:8000/mcp",
+      "headers": {
+        "Authorization": "Basic <base64-encoded username:password>"
+      }
+    }
+  }
+}
+```
+
+Replace the header value with Base64-encoded credentials for your SurrealDB user (for example `root:secret` during local dev). In production, prefer a least-privilege `DEFINE USER` and TLS in front of the server — see [MCP security](/docs/build/ai-agents/mcp#security-checklist).
+
+**VS Code** uses the same URL but wraps it in `servers`:
+
+```json
+{
+  "servers": {
+    "surrealdb": {
+      "type": "http",
+      "url": "http://127.0.0.1:8000/mcp",
+      "headers": {
+        "Authorization": "Basic <base64-encoded username:password>"
+      }
+    }
+  }
+}
+```
+
+After connecting, run the same verification prompt as in Path A.
+
+## What your assistant can do
+
+Once connected, the assistant can use the published tools documented on the [MCP overview](/docs/build/ai-agents/mcp#published-tools). Typical workflows:
+
+- **Explore** — `list` namespaces, databases, and tables; `info` for schema detail.
+- **Context** — `use` to select namespace and database (stdio already sets `--ns` / `--db`, but `use` still helps when switching).
+- **Read and write** — `query` for arbitrary SurrealQL, or `select` / `create` / `insert` / `update` / `delete` / `relate` for structured operations.
+
+Permissions match those for the [`/sql`](/docs/reference/rest-api/http-protocol#post-sql) endpoint: table `PERMISSIONS`, user roles, and server capability flags all apply.
+
+## Troubleshooting
+
+| Symptom | Things to check |
+| --- | --- |
+| Red / disconnected in MCP settings | Is `surreal` on `PATH`? Try the full path in `command`. Run `surreal mcp --user root --pass secret --ns main --db main memory` manually for errors. |
+| Tools list empty | Restart the editor after editing MCP config. Confirm SurrealDB version is 3.1+. |
+| Query timeout | Default tool timeout is 60 seconds (`SURREAL_MCP_QUERY_TIMEOUT_SECS`). Large scans may need a narrower query. |
+| Result truncated | Output is capped (default 256 KiB). Paginate or aggregate in SurrealQL. See [MCP configuration](/docs/build/ai-agents/mcp#configuration). |
+| Permission errors on HTTP | User lacks rights for the operation. Sign in with appropriate credentials or adjust `DEFINE USER` / `PERMISSIONS`. |
+
+## Next steps
+
+- [Model Context Protocol (MCP)](/docs/build/ai-agents/mcp) — transports, tools, environment variables, security
+- [`surreal mcp` CLI reference](/docs/reference/cli/surrealdb-cli/commands/mcp)
+- [Agent Skills](/docs/build/ai-agents/agent-skills) — teach assistants SurrealQL patterns alongside MCP
+- [Why SurrealDB for AI agents](/docs/build/ai-agents) — memory, retrieval, and agent architecture

--- a/src/content/build/ai-agents/index.mdx
+++ b/src/content/build/ai-agents/index.mdx
@@ -16,6 +16,6 @@ AI agents need durable state, flexible querying, and fast retrieval. SurrealDBâ€
 
 You can evolve schemas and indexes as your agent workflows change, keeping operational overhead low. For ready-made connections to popular agent libraries, see the [AI frameworks integrations overview](/docs/build/integrations/ai-frameworks/overview).
 
-<Since v="v3.1.0" /> SurrealDB also exposes a built-in [Model Context Protocol (MCP)](/docs/build/ai-agents/mcp) server (`surreal mcp` on stdio, `/mcp` on `surreal start`) so agents can query and mutate data through a standard tool surface with the same permissions as `/sql`.
+<Since v="v3.1.0" /> SurrealDB also exposes a built-in [Model Context Protocol (MCP)](/docs/build/ai-agents/mcp) server (`surreal mcp` on stdio, `/mcp` on `surreal start`) so agents can query and mutate data through a standard tool surface with the same permissions as `/sql`. New to MCP? Start with [Connect MCP to your coding assistant](/docs/build/ai-agents/connect-mcp-to-your-editor).
 
 What that means in practice is that you can store conversation state and retrieved chunks beside canonical records (users, tickets, products) in one place.

--- a/src/content/build/ai-agents/mcp.mdx
+++ b/src/content/build/ai-agents/mcp.mdx
@@ -10,6 +10,25 @@ description: "Connect AI agents and IDEs to SurrealDB through the built-in MCP s
 
 SurrealDB ships a built-in [Model Context Protocol](https://modelcontextprotocol.io) server so agents and editors can list schema, run SurrealQL, and manipulate records through a standard tool surface. The same access-control rules as [`/sql`](/docs/reference/rest-api/http-protocol#post-sql) and RPC apply: `DEFINE USER` permissions, table `PERMISSIONS`, and server capability flags all gate what tools can do.
 
+Both entry points expose the **same MCP tools** — the difference is how your editor connects and who shares the database.
+
+## When to use `surreal mcp` vs `surreal start`
+
+| | **`surreal mcp`** (stdio) | **`surreal start`** + **`/mcp`** (HTTP) |
+| --- | --- | --- |
+| **How it works** | Your editor spawns SurrealDB as a child process; MCP runs over stdin/stdout | You run a server; the editor connects to `http://…/mcp` |
+| **Database** | Embedded in the MCP process (default `memory`, or a local file path) | The same instance your app, CLI, or Surrealist uses |
+| **Authentication** | Owner-level access for every tool call — no login step | Normal SurrealDB auth (Bearer JWT, HTTP Basic, …) |
+| **Best for** | Learning MCP, solo local dev, quickest editor setup | Shared databases, teams, remote/Cloud instances, production patterns |
+| **Editor config** | `command` + `args` in MCP settings | `url` + auth headers |
+
+**Use `surreal mcp` when** you want the lowest-friction path on a machine you trust — paste a config, restart the editor, and experiment. Think of it as a self-contained database for your assistant.
+
+**Use `surreal start` and `/mcp` when** the agent should work against a database that already exists or that other clients share. That is the right model for least-privilege users, TLS, audit logging, and anything beyond trusted solo local dev.
+
+> [!TIP]
+> New to MCP? Start with [`surreal mcp`](/docs/build/ai-agents/connect-mcp-to-your-editor) in your coding assistant, then move to HTTP once you want the agent on the same SurrealDB instance as your application.
+
 ## Transports
 
 ### HTTP (`/mcp`)
@@ -28,7 +47,7 @@ Run behind TLS in production. The `mcp-session-id` header acts like a bearer tok
 For local IDE integrations (Cursor, VS Code, Claude Desktop, and similar), use the dedicated subcommand. It runs the MCP server in-process with an embedded datastore:
 
 ```bash
-surreal mcp --ns main --db main memory
+surreal mcp --user root --pass secret --ns main --db main memory
 ```
 
 Stdio uses `Session::owner()` for every tool call. **Do not expose this entry point to untrusted users** — there is no per-request credential re-binding on stdio because there is no network handshake to attach headers to.
@@ -73,6 +92,7 @@ Full tables live under [Environment variables](/docs/reference/cli/surrealdb-cli
 
 ## Next steps
 
+- **[Connect MCP to your coding assistant](/docs/build/ai-agents/connect-mcp-to-your-editor)** — step-by-step Cursor, VS Code, and Claude Desktop setup
 - [Why SurrealDB for AI agents](/docs/build/ai-agents) — memory, tools, and retrieval patterns
 - [Agent Skills](/docs/build/ai-agents/agent-skills) — installable SurrealQL and SDK skills for coding agents
 - [AI frameworks integrations](/docs/build/integrations/ai-frameworks/overview)

--- a/src/content/reference/cli/surrealdb-cli/commands/export.mdx
+++ b/src/content/reference/cli/surrealdb-cli/commands/export.mdx
@@ -1,5 +1,5 @@
 ---
-position: 5
+position: 4
 title: export
 description: A command to export data from a SurrealDB database server into a SurrealQL file format.
 ---

--- a/src/content/reference/cli/surrealdb-cli/commands/fix.mdx
+++ b/src/content/reference/cli/surrealdb-cli/commands/fix.mdx
@@ -1,5 +1,5 @@
 ---
-position: 6
+position: 5
 title: fix
 description: A command to convert SurrealDB version 1.x data into a usable format for versions 2.0 and above.
 ---

--- a/src/content/reference/cli/surrealdb-cli/commands/help.mdx
+++ b/src/content/reference/cli/surrealdb-cli/commands/help.mdx
@@ -1,5 +1,5 @@
 ---
-position: 12
+position: 6
 title: help
 description: A command to display all possible top-level commands and arguments used in the the SurrealDB binary.
 ---

--- a/src/content/reference/cli/surrealdb-cli/commands/import.mdx
+++ b/src/content/reference/cli/surrealdb-cli/commands/import.mdx
@@ -1,5 +1,5 @@
 ---
-position: 4
+position: 7
 title: import
 description: A command that imports a file in SurrealQL format into a local or remote SurrealDB database server.
 ---

--- a/src/content/reference/cli/surrealdb-cli/commands/index.mdx
+++ b/src/content/reference/cli/surrealdb-cli/commands/index.mdx
@@ -8,20 +8,22 @@ description: How the SurrealDB CLI is organised into subcommands, with links to 
 
 The `surreal` executable exposes a single entry point with **subcommands** for running the server, executing SurrealQL, importing and exporting data, and maintenance tasks. Each page documents that subcommand’s arguments, related environment variables, and typical usage.
 
+**Sidebar order:** [`start`](/docs/reference/cli/surrealdb-cli/commands/start) and [`sql`](/docs/reference/cli/surrealdb-cli/commands/sql) first, then remaining subcommands alphabetically.
+
 | Subcommand | Purpose |
 | --- | --- |
 | [`start`](/docs/reference/cli/surrealdb-cli/commands/start) | Run a SurrealDB server (in memory, on disk, or clustered). |
 | [`sql`](/docs/reference/cli/surrealdb-cli/commands/sql) | Open an interactive SurrealQL shell or run queries from scripts. |
-| [`import`](/docs/reference/cli/surrealdb-cli/commands/import) | Load SurrealQL from a file into a database. |
 | [`export`](/docs/reference/cli/surrealdb-cli/commands/export) | Dump a database to SurrealQL. |
 | [`fix`](/docs/reference/cli/surrealdb-cli/commands/fix) | Apply data or schema fixes offline. |
-| [`ml`](/docs/reference/cli/surrealdb-cli/commands/ml) | Work with machine-learning features from the CLI. |
-| [`module`](/docs/reference/cli/surrealdb-cli/commands/module) | Build and manage WASM modules (including Surrealism). |
-| [`validate`](/docs/reference/cli/surrealdb-cli/commands/validate) | Validate SurrealQL or configuration. |
-| [`upgrade`](/docs/reference/cli/surrealdb-cli/commands/upgrade) | Upgrade between SurrealDB versions. |
-| [`version`](/docs/reference/cli/surrealdb-cli/commands/version) | Print CLI and server version information. |
 | [`help`](/docs/reference/cli/surrealdb-cli/commands/help) | Show help for the CLI or a subcommand. |
+| [`import`](/docs/reference/cli/surrealdb-cli/commands/import) | Load SurrealQL from a file into a database. |
 | [`isready`](/docs/reference/cli/surrealdb-cli/commands/isready) | Health check for readiness probes. |
 | [`mcp`](/docs/reference/cli/surrealdb-cli/commands/mcp) <Since v="v3.1.0" /> | Start the Model Context Protocol server on stdio for IDE integrations. |
+| [`ml`](/docs/reference/cli/surrealdb-cli/commands/ml) | Work with machine-learning features from the CLI. |
+| [`module`](/docs/reference/cli/surrealdb-cli/commands/module) | Build and manage WASM modules (including Surrealism). |
+| [`upgrade`](/docs/reference/cli/surrealdb-cli/commands/upgrade) | Upgrade between SurrealDB versions. |
+| [`validate`](/docs/reference/cli/surrealdb-cli/commands/validate) | Validate SurrealQL or configuration. |
+| [`version`](/docs/reference/cli/surrealdb-cli/commands/version) | Print CLI and server version information. |
 
 For installation and a minimal end-to-end example, see the [SurrealDB CLI overview](/docs/reference/cli/surrealdb-cli/overview). For environment variables that mirror CLI flags, see [Environment variables](/docs/reference/cli/surrealdb-cli/environment-variables).

--- a/src/content/reference/cli/surrealdb-cli/commands/isready.mdx
+++ b/src/content/reference/cli/surrealdb-cli/commands/isready.mdx
@@ -1,5 +1,5 @@
 ---
-position: 13
+position: 8
 title: isready
 description: A command that determines whether a SurrealDB server has started and is able to accept connections.
 ---

--- a/src/content/reference/cli/surrealdb-cli/commands/mcp.mdx
+++ b/src/content/reference/cli/surrealdb-cli/commands/mcp.mdx
@@ -10,7 +10,7 @@ description: "Start SurrealDB's Model Context Protocol server over stdio for loc
 
 The `surreal mcp` subcommand starts the built-in [Model Context Protocol](https://modelcontextprotocol.io) server on **stdio**, suitable for Cursor, VS Code, Claude Desktop, and other MCP clients. It opens an embedded datastore at the path you pass (default `memory`) and runs every tool call under `Session::owner()`.
 
-For HTTP-based clients against a running server, use [`surreal start`](/docs/reference/cli/surrealdb-cli/commands/start) and connect to **`/mcp`** instead. See [Model Context Protocol (MCP)](/docs/build/ai-agents/mcp) for transports, tools, and security guidance.
+For HTTP-based clients against a running server, use [`surreal start`](/docs/reference/cli/surrealdb-cli/commands/start) and connect to the **`/mcp`** endpoint instead. See [When to use `surreal mcp` vs `surreal start`](/docs/build/ai-agents/mcp#when-to-use-surreal-mcp-vs-surreal-start), [Model Context Protocol (MCP)](/docs/build/ai-agents/mcp) for transports and security, or [Connect MCP to your coding assistant](/docs/build/ai-agents/connect-mcp-to-your-editor) for a step-by-step setup.
 
 > [!WARNING]
 > Stdio MCP is intended for a trusted operator on the same machine. Do not expose this process to untrusted users — there is no per-call HTTP authentication surface to re-bind credentials.

--- a/src/content/reference/cli/surrealdb-cli/commands/mcp.mdx
+++ b/src/content/reference/cli/surrealdb-cli/commands/mcp.mdx
@@ -1,5 +1,5 @@
 ---
-position: 14
+position: 9
 title: mcp
 description: "Start SurrealDB's Model Context Protocol server over stdio for local IDE and agent integrations."
 ---

--- a/src/content/reference/cli/surrealdb-cli/commands/ml.mdx
+++ b/src/content/reference/cli/surrealdb-cli/commands/ml.mdx
@@ -1,5 +1,5 @@
 ---
-position: 7
+position: 10
 title: ml
 description: The ML command can be used to import and export machine learning models.
 ---

--- a/src/content/reference/cli/surrealdb-cli/commands/module.mdx
+++ b/src/content/reference/cli/surrealdb-cli/commands/module.mdx
@@ -1,5 +1,5 @@
 ---
-position: 8
+position: 11
 title: module
 description: A command used to compile, manage and execute Surrealism plugin modules.
 ---

--- a/src/content/reference/cli/surrealdb-cli/commands/upgrade.mdx
+++ b/src/content/reference/cli/surrealdb-cli/commands/upgrade.mdx
@@ -1,5 +1,5 @@
 ---
-position: 10
+position: 12
 title: upgrade
 description: A command to change the current version of SurrealDB to another one, including the latest version, specified version, or nightly.
 ---

--- a/src/content/reference/cli/surrealdb-cli/commands/validate.mdx
+++ b/src/content/reference/cli/surrealdb-cli/commands/validate.mdx
@@ -1,5 +1,5 @@
 ---
-position: 9
+position: 13
 title: validate
 description: A command to confirm whether one or more SurrealQL files are valid or not.
 ---

--- a/src/content/reference/cli/surrealdb-cli/commands/version.mdx
+++ b/src/content/reference/cli/surrealdb-cli/commands/version.mdx
@@ -1,5 +1,5 @@
 ---
-position: 11
+position: 14
 title: version
 description: A command to output the current version of the SurrealDB binary along with the machine architecture.
 ---


### PR DESCRIPTION

* Adds an MCP walkthrough page
* Includes when to prefer `surreal start` vs. `surreal mcp` in this walkthrough as well as the other page in the same section
* Reorganises the CLI commands to what they were before: start and sql, followed by all the rest alphabetically