### PR TITLE
Remove warning about API stability in dotnet index

### DIFF
--- a/src/content/index/languages/dotnet/index.mdx
+++ b/src/content/index/languages/dotnet/index.mdx
@@ -17,9 +17,6 @@ The SurrealDB SDK for C# and .NET enables you to interact with SurrealDB from se
 > The latest version of the SDK is <Version sdk=".net" />.
 > The SDK works with SurrealDB versions `v2.0.0` to <Version />, ensuring compatibility with the latest version.
 
-> [!WARNING]
-> This API is not yet fully stabilised and may be subject to change until the SDK reaches `1.0.0`.
-
 To contribute to the SDK code, submit an Issue or Pull Request in the [surrealdb.net](https://github.com/surrealdb/surrealdb.net) repository. To contribute to this documentation, submit an Issue or Pull Request in the [docs.surrealdb.com](https://github.com/surrealdb/docs.surrealdb.com) repository.
 
 ## Example projects


### PR DESCRIPTION
Removed warning note about API stability from documentation.