### PR TITLE
Duplicate edge ID changes

### DIFF
--- a/src/content/index/languages/javascript/api/queries/relate-promise.mdx
+++ b/src/content/index/languages/javascript/api/queries/relate-promise.mdx
@@ -13,12 +13,12 @@ The `RelatePromise` class provides a chainable interface for configuring RELATE 
 
 **Source:** [query/relate.ts](https://github.com/surrealdb/surrealdb.js/blob/main/packages/sdk/src/query/relate.ts)
 
-## Type Parameters
+## Type parameters
 
 - `T` - The result type (edge record type)
 - `J` - Boolean indicating if result is JSON (default: `false`)
 
-## Configuration Methods
+## Configuration methods
 
 ### `.unique()` {#unique}
 
@@ -185,9 +185,9 @@ relatePromise.stream()
 #### Returns
 `AsyncIterableIterator` - Async iterator
 
-## Complete Examples
+## Complete examples
 
-### Basic Relationship
+### Basic relationship
 
 ```ts
 import { Surreal, RecordId, Table, DateTime } from 'surrealdb';
@@ -208,7 +208,7 @@ console.log('From:', edge.in);  // users:john
 console.log('To:', edge.out);   // posts:1
 ```
 
-### Multiple Relationships
+### Multiple relationships
 
 ```ts
 // Create multiple edges at once
@@ -225,7 +225,7 @@ const edges = await db.relate(
 // jane->follows->bob
 ```
 
-### Unique Relationships
+### Unique relationships
 
 ```ts
 // Prevent duplicate 'likes'
@@ -245,7 +245,7 @@ const duplicate = await db.relate(
 // Returns existing edge
 ```
 
-### Relationship with Data
+### Relationship with data
 
 ```ts
 const friendship = await db.relate(
@@ -261,7 +261,7 @@ const friendship = await db.relate(
 );
 ```
 
-### Specific Edge ID
+### Specific edge ID
 
 ```ts
 // Use specific ID for the edge
@@ -273,7 +273,7 @@ const edge = await db.relate(
 );
 ```
 
-### Fan-out Relationships
+### Fan-out relationships
 
 ```ts
 // One user follows many
@@ -290,7 +290,7 @@ const edges = await db.relate(
 console.log(`Created ${edges.length} follow edges`);
 ```
 
-### Streaming Bulk Relationships
+### Streaming bulk relationships
 
 ```ts
 const users = await db.select(new Table('users'));
@@ -308,7 +308,7 @@ for await (const edge of edges.stream()) {
 }
 ```
 
-### Bidirectional Relationships
+### Bidirectional relationships
 
 ```ts
 // Create friendship in both directions
@@ -325,7 +325,7 @@ await db.relate(
 );
 ```
 
-### Relationship Metadata
+### Relationship metadata
 
 ```ts
 const edge = await db.relate(
@@ -341,7 +341,7 @@ const edge = await db.relate(
 );
 ```
 
-### Temporal Relationships
+### Temporal relationships
 
 ```ts
 // Track when relationship was created
@@ -357,7 +357,7 @@ const edge = await db.relate(
 );
 ```
 
-### Weighted Graph
+### Weighted graph
 
 ```ts
 // Create weighted edges for graph algorithms
@@ -373,7 +373,7 @@ const edge = await db.relate(
 );
 ```
 
-### Delete and Recreate Pattern
+### Delete and recreate pattern
 
 ```ts
 // Remove existing relationship and create new one
@@ -394,7 +394,7 @@ const edge = await db.relate(
 );
 ```
 
-## Graph Traversal Example
+## Graph traversal example
 
 ```ts
 // Create relationships
@@ -412,9 +412,9 @@ const followers = await db.query(
 console.log('Jane has followers:', followers);
 ```
 
-## Best Practices
+## Best practices
 
-### 1. Use Unique for One-to-One
+### 1. Use unique for one-to-one
 
 ```ts
 // Good: Prevent duplicate likes
@@ -425,7 +425,7 @@ await db.relate(from, new Table('likes'), to);
 // May create multiple edges
 ```
 
-### 2. Include Metadata
+### 2. Include metadata
 
 ```ts
 // Good: Track when relationship was created
@@ -438,18 +438,20 @@ await db.relate(from, edge, to, {
 await db.relate(from, edge, to);
 ```
 
-### 3. Use Specific Edge IDs for Updates
+### 3. Use specific edge IDs for updates
 
 ```ts
-// Good: Use specific ID to update later
-const edgeId = new RecordId('likes', Uuid.v7());
+// Good: use a specific ID so you can update the edge later
+const edgeId = new RecordId('likes', [from.toString(), to.toString()]);
 await db.relate(from, edgeId, to, metadata);
 
-// Later: easy to update
+// Later: update by record ID
 await db.update(edgeId).merge({ updated_at: DateTime.now() });
 ```
 
-## See Also
+As of SurrealDB 3.1.5, when the edge ID already exists, `INSERT RELATION` returns an error unless you use `ON DUPLICATE KEY UPDATE`. See [Explicit edge record IDs](/docs/reference/query-language/statements/relate#explicit-edge-record-ids) for more details.
+
+## See also
 
 - [SurrealQueryable.relate()](/docs/languages/javascript/api/core/surreal-queryable#relate) - Method that returns RelatePromise
 - [Graph Relationships](/docs/surrealql/statements/relate) - SurrealQL RELATE documentation

--- a/src/content/learn/data-models/graph/creating-relations.mdx
+++ b/src/content/learn/data-models/graph/creating-relations.mdx
@@ -199,6 +199,59 @@ RELATE person:two->friends_with->person:one;
 with record `friends_with:dblidwpc44qqz5bvioiu`"
 ```
 
+## Duplicate record IDs
+
+Enforced in `INSERT RELATION` statements since SurrealDB 3.1.5, another way to ensure at most one edge between two records is to choose a specific ID. Because an `INSERT RELATION` statement only requires the `in` and `out` paths to be present, a statement like the one below will create a random ID for the edge such as `likes:3lmr630sb72awbzhh4cl`.
+
+```surql
+-- 
+INSERT RELATION INTO likes {
+    in: person:one,
+    out:person:two
+};
+```
+
+If a specific ID is declared, then an attempt to insert a second edge will return an error.
+
+```surql
+INSERT RELATION INTO likes {
+    in: person:one,
+    out:person:two,
+    id: 1
+};
+
+INSERT RELATION INTO likes {
+    in: person:one,
+    out:person:two,
+    id: 1
+};
+```
+
+This can be used as an ad-hoc unique index, especially if the ID itself contains the IDs of the records being linked. The [`array::sort()`](/docs/reference/query-language/functions/database-functions/array#arraysort) function can also be used here for symmetric relations.
+
+```surql
+LET $in = person:three;
+LET $out = person:four;
+
+INSERT RELATION INTO married_to {
+    in: $in,
+    out: $out,
+    id: [$in, $out].sort()
+};
+
+INSERT RELATION INTO married_to {
+    in: $out,
+    out: $in,
+    id: [$in, $out].sort()
+};
+```
+
+The final query returns the following error, thanks to the duplicate ID, despite the attempt to double the relation by putting `in` at the `out` field and vice versa.
+
+```surql title="Output"
+'Database record `likes:[person:four, person:three]` already exists'
+```
+
 Querying symmetric edges with `<->` is covered in [Graph traversal](/docs/learn/data-models/graph/graph-traversal). For friendship-oriented examples, see [Social network patterns](/docs/learn/data-models/graph/social-network-patterns).
 
 ## `RELATE` before both endpoints exist

--- a/src/content/learn/querying/concepts-and-guides/idempotent-operations.mdx
+++ b/src/content/learn/querying/concepts-and-guides/idempotent-operations.mdx
@@ -53,6 +53,10 @@ However, it can be made idempotent by first defining a [unique index](/docs/refe
 DEFINE INDEX only_one ON likes FIELDS in, out UNIQUE;
 ```
 
+Alternatively, from version 3.1.5, you can supply an explicit edge record ID in the `RELATE` path (for example `->likes:[person:one, post:one]->`) or in an [`INSERT RELATION`](/docs/reference/query-language/statements/insert#insert-relation-tables) statement.
+
+A duplicate explicit ID on `INSERT RELATION` returns an error unless you add `ON DUPLICATE KEY UPDATE`. For more, see [Explicit edge record IDs](/docs/reference/query-language/statements/relate#explicit-edge-record-ids).
+
 ## Non-idempotent examples
 
 The following examples will produce different results on every execution, and thus are not idempotent.

--- a/src/content/reference/query-language/statements/insert.mdx
+++ b/src/content/reference/query-language/statements/insert.mdx
@@ -466,3 +466,48 @@ INSERT RELATION INTO likes (in, id, out)
 SELECT VALUE ->likes FROM person;
 
 ```
+
+<Since v="v3.1.5" />
+
+When `INSERT RELATION` specifies an explicit edge `id` that already exists, SurrealDB returns a record-exists error instead of updating the edge in place. You can use `ON DUPLICATE KEY UPDATE` to merge into the existing relation, in the same way as a normal [`INSERT`](/docs/reference/query-language/statements/insert#example-usage):
+
+```surql
+/**[test]
+
+[[test.results]]
+value = "[{ id: person:one }, { id: post:one }]"
+
+[[test.results]]
+value = "[{ id: likes:[person:one, post:one], in: person:one, note: 'first', out: post:one }]"
+
+[[test.results]]
+match = "$error = /Database record .*likes:\\[person:one, post:one\\].* already exists/"
+
+[[test.results]]
+match = "$result[0].note = 'updated'"
+
+*/
+
+CREATE person:one, post:one;
+
+INSERT RELATION INTO likes {
+  in: person:one,
+  out: post:one,
+  id: [person:one, post:one],
+  note: 'first',
+};
+
+INSERT RELATION INTO likes {
+  in: person:one,
+  out: post:one,
+  id: [person:one, post:one],
+  note: 'second',
+};
+
+INSERT RELATION INTO likes {
+  in: person:one,
+  out: post:one,
+  id: [person:one, post:one],
+  note: 'third',
+} ON DUPLICATE KEY UPDATE note = 'updated';
+```

--- a/src/content/reference/query-language/statements/relate.mdx
+++ b/src/content/reference/query-language/statements/relate.mdx
@@ -29,7 +29,7 @@ Graph relations offer built-in bidirectional querying and referential integrity.
   <TabItem label="SurrealQL Syntax">
 
 ```syntax title="SurrealQL Syntax"
-RELATE [ ONLY ] @from_record -> @table -> @to_record
+RELATE [ ONLY ] [ OR UPDATE ] @from_record -> @table | @edge_record -> @to_record
 	[ CONTENT @value
 	  | SET @field = @value ...
 	]
@@ -42,7 +42,7 @@ RELATE [ ONLY ] @from_record -> @table -> @to_record
   <TabItem label="Railroad Diagram">
 
 
-<RailroadDiagram ast='{"type":"Diagram","padding":[10,20,10,20],"children":[{"type":"Sequence","children":[{"type":"Terminal","text":"RELATE"},{"type":"Optional","child":{"type":"Terminal","text":"ONLY"}},{"type":"NonTerminal","text":"@from_record"},{"type":"Terminal","text":"->"},{"type":"NonTerminal","text":"@table"},{"type":"Terminal","text":"->"},{"type":"NonTerminal","text":"@to_record"},{"type":"Optional","child":{"type":"Choice","index":1,"children":[{"type":"Sequence","children":[{"type":"Terminal","text":"CONTENT"},{"type":"NonTerminal","text":"@value"}]},{"type":"Sequence","children":[{"type":"Terminal","text":"SET"},{"type":"NonTerminal","text":"@field = @value ..."}]}]}},{"type":"Optional","child":{"type":"Sequence","children":[{"type":"Terminal","text":"RETURN"},{"type":"Choice","index":1,"children":[{"type":"Terminal","text":"NONE"},{"type":"Terminal","text":"BEFORE"},{"type":"Terminal","text":"AFTER"},{"type":"Terminal","text":"DIFF"},{"type":"NonTerminal","text":"@statement_param, ..."},{"type":"Sequence","children":[{"type":"Terminal","text":"VALUE"},{"type":"NonTerminal","text":"@statement_param"}]}]}]}},{"type":"Optional","child":{"type":"Sequence","children":[{"type":"Terminal","text":"TIMEOUT"},{"type":"NonTerminal","text":"@duration"}]}},{"type":"Terminal","text":";"}]}]}' />
+<RailroadDiagram ast='{"type":"Diagram","padding":[10,20,10,20],"children":[{"type":"Sequence","children":[{"type":"Terminal","text":"RELATE"},{"type":"Optional","child":{"type":"Terminal","text":"ONLY"}},{"type":"Optional","child":{"type":"Sequence","children":[{"type":"Terminal","text":"OR"},{"type":"Terminal","text":"UPDATE"}]}},{"type":"NonTerminal","text":"@from_record"},{"type":"Terminal","text":"->"},{"type":"NonTerminal","text":"@table"},{"type":"Terminal","text":"->"},{"type":"NonTerminal","text":"@to_record"},{"type":"Optional","child":{"type":"Choice","index":1,"children":[{"type":"Sequence","children":[{"type":"Terminal","text":"CONTENT"},{"type":"NonTerminal","text":"@value"}]},{"type":"Sequence","children":[{"type":"Terminal","text":"SET"},{"type":"NonTerminal","text":"@field = @value ..."}]}]}},{"type":"Optional","child":{"type":"Sequence","children":[{"type":"Terminal","text":"RETURN"},{"type":"Choice","index":1,"children":[{"type":"Terminal","text":"NONE"},{"type":"Terminal","text":"BEFORE"},{"type":"Terminal","text":"AFTER"},{"type":"Terminal","text":"DIFF"},{"type":"NonTerminal","text":"@statement_param, ..."},{"type":"Sequence","children":[{"type":"Terminal","text":"VALUE"},{"type":"NonTerminal","text":"@statement_param"}]}]}]}},{"type":"Optional","child":{"type":"Sequence","children":[{"type":"Terminal","text":"TIMEOUT"},{"type":"NonTerminal","text":"@duration"}]}},{"type":"Terminal","text":";"}]}]}' />
 
   </TabItem>
 </Tabs>
@@ -52,6 +52,50 @@ RELATE [ ONLY ] @from_record -> @table -> @to_record
 
 > [!NOTE]
 > If a `RELATE` on the create path sets `id` to an **existing** edge record (for example `RELATE a->edge->b SET id = edge:existing`), SurrealDB returns a record-exists error instead of overwriting that edge. Use [`UPDATE`](/docs/reference/query-language/statements/update) when you intend to modify an existing relation.
+
+### Handling duplicate edge record IDs
+
+<Since v="v3.1.5" />
+
+You can supply the edge record ID directly in the `RELATE` path instead of letting SurrealDB generate one. This is useful when the ID should act like a built-in unique key for the relationship, for example a composite of the `in` and `out` records:
+
+```surql
+RELATE person:one->likes:[person:one, post:one]->post:one
+  SET liked_at = time::now();
+
+RELATE person:one->likes:[person:one, post:one]->post:one
+  SET liked_at = time::now();
+```
+
+As of SurrealDB 3.1.5, redoing a `RELATE` statement on an existing ID will update the edge, but emit a warning. This will become a hard error in a later version of SurrealDB.
+
+To specifically opt in to update semantics on an existing edge and not emit a warning, you can add `OR UPDATE` after `RELATE`.
+
+```surql
+RELATE person:one->likes:[person:one, post:one]->post:one
+  SET liked_at = time::now();
+
+-- Has `OR UPDATE`: will not emit a warning
+RELATE OR UPDATE person:one->likes:[person:one, post:one]->post:one
+  SET liked_at = time::now();
+```
+
+If you prefer a hard error at this point, [`INSERT RELATION`](/docs/reference/query-language/statements/insert#insert-relation-tables) can be used:
+
+```surql
+INSERT RELATION INTO likes {
+  in: person:two,
+  out: post:one,
+  id: [person:two, post:one]
+};
+
+-- Returns an error
+INSERT RELATION INTO likes {
+  in: person:two,
+  out: post:one,
+  id: [person:two, post:one]
+};
+```
 
 ### Example usage
 


### PR DESCRIPTION
A behaviour fix in the next version results in the following when an existing edge ID (e.g.  the `likes:1` in `RELATE person:one->likes:1->person:two` or `INSERT RELATION INTO likes { in: person:one, out:person:two, id: likes:1 }`, which currently will simply update:

* RELATE: still updates but emits a warning. You can change to `RELATE OR UPDATE` to not emit a warning. This will become a hard error in a later version.
* INSERT RELATION: returns an error. This part is a bug fix because INSERT should err by default unless ON DUPLICATE KEY UPDATE is specified.