### PR TITLE
Document filtered KNN pushdown and KnnScan EXPLAIN visibility

### DIFF
--- a/src/content/learn/data-models/vector-search/similarity-search.mdx
+++ b/src/content/learn/data-models/vector-search/similarity-search.mdx
@@ -102,13 +102,16 @@ SELECT id, flag, vector::distance::knn() AS distance FROM actor
 
 ### How the filter is applied
 
-Because `embedding` is indexed, the `flag = true` condition is *not* applied after the nearest neighbours have been gathered. Instead SurrealDB pushes it down *into* the approximate (HNSW or DISKANN) search, so candidates that fail the condition are discarded as the graph is traversed and never occupy one of the `K` result slots. This keeps the result both correct — you still receive up to `K` records that match the condition — and efficient, since the search does not spend its slots on records that would only be filtered out afterwards.
+Because `embedding` is indexed, the `flag = true` condition is *not* applied after the nearest neighbours have been gathered. Instead SurrealDB pushes it down *into* the approximate (HNSW or DISKANN) search, so candidates that fail the condition are discarded as the graph is traversed and never occupy one of the `K` result slots. This keeps the result both correct, and efficient:
+
+* Correct, because you still receive up to `K` records that match the condition.
+* Efficient, since the search does not spend its slots on records that would only be filtered out afterwards.
 
 ### Confirming the pushed-down filter with `EXPLAIN`
 
 <Since v="v3.1.5" />
 
-Append the [`EXPLAIN`](/docs/reference/query-language/statements/explain) statement to the same query to see the plan. The pushed-down condition appears as a `predicate` attribute on the `KnnScan` operator:
+The [`EXPLAIN`](/docs/reference/query-language/statements/explain) clause can be used in the same query to see the query plan. The pushed-down condition appears as a `predicate` attribute on the `KnnScan` operator:
 
 ```surql
 EXPLAIN SELECT id, flag, vector::distance::knn() AS distance FROM actor

--- a/src/content/learn/data-models/vector-search/similarity-search.mdx
+++ b/src/content/learn/data-models/vector-search/similarity-search.mdx
@@ -100,4 +100,29 @@ SELECT id, flag, vector::distance::knn() AS distance FROM actor
 
 `actor:1` and `actor:4` have the closest resemblance with your query vector among those who have also won an Oscar.
 
+### How the filter is applied
+
+Because `embedding` is indexed, the `flag = true` condition is *not* applied after the nearest neighbours have been gathered. Instead SurrealDB pushes it down *into* the approximate (HNSW or DISKANN) search, so candidates that fail the condition are discarded as the graph is traversed and never occupy one of the `K` result slots. This keeps the result both correct — you still receive up to `K` records that match the condition — and efficient, since the search does not spend its slots on records that would only be filtered out afterwards.
+
+### Confirming the pushed-down filter with `EXPLAIN`
+
+<Since v="v3.1.5" />
+
+Append the [`EXPLAIN`](/docs/reference/query-language/statements/explain) statement to the same query to see the plan. The pushed-down condition appears as a `predicate` attribute on the `KnnScan` operator:
+
+```surql
+EXPLAIN SELECT id, flag, vector::distance::knn() AS distance FROM actor
+  WHERE flag = true AND embedding <|2,40|> $person_embedding ORDER BY distance;
+```
+
+```surql title="Output"
+'SelectProject [ctx: Db] [projections: id, flag, distance]
+    SortByKey [ctx: Db] [sort_keys: distance ASC]
+        Compute [ctx: Db] [fields: distance = vector::distance::knn(...)]
+            Filter [ctx: Db] [predicate: flag = true]
+                KnnScan [ctx: Db] [index: hnsw_pts, k: 2, ef: 40, dimension: 4, predicate: flag = true]'
+```
+
+The `predicate: flag = true` on the `KnnScan` line is the condition being evaluated inside the index search. If the attribute is missing, the condition is not being pushed down (for example, when the vector field is not indexed). A DISKANN index produces an identical `KnnScan` line.
+
 For HNSW and DISKANN configuration and the KNN cheat sheet, see [Vector indexes](/docs/learn/data-models/vector-search/vector-indexes).

--- a/src/content/reference/query-language/clauses/explain.mdx
+++ b/src/content/reference/query-language/clauses/explain.mdx
@@ -189,7 +189,7 @@ SELECT * FROM person WHERE email='tobie@surrealdb.com' EXPLAIN FULL;
 
 <Since v="v3.1.5" />
 
-When a [KNN search](/docs/reference/query-language/language-primitives/operators#knn) over an indexed vector field is combined with an additional non-KNN condition, that condition is pushed *into* the index search so that non-matching candidates are rejected during the search rather than afterwards. The plan shows this as a `predicate` attribute on the `KnnScan` operator.
+When a [KNN search](/docs/reference/query-language/language-primitives/operators#knn) over an indexed vector field is combined with an additional non-KNN condition, that condition is pushed *into* the index search so that non-matching candidates are rejected during the search rather than afterwards. The plan shows this as a `predicate` attribute on the `KnnScan` operator. To display the query plan, add the `EXPLAIN` clause to the end of a query as shown in the example below.
 
 ```surql title="Filtered KNN"
 DEFINE INDEX idx_pt ON pts FIELDS point HNSW DIMENSION 4;

