### PR TITLE
Spectron updates, June 17

### DIFF
--- a/src/content/spectron/agent-memory/ingest/authoritative/uploading-documents.mdx
+++ b/src/content/spectron/agent-memory/ingest/authoritative/uploading-documents.mdx
@@ -45,10 +45,10 @@ POST /api/v1/{context_id}/documents
 Content-Type: multipart/form-data
 
 file=<binary>
-metadata={"title":"Returns Policy","scope":["org/acme/team/eng"],"labels":["team=eng"]}
+metadata={"title":"Returns Policy","scopes":[["org/acme/team/eng"]],"labels":["team=eng"]}
 ```
 
-The `metadata` part is JSON. **`scope`** is a `ScopeSet` (slash-path strings). **`labels`** are descriptive `key=value` tags (same validation as fact ingest — keys must not start with `_`; count caps return **`409`**). Omit **`scope`** to tag the document with the caller's full `memory:write` region.
+The `metadata` part is JSON. **`scopes`** is a DNF selector (OR of conjunctive slash-path clauses). **`labels`** are descriptive `key=value` tags (same validation as fact ingest — keys must not start with `_`; count caps return **`409`**). Optional **`observedAt`** (RFC 3339) sets the known time of facts derived from this document — essential for **page-by-page or episode-by-episode ingest** where later plot points must stay hidden until the reader reaches them ([spoiler-safe narrative memory](/docs/spectron/cookbooks/patterns/spoiler-safe-narrative-memory)). Omit **`scopes`** to tag the document with the caller's full `memory:write` region.
 
 Response:
 
@@ -115,7 +115,7 @@ These edges feed **`hybrid_graph`** reranking (document-link density) and citati
 
 Documents and their chunks inherit the caller's **resolved write scope** from the API key when you omit explicit scope on upload — required for scoped keys to recall their own uploads.
 
-You can **narrow** tagging with **`scope`** on **`POST /documents`**, **`spectron documents upload --scope …`**, or MCP **`upload`** — the path must lie within the caller's `memory:write` region (out-of-region scope returns **`403`**).
+You can **narrow** tagging with **`scopes`** on **`POST /documents`**, **`spectron documents upload --scope …`**, or MCP **`upload`** — the path must lie within the caller's `memory:write` region (out-of-region scope returns **`403`**). A document's scope is **fixed at upload** — reprocess rejects a non-empty `scopes` field with **`400`**.
 
 Optional **`labels`** (`key=value` strings) are stamped on the document, chunks, and sections. They follow the same validation rules as fact ingest and are **not** copied onto reconciled graph rows.
 

--- a/src/content/spectron/agent-memory/ingest/experiential/remember.mdx
+++ b/src/content/spectron/agent-memory/ingest/experiential/remember.mdx
@@ -33,6 +33,8 @@ export SPECTRON_CONTEXT_ID=dev
 
 spectron remember "Alice was promoted to CTO." --scope org/acme/user/alice
 
+spectron remember "The reveal happened on page 42." --scope org/acme --as-of 1886-01-01T00:00:00Z
+
 spectron remember --from-file ./transcript.jsonl --scope org/acme/user/alice --extract per_message
 ```
 
@@ -51,9 +53,12 @@ Content-Type: application/json
 {
   "text": "Alice was promoted to CTO.",
   "infer": "full",
-  "scope": ["org/acme/user/alice"]
+  "scopes": [["org/acme/user/alice"]],
+  "observed_at": "2026-05-12T10:00:00Z"
 }
 ```
+
+Optional **`observed_at`** (RFC 3339) stamps derived facts at a caller-supplied **known time** instead of wall-clock ingest. Use this for **narrative playback** — ingest an entire canon but answer only as far as the user has read or watched (see [Spoiler-safe narrative memory](/docs/spectron/cookbooks/patterns/spoiler-safe-narrative-memory)). Omitted keeps the default (ingest time).
 
 **Response (`infer: full`):** nested **`extraction`** with entities, attributes, relations, instructions, and uncertainties, plus `sessionId` and `turnId`.
 
@@ -72,7 +77,7 @@ Content-Type: application/json
     { "role": "user", "content": "I was promoted to CTO." },
     { "role": "assistant", "content": "Congratulations!" }
   ],
-  "scope": ["org/acme/user/alice"],
+  "scopes": [["org/acme/user/alice"]],
   "extract": "whole_conversation"
 }
 ```
@@ -88,7 +93,7 @@ Returns **`extractions`**, **`sessionId`**, and **`turnIds`**.
 await client.facts.create(
     text="Alice was promoted to CTO.",
     infer="full",
-    scope=["org/acme/user/alice"],
+    scope=[["org/acme/user/alice"]],
 )
 ```
 
@@ -98,7 +103,7 @@ Sessions group episodic **turns** for transcript browsing and session-scoped con
 
 ```http
 POST /api/v1/{context_id}/sessions
-{ "scope": ["org/acme/user/alice"] }
+{ "scopes": [["org/acme/user/alice"]] }
 ```
 
 See [Sessions and turns](/docs/spectron/mental-model/sessions-and-turns).

--- a/src/content/spectron/agent-memory/reasoning/reconciliation-and-supersession.mdx
+++ b/src/content/spectron/agent-memory/reasoning/reconciliation-and-supersession.mdx
@@ -57,7 +57,7 @@ Use the public API rather than ad hoc database queries:
 
 ### Unresolved relation objects
 
-When reconciliation cannot resolve a relation’s object entity, it materialises a placeholder typed **`unknown`** so the stated fact is not dropped from recall. These placeholders are observable (`spectron.memory.unresolved_relation_objects` metric) and may not auto-merge with a later properly typed extraction until a maintenance sweep reconciles them.
+When reconciliation cannot resolve a relation’s object entity, it materialises a placeholder typed **`unknown`** so the stated fact is not dropped from recall. These placeholders may not auto-merge with a later properly typed extraction until a maintenance sweep reconciles them.
 
 ## History by default — and forget when you need removal
 

--- a/src/content/spectron/agent-memory/reasoning/temporal-validity.mdx
+++ b/src/content/spectron/agent-memory/reasoning/temporal-validity.mdx
@@ -23,7 +23,7 @@ Together these fields power current-state reads, point-in-time reconstruction, a
 
 **History** — walk the supersession chain for a key to see every value it took, in order.
 
-**Temporal language in chat** — when a turn says “I became CEO in January 2025”, “last week I moved to Berlin”, or “I used to live in Berlin”, extraction sets or adjusts validity bounds where it can. **Relative phrases** (“last week”, “three weeks ago”) resolve against the **turn’s spoken time**, not wall-clock ingest time — the same anchoring documents get from `authored_at`. Unresolved dates may become **`uncertainty`** records instead of guessed timestamps.
+**Temporal language in chat** — when a turn says “I became CEO in January 2025”, “last week I moved to Berlin”, or “I used to live in Berlin”, extraction sets or adjusts validity bounds where it can. **Relative phrases** (“last week”, “three weeks ago”) resolve against the **turn’s spoken time**, not wall-clock ingest time — the same anchoring documents get from `authored_at` or caller-supplied **`observed_at`** / **`observedAt`** on ingest. Unresolved dates may become **`uncertainty`** records instead of guessed timestamps.
 
 ## How it differs from deletion
 
@@ -48,10 +48,37 @@ Two situations set **`valid_until`**:
 
 **Expiry** — a fact ends without a replacement (a promotion that lapses, a time-boxed assignment, an instruction that was revoked). **`valid_until`** is set directly — at extraction when temporal language supplies an end date, or via **`POST /forget`** / lifecycle operations when you expire memory explicitly.
 
+## Narrative playback and spoiler safety
+
+Agents that ingest an entire canon at once — every chapter of a novel, every episode of a series, every film in a franchise — **know things the user has not reached yet**. That is a problem for:
+
+- **Serial fiction** — a reader on chapter 8 of *Dr Jekyll and Mr Hyde* must not learn that Hyde and Jekyll are the same person before the reveal page.
+- **Episodic or franchise media** — a viewer on *The Empire Strikes Back* in release order must not be told Vader is Luke's father before that scene; someone watching in chronological order (I → II → III) needs a **different** spoiler boundary entirely, as the spoiler for the viewer in this case is that Anakin becomes a villain.
+- **Long-running book series** — a *Wheel of Time* reader on book three should not get answers that depend on book twelve.
+
+The fix is not to omit later material from ingest. Ingest everything, but stamp **when each fact entered the reader's timeline**, then query **`asOf`** the user's current position.
+
+| User position | On ingest | On recall |
+| --- | --- | --- |
+| "I've read up to page *N*" | `observed_at` / `observedAt` per page or chapter (a synthetic timeline, not wall-clock) | `asOf` = that page's stamp |
+| "I'm on episode 5 of my chosen order" | One stamp per episode in **viewing order** (release, chronological, or machete) | `asOf` = stamp for episode 5 |
+| "Show me chapter 3 only" | `labels: ["chapter=3"]` on upload | `labels: ["chapter=3"]` (often with `include: ["passages"]`) |
+
+**`asOf` gates the knowledge graph** — attributes **and relations**. A `same_as` edge between two characters only appears once the ingest stamp for the reveal page has passed. Earlier queries see separate entities with no link.
+
+> [!NOTE]
+> Raw **passages** keep wall-clock upload time. Spoiler guarantees on structured answers use the entity/attribute/relation view (`GET /entities/...?asOf=...`, or `/query` with `asOf`). For passage-level navigation ("what's on page 3?"), pair **`labels`** with `include: ["passages"]`. **`lens`** narrows by scope region at every tier (facts and passages).
+
+See the [spoiler-safe narrative memory](/docs/spectron/cookbooks/patterns/spoiler-safe-narrative-memory) cookbook for franchises, non-chronological viewing orders, and page-by-page ingest recipes.
+
+## Caller-supplied known time
+
+When each unit of a serial (page, chapter, episode, policy revision) should appear on a **known-time axis** distinct from when you ran the import, pass **`observed_at`** on `POST /facts` (or **`observedAt`** in document upload metadata). Spectron stamps derived facts with that instant as their **known time** (`created_at`), so **`asOf`** queries reconstruct what the system would have believed at that point in the narrative — not at bulk-import time.
+
 ## Reading validity through the API
 
 - **`GET /entities/{type}/{name}`** — active attributes for an entity; optional temporal query params on the request.
 - **`GET /entities/{type}/{name}/history/{key}`** — ordered supersession history for one key.
-- **`POST /query`** with **`as_of`** — belief-level recall at a past instant.
+- **`POST /query`** with **`asOf`** — belief-level recall at a past instant. **`asOf` now gates relations** as well as attributes: a relationship is visible only when its known time and validity interval include the requested instant.
 
 Field-level schema detail lives in [Data model and schema](/docs/spectron/reference/data-model-and-schema) for operators who manage SurrealDB directly.

--- a/src/content/spectron/agent-memory/retrieve/recall.mdx
+++ b/src/content/spectron/agent-memory/retrieve/recall.mdx
@@ -20,7 +20,7 @@ spectron recall "What role does Alice have?" --json \
   --limit 10
 ```
 
