### PR TITLE
More [$] (last) examples

### DIFF
--- a/src/content/reference/query-language/functions/database-functions/array.mdx
+++ b/src/content/reference/query-language/functions/database-functions/array.mdx
@@ -1629,7 +1629,7 @@ RETURN array::join(["again", "again", "again"], " and ");
 
 ## `array::last`
 
-The `array::last` function returns the last value from an array.
+The `array::last` function returns the last value from an array. You can also use the [`[$]` idiom](/docs/reference/query-language/language-primitives/idioms#last-element) on array values (for example, `my_array[$]`).
 
 ```surql title="API DEFINITION"
 array::last(array) -> any

--- a/src/content/reference/query-language/language-primitives/data-types/arrays.mdx
+++ b/src/content/reference/query-language/language-primitives/data-types/arrays.mdx
@@ -6,7 +6,7 @@ description: "An array is a collection of values contained inside square bracket
 
 # Arrays
 
-An array is a collection of values contained inside `[]` (square brackets), each of which is stored at a certain index. Individual indexes and slices of indexes can be accessed using the same square bracket syntax.
+An array is a collection of values contained inside `[]` (square brackets), each of which is stored at a certain index. Individual indexes and slices of indexes can be accessed using the same square bracket syntax. The first element of an array can be accessed with `[0]`, and `[$]` for the last.
 
 ```surql
 /**[test]
@@ -18,6 +18,9 @@ value = "[1, 2, 3, 4, 5]"
 value = "1"
 
 [[test.results]]
+value = "5"
+
+[[test.results]]
 value = "[1, 2, 3]"
 
 */
@@ -26,6 +29,8 @@ value = "[1, 2, 3]"
 RETURN [1,2,3,4,5];
 -- Return the first ("zeroeth") item
 RETURN [1,2,3,4,5][0];
+-- Return the last item
+RETURN [1,2,3,4,5][$];
 -- Return indexes 0 up to and including 2 of an array
 RETURN [1,2,3,4,5][0..=2];
 ```
@@ -46,6 +51,10 @@ RETURN [1,2,3,4,5][0..=2];
 1
 
 -------- Query 3 --------
+
+5
+
+-------- Query 4 --------
 
 [
 	1,

--- a/src/content/reference/query-language/language-primitives/data-types/sets.mdx
+++ b/src/content/reference/query-language/language-primitives/data-types/sets.mdx
@@ -130,12 +130,30 @@ value = "[3, 4, 5, 6, 7, 9, 18]"
 
 The `[]` index operator can be used on a set in the same manner as an array. Note however that due to a set's automatic ordering, its individual values are technically not assigned an index. This can be seen in the following example in which `[0]` for an array will return whichever item happens to be at that location, while for a set `[0]` will automatically be the item with the least value.
 
+To return the greatest value of a set, the [`set::last()`](/docs/reference/query-language/functions/database-functions/set#setlast) function can be used.
+
 ```surql
+/**[test]
+
+[[test.results]]
+value = "4"
+
+[[test.results]]
+value = "2"
+
+[[test.results]]
+value = "6"
+
+*/
+
 -- Array: returns 4 at index 0
 [4,6,2][0];
 
 -- Set: returns 2, the least item
-(<set>[4,6,2])[0];
+(<set>{4,6,2})[0];
+
+-- Set: returns 6, the greatest item
+{4,6,2}.last();
 ```
 
 ## Filtering and mapping with set functions

--- a/src/content/reference/query-language/language-primitives/idioms.mdx
+++ b/src/content/reference/query-language/language-primitives/idioms.mdx
@@ -154,6 +154,8 @@ SELECT results[0].score FROM student;
 
 Here, `results[0].score` accesses the score of the first student in the `results` array.
 
+Note: the opposite of `[0]` is `[$]`, which returns the last element in an array. See [Last element](#last-element) below.
+
 ## All elements
 
 To access all elements in an array or all fields in an object, use `.*`. This is useful when you want to access all the elements in an array or all the fields in an object.
@@ -404,7 +406,24 @@ SELECT *
 
 ## Last element
 
-Addionally to access the last element of an array, use `[$]`. Refereing to the `student` record above, we can access the last element of the `results` array using the following idiom:
+You can use `[$]` to access the last element of an array (the opposite of `[0]`, which selects the first). This works anywhere idiom access is supported: field paths, `SELECT` projections, and `RETURN` expressions.
+
+```surql
+/**[test]
+
+[[test.results]]
+value = "73"
+
+*/
+
+RETURN [76, 83, 69, 73][$];
+```
+
+```surql title="Output"
+73
+```
+
+Referring to the `student` record above, the following idiom returns the score of the latest result:
 
 ```surql
 SELECT results[$].score FROM student;
@@ -420,7 +439,7 @@ SELECT results[$].score FROM student;
 ]
 ```
 
-This idiom accesses the last element of the `score` array.
+`[$]` applies to arrays. Sets are ordered, but their index operator follows sort order rather than insertion order: `[0]` returns the smallest value. For the greatest value in a set, you can use [`set::last()`](/docs/reference/query-language/functions/database-functions/set#setlast) instead of `[$]`. See [sets](/docs/reference/query-language/language-primitives/data-types/sets#using-the-index-operator-on-sets) for detail.
 
 ## Method chaining
 


### PR DESCRIPTION
Adds a few more mentions and examples of the `[$]` operator (part), which is the opposite of `[0]` in that it returns the last item in an array instead of the first.