### PR TITLE
Remove self-hosting section from cloud documentation

### DIFF
--- a/src/content/index/running/cloud.mdx
+++ b/src/content/index/running/cloud.mdx
@@ -11,7 +11,3 @@ description: "Get a free managed SurrealDB instance with an email sign-in—pers
 In Surrealist you can go from the Sandbox to Cloud with **Deploy to Cloud**, create an instance, and then point your connection at the new instance instead of Sandbox.
 
 For day-to-day management of organisations, instances, and billing, use the documentation under **[SurrealDB Cloud](/docs/manage/cloud)** in the *Manage* section.
-
-## When you are ready to self-host
-
-To install the `surreal` server on your own hardware or VMs, follow **[Installation](/docs/running/installation)**. That path gives you the same database engine, but you operate networking, storage, and upgrades yourself.


### PR DESCRIPTION
Removed the section about self-hosting and installation.