--- a/src/content/reference/query-language/clauses/explain.mdx
+++ b/src/content/reference/query-language/clauses/explain.mdx
@@ -184,3 +184,86 @@ SELECT * FROM person WHERE email='tobie@surrealdb.com' EXPLAIN FULL;
 	total_rows: 1
 }
 ```
+
+### K-nearest neighbours (KNN) searches
+
+<Since v="v3.1.5" />
+
+When a [KNN search](/docs/reference/query-language/language-primitives/operators#knn) over an indexed vector field is combined with an additional non-KNN condition, that condition is pushed *into* the index search so that non-matching candidates are rejected during the search rather than afterwards. The plan shows this as a `predicate` attribute on the `KnnScan` operator.
+
+```surql title="Filtered KNN"
+DEFINE INDEX idx_pt ON pts FIELDS point HNSW DIMENSION 4;
+INSERT INTO pts [
+	{ point: [1, 2, 3, 4], flag: true },
+	{ point: [4, 3, 2, 1], flag: false },
+	{ point: [3, 3, 3, 3], flag: true }
+];
+
+SELECT id, flag, vector::distance::knn() AS distance FROM pts
+	WHERE flag = true AND point <|2,40|> [2, 3, 4, 5]
+	ORDER BY distance EXPLAIN;
+```
+
+```surql title="Output"
+{
+	attributes: {
+		projections: 'id, flag, distance'
+	},
+	children: [
+		{
+			attributes: {
+				sort_keys: 'distance ASC'
+			},
+			children: [
+				{
+					attributes: {
+						fields: 'distance = vector::distance::knn(...)'
+					},
+					children: [
+						{
+							attributes: {
+								predicate: 'flag = true'
+							},
+							children: [
+								{
+									attributes: {
+										dimension: '4',
+										ef: '40',
+										index: 'idx_pt',
+										k: '2',
+										predicate: 'flag = true'
+									},
+									context: 'Db',
+									operator: 'KnnScan'
+								}
+							],
+							context: 'Db',
+							expressions: [
+								{
+									role: 'predicate',
+									sql: 'flag = true'
+								}
+							],
+							operator: 'Filter'
+						}
+					],
+					context: 'Db',
+					expressions: [
+						{
+							role: 'distance',
+							sql: 'vector::distance::knn(...)'
+						}
+					],
+					operator: 'Compute'
+				}
+			],
+			context: 'Db',
+			operator: 'SortByKey'
+		}
+	],
+	context: 'Db',
+	operator: 'SelectProject'
+}
+```
+
+The innermost `KnnScan` operator carries the `predicate: 'flag = true'` attribute — the condition that is evaluated inside the index search. The same condition also appears on the `Filter` operator above it. Adding `EXPLAIN FULL` includes per-operator `metrics`. The query plan is identical for a DISKANN index. For a guided walkthrough, see [Filtering through vector search](/docs/learn/data-models/vector-search/similarity-search#how-the-filter-is-applied).

--- a/src/content/reference/query-language/language-primitives/operators.mdx
+++ b/src/content/reference/query-language/language-primitives/operators.mdx
@@ -1637,6 +1637,12 @@ SELECT id FROM pts WHERE point <|10,40|> [2,3,4,5];
 </TabItem>
 </Tabs>
 
+### Combining a KNN search with a filter
+
+A KNN search over an indexed field can be combined with additional `WHERE` conditions. When the vector field is indexed (HNSW or DISKANN), such a condition is pushed into the index search and evaluated *during* the graph traversal, so non-matching candidates are rejected before they occupy one of the `K` slots — rather than being filtered out after the neighbours have been retrieved.
+
+You can confirm this in the query plan: the condition appears as a `predicate` attribute on the `KnnScan` operator in [`EXPLAIN`](/docs/reference/query-language/statements/explain) output. See [Filtering through vector search](/docs/learn/data-models/vector-search/similarity-search#how-the-filter-is-applied) for a worked example.
+
 <br /><br />
 
 ## Using the `ANY`/`ALL` operators for string indexes

--- a/src/content/reference/query-language/language-primitives/operators.mdx
+++ b/src/content/reference/query-language/language-primitives/operators.mdx
@@ -1641,7 +1641,7 @@ SELECT id FROM pts WHERE point <|10,40|> [2,3,4,5];
 
 A KNN search over an indexed field can be combined with additional `WHERE` conditions. When the vector field is indexed (HNSW or DISKANN), such a condition is pushed into the index search and evaluated *during* the graph traversal, so non-matching candidates are rejected before they occupy one of the `K` slots — rather than being filtered out after the neighbours have been retrieved.
 
-You can confirm this in the query plan: the condition appears as a `predicate` attribute on the `KnnScan` operator in [`EXPLAIN`](/docs/reference/query-language/statements/explain) output. See [Filtering through vector search](/docs/learn/data-models/vector-search/similarity-search#how-the-filter-is-applied) for a worked example.
+You can confirm this by using the [`EXPLAIN`](/docs/reference/query-language/statements/explain) clause after a query to see its plan. Here, the condition appears as a `predicate` attribute on the `KnnScan` operator in  the output. See [Filtering through vector search](/docs/learn/data-models/vector-search/similarity-search#how-the-filter-is-applied) for a worked example.
 
 <br /><br />
 

--- a/src/content/reference/query-language/statements/explain.mdx
+++ b/src/content/reference/query-language/statements/explain.mdx
@@ -209,7 +209,9 @@ LIMIT 2;
 
 <Since v="v3.1.5" />
 
-When a [K-nearest neighbours search](/docs/reference/query-language/language-primitives/operators#knn) over an indexed vector field is combined with an additional non-KNN condition, the planner pushes that residual condition *into* the index search. Non-matching candidates are rejected during the graph traversal, before they can occupy one of the `K` result slots, rather than being filtered out after the neighbours have been retrieved. The `KnnScan` operator surfaces this pushed-down condition as a `predicate` attribute, in the same way that `TableScan` exposes its own `predicate`.
+When a [K-nearest neighbours search](/docs/reference/query-language/language-primitives/operators#knn) over an indexed vector field is combined with an additional non-KNN condition, the planner pushes that residual condition *into* the index search. Non-matching candidates are rejected during the graph traversal, before they can occupy one of the `K` result slots, rather than being filtered out after the neighbours have been retrieved.
+
+This behaviour can be seen by appending the `EXPLAIN` clause to the end of a query to show its plan. Here, the `KnnScan` operator surfaces this pushed-down condition as a `predicate` attribute, in the same way that `TableScan` exposes its own `predicate`.
 
 ```surql
 DEFINE INDEX idx_pt ON pts FIELDS point HNSW DIMENSION 4;