-Pass **`scope`** on the REST body (the CLI does not expose a `--scope` flag on `recall` today):
+Pass **`lens`** on the REST body (the CLI does not expose a `--scope` flag on `recall` today):
 
 ```http
 POST /api/v1/{context_id}/query
@@ -29,8 +29,8 @@ Content-Type: application/json
 
 {
   "query": "What role does Alice have?",
-  "limit": 10,
-  "scope": ["org/acme/user/alice"]
+  "k": 10,
+  "lens": [["org/acme/user/alice"]]
 }
 ```
 
@@ -38,16 +38,16 @@ Content-Type: application/json
 
 | Field | Meaning |
 | --- | --- |
-| `tier` | `direct`, `cache`, `hybrid`, or `full_context` |
-| `hits` | Ranked results; each hit includes **`source`** (`entity`, `attribute`, `memory_chunk`, `chunk`, or `section`) |
+| `tier` | `direct`, `cache`, `hybrid`, or `full_context` — relational questions may resolve at tier 1 when the classifier routes to a structured relation read |
+| `hits` | Ranked results; each hit includes **`source`** (`entity`, `attribute`, `memory_chunk`, `chunk`, or `section`) and optional **`occurredAt`** (known time of the row — use to resolve relative dates in source text) |
 | `queryMs` | Server-side latency in milliseconds |
 | `trace.traceId` | Correlates with `GET .../traces/{traceId}` |
 
