### PR TITLE
Revise Scale cluster details and provisioning text

### DIFF
--- a/src/content/build/deployment/surrealdb-cloud/architecture.mdx
+++ b/src/content/build/deployment/surrealdb-cloud/architecture.mdx
@@ -16,13 +16,13 @@ For development and staging applications with vertically scalable requirements. 
 
 ## Scale
 
-For **business-critical** applications that must stay available when a node fails and scale query throughput horizontally. **Scale** clusters run on [SurrealDS](https://surrealdb.com/platform/surrealds), SurrealDB's distributed storage engine — with quorum consensus, compute–storage separation, and object-storage-backed durability — and start at **three compute units**. The storage tier handles replication and distributed transactions; query nodes can be added or replaced without copying the full dataset to each machine.
+For **business-critical** applications that must stay available when a node fails and scale query throughput horizontally. **Scale** clusters run on [SurrealDS](https://surrealdb.com/platform/surrealds), SurrealDB's distributed storage engine — with quorum consensus, compute–storage separation, and object-storage-backed durability — and start at **three nodes**, with the ability to scale horizontally beyond that. Scale automatically handles data replication and distributed transactions.
 
-Provisioning a production cluster on Cloud avoids the operational work of self-hosting: Kubernetes, replication, patching, backups, and upgrade orchestration are managed for you.
+Provisioning a production cluster on SurrealDB Cloud avoids the operational work of self-hosting: Kubernetes, replication, patching, backups, and upgrade orchestration are managed for you.
 
 <img src="~/assets/img/image/cloud/light/enterprise-multi-node-light.png" darkSrc="~/assets/img/image/cloud/enterprise-multi-node.png" alt="SurrealDB Cloud Scale architecture" />
 
 > [!NOTE]
-> Some Scale capabilities — such as read replicas, database branching, and database forking — are still rolling out. See [Pricing](https://surrealdb.com/pricing) and the [Scale waitlist](https://surrealdb.com/pricing/scale) for current availability.
+> Some Scale capabilities — such as read replicas, database branching, and database forking — are still rolling out. See [Pricing](https://surrealdb.com/pricing) and [Roadmap](https://surrealdb.com/roadmap) for current availability.
 
 To learn more about deployment models and self-hosted SurrealDS, see [Deployment](/docs/build/deployment) and [SurrealDS](https://surrealdb.com/platform/surrealds).


### PR DESCRIPTION
Updated descriptions for Scale clusters and provisioning on SurrealDB Cloud. Changed references from 'three compute units' to 'three nodes' and updated links for current availability.