--- a/src/content/reference/query-language/statements/explain.mdx
+++ b/src/content/reference/query-language/statements/explain.mdx
@@ -124,6 +124,7 @@ GraphEdgeScan
 IfElse
 IndexCountScan
 IndexScan
+KnnScan
 Let
 Limit
 ProjectValue
@@ -203,3 +204,32 @@ LIMIT 2;
                         
                         Total rows: 0"
 ```
+
+### Filtered KNN and the `predicate` attribute on `KnnScan`
+
+<Since v="v3.1.5" />
+
+When a [K-nearest neighbours search](/docs/reference/query-language/language-primitives/operators#knn) over an indexed vector field is combined with an additional non-KNN condition, the planner pushes that residual condition *into* the index search. Non-matching candidates are rejected during the graph traversal, before they can occupy one of the `K` result slots, rather than being filtered out after the neighbours have been retrieved. The `KnnScan` operator surfaces this pushed-down condition as a `predicate` attribute, in the same way that `TableScan` exposes its own `predicate`.
+
+```surql
+DEFINE INDEX idx_pt ON pts FIELDS point HNSW DIMENSION 4;
+INSERT INTO pts [
+	{ point: [1, 2, 3, 4], flag: true },
+	{ point: [4, 3, 2, 1], flag: false },
+	{ point: [3, 3, 3, 3], flag: true }
+];
+
+EXPLAIN SELECT id, flag, vector::distance::knn() AS distance FROM pts
+	WHERE flag = true AND point <|2,40|> [2, 3, 4, 5]
+	ORDER BY distance;
+```
+
+```surql title="Output"
+'SelectProject [ctx: Db] [projections: id, flag, distance]
+    SortByKey [ctx: Db] [sort_keys: distance ASC]
+        Compute [ctx: Db] [fields: distance = vector::distance::knn(...)]
+            Filter [ctx: Db] [predicate: flag = true]
+                KnnScan [ctx: Db] [index: idx_pt, k: 2, ef: 40, dimension: 4, predicate: flag = true]'
+```
+
+The `KnnScan` line shows that the index `idx_pt` is searched for `k: 2` neighbours with an exploration factor of `ef: 40` (the two values of the `<|2,40|>` operator), and that the `flag = true` condition is applied *inside* the search as a `predicate`. The same condition also appears on the `Filter` line above; the difference is that the `predicate` on `KnnScan` is what causes non-matching candidates to be discarded *during* the search rather than only afterwards. Without an extra condition the `predicate` attribute is absent. DISKANN indexes use the same `KnnScan` operator and render an identical line.


### PR DESCRIPTION
## What

Documents **filtered KNN** and its new visibility in `EXPLAIN`. When a KNN search over an indexed vector field is combined with an additional non-KNN `WHERE` condition, that condition is pushed *into* the HNSW/DiskANN search (so non-matching candidates are rejected during graph traversal, before they consume one of the `K` slots). SurrealDB now surfaces it as a **`predicate` attribute on the `KnnScan` operator** in `EXPLAIN` output — previously this was invisible.

## Why

The pushdown behaviour was only ever shown by example, never explained, and `KnnScan` was entirely absent from the `EXPLAIN` reference. This makes the optimisation discoverable and gives users a way to confirm it.

## Changed pages

- **`reference/query-language/statements/explain`** — adds `KnnScan` to the operator list and a worked example showing the textual plan with `predicate`.
- **`learn/data-models/vector-search/similarity-search`** — explains the pushdown (filter applied *during* traversal, not after) and adds an `EXPLAIN`-confirmation example.
- **`reference/query-language/language-primitives/operators`** (KNN) — a short note on combining a KNN search with a filter, cross-linked to the above.
- **`reference/query-language/clauses/explain`** — a filtered-KNN `SELECT … EXPLAIN` example showing the JSON-tree form.

## Verification

- All `EXPLAIN` output is **copied from a local SurrealDB build containing the change** (run in-memory), not hand-written — both the textual form and the JSON tree.
- Confirmed the output appears under the **default** planner (no experimental flag needed) and that **DiskANN renders an identical `KnnScan` line**.
- All four pages render locally (`bun run dev`): HTTP 200, content present, no MDX compile errors. British English checked.

## For the reviewer

- ⚠️ **Version tag:** the new sections are marked `<Since v="v3.1.5" />`. The latest released 3.1 tag is `v3.1.4` and the change isn't in a release tag yet, so `v3.1.5` is the expected next patch — **please confirm/adjust** if the release plan differs (it appears in 3 files).
- Note: `bun run qa`/`qc` (biome) ignore `.mdx`, so they don't cover these changes; verification was done by rendering instead.