-Optional read modifiers: **`labels`** (descriptor filter only), **`lens`** (filter by scope-path involvement), **`scope_view`** (`strict`, `crossTeam`, `merged` — the latter two resolve like **`strict`**; see [Contexts and scope](/docs/spectron/mental-model/contexts-and-scope#labels-lens-and-scope-views-reads)), **`include`** (`facts`, `passages`, or both — narrows the response only; retrieval considers all families), **`includeDuplicates`** (default `false` — excludes near-duplicate passage chunks from fused recall; set `true` for parity with `/documents/query`).
+Optional read modifiers: **`labels`** (descriptor filter only), **`lens`** (DNF scope filter by involvement), **`asOf`** (known-time playback — hide facts and relations from later chapters or episodes; see [spoiler-safe narrative memory](/docs/spectron/cookbooks/patterns/spoiler-safe-narrative-memory)), **`scope_view`** (`strict`, `crossTeam`, `merged` — the latter two resolve like **`strict`**; see [Contexts and scope](/docs/spectron/mental-model/contexts-and-scope#labels-lens-and-scope-views-reads)), **`include`** (`facts`, `passages`, or both — narrows the response only; retrieval considers all families), **`includeDuplicates`** (default `false` — excludes near-duplicate passage chunks from fused recall; set `true` for parity with `/documents/query`).
 
-**`limit`** defaults to **10** and is capped at **50** per deployment (`SPECTRON_MAX_QUERY_K`). The internal retrieval pool is independent of `limit` — see [Hybrid search](/docs/spectron/agent-memory/retrieve/hybrid-search#answer-size-vs-search-breadth).
+**`k`** defaults to **10** and is capped at **50** per deployment (`SPECTRON_MAX_QUERY_K`). The internal retrieval pool is independent of `k` — see [Hybrid search](/docs/spectron/agent-memory/retrieve/hybrid-search#answer-size-vs-search-breadth).
 
-CLI flags: `--limit`, `--mode hybrid|vector|bm25|graph`, `--include facts,passages`, tri-temporal `--as-of`, `--at-instant`, `--valid-from`, `--valid-until`.
+CLI flags: `--limit` (maps to `k`), `--mode hybrid|vector|bm25|graph`, `--include facts,passages`, tri-temporal `--as-of`, `--at-instant`, `--valid-from`, `--valid-until`.
 
 > [!NOTE]
 > **`--min-trust`** is not supported yet — the `/query` response does not expose per-hit trust scores, so the CLI rejects the flag rather than silently returning unfiltered results.
@@ -62,8 +62,8 @@ Content-Type: application/json
 
 {
   "query": "What role does Alice have?",
-  "limit": 10,
-  "scope": ["org/acme/user/alice"]
+  "k": 10,
+  "lens": [["org/acme/user/alice"]]
 }
 ```
 

--- a/src/content/spectron/agent-memory/sessions/creating-sessions.mdx
+++ b/src/content/spectron/agent-memory/sessions/creating-sessions.mdx
@@ -19,10 +19,10 @@ Sessions answer both. The session is the provenance anchor: every extracted fact
 
 ## Session scope
 
-Scope is a **ScopeSet**: an ordered array of hierarchical slash paths (for example `["org/acme/user/alice"]`). Register paths with `spectron scopes create` before first use. Spectron propagates the session scope to all records created during the session.
+Scope on create is a **DNF selector** (`scopes`): an OR of conjunctive slash-path clauses (for example `[["org/acme/user/alice"]]`). Register paths with `spectron scopes create` before first use. Spectron propagates the session scope to all records created during the session.
 
 ```json
-["org/acme/user/alice"]
+[["org/acme/user/alice"]]
 ```
 
 Scope is used in two places:
@@ -41,7 +41,7 @@ POST /api/v1/{context_id}/sessions
 Content-Type: application/json
 
 {
-  "scope": ["org/acme/user/alice"],
+  "scopes": [["org/acme/user/alice"]],
   "metadata": { "channel": "web-chat", "locale": "en-GB" }
 }
 ```
@@ -51,8 +51,8 @@ Response:
 ```json
 {
   "id": "session:01hx7…",
-  "scope": ["org/acme/user/alice"],
-  "created_at": "2026-05-12T16:24:00Z"
+  "scopes": [["org/acme/user/alice"]],
+  "createdAt": "2026-05-12T16:24:00Z"
 }
 ```
 
@@ -82,12 +82,12 @@ import { Spectron } from "@surrealdb/spectron";
 const memory = new Spectron({ context: "acme-prod", apiKey: process.env.SPECTRON_API_KEY });
 
 const session = await memory.sessions.create({
-    scope: ["org/acme/user/alice"],
+    scopes: [["org/acme/user/alice"]],
     metadata: { channel: "web-chat" },
 });
 
-console.log(session.id);    // session:01hx7…
-console.log(session.scope); // ["org/acme/user/alice"]
+console.log(session.id);     // session:01hx7…
+console.log(session.scopes);   // [["org/acme/user/alice"]]
 ```
 
 ## Session lifecycle

--- a/src/content/spectron/cookbooks/patterns/spoiler-safe-narrative-memory.mdx
+++ b/src/content/spectron/cookbooks/patterns/spoiler-safe-narrative-memory.mdx
@@ -1,0 +1,122 @@
+---
+position: 6
+title: Spoiler-safe narrative memory
+description: "Ingest full canon; answer only as far as the user has read or watched."
+---
+
+# Spoiler-safe narrative memory
+
+Spectron can hold an entire story — novel, series, franchise, training curriculum released in modules — while an agent answers **only from what the user has reached so far**. The pattern combines three ideas you already have elsewhere in the docs:
+
+1. **`observed_at` / `observedAt` on ingest** — stamp each chapter, page, or episode with a synthetic **known time** on the narrative axis (not wall-clock import time).
+2. **`asOf` on recall** — the user's current position ("I'm on chapter 8", "I've finished episode V") selects which stamped facts and **relations** are visible.
+3. **`labels` and `lens`** (optional) — navigate by `chapter=3` / `page=5`, or narrow a query to a scope region without changing permissions.
+
+See [Temporal validity](/docs/spectron/agent-memory/reasoning/temporal-validity#narrative-playback-and-spoiler-safety) for the model; this page is the recipe.
+
+## When to use it
+
+| Scenario | Why bulk ingest breaks | What you gate |
+| --- | --- | --- |
+| Novel with a late reveal | Hyde/Jekyll-style identity twist | Relation edges and attributes stamped at the reveal |
+| TV or film franchise | Viewing order ≠ story chronology | Per-episode stamps in **the order the user chose** |
+| Long book series | Reader is on book 3 of 14 | `asOf` at book 3's end — later books ingested but hidden |
+| Policy / curriculum modules | User certified on module 2 only | Module-scoped stamps + labels |
+
+## Worked example: *Dr Jekyll and Mr Hyde*
+
+*The Strange Case of Dr Jekyll and Mr Hyde* is a useful mental model: the whole plot is a single-entity reveal. Ingest each chapter (or page) with its own synthetic `observedAt`, monotonically increasing through the book. Stamp the Hyde↔Jekyll `same_as` relation only when you ingest the reveal chapter.
+
+- Query with **`asOf`** at “chapter 8” → Hyde and Jekyll stay separate in the graph; no spoiler link.
+- Query with **`asOf`** at “book finished” → the `same_as` edge is visible.
+
+Same reader, same permissions — only the **`asOf`** instant changes.
+
+## Franchise and non-chronological orders
+
+Release order and story order are different problems with the same mechanism: **stamps follow discovery order, not calendar dates**.
+
+**Star Wars (release order IV → V → VI, then I → II → III)**
+
+Ingest each film with `observedAt` (or per-scene triples with `observed_at`) on a timeline that matches **when a release-order viewer learns each fact**. "Darth Vader is Luke's father" gets a stamp after *Empire* — not after *A New Hope*. A separate reader profile watching I → II → III first would use a different stamp sequence on the same ingested records (or separate scope paths per viewing track), because for this viewer there is no spoiler in Episode V that Anakin Skywalker and Darth Vader are the same person. However, a viewer following this path does have a reveal in Episode III that Anakin is no longer a hero, a fact that a user watching in release order would already be aware of when viewing the prequels.
+
+**Wheel of Time (reader on book 3)**
+
+Ingest all books if you want one substrate, but stamp facts extracted from book *N* with monotonically increasing known times per book (or per chapter). Recall with `asOf` set to "end of book 3" so prophecies, deaths, and alliances from later books stay out of answers.
+
+```http
+POST /api/v1/{context_id}/facts
+Content-Type: application/json
+
+{
+  "text": "… excerpt from The Dragon Reborn …",
+  "infer": "full",
+  "scopes": [["org/my-app/reader/alice"]],
+  "observed_at": "2000-10-15T00:00:00Z",
+  "labels": ["book=3", "chapter=12"]
+}
+```
+
+```http
+POST /api/v1/{context_id}/query
+Content-Type: application/json
+
+{
+  "query": "Who is Rand al'Thor allied with?",
+  "k": 10,
+  "asOf": "2000-10-15T00:00:00Z",
+  "lens": [["org/my-app/reader/alice"]],
+  "labels": ["book=3"]
+}
+```
+
+Adjust the synthetic timeline to your ordering scheme; the important part is that **later books never share an earlier stamp**.
+
+## Document ingest (page-by-page)
+
+For PDFs or markdown split into pages:
+
+```bash
+spectron documents upload ./chapters/ch08.txt \
+  --scope org/my-app/reader/alice \
+  --label chapter=8 --label page=5 \
+  --as-of 1886-03-01T00:00:00Z
+```
+
+Metadata JSON equivalent:
+
+```json
+{
+  "title": "Dr Jekyll and Mr Hyde — ch. 8",
+  "scopes": [["org/my-app/reader/alice"]],
+  "labels": ["chapter=8", "page=5"],
+  "observedAt": "1886-03-01T00:00:00Z"
+}
+```
+
+Then query with matching `asOf` and optional `labels` for passage-only navigation.
+
+## Composing narrowings
+
+On a single full-access reader you can combine three independent slices:
+
+| Narrowing | Question | Mechanism |
+| --- | --- | --- |
+| Time | How far have I read? | `asOf` — gates facts and relations by known time |
+| Scope lens | Limit this query to chapters 1–8 | `lens: [["chapter/1"], …]` — involvement filter within grant |
+| Labels | What's on page 3? | `labels: ["page=3"]` — row filter; use with `include: ["passages"]` for text |
+
+Use time for **spoiler boundaries on the graph**; use labels for **locating** content within what time already allows.
+
+## Limits to know
+
+- **Passages** are not reading-time-gated by `asOf` alone — they retain upload-time metadata. Rely on the structured graph for spoiler-safe *answers*, or filter passages with **`labels`**.
+- **`asOf` on `/query`** walks known-time on attributes and relations; pair with [Temporal validity](/docs/spectron/agent-memory/reasoning/temporal-validity) for `valid_from` / `valid_until` on in-world dates.
+- Response caching is bypassed when temporal filters are present — correct for narrative playback, slightly higher latency.
+
+## Related reading
+
+- [Storing memories](/docs/spectron/agent-memory/ingest/experiential/remember) — `observed_at` and `--as-of` on the CLI
+- [Uploading documents](/docs/spectron/agent-memory/ingest/authoritative/uploading-documents) — `observedAt` in upload metadata
+- [Recalling memories](/docs/spectron/agent-memory/retrieve/recall) — `asOf` and `occurredAt` on hits
+- [Contexts and scope](/docs/spectron/mental-model/contexts-and-scope) — `lens` and labels

--- a/src/content/spectron/index/architecture/surface-security-and-models.mdx
+++ b/src/content/spectron/index/architecture/surface-security-and-models.mdx
@@ -47,7 +47,7 @@ Spectron supports **OpenAI-compatible endpoints** plus **first-class Anthropic a
 - **Encryption** – **In transit:** terminate TLS at your reverse proxy or load balancer (typical deployments run Spectron on HTTP behind the proxy). **At rest:** configure encryption on your SurrealDB storage backend and object-store bucket (for example KMS on S3 or GCS); Spectron inherits whatever those backends provide.
 - **Graph-resident audit** – writes emit `decision_trace`; reads emit `retrieval_trace`; `/chat` and `/reflect` emit `response_trace`. Together these record which caller asked what, against which scope, with which key, and which records were considered or returned.
 - **Operational audit events** – alongside the trace graph, Spectron emits structured audit events for reads, destructive operations (`forget`), scope changes, background jobs, and **denied** authorisation attempts so refused access is on the record even when no trace record is written.
-- **Prompt-injection handling** – ingest-time scanning on uploads and batched turns; `spectron fsck --check injection` for sweeps.
+- **Prompt-injection handling** – ingest-time scanning on uploads and batched turns.
 - **Right to be forgotten** – `forget` soft-deletes or purges per policy; supersession history optional for audit.
 
 ## Inspectability and operational signals

--- a/src/content/spectron/index/mental-model/contexts-and-scope.mdx
+++ b/src/content/spectron/index/mental-model/contexts-and-scope.mdx
@@ -61,12 +61,28 @@ For the common case — a single clause with one or two tags — behaviour match
 
 Org-wide facts appear in user-level queries; user-specific facts do not appear in org-only queries.
 
+### Wire format (`ScopeSets`)
+
+On the wire, scope selectors use **disjunctive normal form** — an OR of conjunctive clauses:
+
+| Intent | `scopes` / `lens` value |
+| --- | --- |
+| Tag or read at one path | `[["org/acme/user/alice"]]` — or a bare string `"org/acme/user/alice"` (accepted as a singleton clause) |
+| Co-own across two owners (OR) | `[["org/acme/user/alice"], ["org/acme/user/bob"]]` |
+| Require two paths together (AND) | `[["org/acme", "org/acme/team/eng"]]` |
+
+- **Writes** use **`scopes`** on facts, sessions, uploads, and MCP tools. The legacy field name **`scope`** is still accepted as an alias.
+- **Reads** use **`lens`** on `/query`, `/context`, and MCP recall — same DNF shape, but the lens **filters by involvement** within your grant; it never widens access.
+
+> [!WARNING]
+> **Breaking change (pre-GA):** a flat two-element array such as `["org/acme", "project/support"]` now means **OR** (`org/acme` **or** `project/support`), not AND. To express AND, nest the paths in one inner array: `[["org/acme", "project/support"]]`.
+
 ### Example queries
 
-**As a specific user:**
+**As a specific user** (read lens):
 
 ```json
-{ "scope": ["org/acme/user/alice"] }
+{ "lens": [["org/acme/user/alice"]] }
 ```
 
 Matches org-wide facts at `org/acme` and user-specific facts at `org/acme/user/alice` when your grant covers both.
@@ -74,7 +90,7 @@ Matches org-wide facts at `org/acme` and user-specific facts at `org/acme/user/a
 **At org level:**
 
 ```json
-{ "scope": ["org/acme"] }
+{ "lens": [["org/acme"]] }
 ```
 
 Matches org-wide memory only — not Alice’s private rows unless your grant includes her path.

--- a/src/content/spectron/index/quickstarts/self-hosted.mdx
+++ b/src/content/spectron/index/quickstarts/self-hosted.mdx
@@ -27,7 +27,7 @@ Spectron listens on port **9090** by default (check your compose file if you map
 
 Follow the first-run steps in the Docker guide: create a management key, then create a Context and an end-user API key via the management API or CLI inside the container.
 
-For a **native dev** bring-up (`spectrond dev start` + SurrealDB on the host), use the step-by-step [local quickstart](https://github.com/surrealdb/spectron/blob/main/doc/reference/local-quickstart.md) in the Spectron repository — it mirrors the CI end-to-end flow, including `spectron principals create` for scoped principals.
+For **native dev** on the host (`spectrond dev start` + local SurrealDB), see the [CLI](/docs/spectron/reference/cli#development-runtime) **dev start** section and [Configuration](/docs/spectron/reference/configuration).
 
 Export:
 

--- a/src/content/spectron/index/quickstarts/surrealdb-cloud.mdx
+++ b/src/content/spectron/index/quickstarts/surrealdb-cloud.mdx
@@ -23,27 +23,28 @@ Customers integrate against the **context host** and **`sk-ctx-…` API keys** f
 | --- | --- |
 | **Owner** | Subscribe to Spectron plans, billing, delete contexts |
 | **Admin** | Create contexts, mint API keys, call admin proxy routes (principals, scopes, grants, usage) |
-| **Member** | Broker a short-lived access token for their own principal (`POST …/access_tokens`) |
+| **Member** | Use Playground, Memory, Documents, and Scopes in Surrealist; broker a short-lived access token for SDK use |
 
 Admin proxy routes return **403** for members. See [API keys and delegation](/docs/spectron/self-hosting/security/api-keys-and-delegation#surrealdb-cloud-surrealist).
 
 ## What Surrealist exposes
 
-| Feature | Status |
+| Feature | In Surrealist |
 | --- | --- |
-| Context list, deploy, billing, delete | Live |
-| API keys + per-context endpoint | Live |
-| Integration snippets | Live (verify package names — use `@surrealdb/spectron` / `surrealdb`) |
-| Playground | Preview demo with local mock chat |
-| Memories / Knowledge explorers | Preview — explorer and upload not enabled |
+| Context list, deploy, billing, delete | Yes |
+| API keys + per-context endpoint | Yes |
+| Playground (live chat + memory updates) | Yes |
+| Memory explorer (entities, relations, traces) | Yes |
+| Documents (upload, browse, search) | Yes |
+| Scopes (register and browse paths) | Yes |
+| Integration snippets (SDK, REST, MCP, frameworks) | Yes |
+| Settings — users, configuration, usage | Admins and owners |
 
-For first **`remember`** / **`recall`** calls, use [Hosted quickstart](/docs/spectron/quickstarts/hosted). For the UI tour, see [Surrealist dashboard quickstart](/docs/spectron/quickstarts/surrealist-dashboard).
+For a UI tour, see [Surrealist dashboard quickstart](/docs/spectron/quickstarts/surrealist-dashboard). For terminal-first **remember** / **recall**, see [Hosted quickstart](/docs/spectron/quickstarts/hosted).
 
 ## Scope on Cloud
 
-Data-plane **scope** is always slash paths on the wire — for example `["org/acme/user/alice"]`. Register paths before scoped writes (`spectron scopes create org/acme/user/alice` locally, or the Cloud admin scopes proxy).
-
-SDKs accept `scope=["org/acme/user/alice"]` or `scope="org/acme/user/alice"`.
+Data-plane **scope** uses hierarchical slash paths — for example `[["org/acme/user/alice"]]` on writes and **`lens`** on reads. Register paths in Surrealist **Scopes**, via the CLI, or through the Cloud admin scopes proxy.
 
 ## Cloud vs self-hosted
 

--- a/src/content/spectron/index/quickstarts/surrealist-dashboard.mdx
+++ b/src/content/spectron/index/quickstarts/surrealist-dashboard.mdx
@@ -6,7 +6,7 @@ description: "Create a Spectron Context in SurrealDB Cloud via Surrealist, mint 
 
 # Surrealist dashboard quickstart
 
-Spectron **Contexts** are a **SurrealDB Cloud** product inside **[Surrealist](https://surrealdb.com/surrealist)** — alongside database instances, not a separate console. This page describes what you can do in Surrealist today and how it connects to the Spectron [REST API](/docs/spectron/reference/rest-api) and [SDKs](/docs/spectron/integrations).
+Spectron **Contexts** live inside **[Surrealist](https://surrealdb.com/surrealist)** as a SurrealDB Cloud product — alongside database instances, not a separate console. Use this page to find your context in the UI, explore memory and documents, and wire up API keys for your app.
 
 > [!NOTE]
 > **Preview:** Spectron on Cloud is rolling out behind the **`create_memory_store`** profile flag. Organisation **owners** subscribe to a Spectron plan; **admins** create contexts. If you do not see **Contexts** in your organisation sidebar, your account may not be enabled yet.
@@ -19,31 +19,35 @@ Spectron **Contexts** are a **SurrealDB Cloud** product inside **[Surrealist](ht
 
 Context names cannot be changed after creation.
 
-Routes you will see:
-
 | Route | Purpose |
 | --- | --- |
 | `/o/:org/contexts` | List contexts |
 | `/o/:org/contexts/deploy` | Create a context (admin) |
 | `/o/:org/contexts/plan` / `checkout` | Spectron billing (owner) |
-| `/s/:org/:context/dashboard` | Context home |
-| `/s/:org/:context/integration` | Setup snippets |
-| `/s/:org/:context/api-keys` | **Live** — keys and endpoint |
-| `/s/:org/:context/settings` | Metadata and delete |
+| `/s/:org/:context/dashboard` | Overview — principal, access summary |
+| `/s/:org/:context/playground` | Live chat with recall and memory updates |
+| `/s/:org/:context/memory` | Browse state, entities, attributes, relations |
+| `/s/:org/:context/documents` | Upload, browse, and search documents |
+| `/s/:org/:context/scopes` | Scope hierarchy (register and manage paths) |
+| `/s/:org/:context/integration` | SDK, REST, MCP, and framework snippets |
+| `/s/:org/:context/api-keys` | Create and revoke data-plane keys |
+| `/s/:org/:context/settings/…` | Admin: users, service accounts, configuration, usage |
 
-## Surrealist views
+## Workspace views
 
-| View | Status |
+| View | What you can do |
 | --- | --- |
-| **Contexts** (create, list, billing, delete) | Available via SurrealDB Cloud API |
-| **API keys** | Available — create, list, revoke; one-time secret; per-context **host** URL |
-| **Integration** | Available — copy-ready snippets (use `@surrealdb/spectron` / `surrealdb`; see [Integrations](/docs/spectron/integrations)) |
-| **Dashboard** | Available — links to other views |
-| **Playground** | Preview demo with local mock chat |
-| **Memories** | Preview — explorer not available |
-| **Knowledge** | Preview — upload not enabled |
+| **Overview** | See your principal, grants, and shortcuts into the rest of the workspace |
+| **Playground** | Chat against the live data plane; watch recalled hits and memory updates from each turn |
+| **Memory** | Explore experiential memory — profile, entities, attributes, relations, and traces |
+| **Documents** | Upload files (PDF, markdown, and more); track pipeline status; search chunks |
+| **Scopes** | Browse the slash-path tree; register new scope paths for partitioned memory |
+| **Integrations** | Copy-ready snippets for Python, TypeScript, REST, MCP, LangChain, Vercel AI SDK, and others |
+| **API keys** | Create keys; copy the per-context **host**, **context id**, and one-time `sk-ctx-…` secret |
 
-For **remember**, **recall**, **chat**, and **document upload**, use **API keys** with the [Hosted quickstart](/docs/spectron/quickstarts/hosted) or an official SDK.
+**Settings** (organisation admins and owners only) covers context metadata, member principals, service accounts, model configuration, and usage.
+
+You do not need the CLI for day-to-day exploration — **Playground**, **Memory**, **Documents**, and **Scopes** call the same Spectron data API your application uses. For scripted **remember** / **recall**, use [Hosted quickstart](/docs/spectron/quickstarts/hosted) or an [SDK](/docs/spectron/integrations).
 
 ## How Cloud authentication works
 
@@ -51,59 +55,39 @@ SurrealDB Cloud uses **two planes**:
 
 | Plane | Who | Purpose |
 | --- | --- | --- |
-| **Cloud API** (`/v1/organizations/…`) | Surrealist | Context lifecycle, billing, API keys, (admin) principals/scopes proxy |
-| **Spectron data API** (`https://{context.host}/api/v1/…`) | Your app / SDK | Memory, knowledge, chat |
+| **Cloud API** (`/v1/organizations/…`) | Surrealist | Context lifecycle, billing, API keys, admin proxies |
+| **Spectron data API** (`https://{context.host}/api/v1/…`) | Your app / SDK | Memory, knowledge, chat, documents |
 
 End users **never** paste Spectron's root **management API key** into Surrealist. Cloud holds that credential server-side.
 
-**Members** (org role) can obtain a **short-lived brokered token** via Cloud (`POST …/spectron_contexts/{id}/access_tokens`) — mapped to a Spectron principal with `external_id = surreal-cloud:<user_id>`.
+**Members** obtain a **short-lived brokered token** via Cloud (`POST …/spectron_contexts/{id}/access_tokens`) — mapped to a Spectron principal with `external_id = surreal-cloud:<user_id>`. Surrealist uses this token to power **Playground**, **Memory**, **Documents**, and **Scopes** in the browser.
 
-**Admins and owners** manage contexts through Cloud. The SurrealDB Cloud API also **proxies** Spectron management operations (principals, grants, scopes, usage, providers) for admin callers. Surrealist does not expose full principals/scopes administration in the UI; use API keys for integrations, or the Cloud API for advanced grant tuning when building custom tooling.
-
-Grant projection from org role (simplified):
-
-| Org role | Typical Spectron grants (on first provision) |
-| --- | --- |
-| Owner / admin | Broad `/*` on memory and scope verbs (management proxy) |
-| Member | Minimal read base until an admin widens grants |
+**Admins and owners** manage contexts through Cloud. The SurrealDB Cloud API also **proxies** Spectron management operations (principals, grants, scopes, usage, providers) for admin callers.
 
 See [API keys and delegation](/docs/spectron/self-hosting/security/api-keys-and-delegation#self-service-keys-and-cloud-brokerage) for broker semantics on the Spectron side.
 
-## API keys (recommended integration path)
+## API keys (application integration)
 
 Open **API keys** inside your context. You will see:
 
-- **Endpoint** — `https://{context.host}` (per-context hostname, not a single global URL)
+- **Endpoint** — `https://{context.host}` (per-context hostname)
 - **Context ID** — the Spectron context identifier
 - **Create key** — name the key; the secret (`sk-ctx-…`) is shown **once**
 
-Keys are **principal-bound** on the Spectron side (created through Cloud, which calls Spectron management on your behalf). Use **`Authorization: Bearer sk-ctx-…`** on the data plane — see [REST API](/docs/spectron/reference/rest-api).
+Use **`Authorization: Bearer sk-ctx-…`** on the data plane — see [REST API](/docs/spectron/reference/rest-api).
 
 ```bash
 curl -sS "https://<host>/api/v1/<context_id>/facts" \
   -H "Authorization: Bearer sk-ctx-..." \
   -H "Content-Type: application/json" \
-  -d '{"text":"I was promoted to CTO.","infer":"full","scope":["org/acme/user/alice"]}'
+  -d '{"text":"I was promoted to CTO.","infer":"full","scopes":[["org/acme/user/alice"]]}'
 ```
 
-Register scope paths before scoped writes (`spectron scopes create org/acme/user/alice` or the Cloud scopes proxy when available).
-
-> [!NOTE]
-> Surrealist quick-start snippets may reference placeholder packages (`@surrealdb/memory`, `surrealdb-context`, `/memories` paths). Use **`surrealdb`** (Python) and **`@surrealdb/spectron`** (TypeScript) as documented in [Integrations](/docs/spectron/integrations).
-
-## Playground, Memories, and Knowledge
-
-The sidebar includes **Playground**, **Memories**, and **Knowledge** as preview views:
-
-- **Playground** — chat UX demo with canned responses; does not persist to Spectron.
-- **Memories** — memory graph concept preview; explorer not available.
-- **Knowledge** — authoritative ingestion preview; upload not enabled.
-
-Use API keys and the [Hosted quickstart](/docs/spectron/quickstarts/hosted) for memory and knowledge operations.
+Register scope paths in **Scopes** (or via the CLI / Cloud admin proxy) before scoped writes.
 
 ## Next steps
 
-- **[Hosted quickstart](/docs/spectron/quickstarts/hosted)** — first **remember** / **recall** with your context host and API key
+- **[Hosted quickstart](/docs/spectron/quickstarts/hosted)** — first **remember** / **recall** from your terminal
 - **[Integrations](/docs/spectron/integrations)** — Python, TypeScript, and Swift SDKs
 - **[Contexts and scope](/docs/spectron/mental-model/contexts-and-scope)** — slash-path scope model
 - **[Eight pillars and six categories](/docs/spectron/architecture/eight-pillars-and-categories)** — how experiential and authoritative memory relate

--- a/src/content/spectron/integrations/mcp-server/tools-reference.mdx
+++ b/src/content/spectron/integrations/mcp-server/tools-reference.mdx
@@ -322,7 +322,6 @@ The returned object shape depends on the record type:
 | `id` | string | Document ID |
 | `title` | string | Document title |
 | `content_type` | string | MIME type |
-| `chunk_count` | integer | Number of chunks the document was split into |
 | `metadata` | object | Metadata attached during ingestion |
 | `created_at` | string | ISO 8601 datetime |
 
@@ -367,8 +366,9 @@ Upload a document to the knowledge layer. Accepts base64-encoded bytes (MCP-frie
 | `source` | string | No | Provenance tag |
 | `mime_type` | string | No | Declared MIME type |
 | `filename` | string | No | Original filename |
-| `scope` | string[] | No | Slash paths **narrower than** the caller's `memory:write` region |
+| `scope` | string[] | No | DNF scope selector — slash paths **narrower than** the caller's `memory:write` region. Use nested arrays for AND clauses; a flat multi-element array is OR. Prefer **`scopes`** on new integrations. |
 | `labels` | string[] | No | `key=value` tags stamped on document-owned rows |
+| `observedAt` | string | No | Optional RFC 3339 known time for facts derived from this upload |
 
 ### Output
 

--- a/src/content/spectron/reference/cli.mdx
+++ b/src/content/spectron/reference/cli.mdx
@@ -70,7 +70,7 @@ spectrond dev start \
 
 Export LLM provider keys before `dev start` if you need extraction or chat (`infer: full` is not embeddings-only). A bare `spectrond start` alias exists for older single-process layouts but is hidden from `--help` — prefer `dev start` or the split production roles below.
 
-For a full copy-paste provisioning walkthrough (bootstrap, scopes, principals, keys, upload, query), see the [local quickstart](https://github.com/surrealdb/spectron/blob/main/doc/reference/local-quickstart.md) in the Spectron repository.
+For a full provisioning walkthrough (bootstrap, scopes, principals, keys, upload, query), follow the [Self-hosted quickstart](/docs/spectron/quickstarts/self-hosted) and [CLI](#connection-flags-client) reference below.
 
 ### Production roles
 

--- a/src/content/spectron/reference/configuration.mdx
+++ b/src/content/spectron/reference/configuration.mdx
@@ -139,7 +139,7 @@ Each Context stores a `config` object in the control plane. This is updated via 
 
 ### Provider API key visibility
 
-Provider API keys are **write-only** on the API surface. The read projection for a Context replaces the key values with a `providers_configured` summary:
+Provider API keys are **write-only** on the API surface. The read projection for a Context replaces the key values with a **`providers_configured`** summary — names of providers for which **this Context** stores its own key:
 
 ```json
 {
@@ -148,6 +148,8 @@ Provider API keys are **write-only** on the API surface. The read projection for
   }
 }
 ```
+
+This is **not** the same as **`GET /api/v1/{context_id}/providers`**, which lists providers reachable via a global deployment key **or** a per-Context key and includes selectable model ids. The two surfaces are not derivable from each other.
 
 The raw key values never appear in read responses.
 

--- a/src/content/spectron/reference/data-model-and-schema.mdx
+++ b/src/content/spectron/reference/data-model-and-schema.mdx
@@ -68,10 +68,8 @@ DEFINE FIELD source             ON document TYPE string;
 DEFINE FIELD storage_key        ON document TYPE string;
 DEFINE FIELD content_hash       ON document TYPE string;
 DEFINE FIELD size_bytes         ON document TYPE int;
-DEFINE FIELD language           ON document TYPE option<string>;
-DEFINE FIELD chunk_count        ON document TYPE option<int>;
-DEFINE FIELD keyword_count      ON document TYPE option<int>;
-DEFINE FIELD scope              ON document TYPE set<record<scope_attribute>>;
+DEFINE FIELD observed_at        ON document TYPE option<datetime>;
+DEFINE FIELD scope              ON document TYPE array<record<scope_sets>>;
 DEFINE FIELD version            ON document TYPE int DEFAULT 1;
 DEFINE FIELD status             ON document TYPE string DEFAULT "queued"
     ASSERT $value IN ["queued", "extracting", "chunking", "embedding", "keywording", "ready", "failed"];
@@ -309,10 +307,4 @@ Audit record for every retrieval and storage operation.
 
 ## Migrations
 
-Schema migrations are SurrealQL files bundled into the Spectron binary and applied automatically:
-
-| Migration | Contents |
-|---|---|
-| `V1__schema.surql` | Full Context schema (documents, entities, sessions, traces, scope, principals, and related indexes) |
-
-Migrations are applied once per Context database. Spectron tracks applied migrations in a `_migrations` table in each Context database. See [Migrations and upgrades](/docs/spectron/self-hosting/operations/migrations-and-upgrades).
+Schema is bundled into the Spectron binary and applied automatically when a Context is created or upgraded. See [Migrations and upgrades](/docs/spectron/self-hosting/operations/migrations-and-upgrades).

--- a/src/content/spectron/reference/management-api.mdx
+++ b/src/content/spectron/reference/management-api.mdx
@@ -96,7 +96,7 @@ When **`admin_external_id`** is set, Spectron seeds an initial **`principal:admi
 GET /api/v1/contexts/{context_id}
 ```
 
-Returns the Context record. Provider API key values are replaced with a `providers_configured` summary.
+Returns the Context record. Provider API key values are replaced with a `providers_configured` summary (per-Context keys only). For the full provider and model catalogue — including providers reachable via deployment-wide keys — use **`GET /api/v1/{context_id}/providers`** on the data-plane API.
 
 ### Update Context config
 
@@ -207,6 +207,8 @@ Duplicate key names within a Context return **`409 Conflict`** (names are unique
 GET /api/v1/contexts/{context_id}/principals/{principal_id}/keys
 ```
 
+Each entry includes **`id`**, **`name`**, and optional **`grants`** — the per-key attenuating grant map. When **`grants`** is omitted, the key inherits the principal's grants wholesale; when present, it only narrows per verb.
+
 ### Rotate or delete (principal-nested)
 
 ```http
@@ -225,6 +227,8 @@ GET    /api/v1/contexts/{context_id}/keys
 DELETE /api/v1/contexts/{context_id}/keys/{key_name}
 POST   /api/v1/contexts/{context_id}/keys/{key_name}/rotate?ttl_seconds=2592000
 ```
+
+List responses include optional **`grants`** on each key (same semantics as the principal-nested list).
 
 The secret is never returned after creation except on mint and rotate.
 

--- a/src/content/spectron/reference/mcp-tools.mdx
+++ b/src/content/spectron/reference/mcp-tools.mdx
@@ -9,7 +9,7 @@ description: "Tool payloads and ACL alignment."
 Spectron's MCP server exposes seven tools at `/mcp`. Each tool maps to one or more REST endpoints and carries the same authentication and scope semantics.
 
 > [!NOTE]
-> REST responses use **camelCase** (`queryMs`, `traceId`, `trace.traceId`). **Scope** on the wire is an array of slash paths (for example `["org/acme/user/alice"]`). Register paths with `spectron scopes create` before use.
+> REST responses use **camelCase** (`queryMs`, `traceId`, `trace.traceId`). **Scope selectors** on the wire use DNF (`ScopeSets`): writes take **`scopes`**, reads take **`lens`** — an OR of conjunctive slash-path clauses. Register paths with `spectron scopes create` before use. See [Contexts and scope](/docs/spectron/mental-model/contexts-and-scope#wire-format-scopesets).
 
 ## Authentication
 
@@ -36,7 +36,7 @@ All tools use **`Authorization: Bearer`** authentication (same as REST). Pass th
 Scope is layered on each tool call:
 
 1. **Grant region** (from the API key's principal) – enforced server-side; cannot be widened past what the key allows.
-2. **Per-call `scope` argument** – slash paths (for example `["org/acme/user/alice"]`) that narrow the operation within the grant.
+2. **Per-call `scopes` / `lens` argument** – DNF selector narrowing the operation within the grant (`scopes` on writes, `lens` on recall/context).
 
 Register paths with `spectron scopes create` before first use.
 
@@ -54,7 +54,7 @@ Store a memory from the current conversation. Auto-classifies into Identity / Kn
   "content": "I just got promoted to CTO.",   // required
   "role": "user",                              // optional, default "user"
   "session_id": "sess_abc123",                 // optional – creates implicit session if omitted
-  "scope": ["org/acme/user/alice"]
+  "scopes": [["org/acme/user/alice"]]
 }
 ```
 
@@ -87,7 +87,7 @@ Retrieve relevant memory and knowledge for a query. Returns a formatted context 
 {
   "query": "What does Alice do at Acme?",  // required
   "k": 10,                                  // optional, default 10
-  "scope": ["org/acme"]
+  "lens": [["org/acme"]]
 }
 ```
 
@@ -118,7 +118,7 @@ Synthesise patterns or insights from existing memory. Can optionally persist the
 {
   "query": "What recurring complaints have customers raised this month?",
   "persist": true,                                 // optional, default false
-  "scope": ["org/acme", "project/support"]
+  "lens": [["org/acme"], ["project/support"]]   // OR: org-wide OR project/support involvement
 }
 ```
 
@@ -147,7 +147,7 @@ Get the aggregated profile for the active scope – static facts, dynamic contex
 **Input:**
 ```jsonc
 {
-  "scope": ["org/acme/user/alice"]
+  "scopes": [["org/acme/user/alice"]]
 }
 ```
 
@@ -258,7 +258,7 @@ Upload a document to the knowledge layer. Bytes are base64-encoded on the wire; 
   "source": "returns.pdf",
   "mime_type": "application/pdf",
   "filename": "returns.pdf",
-  "scope": ["org/acme/team/eng"],      // optional — narrower than memory:write
+  "scopes": [["org/acme/team/eng"]],      // optional — narrower than memory:write
   "labels": ["team=eng"]               // optional — stamped on document rows
 }
 ```
@@ -288,7 +288,7 @@ Stop believing something. Sets `valid_until` on attributes that semantically mat
 ```jsonc
 {
   "query": "anything about my previous role at the old company", // required
-  "scope": ["org/acme/user/alice"]
+  "scopes": [["org/acme/user/alice"]]
 }
 ```
 

--- a/src/content/spectron/reference/rest-api.mdx
+++ b/src/content/spectron/reference/rest-api.mdx
@@ -49,9 +49,16 @@ https://<host>/api/v1/{context_id}
 
 Replace `{context_id}` with the identifier you chose at bootstrap (for example `dev` or `docs_test`).
 
-## Scope paths on the wire
+## Scope selectors on the wire
 
-**Scope** on read and write requests is an array of **hierarchical slash paths** — for example `org/acme/user/alice` (a trailing `/` is optional).
+Scope on requests is a **DNF selector** (`ScopeSets`): an OR of conjunctive clauses, each clause an AND of hierarchical slash paths (for example `org/acme/user/alice`; a trailing `/` is optional).
+
+| Direction | Field | Shape |
+| --- | --- | --- |
+| Write (facts, sessions, uploads) | **`scopes`** | `[[\"org/acme/user/alice\"]]` — legacy alias **`scope`** still accepted |
+| Read (`/query`, `/context`) | **`lens`** | Same DNF shape; filters by involvement within the caller’s grant |
+
+A flat `["a", "b"]` means **a OR b**. For **a AND b** in one clause, nest: `[["a", "b"]]`. Single-path tagging is unchanged in practice — `[["org/acme/user/alice"]]` or a bare string.
 
 Register paths before first use:
 
@@ -90,11 +97,14 @@ Content-Type: application/json
 {
   "text": "King Charles III became head of state of the United Kingdom in September 2022.",
   "infer": "full",
-  "scope": ["org/acme/user/alice"]
+  "scopes": [["org/acme/user/alice"]],
+  "observed_at": "2022-09-08T12:00:00Z"
 }
 ```
 
 `infer` values: `full` (LLM extraction, default), `triples` (caller-supplied structured triples), `preview` (dry run), `none` (literal store).
+
+Optional **`observed_at`** (RFC 3339) sets the **known time** (`created_at`) of derived facts. Use when ingesting serial narrative — novels, episodes, franchise films — so **`asOf`** recall matches how far the user has read or watched, not when you bulk-imported the corpus. In the example above, this would be useful to replay a narrative in which a user or character is unaware of the fact until the date indicated. See [Narrative playback and spoiler safety](/docs/spectron/agent-memory/reasoning/temporal-validity#narrative-playback-and-spoiler-safety). Omitted means wall-clock ingest time.
 
 **Response (`infer: full`):** nested **`extraction`** (entities, attributes, relations, …), plus `sessionId`, `turnId`, and `mode`. **`infer: none`** returns `chunkId`, `sessionId`, and `turnId` for the literal memory chunk.
 
@@ -115,7 +125,7 @@ Idempotency-Key: conv-01HF...
     { "role": "user", "content": "I was just promoted to CTO.", "ts": "2026-05-12T10:00:00Z" },
     { "role": "assistant", "content": "Congratulations!", "ts": "2026-05-12T10:00:05Z" }
   ],
-  "scope": ["org/acme/user/alice"],
+  "scopes": [["org/acme/user/alice"]],
   "session_id": "sess_01HF...",
   "extract": "whole_conversation"
 }
@@ -145,7 +155,7 @@ Create session body:
 
 ```json
 {
-  "scope": ["org/acme/user/alice"],
+  "scopes": [["org/acme/user/alice"]],
   "metadata": { "source": "chat-ui" }
 }
 ```
@@ -162,31 +172,29 @@ Content-Type: application/json
 
 {
   "query": "What is Alice's role?",
-  "limit": 10,
-  "scope": ["org/acme/user/alice"],
+  "k": 10,
+  "lens": [["org/acme/user/alice"]],
   "labels": ["subject=alice"],
-  "lens": ["org/acme/user/alice"],
   "scope_view": "strict",
-  "as_of": "2025-02-01T00:00:00Z",
+  "asOf": "2025-02-01T00:00:00Z",
   "source": "ingest-cli"
 }
 ```
 
 | Field | Purpose |
 | --- | --- |
-| `scope` | Scope paths the caller wants to read within (clamped to the key’s grant). |
+| `lens` | DNF scope selector narrowing the read region (clamped to the key’s grant). |
 | `labels` | Descriptive `key=value` tags that **filter** hits within the allowed region — labels never widen access on their own. |
-| `lens` | Optional hierarchical paths that **filter by involvement** within the grant — hits must touch the lens node(s), but need not match an exact clause size. |
 | `scope_view` | How broadly to fold results within the grant: `strict` (default — caller’s region only), `crossTeam` (cross-principal shared reads), or `merged` (same-fact records at narrower scopes). **`crossTeam`** and **`merged`** resolve like **`strict`**. None widen past the caller’s grant. |
 | `include` | Which result families to return: `facts` (entities and attributes) and/or `passages` (document chunks and sections). Default: both. Omitted or empty means no narrowing. Filters the **response** only — retrieval and trace reinforcement still see the full candidate set. |
 | `mode` | Closed set: `hybrid`, `vector`, `bm25`, or `graph`. Invalid values return `400`. |
-| `as_of` | Known-time filter — recall what the system would have believed at this instant (supersession walk by `created_at`, not valid-time). Omitted means current state. |
+| `asOf` | Known-time filter — recall what the system would have believed at this instant (supersession walk by `created_at` for attributes; relations are gated by `created_at` and open validity). Omitted means current state. |
 | `includeDuplicates` | When `false` (default), passage chunks flagged as near-duplicates (`duplicate_of` set) are excluded from fused chunk recall so the same text does not occupy multiple ranks. Set `true` to include them (parity with `/documents/query`). |
 | `source` | Free-form label recorded on the retrieval trace for audit replay; does not affect ranking. |
 
-**`limit`** on `/query` and **`k`** on document query default to **10** and are capped at **50** (operator-tunable downward only — see [Configuration](/docs/spectron/reference/configuration#request-and-list-limits)). The internal retrieval pool is fixed separately from `k`.
+**`k`** on `/query` and document query default to **10** and are capped at **50** (operator-tunable downward only — see [Configuration](/docs/spectron/reference/configuration#request-and-list-limits)). The internal retrieval pool is fixed separately from `k`.
 
-Response includes `tier` (`direct`, `cache`, `hybrid`, or `full_context`), `hits` (each with **`source`** as a **`ResultKind`**: `entity`, `attribute`, `memory_chunk`, `chunk`, or `section`), **`queryMs`**, and inline **`trace`** (with **`traceId`** for `GET .../traces/{id}`).
+Response includes `tier` (`direct`, `cache`, `hybrid`, or `full_context`), `hits` (each with **`source`** as a **`ResultKind`**: `entity`, `attribute`, `memory_chunk`, `chunk`, or `section`; optional **`occurredAt`** — known time of the underlying row for temporal resolution), **`queryMs`**, and inline **`trace`** (with **`traceId`** for `GET .../traces/{id}`).
 
 ### Formatted context block (`/context`)
 
@@ -196,8 +204,8 @@ Content-Type: application/json
 
 {
   "query": "What is Alice's role?",
-  "limit": 10,
-  "scope": ["org/acme/user/alice"]
+  "k": 10,
+  "lens": [["org/acme/user/alice"]]
 }
 ```
 
@@ -211,7 +219,7 @@ Content-Type: application/json
 
 {
   "message": "Summarise what you know about me",
-  "scope": ["org/acme/user/alice"],
+  "scopes": [["org/acme/user/alice"]],
   "session_id": "sess_01HF..."
 }
 ```
@@ -275,17 +283,26 @@ The `metadata` part is JSON. Optional fields:
 
 | Field | Purpose |
 | --- | --- |
-| `title`, `source`, `mime_type`, `filename` | Display and provenance |
-| `scope` | `ScopeSet` (slash-path strings) **narrower than** the caller's `memory:write` region — same semantics as `remember`. Out-of-region scope returns **`403`**. Omit to tag the document with the caller's full write region. |
+| `title`, `source`, `mimeType`, `filename` | Display and provenance |
+| `scopes` | DNF scope selector **narrower than** the caller's `memory:write` region — same semantics as `remember`. Out-of-region scope returns **`403`**. Omit to tag the document with the caller's full write region. Legacy alias **`scope`**. |
 | `labels` | Descriptive `key=value` tags stamped on the document and its chunks (not on reconciled graph rows). Keys must not start with `_` (`400`); count caps return **`409`**. |
+| `observedAt` | Optional RFC 3339 known time for derived facts — stamp each page or episode on a narrative timeline so `asOf` queries stay spoiler-safe ([cookbook](/docs/spectron/cookbooks/patterns/spoiler-safe-narrative-memory)). Omitted means facts date to ingest time. |
 
 ```http
 POST /api/v1/{context_id}/documents
 Content-Type: multipart/form-data
 
 file=<binary>
-metadata={"title":"Returns Policy","scope":["org/acme/team/eng"],"labels":["team=eng"]}
+metadata={"title":"Returns Policy","scopes":[["org/acme/team/eng"]],"labels":["team=eng"],"observedAt":"2024-01-15T00:00:00Z"}
 ```
+
+### List documents
+
+```http
+GET /api/v1/{context_id}/documents?pageSize=20&mimeType=application/pdf
+```
+
+Query parameters use **camelCase** (`pageSize`, `mimeType`). Pagination is **zero-indexed** (`page=0` is the first page).
 
 ### Document query (`/documents/query`)
 

--- a/src/content/spectron/self-hosting/observability/live-queries-and-dashboards.mdx
+++ b/src/content/spectron/self-hosting/observability/live-queries-and-dashboards.mdx
@@ -147,6 +147,11 @@ Spectron exposes Prometheus metrics at `/metrics`:
 | `spectron_documents_queued` | Gauge | Documents currently in the ingestion queue |
 | `spectron_cache_hits_total` | Counter | Semantic response cache hits |
 | `spectron_cache_misses_total` | Counter | Semantic response cache misses |
+| `spectron_storage_bytes_written_total` | Counter | Bytes written to object storage |
+| `spectron_storage_bytes_read_total` | Counter | Bytes read from object storage |
+| `spectron_documents_bytes_ingested_total` | Counter | Raw document bytes accepted for ingest |
+
+Byte-valued counters omit a doubled `bytes` suffix in Prometheus — the OTel exporter does not repeat a unit word already present in the metric name.
 
 Use these metrics with Prometheus + Grafana for production dashboarding without direct SurrealDB access.
 

--- a/src/content/spectron/self-hosting/operations/migrations-and-upgrades.mdx
+++ b/src/content/spectron/self-hosting/operations/migrations-and-upgrades.mdx
@@ -10,33 +10,11 @@ Spectron bundles schema migrations into the binary and applies them automaticall
 
 ## How migrations work
 
-Each Context database is created from a single greenfield schema file bundled into the server binary:
+Each Context database is created from schema bundled into the server binary. Migrations are **append-only** — applied automatically on context creation and on server startup. Applied versions are tracked in each Context database.
 
-| Migration file | Contents |
-|---|---|
-| `V1__schema.surql` | Full Context schema: scope and principals, documents and chunks, entities and attributes, sessions and turns, traces, idempotency, and background-job metadata |
-| `V7__…` | Drops the `keyword_cooccurs_with` table and related PMI co-occurrence retrieval signal (superseded by other ranker legs) |
+Most upgrades are **additive** (new tables, fields, indexes). A minority include **destructive** steps (dropping retired tables or fields). Always take a SurrealDB backup before upgrading production Contexts.
 
-Additional schema versions ship as `V2__…`, `V3__…`, and so on in an append-only sequence when included in the binary.
-
-### When migrations run
-
-Migrations run in two scenarios:
-
-1. **Context creation** – when `POST /api/v1/contexts/{id}` is called, the schema is applied to the new database from scratch.
-2. **Server startup** – at startup, Spectron checks each registered Context for pending migrations and applies them automatically.
-
-Applied migrations are tracked in a `_migrations` table inside each Context database:
-
-```surql
-SELECT * FROM _migrations ORDER BY applied_at ASC;
-```
-
-### Migration safety
-
-Most Spectron migrations are **additive** — they add tables, fields, and indexes without renaming existing columns. A minority of upgrades include **destructive** steps (for example dropping retired tables such as `keyword_cooccurs_with` in `V7`). Always take a SurrealDB backup before upgrading production Contexts.
-
-After upgrades that change scope semantics, operators may need to **re-tag legacy rows** that still carry empty scope (`scope = []`) so enforcing readers can see them. Spectron documents a one-shot operator recipe for this case; it is not applied automatically.
+After upgrades that change **scope semantics**, audit clients that pass multi-path flat arrays: `["a", "b"]` is now **OR**, not AND — use `[["a", "b"]]` for conjunction.
 
 Downgrading after a destructive migration is not supported — the older binary may not start against the new schema.
 
@@ -65,13 +43,7 @@ For single-server deployments:
 
 ### Verifying migration success
 
-After upgrade, confirm migrations applied:
-
-```surql
-SELECT * FROM _migrations ORDER BY applied_at ASC;
-```
-
-You should see `V1__schema.surql` (and any newer versions shipped with your binary). If a migration fails, Spectron logs the error and refuses to serve requests for the affected Context until the schema is consistent.
+After upgrade, check server logs for migration completion. If a migration fails, Spectron logs the error and refuses to serve requests for the affected Context until the schema is consistent.
 
 ## Version compatibility
 

--- a/src/content/spectron/self-hosting/security/scope-as-security-boundary.mdx
+++ b/src/content/spectron/self-hosting/security/scope-as-security-boundary.mdx
@@ -15,7 +15,7 @@ API keys bind a **scope floor** so a client cannot read or write outside what th
 
 ## Data partitioning vs security enforcement
 
-**Data partitioning** is what happens when you set `scope: ["org/acme/user/alice"]` on a recall query. Spectron filters results to facts within that scope.
+**Data partitioning** is what happens when you set `lens: [["org/acme/user/alice"]]` on a recall query. Spectron filters results to facts whose scope clauses match within your grant.
 
 **Security enforcement** happens at the API key level. A key whose grant region covers `org/acme/agent/planner` cannot read or write outside that region. The effective scope is the intersection of the requested scope and the key's grants.
 


### PR DESCRIPTION
More updates. A particularly interesting one: the ability to keep reveals spoiler free via specifying `asOf`.