### PR TITLE
Mention new build flags needed for Surrealism

### DIFF
--- a/src/content/learn/extensions/guides/creating-custom-modules.mdx
+++ b/src/content/learn/extensions/guides/creating-custom-modules.mdx
@@ -6,7 +6,7 @@ description: "Step-by-step guide to scaffolding a Surrealism module, exposing fu
 
 # Creating custom modules
 
-This page walks you through the options avialable when building a [Surrealism](/docs/learn/extensions/plugins/overview) module from scratch.
+This page walks you through the options available when building a [Surrealism](/docs/learn/extensions/plugins/overview) module from scratch.
 
 ## Prerequisites
 
@@ -26,7 +26,12 @@ The fastest way to start is `surreal module init`:
 surreal module init
 ```
 
-This creates the project scaffold (`Cargo.toml`, `surrealism.toml`, and `src/lib.rs`) ready for Surrealism builds.
+This creates the project scaffold (`Cargo.toml`, `surrealism.toml`, `.cargo/Config.toml` with flags needed for the WASI build, and `src/lib.rs`) ready for Surrealism builds.
+
+```toml title=".cargo/Config.toml flags"
+[build]
+rustflags = ["--cfg", "tokio_unstable"]
+```
 
 To automatically set the name and organisation for a project, you can use the following flags:
 

--- a/src/content/reference/cli/surrealdb-cli/commands/module.mdx
+++ b/src/content/reference/cli/surrealdb-cli/commands/module.mdx
@@ -45,10 +45,17 @@ surreal module sig --fnc can_drive demo.surli
 
 ## `surreal module init`
 
-Scaffold a new Surrealism module project (Rust crate, `surrealism.toml`, and starter `src/lib.rs`):
+Scaffold a new Surrealism module project (Rust crate, `surrealism.toml`, `.cargo/Config.toml`, and starter `src/lib.rs`):
 
 ```bash
 surreal module init
+```
+
+`surreal module init` writes the WASI build flags Surrealism needs into `.cargo/config.toml`. `surreal module build` applies the same flags when it invokes Cargo, so existing projects pick them up even if the file was not scaffolded yet.
+
+```toml title=".cargo/Config.toml flags"
+[build]
+rustflags = ["--cfg", "tokio_unstable"]
 ```
 
 For scripts or CI, use non-interactive mode:


### PR DESCRIPTION
Surrealism can now take async functions which requires an extra flag inside .cargo/Config.toml to build on the user side.