### PR TITLE
Restore and improve docs search

### DIFF
--- a/api/search.ts
+++ b/api/search.ts
@@ -2,7 +2,7 @@ import {
     handleSearch,
     MAX_QUERY_LENGTH,
     normaliseQuery,
-    type SearchResult,
+    type SearchProduct,
 } from "@surrealdb/docs-search-common";
 import type { VercelRequest, VercelResponse } from "@vercel/node";
 
@@ -22,27 +22,15 @@ const CACHE_CONTROL = "public, s-maxage=3600, stale-while-revalidate=86400";
 
 // Products are isolated at the URL prefix level: every Spectron
 // page lives under /docs/spectron, every SurrealDB page does not.
-// We filter results in the API wrapper so the search index can
-// stay shared while UX is fully product-scoped.
-const SPECTRON_PATH_PREFIX = "/docs/spectron";
-
-const PRODUCTS = ["surrealdb", "spectron"] as const;
+// The product is passed to handleSearch, which filters the search
+// index (shared across products) before applying the relevance
+// threshold and result cap — so each product gets its full quota
+// of results rather than whatever survives a global cut.
+const PRODUCTS = ["surrealdb", "spectron"] as const satisfies readonly SearchProduct[];
 type ProductId = (typeof PRODUCTS)[number];
 
 function isProductId(value: string): value is ProductId {
     return (PRODUCTS as readonly string[]).includes(value);
-}
-
-function isSpectronUrl(url: string | undefined): boolean {
-    if (!url) return false;
-    return url === SPECTRON_PATH_PREFIX || url.startsWith(`${SPECTRON_PATH_PREFIX}/`);
-}
-
-function filterByProduct(results: SearchResult[], product: ProductId): SearchResult[] {
-    if (product === "spectron") {
-        return results.filter((result) => isSpectronUrl(result.url));
-    }
-    return results.filter((result) => !isSpectronUrl(result.url));
 }
 
 function setCors(res: VercelResponse) {
@@ -105,8 +93,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     }
 
     try {
-        const allResults = await handleSearch(query);
-        const results = filterByProduct(allResults, product);
+        const results = await handleSearch(query, product);
         res.setHeader("Cache-Control", CACHE_CONTROL);
         return res.status(200).json({ success: true, results });
     } catch (err) {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
         "dev": "vike dev",
         "prebuild": "bun scripts/generate-valid-paths.mjs",
         "build": "bun run --filter @surrealdb/docs-search-common build && vike build",
+        "postbuild": "bun scripts/index-search.ts",
         "preview": "vike build && vike preview",
         "lint": "biome lint --write .",
         "qc": "biome check .",

--- a/search/schema.surql
+++ b/search/schema.surql
@@ -18,12 +18,18 @@
 
 -- Tokeniser chain: split on whitespace (blank), unicode class
 -- boundaries (class), camelCase transitions (camel), and
--- punctuation (punct). The snowball(english) filter then stems
--- tokens ("running" → "run", "tables" → "tabl") so that
--- morphological variants match each other.
+-- punctuation (punct). Filters run in order: ascii folds accented
+-- characters to their plain form ("café" → "cafe") so accented
+-- input still matches, then snowball(english) stems tokens
+-- ("running" → "run", "tables" → "tabl") so morphological variants
+-- match each other.
+--
+-- NOTE: changing this analyzer only takes effect once the schema is
+-- re-applied (`bun run search:schema`) AND records are re-indexed so
+-- the full-text indexes are rebuilt with the new token stream.
 DEFINE ANALYZER OVERWRITE simple
     TOKENIZERS blank, class, camel, punct
-    FILTERS snowball(english);
+    FILTERS ascii, snowball(english);
 
 -- ────────────────────────────────────────────────────────────
 -- PAGE table

--- a/search/scripts/crawler.ts
+++ b/search/scripts/crawler.ts
@@ -22,33 +22,81 @@ import { readdir, readFile } from "node:fs/promises";
 import { join, relative } from "node:path";
 import { type AnyNode, type BlockNode, parseMarkdown, type Root, visit } from "@surrealdb/ui";
 import matter from "gray-matter";
-import {
-    abstractDoc,
-    type DocCollection,
-    docCollections,
-    urlForCollection,
-    versionedSdks,
-} from "../../src/content/config";
 import type { CrawledEntry, CrawledPage, CrawledSection } from "../src/types";
 
 const CONTENT_DIR = join(import.meta.dirname, "../../src/content");
+
+// A content collection is any directory under src/content/ that
+// contains a +Content.ts file (the vike-content-collection marker).
+// The collection id is its path relative to src/content/, e.g.
+// "learn/security" or "reference/query-language".
+const COLLECTION_MARKER = "+Content.ts";
+
+// Collections excluded from search indexing. "labs-items" uses a
+// different schema (labSchema) and is rendered as a listing rather
+// than as doc pages, so it has no per-entry doc URLs to index.
+const EXCLUDED_COLLECTIONS = new Set<string>(["labs-items"]);
+
+// URL prefix overrides. A page's URL is derived as
+// `/docs/<prefix>/<slug>`, where the prefix defaults to the
+// collection id — mirroring `resolveDataFromCollection` in
+// src/utils/data.ts, where `prefix = urlPrefix ?? id`. The entries
+// below override that default and must stay in sync with the
+// `urlPrefix` argument passed in each collection's +data.ts.
+const URL_PREFIX_OVERRIDES: Record<string, string> = {
+    // Served from the docs root (/docs/<slug>).
+    index: "",
+    // Served from /docs/spectron rather than /docs/spectron/index.
+    "spectron/index": "spectron",
+};
+
+/** The site is served under a `/docs` base path (see vite.config.ts). */
+const URL_BASE = "/docs";
 
 interface CategoryMeta {
     title: string;
     position: number;
 }
 
-// Versioned SDK collections (e.g. "doc-sdk-javascript-1x") are
-// skipped because only the latest version should be indexed.
-const VERSIONED_COLLECTION_IDS = new Set(
-    Object.entries(versionedSdks).flatMap(([sdk, config]) =>
-        config ? config.versions.map((v) => `doc-sdk-${sdk}-${v.replace(".", "")}`) : [],
-    ),
-);
+/** Frontmatter fields the crawler needs. Full validation happens at
+ *  build time via the collection's `pageSchema`, so we read loosely. */
+interface PageFrontmatter {
+    title?: string;
+    description?: string;
+}
 
 // ──────────────────────────────────────────────────────────
 // Filesystem helpers
 // ──────────────────────────────────────────────────────────
+
+/**
+ * Discovers all content collections by walking src/content/ for
+ * directories containing a +Content.ts marker. Collections never
+ * nest inside one another, so recursion stops once a marker is
+ * found. Excluded collections are filtered out.
+ */
+async function discoverCollections(): Promise<string[]> {
+    const collections: string[] = [];
+
+    async function scan(dir: string) {
+        const entries = await readdir(dir, { withFileTypes: true });
+
+        if (entries.some((e) => e.isFile() && e.name === COLLECTION_MARKER)) {
+            const id = relative(CONTENT_DIR, dir);
+            if (!EXCLUDED_COLLECTIONS.has(id)) collections.push(id);
+            return;
+        }
+
+        for (const entry of entries) {
+            if (entry.isDirectory()) {
+                await scan(join(dir, entry.name));
+            }
+        }
+    }
+
+    await scan(CONTENT_DIR);
+    return collections.sort();
+}
 
 /** Recursively yields all .md and .mdx file paths in a directory. */
 async function* walkMarkdown(dir: string): AsyncGenerator<string> {
@@ -228,14 +276,14 @@ function splitAtHeadings(
 // and the page title, producing strings like:
 //   "SurrealQL > Statements > DEFINE > TABLE"
 //
-// URLs are built from the collection's URL prefix (defined in
-// src/content/config.ts) and the file's slug:
-//   collection "doc-surrealql" + slug "statements/select"
-//   → "/docs/surrealql/statements/select"
+// URLs are built from the collection's URL prefix (the collection
+// id by default, see URL_PREFIX_OVERRIDES) and the file's slug:
+//   collection "reference/query-language" + slug "statements/select"
+//   → "/docs/reference/query-language/statements/select"
 // ──────────────────────────────────────────────────────────
 
 function buildBreadcrumb(
-    collection: DocCollection,
+    collection: string,
     slug: string,
     categories: Map<string, CategoryMeta>,
     pageLabel: string,
@@ -279,9 +327,9 @@ function buildSlug(filePath: string, collectionDir: string): string {
     return slug;
 }
 
-function buildUrl(collection: DocCollection, slug: string): string {
-    const base = urlForCollection[collection as keyof typeof urlForCollection];
-    const segments = ["/docs", base, slug].filter(Boolean);
+function buildUrl(collection: string, slug: string): string {
+    const prefix = URL_PREFIX_OVERRIDES[collection] ?? collection;
+    const segments = [URL_BASE, prefix, slug].filter(Boolean);
     return segments.join("/");
 }
 
@@ -336,28 +384,16 @@ function contentHash(...parts: string[]): string {
 // ──────────────────────────────────────────────────────────
 
 export async function* crawl(): AsyncGenerator<CrawledEntry> {
-    for (const collection of docCollections) {
-        // Skip versioned SDK collections (e.g. 1.x docs) — only
-        // the latest version is indexed.
-        if (VERSIONED_COLLECTION_IDS.has(collection)) continue;
+    const collections = await discoverCollections();
 
+    for (const collection of collections) {
         const collectionDir = join(CONTENT_DIR, collection);
-
-        let dirExists = true;
-        try {
-            await readdir(collectionDir);
-        } catch {
-            dirExists = false;
-        }
-
-        if (!dirExists) continue;
-
         const categories = await loadCategoryMap(collectionDir);
 
         for await (const filePath of walkMarkdown(collectionDir)) {
             const raw = await readFile(filePath, "utf-8");
             const { data: frontmatter, content: body } = matter(raw);
-            const parsed = abstractDoc.parse(frontmatter);
+            const parsed = frontmatter as PageFrontmatter;
 
             const slug = buildSlug(filePath, collectionDir);
             const ast = parseMarkdown(body);

--- a/search/scripts/crawler.ts
+++ b/search/scripts/crawler.ts
@@ -363,13 +363,22 @@ function createAnchorDeduplicator(): (raw: string) => string {
     };
 }
 
+// Version token mixed into every content hash. Bump it whenever the
+// embedding strategy changes (model, content truncation length, embed
+// text structure) so the incremental indexer treats all existing
+// records as changed and re-embeds them once. "c8000" = 8000-char
+// content limit (see EMBED_CONTENT_LIMIT in search/src/embed.ts).
+const EMBED_VERSION = "v2-c8000";
+
 /**
  * SHA-256 hash used for incremental indexing — if the hash
  * hasn't changed since last index, we skip re-embedding and
- * re-upserting the record to save OpenAI API calls.
+ * re-upserting the record to save OpenAI API calls. EMBED_VERSION
+ * is folded in so embedding-strategy changes force a re-index.
  */
 function contentHash(...parts: string[]): string {
     const hash = createHash("sha256");
+    hash.update(EMBED_VERSION);
     for (const part of parts) hash.update(part);
     return hash.digest("hex");
 }

--- a/search/src/embed.ts
+++ b/search/src/embed.ts
@@ -7,6 +7,12 @@ import type { CrawledEntry } from "./types";
 // index time and query time.
 const MODEL = "text-embedding-3-small";
 
+// Query-time embedding sits on the critical path of every search
+// request, so cap it: if OpenAI stalls, fail fast (the API layer's
+// stale-while-revalidate cache can still serve the last good
+// response) rather than hanging until the serverless timeout.
+const QUERY_EMBED_TIMEOUT_MS = 5000;
+
 let client: OpenAI | null = null;
 
 function getClient(): OpenAI {
@@ -18,10 +24,13 @@ function getClient(): OpenAI {
 
 /** Embed a single text string (used at query time). */
 export async function embed(text: string): Promise<number[]> {
-    const res = await getClient().embeddings.create({
-        model: MODEL,
-        input: text,
-    });
+    const res = await getClient().embeddings.create(
+        {
+            model: MODEL,
+            input: text,
+        },
+        { timeout: QUERY_EMBED_TIMEOUT_MS },
+    );
 
     return res.data[0].embedding;
 }
@@ -48,10 +57,14 @@ export async function embedBatch(texts: string[]): Promise<number[][]> {
  * Structured as labelled fields so the embedding model captures
  * the semantic role of each piece (title vs breadcrumb vs content).
  *
- * Content is truncated to 2000 chars because embedding models
- * have limited context windows and the most important information
- * is usually near the top of a page.
+ * Content is truncated to EMBED_CONTENT_LIMIT chars. text-embedding-3-small
+ * accepts ~8191 tokens (≈30k chars), so 8000 chars comfortably fits within
+ * one request while capturing far more of a long page than the previous
+ * 2000-char cap (which left most of a long reference page unembedded and
+ * relied on section vectors to compensate).
  */
+export const EMBED_CONTENT_LIMIT = 8000;
+
 export function buildEmbedText(entry: CrawledEntry): string {
     const parts = [`Title: ${entry.title}`, `Breadcrumb: ${entry.breadcrumb}`];
 
@@ -59,6 +72,6 @@ export function buildEmbedText(entry: CrawledEntry): string {
         parts.push(`Description: ${entry.description}`);
     }
 
-    parts.push(`Content: ${entry.content.slice(0, 2000)}`);
+    parts.push(`Content: ${entry.content.slice(0, EMBED_CONTENT_LIMIT)}`);
     return parts.join("\n");
 }

--- a/search/src/handler.ts
+++ b/search/src/handler.ts
@@ -22,6 +22,33 @@ import type { RawSearchHit, SearchResult, SearchResultItem } from "./types";
 export const MAX_QUERY_LENGTH = 500;
 
 // ──────────────────────────────────────────────────────────
+// Product scoping
+//
+// The search index is shared across products, but the UX is
+// product-scoped: every Spectron page lives under /docs/spectron,
+// everything else is SurrealDB. Filtering happens HERE — before
+// boosting, grouping, the relevance threshold, and the result cap
+// — so the much larger SurrealDB corpus can't crowd the smaller
+// Spectron product out of the global top-N. (This previously ran
+// in the API wrapper after the cap, which starved Spectron
+// results: a Spectron query could return few or zero hits even
+// when relevant Spectron pages existed.)
+// ──────────────────────────────────────────────────────────
+
+const SPECTRON_PATH_PREFIX = "/docs/spectron";
+
+export type SearchProduct = "surrealdb" | "spectron";
+
+function isSpectronPath(path: string): boolean {
+    return path === SPECTRON_PATH_PREFIX || path.startsWith(`${SPECTRON_PATH_PREFIX}/`);
+}
+
+function matchesProduct(hit: RawSearchHit, product: SearchProduct): boolean {
+    const spectron = isSpectronPath(hit.page_path || hit.url || "");
+    return product === "spectron" ? spectron : !spectron;
+}
+
+// ──────────────────────────────────────────────────────────
 // SurrealQL hybrid search query
 //
 // Runs four sub-queries and fuses them with RRF. The query
@@ -31,10 +58,12 @@ export const MAX_QUERY_LENGTH = 500;
 // ──────────────────────────────────────────────────────────
 const SEARCH_SQL = /* surql */ `
     -- ── Page vector search ──
-    -- Finds the 30 pages whose embeddings are closest to the
-    -- query embedding. The <|30,100|> syntax means: return 30
-    -- neighbours, exploring up to 100 candidates in the HNSW
-    -- graph (higher = more accurate but slower).
+    -- Finds the 60 pages whose embeddings are closest to the
+    -- query embedding. The <|60,240|> syntax means: return 60
+    -- neighbours, exploring up to 240 candidates in the HNSW
+    -- graph (higher = more accurate but slower). The pool is kept
+    -- generous because results are product-filtered downstream, and
+    -- the smaller product (Spectron) must not be crowded out.
     LET $page_vs = (
         SELECT
             id,
@@ -48,9 +77,9 @@ const SEARCH_SQL = /* surql */ `
             content,
             vector::distance::knn() AS distance
         FROM page
-        WHERE embedding <|30,100|> $qvec
+        WHERE embedding <|60,240|> $qvec
         ORDER BY distance ASC
-        LIMIT 30
+        LIMIT 60
     );
 
     -- ── Page full-text search ──
@@ -88,7 +117,7 @@ const SEARCH_SQL = /* surql */ `
             OR description @3@ $query
             OR content @4@ $query
         ORDER BY ft_score DESC
-        LIMIT 30
+        LIMIT 60
     );
 
     -- ── Section vector search ──
@@ -107,9 +136,9 @@ const SEARCH_SQL = /* surql */ `
             content,
             vector::distance::knn() AS distance
         FROM section
-        WHERE embedding <|30,100|> $qvec
+        WHERE embedding <|60,240|> $qvec
         ORDER BY distance ASC
-        LIMIT 30
+        LIMIT 60
     );
 
     -- ── Section full-text search ──
@@ -138,7 +167,7 @@ const SEARCH_SQL = /* surql */ `
             OR breadcrumb @1@ $query
             OR content @2@ $query
         ORDER BY ft_score DESC
-        LIMIT 30
+        LIMIT 60
     );
 
     -- ── Reciprocal Rank Fusion ──
@@ -147,8 +176,8 @@ const SEARCH_SQL = /* surql */ `
     -- across all lists the result appears in.
     --   arg 1: array of ranked lists to fuse
     --   arg 2: k=60 (smoothing constant, standard RRF default)
-    --   arg 3: limit=80 (max candidates to consider)
-    LET $fused = search::rrf([$page_ft, $page_vs, $section_ft, $section_vs], 60, 80);
+    --   arg 3: limit=160 (max candidates to consider)
+    LET $fused = search::rrf([$page_ft, $page_vs, $section_ft, $section_vs], 60, 160);
 
     RETURN (
         SELECT
@@ -494,6 +523,56 @@ function stripQuestionPrefix(query: string): string {
     return q;
 }
 
+// ──────────────────────────────────────────────────────────
+// Domain synonym expansion (BM25 only)
+//
+// BM25 is purely lexical: a query for "perms" never matches a
+// page that only says "permissions". We append a small, curated
+// set of SurrealDB-specific synonyms to the BM25 query so common
+// aliases and acronyms still retrieve the right pages. Expansion
+// is applied ONLY to the keyword query — the vector embedding
+// uses the original wording and already handles paraphrase.
+//
+// Keep this map small and high-precision: every added term widens
+// recall but slightly dilutes BM25 scoring.
+// ──────────────────────────────────────────────────────────
+
+const SYNONYMS: Record<string, string[]> = {
+    sql: ["surrealql"],
+    surrealql: ["sql"],
+    perms: ["permissions"],
+    perm: ["permission"],
+    auth: ["authentication"],
+    authz: ["authorisation", "permissions"],
+    authn: ["authentication"],
+    js: ["javascript"],
+    ts: ["typescript"],
+    rel: ["relate"],
+    fts: ["full-text", "search"],
+    db: ["database"],
+    "record id": ["recordid"],
+    recordid: ["record"],
+};
+
+function expandSynonyms(query: string): string {
+    const lower = query.toLowerCase();
+    const tokens = tokenise(query);
+    const additions: string[] = [];
+
+    for (const [term, synonyms] of Object.entries(SYNONYMS)) {
+        // Multi-word keys are matched as substrings; single-word
+        // keys must match a whole token to avoid spurious hits.
+        const present = term.includes(" ") ? lower.includes(term) : tokens.includes(term);
+        if (!present) continue;
+
+        for (const synonym of synonyms) {
+            if (!lower.includes(synonym)) additions.push(synonym);
+        }
+    }
+
+    return additions.length > 0 ? `${query} ${additions.join(" ")}` : query;
+}
+
 /**
  * Normalises a raw search query into a canonical form suitable
  * for use as a CDN cache key. Two queries that normalise to the
@@ -583,12 +662,16 @@ function groupByPage(hits: RawSearchHit[], query: string): SearchResult[] {
 // Main entry point
 // ──────────────────────────────────────────────────────────
 
-export async function handleSearch(query: string): Promise<SearchResult[]> {
+export async function handleSearch(
+    query: string,
+    product?: SearchProduct,
+): Promise<SearchResult[]> {
     const connection = await getDb();
 
-    // Strip question words for BM25 but embed the original
-    // query — the vector model understands natural language.
-    const ftQuery = stripQuestionPrefix(query);
+    // Strip question words and expand domain synonyms for BM25, but
+    // embed the original query — the vector model understands
+    // natural language and paraphrase natively.
+    const ftQuery = expandSynonyms(stripQuestionPrefix(query));
     const qvec = await embed(query);
 
     // The query returns 6 results (5 LET statements + 1 RETURN),
@@ -600,7 +683,11 @@ export async function handleSearch(query: string): Promise<SearchResult[]> {
         )
         .collect();
 
-    const boosted = boostResults(hits, query);
+    // Filter by product BEFORE boosting/grouping/threshold so the
+    // relevance cutoff and result cap apply within the product.
+    const scoped = product ? hits.filter((hit) => matchesProduct(hit, product)) : hits;
+
+    const boosted = boostResults(scoped, query);
     const grouped = groupByPage(boosted, query);
     return applyRelevanceThreshold(grouped);
 }

--- a/search/src/handler.ts
+++ b/search/src/handler.ts
@@ -207,21 +207,23 @@ function isTokenPrefix(shorter: string[], longer: string[]): boolean {
 // ──────────────────────────────────────────────────────────
 
 /**
- * Non-SDK doc collections get a small ranking boost because
- * generic queries like "authentication" should prefer the
- * core concept page over an SDK API reference page that
- * happens to mention auth as one of many methods.
+ * SDK / client-library reference lives under `/docs/languages/` (the
+ * per-language API docs in the `index` collection). Generic queries
+ * like "authentication" should prefer a core concept page over an SDK
+ * API reference page that merely mentions the term as one of many
+ * methods, so every non-SDK page gets a small boost.
+ *
+ * The documentation restructure (#1699) folded the former standalone
+ * SDK collections (`doc-sdk-*`) into `index/languages/*`, so this is
+ * now matched by URL prefix rather than by collection id.
  */
-const CORE_COLLECTIONS = new Set([
-    "doc-surrealdb",
-    "doc-surrealql",
-    "doc-tutorials",
-    "doc-cloud",
-    "doc-surrealist",
-    "doc-surrealml",
-    "doc-surrealkv",
-    "doc-integrations",
-]);
+const SDK_REFERENCE_URL_PREFIX = "/docs/languages/";
+
+/** True for any hit that is not an SDK/client-library reference page. */
+function isCoreDoc(hit: RawSearchHit): boolean {
+    const path = hit.page_path || hit.url || "";
+    return !path.startsWith(SDK_REFERENCE_URL_PREFIX);
+}
 
 /**
  * Detects whether the user is comparing two concepts and
@@ -304,10 +306,10 @@ function boostResults(hits: RawSearchHit[], query: string): RawSearchHit[] {
             boost *= 1.1;
         }
 
-        // Prefer core docs over SDK API reference pages for
-        // general queries. SDK-specific queries still rank well
-        // because they'll have stronger BM25/vector base scores.
-        if (hit.collection && CORE_COLLECTIONS.has(hit.collection)) {
+        // Prefer core docs over SDK/client-library reference pages for
+        // general queries. SDK-specific queries still rank well because
+        // they'll have stronger BM25/vector base scores.
+        if (isCoreDoc(hit)) {
             boost *= 1.15;
         }
 

--- a/search/src/index.ts
+++ b/search/src/index.ts
@@ -1,5 +1,6 @@
 export { connectDb, getDb } from "./db";
 export { buildEmbedText, embed, embedBatch } from "./embed";
+export type { SearchProduct } from "./handler";
 export { handleSearch, MAX_QUERY_LENGTH, normaliseQuery } from "./handler";
 export type {
     CrawledEntry,

--- a/src/components/SearchDocs/index.tsx
+++ b/src/components/SearchDocs/index.tsx
@@ -70,6 +70,16 @@ export function SearchDocs(props: UnstyledButtonProps) {
                 search_product: product,
             });
 
+            // Surface queries that find nothing so content gaps are
+            // measurable rather than inferred from missing clicks.
+            if (results.length === 0) {
+                window.dataLayer?.push({
+                    event: "search_no_results",
+                    search_term: debouncedSearch,
+                    search_product: product,
+                });
+            }
+
             return results;
         },
         enabled: debouncedSearch.length > 0,


### PR DESCRIPTION
## Part 1 — Restore indexing (the build was failing)

Docs search indexing had not run on production. Two compounding regressions:

1. **The `postbuild` trigger was dropped.** #1702 added `"postbuild": "bun scripts/index-search.ts"`; #1706 rewrote the `build` script and silently removed it. Restored it — `bun run build` runs `prebuild` → `build` → `postbuild` automatically, and `index-search.ts` already gates on `VERCEL_ENV === "production"`.
2. **The crawler was never updated for the content restructure (#1699)** — it imported `abstractDoc`/`docCollections`/`urlForCollection`/`versionedSdks` from the deleted `src/content/config`. Rewired to the current vike-content-collection layout: dynamic collection discovery via `+Content.ts`, `/docs/<prefix>/<slug>` URLs (prefix = collection id, overridden for `index`→`""` and `spectron/index`→`"spectron"`), dropped `versionedSdks`, loose frontmatter read.
3. **Re-keyed the `CORE_COLLECTIONS` ranking boost** (`handler.ts`) — it was keyed on removed `doc-*` ids and matched nothing. Now boosts every page not under `/docs/languages/` (SDK reference), preserving the original intent.

## Part 2 — Search quality improvements

4. **Product filtering before the result cap** (`handler.ts`, `api/search.ts`). Filtering ran in the API wrapper *after* `handleSearch` grouped, thresholded, and capped to 20 results — so the much larger SurrealDB corpus crowded Spectron out of the global top-N, and a Spectron query could return few/zero hits despite relevant pages existing. Product is now passed into `handleSearch` and applied to the raw hits **before** boost/group/threshold, with an enlarged candidate pool (KNN 30→60, per-subquery LIMIT 30→60, RRF limit 80→160) so the smaller product isn't starved.
5. **Larger embedding input** (`embed.ts`, `crawler.ts`). Content truncation 2000→8000 chars (model accepts ~8191 tokens) for better recall on long pages. An `EMBED_VERSION` token folded into the content hash forces the incremental indexer to re-embed existing records once.
6. **Domain synonym expansion for BM25** (`handler.ts`) — curated map (`sql`↔`surrealql`, `perms`→`permissions`, `auth`→`authentication`, …) appended to the keyword query; vector path unchanged.
7. **ASCII folding in the analyzer** (`schema.surql`) so accented input matches.
8. **`search_no_results` analytics event** (`SearchDocs`) to measure content gaps directly.
9. **Query-time embedding timeout** (`embed.ts`, 5 s) so a stalled OpenAI call fails fast and `stale-while-revalidate` can serve the last good response.

## Verification

- Crawler dry-run: **900 pages / 3741 sections / 28 collections**, URLs match live routes.
- Search lib + API typecheck clean; the `@surrealdb/docs-search-common` bundle builds; `bun run qc` passes.

## Deploy prerequisites / ordering

- [ ] Production Vercel env vars present: `SURREAL_ENDPOINT`, `SURREAL_NAMESPACE`, `SURREAL_DATABASE`, `SURREAL_USERNAME`, `SURREAL_PASSWORD`, `OPENAI_API_KEY` (a missing var fails the production build).
- [ ] **Re-apply the schema** (`bun run search:schema`) against the target SurrealDB — required for the ASCII-folding analyzer change (#7) and assumed-present `page`/`section` tables + `fn::search`.
- [ ] The next production index will **re-embed every record once** (EMBED_VERSION bump, #5). This is a one-time cost (~4.6k embeddings, batched) and also rebuilds the full-text indexes with the new analyzer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)