### PR TITLE
Document DISKANN memory model and SURREAL_DISKANN_CACHE_SIZE

### DIFF
--- a/src/content/learn/data-models/vector-search/vector-indexes.mdx
+++ b/src/content/learn/data-models/vector-search/vector-indexes.mdx
@@ -31,7 +31,7 @@ SurrealDB offers two **approximate** graph indexes for k-nearest-neighbour searc
 | Index | Best for | Storage |
 | --- | --- | --- |
 | [HNSW](https://en.wikipedia.org/wiki/Hierarchical_navigable_small_world) ([`DEFINE INDEX … HNSW`](/docs/reference/query-language/statements/define/indexes#hnsw-hierarchical-navigable-small-world)) | Low-latency ANN when the graph fits comfortably in memory with headroom for the bounded vector cache | In-memory hot graph + persistence |
-| [DISKANN](https://arxiv.org/abs/1907.01668) ([`DEFINE INDEX … DISKANN`](/docs/reference/query-language/statements/define/indexes#diskann-disk-based-approximate-nearest-neighbours)) *(SurrealDB 3.1+)* | Very large corpora where RAM cannot hold the full graph — optimises for **disk-resident** graphs and quantisation-friendly types | On-disk graph with caching (not on **WASM** targets) |
+| [DISKANN](https://arxiv.org/abs/1907.01668) ([`DEFINE INDEX … DISKANN`](/docs/reference/query-language/statements/define/indexes#diskann-disk-based-approximate-nearest-neighbours)) *(SurrealDB 3.1+)* | Very large corpora where RAM cannot hold the full graph — full-precision vectors and graph stay in the key-value store and are paged through a bounded cache | Key-value-backed graph + bounded in-memory cache (not on **WASM** targets) |
 
 Both are [proximity graph](/docs/reference/query-language/statements/define/indexes#hnsw-hierarchical-navigable-small-world)-style indexes. Queries use the same [`<|K, …|>` KNN operator shapes](/docs/reference/query-language/language-primitives/operators#knn); the optimiser picks the index when distances and types line up.
 
@@ -86,7 +86,9 @@ DEFINE INDEX diskann_idx
   ON pts FIELDS point DISKANN DIMENSION 4 DIST COSINE TYPE F32;
 ```
 
-See [`DEFINE INDEX` → DISKANN](/docs/reference/query-language/statements/define/indexes#diskann-disk-based-approximate-nearest-neighbours) for platform notes (including **no WASM support**).
+DISKANN keeps its graph and full-precision vectors in the key-value store and answers queries through a bounded in-memory cache, so resident memory is bounded by the cache rather than by the dataset. (DISKANN does not apply product quantisation; per-vector size is governed only by the chosen `TYPE`.) The cache defaults to 256 MiB and is shared across all DISKANN indexes; cap it with [`SURREAL_DISKANN_CACHE_SIZE`](/docs/reference/cli/surrealdb-cli/environment-variables#cache-config).
+
+See [`DEFINE INDEX` → DISKANN](/docs/reference/query-language/statements/define/indexes#diskann-disk-based-approximate-nearest-neighbours) for the full memory model and platform notes (including **no WASM support**).
 
 ### Querying
 

--- a/src/content/reference/cli/surrealdb-cli/environment-variables.mdx
+++ b/src/content/reference/cli/surrealdb-cli/environment-variables.mdx
@@ -91,6 +91,12 @@ These environment variables can be used to configure a SurrealDB server to confi
       <td scope="row" data-label="Allowed values">A usize</td>
       <td scope="row" data-label="Notes">The maximum size of the HNSW vector cache.</td>
     </tr>
+    <tr>
+      <td scope="row" data-label="Env var"><code>SURREAL_DISKANN_CACHE_SIZE</code><Since v="v3.1.0" /></td>
+      <td scope="row" data-label="Default">268,435,456 (256 MiB)</td>
+      <td scope="row" data-label="Allowed values">A usize</td>
+      <td scope="row" data-label="Notes">The maximum total size, in bytes, of the DISKANN index cache, shared across all DISKANN indexes in the process. DISKANN graph data lives in the key-value store and is paged through this bounded cache. The DISKANN counterpart of <code>SURREAL_HNSW_CACHE_SIZE</code>.</td>
+    </tr>
   </tbody>
 </table>
 

--- a/src/content/reference/query-language/statements/define/indexes.mdx
+++ b/src/content/reference/query-language/statements/define/indexes.mdx
@@ -356,13 +356,21 @@ DEFINE INDEX diskann_pts
 
 Queries use the **same** KNN operator shape as HNSW: `<|K, EF|>` (approximate) or `<|K, DIST|>` when the distance matches the index, letting the optimiser pick the DISKANN graph. The second number in the approximate form bounds the dynamic candidate list during search (analogous to HNSW `EF`).
 
+#### Memory model and cache size
+
+Unlike HNSW — whose graph is held resident in memory — a DISKANN index is **key-value-backed**. The graph, its adjacency lists, and the full-precision element vectors are persisted in the key-value store (for example, on disk under RocksDB) and remain the source of truth. Only a bounded in-memory cache holds the hot working set; cold nodes and vectors are streamed from the key-value store on demand. A DISKANN index's resident memory is therefore bounded by the cache size rather than by the size of the dataset, which is what makes it suitable for larger-than-memory workloads.
+
+Vectors are stored and searched at **full precision** — DISKANN applies no product quantisation or other compression. The only lever on per-vector size is the chosen `TYPE` (`F32`, `F16`, `I8`, or `U8`).
+
+The cache is a single budget **shared across every DISKANN index** in the process. It defaults to 256 MiB and can be capped with the `SURREAL_DISKANN_CACHE_SIZE` [environment variable](/docs/reference/cli/surrealdb-cli/environment-variables#cache-config), the DISKANN counterpart of `SURREAL_HNSW_CACHE_SIZE`. The value is an integer number of bytes — for example, `268435456` for the 256 MiB default.
+
 #### Choosing HNSW or DISKANN
 
 | Concern | Prefer HNSW | Prefer DISKANN |
 | --- | --- | --- |
 | Working set size | Fits comfortably in memory with headroom for the HNSW cache | Much larger than RAM; cold data should stay on disk |
 | Latency profile | Lowest latency when the graph is hot in cache | Extra I/O; better for throughput to cost on huge corpora |
-| Vector element types | Full set (`F64` … `I16` in docs above) | Quantised-friendly types (`F32`, `F16`, `I8`, `U8`) |
+| Vector element types | Full set (`F64` … `I16` in docs above) | Compact types (`F32`, `F16`, `I8`, `U8`) |
 | Deployment target | Includes WASM | Server / native binaries only |
 
 ### Brute Force method

--- a/src/content/reference/query-language/statements/define/indexes.mdx
+++ b/src/content/reference/query-language/statements/define/indexes.mdx
@@ -358,9 +358,9 @@ Queries use the **same** KNN operator shape as HNSW: `<|K, EF|>` (approximate) o
 
 #### Memory model and cache size
 
-Unlike HNSW — whose graph is held resident in memory — a DISKANN index is **key-value-backed**. The graph, its adjacency lists, and the full-precision element vectors are persisted in the key-value store (for example, on disk under RocksDB) and remain the source of truth. Only a bounded in-memory cache holds the hot working set; cold nodes and vectors are streamed from the key-value store on demand. A DISKANN index's resident memory is therefore bounded by the cache size rather than by the size of the dataset, which is what makes it suitable for larger-than-memory workloads.
+While HNSW's graph is held resident in memory, a DISKANN index is **key-value-backed**. The graph, its adjacency lists, and the full-precision element vectors are persisted in the key-value store (for example, on disk under RocksDB) and remain the source of truth. Only a bounded in-memory cache holds the hot working set, while cold nodes and vectors are streamed from the key-value store on demand. A DISKANN index's resident memory is therefore bounded by the cache size rather than by the size of the dataset, which is what makes it suitable for larger-than-memory workloads.
 
-Vectors are stored and searched at **full precision** — DISKANN applies no product quantisation or other compression. The only lever on per-vector size is the chosen `TYPE` (`F32`, `F16`, `I8`, or `U8`).
+Vectors are stored and searched at **full precision**, applying no product quantisation or other compression. The only lever on per-vector size is the chosen `TYPE` (`F32`, `F16`, `I8`, or `U8`).
 
 The cache is a single budget **shared across every DISKANN index** in the process. It defaults to 256 MiB and can be capped with the `SURREAL_DISKANN_CACHE_SIZE` [environment variable](/docs/reference/cli/surrealdb-cli/environment-variables#cache-config), the DISKANN counterpart of `SURREAL_HNSW_CACHE_SIZE`. The value is an integer number of bytes — for example, `268435456` for the 256 MiB default.
 


### PR DESCRIPTION
## What

Documents SurrealDB's **DISKANN** vector-index memory model and the **`SURREAL_DISKANN_CACHE_SIZE`** setting. Both have existed in the engine since **v3.1.0** but were undocumented, so operators had no way to discover how to cap a DISKANN index's resident memory.

This closes the gap raised in [surrealdb/surrealdb#7337](https://github.com/surrealdb/surrealdb/issues/7337), where an operator couldn't find any knob to bound DISKANN memory and assumed none existed.

## Facts documented (verified against the engine source)

- **DISKANN is key-value-backed, not in-RAM.** The graph, adjacency lists, and full-precision element vectors are persisted in the KV store (e.g. RocksDB) and remain the source of truth. A single bounded in-process cache holds the hot working set; cold nodes/vectors are streamed on demand. Resident memory is therefore bounded by the cache size, not by the dataset size — which is what makes DISKANN suitable for larger-than-memory workloads.
- **`SURREAL_DISKANN_CACHE_SIZE`** is the DISKANN analogue of `SURREAL_HNSW_CACHE_SIZE`. It caps the total cache size as a raw integer **number of bytes**. **Default: 256 MiB (268435456 bytes).** It is a single budget **shared across all DISKANN indexes** in the process.
- **No product quantisation / no compression.** Vectors are stored and searched at full precision; the only lever on per-vector size is the chosen `TYPE` (`F32` / `F16` / `I8` / `U8`). The "larger-than-memory" property comes from the KV store being the source of truth plus the bounded cache — *not* from PQ.

Verified against `core/src/cnf/mod.rs` (`diskann_cache_size: u64 = 256 * 1024 * 1024`; `parse_key("diskann_cache_size", …)` → env var `SURREAL_DISKANN_CACHE_SIZE`) and `core/src/idx/trees/diskann/cache.rs` (*"The persisted KV layout remains the source of truth"*; the cache is one weighted, byte-bounded instance per datastore).

## Changes

- **`reference/cli/surrealdb-cli/environment-variables.mdx`** — adds `SURREAL_DISKANN_CACHE_SIZE` to the *Cache config* table, mirroring the `SURREAL_HNSW_CACHE_SIZE` row.
- **`reference/query-language/statements/define/indexes.mdx`** — adds a *Memory model and cache size* subsection to the DISKANN section; replaces the misleading "Quantised-friendly types" comparison cell with "Compact types".
- **`learn/data-models/vector-search/vector-indexes.mdx`** — corrects the comparison table and DISKANN section so the memory model is accurate (KV-backed source of truth + bounded cache, full precision / no PQ).

## Scope

Documents existing v3.1.0 behaviour only. Deliberately does **not** document human-readable size strings (e.g. `256MiB`) for this variable — it accepts a raw integer byte count — and promises no unshipped features.

## Checks

- `bun run build` — ✅ passes (all MDX compiles; sitemap + search index generated).
- `bun run qc` — no new findings. The pre-existing errors reported are SVG-asset accessibility lints already on `main`, unrelated to this change (and biome does not lint `.mdx`).
