### PR TITLE
Fix ordering, capitalisation, spelling

### DIFF
--- a/.agents/skills/humanizer/SKILL.md
+++ b/.agents/skills/humanizer/SKILL.md
@@ -301,13 +301,30 @@ Before returning the final rewrite, scan it for `—` and `–`. Any hit means t
 
 ### 17. Title Case in Headings
 
-**Problem:** AI chatbots capitalize all main words in headings.
+**Problem:** AI chatbots capitalize all main words in headings (Title Case).
+
+**SurrealDB docs convention:** sentence case for multi-word subheaders; fully
+capitalised single-word subheaders.
+
+| Pattern | Correct | Incorrect |
+| ------- | ------- | --------- |
+| Single word | `#### Parameters` | `#### parameters` |
+| Multiple words | `### Complete examples` | `### Complete Examples` |
+| Numbered | `### 3. Don't reuse transactions` | `### 3. don't reuse transactions` |
+| Names / acronyms | `### Basic API calls` | `### Basic api calls` |
 
 **Before:**
 > ## Strategic Negotiations And Global Partnerships
+> ### Custom Functions
+> ### 3. don't reuse transactions
 
 **After:**
 > ## Strategic negotiations and global partnerships
+> ### Custom functions
+> ### 3. Don't reuse transactions
+
+Keep acronyms, product names, SDK types, and SurrealQL keywords capitalised where
+appropriate (`API`, `SurrealQL`, `RecordId`, `INSERT`).
 
 
 ### 18. Emojis

--- a/.agents/skills/seo-audit/SKILL.md
+++ b/.agents/skills/seo-audit/SKILL.md
@@ -80,7 +80,7 @@ Reporting "no schema found" based solely on `web_fetch` or `curl` leads to false
 - No orphan pages
 
 **Crawl Budget Issues** (for large sites)
-- Parameterized URLs under control
+- Parameterised URLs under control
 - Faceted navigation handled properly
 - Infinite scroll with pagination fallback
 - Session IDs not in URLs

--- a/.agents/skills/technical-writing/SKILL.md
+++ b/.agents/skills/technical-writing/SKILL.md
@@ -272,6 +272,12 @@ curl -X GET "https://api.example.com/api/v1/users?page=1&limit=20" \
 
 **Structure**:
 - Use hierarchical headings (H1, H2, H3)
+- **Subheader capitalisation** (SurrealDB docs convention):
+  - Single word: capitalise (`#### Parameters`, `## Syntax`)
+  - Multiple words: sentence case — first word only (`## Type parameters`, `### Complete examples`)
+  - Numbered: capitalise first word after the number (`### 3. Don't reuse transactions`)
+  - Keep acronyms, product names, SDK types, and SurrealQL keywords capitalised (`API`, `RecordId`, `INSERT`)
+  - Avoid Title Case on every main word (`### Custom functions`, not `### Custom Functions`)
 - Break content into sections
 - Use lists for multiple items
 - Use tables for structured data

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,36 @@ Apply SOLID where it fits:
 
 All user-facing text uses **British English** spelling (`-ise`, `-our`, `-re`, `-ogue`).
 
+### Headings and subheaders
+
+Use **sentence case** for multi-word headings (`##`, `###`, `####`). Do not use
+Title Case on every main word.
+
+| Pattern | Rule | Examples |
+| ------- | ---- | -------- |
+| Single word | Capitalise the word | `## Syntax`, `#### Parameters`, `#### Returns` |
+| Multiple words | Capitalise the **first word only**; lowercase the rest | `## Type parameters`, `### Complete examples`, `### Default response` |
+| Numbered lists | Same as multiple words — capitalise the first word after the number | `### 3. Don't reuse transactions`, `## 1. Install the SDK` |
+
+**Keep capitalised** where they are names, not prose:
+
+- Acronyms and protocols: `API`, `HTTP`, `JSON`, `UUID`, `SQL`
+- Product and language names: `SurrealDB`, `SurrealQL`, `JavaScript`
+- SDK types and identifiers: `RecordId`, `DateTime`, `ApiPromise`
+- SurrealQL keywords when cited literally: `INSERT`, `CREATE`, `LIVE SELECT`
+
+**Avoid** AI-style Title Case in subheaders:
+
+- ~~`### Custom Functions`~~ → `### Custom functions`
+- ~~`### Basic API Calls`~~ → `### Basic API calls`
+- ~~`### Type-Safe Record IDs`~~ → `### Type-safe record IDs`
+
+Hyphenated compounds follow sentence case on the second part unless it is a proper
+name: `Full-text search`, `Type-safe queries`, `Half-open ranges`.
+
+Code-block `title="…"` labels on fenced blocks should follow the same rules when
+they describe the example (e.g. `title="Method syntax"`, not `title="Method Syntax"`).
+
 ## Documentation voice
 
 The docs site mixes reference material, SDK guides, tutorials, and operational

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -13,11 +13,21 @@ for conventions, documentation voice, and architectural detail.
 - [ ] `bun run qts` (TypeScript `--noEmit`) reports no type errors.
 - [ ] No secrets, `.env` values, or credentials are included in the diff.
 
-## 2. Language
+## 2. Language and headings
 
 - [ ] All user-facing text uses **British English** spelling:
   `-ise` (not `-ize`), `-our` (not `-or`), `-re` (not `-er`),
   `-ogue` (not `-og`).
+- [ ] **Subheaders** (`##`–`####`) follow sentence case (see `AGENTS.md`):
+  - Single-word headings are capitalised (`#### Parameters`, `## Syntax`).
+  - Multi-word headings capitalise the first word only (`## Type parameters`,
+    `### Complete examples`).
+  - Numbered headings capitalise the first word after the number
+    (`### 3. Don't reuse transactions`).
+  - Acronyms, product names, SDK types, and SurrealQL keywords stay capitalised
+    where appropriate (`API`, `RecordId`, `INSERT`).
+  - No Title Case on every main word (`### Custom functions`, not
+    `### Custom Functions`).
 
 ## 3. SOLID principles
 

--- a/public/integrations/agent-rules/surrealdb-python.mdc
+++ b/public/integrations/agent-rules/surrealdb-python.mdc
@@ -8,13 +8,13 @@ alwaysApply: false
 This will persist the data in a `database` folder:
 
 ```bash
-surreal start -u root -p root rocksdb:database
+surreal start -u root -p secret rocksdb:database
 ```
 
 This will store the data in-memory:
 
 ```bash
-surreal start -u root -p root
+surreal start -u root -p secret
 ```
 
 ## Example

--- a/public/integrations/agent-rules/surrealql.mdc
+++ b/public/integrations/agent-rules/surrealql.mdc
@@ -24,8 +24,8 @@ Use `relate` to create graph relationships:
 ## Best practices
 
 1. **Use specific record IDs** when you know them for better performance
-2. **Use parameterized queries** to prevent SQL injection when dealing with user input
-3. **Use the enhanced select tool** which safely parameterizes table names and supports user parameters
+2. **Use parameterised queries** to prevent SQL injection when dealing with user input
+3. **Use the enhanced select tool** which safely parameterises table names and supports user parameters
 4. **Use the raw query tool** for complex operations not covered by convenience functions
 5. **Use merge/patch modes** when updating records to preserve existing data
 6. **Create relationships** to model graph data and enable complex queries

--- a/src/content/build/integrations/data-management/n8n.mdx
+++ b/src/content/build/integrations/data-management/n8n.mdx
@@ -21,12 +21,12 @@ The official n8n node for SurrealDB. It provides both action and tool nodes to i
 - **Dual Node Types**: Functions as both an action node and a tool node for AI workflows
 - **Complete CRUD Operations**: Create, read, update, and delete SurrealDB records
 - **Custom Queries**: Execute any SurrealQL query with full parameter support
-- **Enhanced Query Builder**: Visual interface for building `SELECT` queries with `WHERE`, `ORDER BY`, `GROUP BY`, and other clauses
+- **Enhanced query builder**: Visual interface for building `SELECT` queries with `WHERE`, `ORDER BY`, `GROUP BY`, and other clauses
 - **Table Operations**: List fields and explore table structure
 - **Relationship Support**: Query and manage record relationships
 - **Native Data Format**: Works with SurrealDB's native data formats
 - **Connection Pooling**: Configurable connection pooling for improved performance and resource management
-- **Enhanced Error Handling**: Comprehensive error classification, automatic retry logic, and connection recovery
+- **Enhanced error handling**: Comprehensive error classification, automatic retry logic, and connection recovery
     - **Intelligent Recovery**: Different error handling strategies for different operation types
     - **Detailed Error Reporting**: Rich error context with categorization and severity levels
 - **Pool Monitoring**: Built-in pool statistics and performance monitoring

--- a/src/content/index/languages/golang/concepts/executing-queries.mdx
+++ b/src/content/index/languages/golang/concepts/executing-queries.mdx
@@ -8,7 +8,7 @@ description: The Go SDK provides generic functions for executing SurrealQL queri
 
 The Go SDK provides two ways to execute SurrealQL queries: [`Query`](/docs/languages/golang/api/core/db#query) for typed, parameterised queries and [`QueryRaw`](/docs/languages/golang/api/core/db#queryraw) for composing multiple statements with per-statement results. Both are generic functions that work with [`*DB`](/docs/languages/golang/api/core/db), [`*Session`](/docs/languages/golang/api/core/session), and [`*Transaction`](/docs/languages/golang/api/core/transaction).
 
-This page covers running queries, parameterizing them, handling multi-statement results, and managing connection-scoped variables.
+This page covers running queries, parameterising them, handling multi-statement results, and managing connection-scoped variables.
 
 ## API references
 
@@ -59,7 +59,7 @@ for _, qr := range *results {
 
 The function returns `*[]QueryResult[T]`, where each [`QueryResult`](/docs/languages/golang/api/types#queryresult) contains the `Status`, execution `Time`, `Result`, and an optional `Error` for that statement.
 
-## Parameterizing queries
+## Parameterising queries
 
 Always use parameters (`$name`) instead of string interpolation to prevent injection attacks and ensure correct CBOR encoding of [value types](/docs/languages/golang/concepts/value-types).
 

--- a/src/content/index/languages/java/api/core/surreal.mdx
+++ b/src/content/index/languages/java/api/core/surreal.mdx
@@ -344,7 +344,7 @@ List<User> users = response.take(User.class, 0);
 
 ### `.queryBind(sql, params)` {#query-bind}
 
-Executes a parameterized SurrealQL query. Parameters are safely injected into the query, preventing SurrealQL injection.
+Executes a parameterised SurrealQL query. Parameters are safely injected into the query, preventing SurrealQL injection.
 
 ```java title="Method Syntax"
 db.queryBind(sql, params)

--- a/src/content/index/languages/java/api/core/transaction.mdx
+++ b/src/content/index/languages/java/api/core/transaction.mdx
@@ -15,7 +15,7 @@ The `Transaction` class wraps a set of operations into an atomic unit. Changes m
 ## Methods
 
 > [!NOTE]
-> The `Transaction` class only supports `.query()` with raw SurrealQL strings. Parameterized queries via `.queryBind()` are not available inside transactions. To pass dynamic values, interpolate them directly in the SurrealQL string or use SurrealQL parameters defined earlier in the transaction.
+> The `Transaction` class only supports `.query()` with raw SurrealQL strings. Parameterised queries via `.queryBind()` are not available inside transactions. To pass dynamic values, interpolate them directly in the SurrealQL string or use SurrealQL parameters defined earlier in the transaction.
 
 ### `.query(sql)` {#query}
 

--- a/src/content/index/languages/java/api/values/__category.json
+++ b/src/content/index/languages/java/api/values/__category.json
@@ -1,4 +1,4 @@
 {
-    "title": "Data Types",
+    "title": "Data types",
     "position": 4
 }

--- a/src/content/index/languages/java/concepts/executing-queries.mdx
+++ b/src/content/index/languages/java/concepts/executing-queries.mdx
@@ -24,7 +24,7 @@ The Java SDK provides methods for executing raw [SurrealQL](/docs/reference/quer
 		</tr>
 		<tr>
 			<td scope="row" data-label="Method"><a href="/docs/languages/java/api/core/surreal#query-bind"><code>db.queryBind(sql, params)</code></a></td>
-			<td scope="row" data-label="Description">Executes a parameterized query</td>
+			<td scope="row" data-label="Description">Executes a parameterised query</td>
 		</tr>
 		<tr>
 			<td scope="row" data-label="Method"><a href="/docs/languages/java/api/core/surreal#run"><code>db.run(name, args)</code></a></td>
@@ -46,7 +46,7 @@ List<Post> posts = response.take(Post.class, 1);
 
 ## Using query parameters
 
-The [`.queryBind()`](/docs/languages/java/api/core/surreal#query-bind) method accepts a `Map<String, ?>` of parameters that are safely injected into the query. Parameterized queries prevent SurrealQL injection and ensure values are properly escaped.
+The [`.queryBind()`](/docs/languages/java/api/core/surreal#query-bind) method accepts a `Map<String, ?>` of parameters that are safely injected into the query. Parameterised queries prevent SurrealQL injection and ensure values are properly escaped.
 
 ```java
 Map<String, Object> params = Map.of("min_age", 18);

--- a/src/content/index/languages/java/concepts/transactions.mdx
+++ b/src/content/index/languages/java/concepts/transactions.mdx
@@ -50,7 +50,7 @@ Transaction tx = db.beginTransaction();
 The [`tx.query()`](/docs/languages/java/api/core/transaction#query) method works like `db.query()` but executes within the transaction scope. Each call returns a [`Response`](/docs/languages/java/api/core/response) that you can inspect immediately, but the underlying changes are not visible outside the transaction until it is committed.
 
 > [!NOTE]
-> Parameterized queries via `.queryBind()` are not available inside transactions. To pass dynamic values, use SurrealQL `LET` statements or inline the values in the query string.
+> Parameterised queries via `.queryBind()` are not available inside transactions. To pass dynamic values, use SurrealQL `LET` statements or inline the values in the query string.
 
 ```java
 Transaction tx = db.beginTransaction();

--- a/src/content/index/languages/javascript/api/core/surreal-api.mdx
+++ b/src/content/index/languages/javascript/api/core/surreal-api.mdx
@@ -28,7 +28,7 @@ const api = db.api<MyPaths>();
 const users = await api.get("/users"); // Type: User[]
 ```
 
-## Creating an API Instance
+## Creating an API instance
 
 API instances are created through the [`api`](/docs/languages/javascript/api/core/surreal-queryable#api) property on [`Surreal`](/docs/languages/javascript/api/core/surreal), [`SurrealSession`](/docs/languages/javascript/api/core/surreal-session), or [`SurrealTransaction`](/docs/languages/javascript/api/core/surreal-transaction):
 
@@ -43,7 +43,7 @@ const api = db.api<MyPaths>();
 const usersApi = db.api<MyPaths>("/users");
 ```
 
-## Type Definitions
+## Type definitions
 
 ### `PathDef` {#pathdef}
 
@@ -55,7 +55,7 @@ type HttpMethod = "get" | "post" | "put" | "delete" | "patch" | "trace";
 type MethodDef = [RequestBody, ResponseBody] | [];
 ```
 
-### Example Path Definitions
+### Example path definitions
 
 ```ts
 type MyApiPaths = {
@@ -413,9 +413,9 @@ api.trace(path, body?)
 #### Returns
 [`ApiPromise<RequestBody, ResponseBody>`](/docs/languages/javascript/api/queries/api-promise) - A promise for the TRACE response
 
-## Complete Examples
+## Complete examples
 
-### Basic API Usage
+### Basic API usage
 
 ```ts
 import { Surreal } from 'surrealdb';
@@ -435,7 +435,7 @@ const created = await api.post('/users', {
 });
 ```
 
-### Type-Safe API
+### Type-safe API
 
 ```ts
 // Define your API contract
@@ -466,7 +466,7 @@ const newUser: User = await api.post("/users", {
 });
 ```
 
-### Using Headers
+### Using headers
 
 ```ts
 const api = db.api();
@@ -482,7 +482,7 @@ const protected Data = await api.get('/protected-endpoint');
 api.header('Authorization', null);
 ```
 
-### API with Prefix
+### API with prefix
 
 ```ts
 type UserPaths = {
@@ -503,7 +503,7 @@ const user = await usersApi.get("/123");          // GET /users/123
 const updated = await usersApi.put("/123", data); // PUT /users/123
 ```
 
-### Error Handling
+### Error handling
 
 ```ts
 const api = db.api();
@@ -520,7 +520,7 @@ try {
 }
 ```
 
-### With Transaction
+### With transaction
 
 ```ts
 const txn = await db.beginTransaction();
@@ -541,9 +541,9 @@ try {
 }
 ```
 
-## Best Practices
+## Best practices
 
-### 1. Define API Types
+### 1. Define API types
 
 Always define types for your API paths for better developer experience:
 
@@ -558,7 +558,7 @@ const api = db.api<MyApi>();
 const api = db.api();
 ```
 
-### 2. Reuse API Instances
+### 2. Reuse API instances
 
 Create and reuse API instances rather than creating new ones for each call:
 
@@ -573,7 +573,7 @@ await db.api().get('/users');
 await db.api().get('/posts');
 ```
 
-### 3. Use Prefixes for Namespacing
+### 3. Use prefixes for namespacing
 
 Use path prefixes to organize related endpoints:
 
@@ -585,7 +585,7 @@ await usersApi.get("/123");  // GET /users/123
 await postsApi.get("/456");  // GET /posts/456
 ```
 
-## See Also
+## See also
 
 - [SurrealQueryable.api](/docs/languages/javascript/api/core/surreal-queryable#api) - Creating API instances
 - [ApiPromise](/docs/languages/javascript/api/queries/api-promise) - API response handling

--- a/src/content/index/languages/javascript/api/core/surreal-queryable.mdx
+++ b/src/content/index/languages/javascript/api/core/surreal-queryable.mdx
@@ -65,7 +65,7 @@ const usersApi = db.api<MyPaths>("/users");
 const user = await usersApi.get("123"); // GET /users/123
 ```
 
-## Query Methods
+## Query methods
 
 ### `.query()` {#query}
 
@@ -99,7 +99,7 @@ db.query<R>(boundQuery)
     </tbody>
 </table>
 
-#### Type Parameters
+#### Type parameters
 - `R extends unknown[]` - Array of result types for each query statement
 
 #### Returns
@@ -670,10 +670,10 @@ const user = await db.auth();
 console.log('Current user:', user);
 ```
 
-## See Also
+## See also
 
 - [SurrealSession](/docs/languages/javascript/api/core/surreal-session) - Session management extending this class
 - [SurrealTransaction](/docs/languages/javascript/api/core/surreal-transaction) - Transaction support extending this class
-- [Query Builders](/docs/languages/javascript/api/queries/) - Detailed query builder documentation
+- [Query builders](/docs/languages/javascript/api/queries/) - Detailed query builder documentation
 - [SelectPromise](/docs/languages/javascript/api/queries/select-promise) - SELECT query configuration
 - [CreatePromise](/docs/languages/javascript/api/queries/create-promise) - CREATE query configuration

--- a/src/content/index/languages/javascript/api/core/surreal-session.mdx
+++ b/src/content/index/languages/javascript/api/core/surreal-session.mdx
@@ -96,7 +96,7 @@ if (session.isValid) {
 }
 ```
 
-## Session Management Methods
+## Session management methods
 
 ### `.forkSession()` {#forksession}
 
@@ -148,7 +148,7 @@ await session.closeSession();
 console.log(session.isValid); // false
 ```
 
-## Transaction Methods
+## Transaction methods
 
 ### `.beginTransaction()` {#begintransaction}
 
@@ -189,7 +189,7 @@ try {
 }
 ```
 
-## Session Configuration Methods
+## Session configuration methods
 
 ### `.use()` {#use}
 
@@ -348,7 +348,7 @@ console.log(session.accessToken); // undefined
 console.log(session.parameters); // {}
 ```
 
-## Authentication Methods
+## Authentication methods
 
 ### `.signup()` {#signup}
 
@@ -598,7 +598,7 @@ const unsubscribe = session.subscribe('auth', (tokens) => {
 unsubscribe();
 ```
 
-## Inherited Methods
+## Inherited methods
 
 As `SurrealSession` extends [`SurrealQueryable`](/docs/languages/javascript/api/core/surreal-queryable), it inherits all query execution methods:
 
@@ -616,7 +616,7 @@ As `SurrealSession` extends [`SurrealQueryable`](/docs/languages/javascript/api/
 - [`auth()`](/docs/languages/javascript/api/core/surreal-queryable#auth) - Get authenticated record user
 - [`api()`](/docs/languages/javascript/api/core/surreal-queryable#api) - Access user-defined APIs
 
-## Async Disposal
+## Async disposal
 
 ### `[Symbol.asyncDispose]()` {#symbol-asyncdispose}
 
@@ -639,7 +639,7 @@ session[Symbol.asyncDispose]()
 // Session is automatically disposed when leaving the block
 ```
 
-## Complete Example
+## Complete example
 
 ```ts
 import { Surreal } from 'surrealdb';
@@ -707,7 +707,7 @@ await childSession.reset();
 await session.closeSession();
 ```
 
-## See Also
+## See also
 
 - [Surreal](/docs/languages/javascript/api/core/surreal) - Main connection class
 - [SurrealQueryable](/docs/languages/javascript/api/core/surreal-queryable) - Query execution methods

--- a/src/content/index/languages/javascript/api/core/surreal-transaction.mdx
+++ b/src/content/index/languages/javascript/api/core/surreal-transaction.mdx
@@ -36,7 +36,7 @@ try {
 
 The constructor is not called directly. Use [`SurrealSession.beginTransaction()`](/docs/languages/javascript/api/core/surreal-session#begintransaction) to create transactions.
 
-## Transaction Methods
+## Transaction methods
 
 ### `.commit()` {#commit}
 
@@ -96,11 +96,11 @@ try {
 }
 ```
 
-## Inherited Methods
+## Inherited methods
 
 As `SurrealTransaction` extends [`SurrealQueryable`](/docs/languages/javascript/api/core/surreal-queryable), it inherits all query execution methods. All queries executed on a transaction instance are part of the transaction scope:
 
-### Query Methods
+### Query methods
 - [`query()`](/docs/languages/javascript/api/core/surreal-queryable#query) - Execute raw SurrealQL
 - [`select()`](/docs/languages/javascript/api/core/surreal-queryable#select) - Select records
 - [`create()`](/docs/languages/javascript/api/core/surreal-queryable#create) - Create records
@@ -117,9 +117,9 @@ As `SurrealTransaction` extends [`SurrealQueryable`](/docs/languages/javascript/
 
 All of these operations are executed within the transaction context and will be committed or canceled together.
 
-## Complete Examples
+## Complete examples
 
-### Basic Transaction
+### Basic transaction
 
 ```ts
 import { Surreal, RecordId } from 'surrealdb';
@@ -162,7 +162,7 @@ try {
 }
 ```
 
-### Money Transfer Transaction
+### Money transfer transaction
 
 ```ts
 async function transferMoney(
@@ -217,7 +217,7 @@ async function transferMoney(
 await transferMoney(db, 'alice', 'bob', 50);
 ```
 
-### Complex Transaction with Graph Relationships
+### Complex transaction with graph relationships
 
 ```ts
 async function createUserWithFollows(
@@ -263,7 +263,7 @@ async function createUserWithFollows(
 }
 ```
 
-### Transaction with Error Handling
+### Transaction with error handling
 
 ```ts
 async function atomicBulkOperation(db: Surreal, records: any[]) {
@@ -300,9 +300,9 @@ async function atomicBulkOperation(db: Surreal, records: any[]) {
 }
 ```
 
-## Best Practices
+## Best practices
 
-### 1. Always Handle Errors
+### 1. Always handle errors
 
 Always use try-catch blocks to ensure transactions are properly canceled on errors:
 
@@ -317,7 +317,7 @@ try {
 }
 ```
 
-### 2. Keep Transactions Short
+### 2. Keep transactions short
 
 Execute transactions quickly to avoid locking resources:
 
@@ -334,7 +334,7 @@ await txn.update(recordId).merge(data);
 await txn.commit();
 ```
 
-### 3. Don't Reuse Transactions
+### 3. Don't reuse transactions
 
 Once a transaction is committed or canceled, create a new one for subsequent operations:
 
@@ -349,7 +349,7 @@ await txn2.create(record2);
 await txn2.commit();
 ```
 
-### 4. Validate Before Transaction
+### 4. Validate before transaction
 
 Perform validation before starting a transaction when possible:
 
@@ -365,8 +365,8 @@ const txn = await db.beginTransaction();
 await txn.commit();
 ```
 
-## See Also
+## See also
 
 - [SurrealSession.beginTransaction()](/docs/languages/javascript/api/core/surreal-session#begintransaction) - Creating transactions
 - [SurrealQueryable](/docs/languages/javascript/api/core/surreal-queryable) - Available query methods
-- [Query Builders](/docs/languages/javascript/api/queries/) - Query builder classes
+- [Query builders](/docs/languages/javascript/api/queries/) - Query builder classes

--- a/src/content/index/languages/javascript/api/core/surreal.mdx
+++ b/src/content/index/languages/javascript/api/core/surreal.mdx
@@ -701,4 +701,4 @@ await db.close();
 - [SurrealQueryable](/docs/languages/javascript/api/core/surreal-queryable) - Query execution methods
 - [SurrealTransaction](/docs/languages/javascript/api/core/surreal-transaction) - Transaction support
 - [Connection Engines](/docs/languages/javascript/engines) - Engine-specific documentation
-- [Data Types](/docs/languages/javascript/api/values) - Working with data types
+- [Data types](/docs/languages/javascript/api/values) - Working with data types

--- a/src/content/index/languages/javascript/api/core/surreal.mdx
+++ b/src/content/index/languages/javascript/api/core/surreal.mdx
@@ -99,7 +99,7 @@ await db.ready;
 console.log('Connection is ready');
 ```
 
-### Inherited Properties
+### Inherited properties
 
 The `Surreal` class inherits all properties from [`SurrealSession`](/docs/languages/javascript/api/core/surreal-session), including:
 
@@ -110,7 +110,7 @@ The `Surreal` class inherits all properties from [`SurrealSession`](/docs/langua
 - `session` - Session ID
 - `isValid` - Session validity status
 
-## Connection Methods
+## Connection methods
 
 ### `.connect()` {#connect}
 
@@ -282,7 +282,7 @@ if (db.isFeatureSupported(Features.LiveQueries)) {
 }
 ```
 
-## Session Management Methods
+## Session management methods
 
 ### `.sessions()` {#sessions}
 
@@ -345,7 +345,7 @@ db.closeSession()
 await db.closeSession();
 ```
 
-## Data Management Methods
+## Data management methods
 
 ### `.export()` {#export}
 
@@ -554,7 +554,7 @@ db.subscribe('error', (error) => {
 });
 ```
 
-### Inherited Events
+### Inherited events
 
 The `Surreal` class also inherits and re-emits events from [`SurrealSession`](/docs/languages/javascript/api/core/surreal-session):
 
@@ -605,23 +605,23 @@ const unsubscribe = db.subscribe('connected', (version) => {
 unsubscribe();
 ```
 
-## Inherited Methods
+## Inherited methods
 
 As `Surreal` extends [`SurrealSession`](/docs/languages/javascript/api/core/surreal-session), it inherits all authentication and query methods:
 
-### Authentication Methods
+### Authentication methods
 - [`signup()`](/docs/languages/javascript/api/core/surreal-session#signup) - Sign up a new user
 - [`signin()`](/docs/languages/javascript/api/core/surreal-session#signin) - Sign in with credentials
 - [`authenticate()`](/docs/languages/javascript/api/core/surreal-session#authenticate) - Authenticate with a token
 - [`invalidate()`](/docs/languages/javascript/api/core/surreal-session#invalidate) - Invalidate the session
 
-### Session Configuration Methods
+### Session configuration methods
 - [`use()`](/docs/languages/javascript/api/core/surreal-session#use) - Set namespace and database
 - [`set()`](/docs/languages/javascript/api/core/surreal-session#set) - Set a session parameter
 - [`unset()`](/docs/languages/javascript/api/core/surreal-session#unset) - Remove a session parameter
 - [`reset()`](/docs/languages/javascript/api/core/surreal-session#reset) - Reset the session
 
-### Query Methods
+### Query methods
 
 As `Surreal` extends [`SurrealQueryable`](/docs/languages/javascript/api/core/surreal-queryable) (via `SurrealSession`), it also inherits all query execution methods:
 
@@ -636,14 +636,14 @@ As `Surreal` extends [`SurrealQueryable`](/docs/languages/javascript/api/core/su
 - [`live()`](/docs/languages/javascript/api/core/surreal-queryable#live) - Subscribe to live queries
 - [`run()`](/docs/languages/javascript/api/core/surreal-queryable#run) - Execute functions
 
-### Transaction Method
+### Transaction method
 - [`beginTransaction()`](/docs/languages/javascript/api/core/surreal-transaction) - Start a transaction
 
-## Type Parameters
+## Type parameters
 
 This class does not use generic type parameters.
 
-## Complete Example
+## Complete example
 
 ```ts
 import { Surreal } from 'surrealdb';
@@ -695,7 +695,7 @@ console.log('Backup size:', backup.length);
 await db.close();
 ```
 
-## See Also
+## See also
 
 - [SurrealSession](/docs/languages/javascript/api/core/surreal-session) - Session management and authentication
 - [SurrealQueryable](/docs/languages/javascript/api/core/surreal-queryable) - Query execution methods

--- a/src/content/index/languages/javascript/api/errors/index.mdx
+++ b/src/content/index/languages/javascript/api/errors/index.mdx
@@ -8,7 +8,7 @@ description: Error classes for handling different types of failures in the SDK.
 
 The SDK defines specific error classes for different failure scenarios. All error classes extend the base `SurrealError` class, allowing you to catch and handle specific error types.
 
-## Base Error
+## Base error
 
 ### `SurrealError` {#surrealerror}
 
@@ -27,7 +27,7 @@ try {
 }
 ```
 
-## Connection Errors
+## Connection errors
 
 ### `ConnectionUnavailableError` {#connectionunavailableerror}
 
@@ -132,7 +132,7 @@ try {
 }
 ```
 
-## Reconnection Errors
+## Reconnection errors
 
 ### `ReconnectExhaustionError` {#reconnectexhaustionerror}
 
@@ -157,7 +157,7 @@ Thrown when a reconnect iterator fails to iterate.
 
 **Message:** `"The reconnect iterator failed to iterate"`
 
-## Server Errors
+## Server errors
 
 Server errors represent structured errors returned by the SurrealDB server. They form a class hierarchy rooted at `ServerError`, which replaces the former `ResponseError` class.
 
@@ -429,7 +429,7 @@ try {
 }
 ```
 
-## Authentication Errors
+## Authentication errors
 
 ### `AuthenticationError` {#authenticationerror}
 
@@ -476,7 +476,7 @@ try {
 }
 ```
 
-## Live Query Errors
+## Live query errors
 
 ### `LiveSubscriptionError` {#livesubscriptionerror}
 
@@ -497,7 +497,7 @@ try {
 }
 ```
 
-## Version Errors
+## Version errors
 
 ### `UnsupportedVersionError` {#unsupportedversionerror}
 
@@ -524,7 +524,7 @@ try {
 }
 ```
 
-## Expression Errors
+## Expression errors
 
 ### `ExpressionError` {#expressionerror}
 
@@ -547,7 +547,7 @@ try {
 }
 ```
 
-## Event Errors
+## Event errors
 
 ### `PublishError` {#publisherror}
 
@@ -565,7 +565,7 @@ db.subscribe('auth', () => {
 // When the event fires, a PublishError may be emitted
 ```
 
-## Date and Time Errors
+## Date and time errors
 
 ### `InvalidDateError` {#invaliddateerror}
 
@@ -586,7 +586,7 @@ try {
 }
 ```
 
-## Feature Errors
+## Feature errors
 
 ### `UnsupportedFeatureError` {#unsupportedfeatureerror}
 
@@ -628,7 +628,7 @@ try {
 }
 ```
 
-## API Errors
+## API errors
 
 ### `UnsuccessfulApiError` {#unsuccessfulapierror}
 
@@ -652,7 +652,7 @@ try {
 }
 ```
 
-## Session Errors
+## Session errors
 
 ### `InvalidSessionError` {#invalidsessionerror}
 
@@ -675,7 +675,7 @@ try {
 }
 ```
 
-## Value Validation Errors
+## Value validation errors
 
 ### `InvalidRecordIdError` {#invalidrecordiderror}
 
@@ -743,9 +743,9 @@ try {
 }
 ```
 
-## Error Handling Patterns
+## Error handling patterns
 
-### Basic Error Handling
+### Basic error handling
 
 ```ts
 try {
@@ -761,7 +761,7 @@ try {
 }
 ```
 
-### Specific Error Handling
+### Specific error handling
 
 ```ts
 try {
@@ -781,7 +781,7 @@ try {
 }
 ```
 
-### Error Recovery
+### Error recovery
 
 ```ts
 async function executeWithRetry(fn: () => Promise<any>, maxRetries = 3) {
@@ -807,7 +807,7 @@ const result = await executeWithRetry(() =>
 );
 ```
 
-### Global Error Handler
+### Global error handler
 
 ```ts
 db.subscribe('error', (error) => {
@@ -821,9 +821,9 @@ db.subscribe('error', (error) => {
 });
 ```
 
-## Best Practices
+## Best practices
 
-### 1. Catch Specific Errors
+### 1. Catch specific errors
 
 Handle specific error types for better error recovery:
 
@@ -847,7 +847,7 @@ try {
 }
 ```
 
-### 2. Use Type Guards
+### 2. Use type guards
 
 TypeScript type guards provide better type safety:
 
@@ -862,7 +862,7 @@ if (isConnectionError(error)) {
 }
 ```
 
-### 3. Log Error Details
+### 3. Log error details
 
 Include error details in logs for debugging:
 
@@ -879,7 +879,7 @@ catch (error) {
 }
 ```
 
-### 4. Clean Up on Error
+### 4. Clean up on error
 
 Ensure resources are cleaned up even when errors occur:
 
@@ -892,7 +892,7 @@ try {
 }
 ```
 
-## See Also
+## See also
 
 - [Core Classes](/docs/languages/javascript/api/core/) - Classes that may throw errors
 - [Surreal](/docs/languages/javascript/api/core/surreal) - Connection methods that may throw errors

--- a/src/content/index/languages/javascript/api/queries/__category.json
+++ b/src/content/index/languages/javascript/api/queries/__category.json
@@ -1,4 +1,4 @@
 {
-    "title": "Query Builders",
+    "title": "Query builders",
     "position": 2
 }

--- a/src/content/index/languages/javascript/api/queries/api-promise.mdx
+++ b/src/content/index/languages/javascript/api/queries/api-promise.mdx
@@ -13,14 +13,14 @@ The `ApiPromise` class provides an interface for executing user-defined API endp
 
 **Source:** [query/api.ts](https://github.com/surrealdb/surrealdb.js/blob/main/packages/sdk/src/query/api.ts)
 
-## Type Parameters
+## Type parameters
 
 - `Req` - The request body type
 - `Res` - The response body type
 - `V` - Boolean for value-only response (default: `false`)
 - `J` - Boolean indicating if result is JSON (default: `false`)
 
-## Configuration Methods
+## Configuration methods
 
 ### `.json()` {#json}
 
@@ -182,9 +182,9 @@ const result = await db.api().get('/users')
     .value();
 ```
 
-## Response Structure
+## Response structure
 
-### Default Response (without `.value()`)
+### Default response (without `.value()`)
 
 ```ts
 interface ApiResponse<T> {
@@ -194,15 +194,15 @@ interface ApiResponse<T> {
 }
 ```
 
-### Value Response (with `.value()`)
+### Value response (with `.value()`)
 
 ```ts
 // Returns Res directly instead of ApiResponse<Res>
 ```
 
-## Complete Examples
+## Complete examples
 
-### Basic API Calls
+### Basic API calls
 
 ```ts
 import { Surreal } from 'surrealdb';
@@ -230,7 +230,7 @@ const updated = await api.put('/users/123', {
 await api.delete('/users/123').value();
 ```
 
-### With Full Response
+### With full response
 
 ```ts
 const response = await db.api().get('/users');
@@ -244,7 +244,7 @@ if (response.status === 200) {
 }
 ```
 
-### Custom Headers
+### Custom headers
 
 ```ts
 const result = await db.api().post('/protected', data)
@@ -253,7 +253,7 @@ const result = await db.api().post('/protected', data)
     .value();
 ```
 
-### Type-Safe API Calls
+### Type-safe API calls
 
 ```ts
 interface User {
@@ -286,7 +286,7 @@ const newUser: User = await api.post('/users', {
 }).value();
 ```
 
-### Error Handling
+### Error handling
 
 ```ts
 try {
@@ -311,7 +311,7 @@ const page1 = await fetchPage(1, 20);
 const page2 = await fetchPage(2, 20);
 ```
 
-### File Upload
+### File upload
 
 ```ts
 const formData = new FormData();
@@ -323,7 +323,7 @@ const result = await db.api().post('/upload', formData)
     .value();
 ```
 
-### Authentication Flow
+### Authentication flow
 
 ```ts
 // Login
@@ -342,7 +342,7 @@ const profile = await api.get('/profile').value();
 const orders = await api.get('/orders').value();
 ```
 
-### Conditional Requests
+### Conditional requests
 
 ```ts
 const api = db.api();
@@ -359,7 +359,7 @@ if (checkResponse.status === 404) {
 }
 ```
 
-### Batch Operations
+### Batch operations
 
 ```ts
 const api = db.api();
@@ -372,7 +372,7 @@ const users = await Promise.all(promises);
 console.log(`Fetched ${users.length} users`);
 ```
 
-### Response Transformation
+### Response transformation
 
 ```ts
 const response = await db.api().get('/users');
@@ -385,7 +385,7 @@ const transformed = {
 };
 ```
 
-### Retry Pattern
+### Retry pattern
 
 ```ts
 async function apiWithRetry(
@@ -407,7 +407,7 @@ const result = await apiWithRetry(() =>
 );
 ```
 
-### Query Parameters
+### Query parameters
 
 ```ts
 // Build query params manually
@@ -420,7 +420,7 @@ const params = new URLSearchParams({
 const users = await db.api().get(`/users?${params}`).value();
 ```
 
-### WebSocket vs API Endpoints
+### WebSocket vs API endpoints
 
 ```ts
 // Both use the same connection
@@ -436,7 +436,7 @@ const users2 = await db.api().get('/users').value();
 // Both work, but API endpoints allow custom logic
 ```
 
-## Response Headers
+## Response headers
 
 ```ts
 const response = await db.api().get('/users');
@@ -446,9 +446,9 @@ console.log('Cache-Control:', response.headers?.['Cache-Control']);
 console.log('X-Custom:', response.headers?.['X-Custom-Header']);
 ```
 
-## Best Practices
+## Best practices
 
-### 1. Use Type Definitions
+### 1. Use type definitions
 
 ```ts
 // Good: Type-safe API
@@ -461,7 +461,7 @@ const api = db.api<MyApi>();
 const api = db.api();
 ```
 
-### 2. Use .value() for Simpler Code
+### 2. Use .value() for simpler code
 
 ```ts
 // Good: Direct value access
@@ -472,7 +472,7 @@ const response = await api.get('/users');
 const users = response.body;
 ```
 
-### 3. Handle Errors Gracefully
+### 3. Handle errors gracefully
 
 ```ts
 // Good: Specific error handling
@@ -485,9 +485,9 @@ try {
 }
 ```
 
-## See Also
+## See also
 
 - [SurrealApi](/docs/languages/javascript/api/core/surreal-api) - API instance methods
 - [SurrealQueryable.api](/docs/languages/javascript/api/core/surreal-queryable#api) - Creating API instances
 - [User-Defined APIs](/docs/reference/query-language/statements/define/api) - Defining APIs in SurrealDB
-- [Query Overview](/docs/languages/javascript/api/queries/) - All query builder classes
+- [Query overview](/docs/languages/javascript/api/queries/) - All query builder classes

--- a/src/content/index/languages/javascript/api/queries/create-promise.mdx
+++ b/src/content/index/languages/javascript/api/queries/create-promise.mdx
@@ -13,13 +13,13 @@ The `CreatePromise` class provides a chainable interface for configuring CREATE 
 
 **Source:** [query/create.ts](https://github.com/surrealdb/surrealdb.js/blob/main/packages/sdk/src/query/create.ts)
 
-## Type Parameters
+## Type parameters
 
 - `T` - The result type
 - `I` - The input type for record data
 - `J` - Boolean indicating if result is JSON (default: `false`)
 
-## Configuration Methods
+## Configuration methods
 
 ### `.content()` {#content}
 
@@ -309,9 +309,9 @@ for await (const user of results.stream()) {
 }
 ```
 
-## Complete Examples
+## Complete examples
 
-### Basic Creation
+### Basic creation
 
 ```ts
 import { Surreal, RecordId, Table } from 'surrealdb';
@@ -336,7 +336,7 @@ const post = await db.create(new Table('posts'))
     });
 ```
 
-### Creation with Output Control
+### Creation with output control
 
 ```ts
 // Only return the ID
@@ -350,7 +350,7 @@ const summary = await db.create(new Table('users'))
     .output('id', 'name', 'created_at');
 ```
 
-### Bulk Creation with Streaming
+### Bulk creation with streaming
 
 ```ts
 const users = [
@@ -364,7 +364,7 @@ for await (const user of db.create(new Table('users')).content(users).stream()) 
 }
 ```
 
-### With Relationships
+### With relationships
 
 ```ts
 const post = await db.create(new Table('posts'))
@@ -380,7 +380,7 @@ const post = await db.create(new Table('posts'))
     });
 ```
 
-### Error Handling
+### Error handling
 
 ```ts
 try {
@@ -393,7 +393,7 @@ try {
 }
 ```
 
-### With Timeout
+### With timeout
 
 ```ts
 const user = await db.create(new Table('users'))
@@ -401,7 +401,7 @@ const user = await db.create(new Table('users'))
     .timeout(Duration.parse('10s'));
 ```
 
-## Chaining Pattern
+## Chaining pattern
 
 All configuration methods return a new `CreatePromise`, allowing method chaining:
 
@@ -412,9 +412,9 @@ const result = await db.create(new Table('users'))
     .timeout(Duration.parse('5s'));
 ```
 
-## See Also
+## See also
 
 - [SurrealQueryable.create()](/docs/languages/javascript/api/core/surreal-queryable#create) - Method that returns CreatePromise
 - [InsertPromise](/docs/languages/javascript/api/queries/insert-promise) - Bulk insertion
 - [UpsertPromise](/docs/languages/javascript/api/queries/upsert-promise) - Insert or replace
-- [Query Overview](/docs/languages/javascript/api/queries/) - All query builder classes
+- [Query overview](/docs/languages/javascript/api/queries/) - All query builder classes

--- a/src/content/index/languages/javascript/api/queries/delete-promise.mdx
+++ b/src/content/index/languages/javascript/api/queries/delete-promise.mdx
@@ -13,12 +13,12 @@ The `DeletePromise` class provides a chainable interface for configuring DELETE 
 
 **Source:** [query/delete.ts](https://github.com/surrealdb/surrealdb.js/blob/main/packages/sdk/src/query/delete.ts)
 
-## Type Parameters
+## Type parameters
 
 - `T` - The result type (deleted record data)
 - `J` - Boolean indicating if result is JSON (default: `false`)
 
-## Configuration Methods
+## Configuration methods
 
 ### `.output()` {#output}
 
@@ -184,9 +184,9 @@ deletePromise.stream()
 #### Returns
 `AsyncIterableIterator` - Async iterator
 
-## Complete Examples
+## Complete examples
 
-### Basic Deletion
+### Basic deletion
 
 ```ts
 import { Surreal, RecordId, Table } from 'surrealdb';
@@ -209,7 +209,7 @@ const deleted = await db.delete(new Table('temp_data'));
 console.log(`Deleted ${deleted.length} records`);
 ```
 
-### Capture Deleted Data
+### Capture deleted data
 
 ```ts
 // Store deleted data before removing
@@ -224,7 +224,7 @@ await db.create(new RecordId('archived_users', user.id))
     });
 ```
 
-### Conditional Deletion
+### Conditional deletion
 
 ```ts
 // Note: WHERE clauses are not directly supported on delete promises
@@ -236,7 +236,7 @@ const result = await db.query(
 console.log(`Deleted ${result[0].result.length} inactive users`);
 ```
 
-### Bulk Deletion with Streaming
+### Bulk deletion with streaming
 
 ```ts
 const deletedRecords = db.delete(new Table('old_logs'));
@@ -250,7 +250,7 @@ for await (const record of deletedRecords.stream()) {
 }
 ```
 
-### Soft Delete Pattern
+### Soft delete pattern
 
 ```ts
 // Instead of deleting, mark as deleted
@@ -270,7 +270,7 @@ if (user) {
 }
 ```
 
-### Delete with Error Handling
+### Delete with error handling
 
 ```ts
 try {
@@ -288,7 +288,7 @@ try {
 }
 ```
 
-### Performance Optimization
+### Performance optimization
 
 ```ts
 // Don't wait for deleted data if not needed
@@ -297,7 +297,7 @@ await db.delete(new Table('temp_cache'))
 // Faster execution
 ```
 
-### Delete with Timeout
+### Delete with timeout
 
 ```ts
 // For large deletions
@@ -305,7 +305,7 @@ const deleted = await db.delete(new Table('old_logs'))
     .timeout(Duration.parse('30s'));
 ```
 
-### Cascading Deletes
+### Cascading deletes
 
 ```ts
 // Delete user and all related data
@@ -327,7 +327,7 @@ await db.query(
 console.log('User and related data deleted');
 ```
 
-### Batch Deletion
+### Batch deletion
 
 ```ts
 const idsToDelete = ['user1', 'user2', 'user3'];
@@ -342,7 +342,7 @@ const result = await db.query(
 ).collect();
 ```
 
-### Archive Before Delete
+### Archive before delete
 
 ```ts
 async function archiveAndDelete(recordId: RecordId) {
@@ -369,7 +369,7 @@ async function archiveAndDelete(recordId: RecordId) {
 await archiveAndDelete(new RecordId('users', 'john'));
 ```
 
-## Important Notes
+## Important notes
 
 > [!WARNING]
 > DELETE operations are permanent and cannot be undone. Always ensure you have backups or use the `.output('BEFORE')` method to capture data before deletion.
@@ -377,7 +377,7 @@ await archiveAndDelete(new RecordId('users', 'john'));
 > [!NOTE: Tip]
 > For conditional deletions, use [`db.query()`](/docs/languages/javascript/api/core/surreal-queryable#query) with a DELETE statement including a WHERE clause.
 
-## Chaining Pattern
+## Chaining pattern
 
 ```ts
 const result = await db.delete(new Table('users'))
@@ -385,9 +385,9 @@ const result = await db.delete(new Table('users'))
     .timeout(Duration.parse('10s'));
 ```
 
-## See Also
+## See also
 
 - [SurrealQueryable.delete()](/docs/languages/javascript/api/core/surreal-queryable#delete) - Method that returns DeletePromise
 - [UpdatePromise](/docs/languages/javascript/api/queries/update-promise) - Update records
 - [Query](/docs/languages/javascript/api/queries/query) - Raw SurrealQL for conditional deletes
-- [Query Overview](/docs/languages/javascript/api/queries/) - All query builder classes
+- [Query overview](/docs/languages/javascript/api/queries/) - All query builder classes

--- a/src/content/index/languages/javascript/api/queries/insert-promise.mdx
+++ b/src/content/index/languages/javascript/api/queries/insert-promise.mdx
@@ -13,12 +13,12 @@ The `InsertPromise` class provides a chainable interface for configuring INSERT 
 
 **Source:** [query/insert.ts](https://github.com/surrealdb/surrealdb.js/blob/main/packages/sdk/src/query/insert.ts)
 
-## Type Parameters
+## Type parameters
 
 - `T` - The result type
 - `J` - Boolean indicating if result is JSON (default: `false`)
 
-## Configuration Methods
+## Configuration methods
 
 ### `.relation()` {#relation}
 
@@ -219,9 +219,9 @@ insertPromise.stream()
 #### Returns
 `AsyncIterableIterator` - Async iterator
 
-## Complete Examples
+## Complete examples
 
-### Basic Insertion
+### Basic insertion
 
 ```ts
 import { Surreal, RecordId } from 'surrealdb';
@@ -243,7 +243,7 @@ const users = await db.insert([
 ]);
 ```
 
-### Insert into Table
+### Insert into table
 
 ```ts
 // Let database generate IDs
@@ -253,7 +253,7 @@ const users = await db.insert(new Table('users'), [
 ]);
 ```
 
-### Ignore Duplicates
+### Ignore duplicates
 
 ```ts
 // Skip existing records without error
@@ -265,7 +265,7 @@ const users = await db.insert([
 console.log(`Inserted ${users.length} new users`);
 ```
 
-### Bulk Insert with Streaming
+### Bulk insert with streaming
 
 ```ts
 const largeDataset = generateThousandsOfRecords();
@@ -279,7 +279,7 @@ for await (const record of db.insert(largeDataset).stream()) {
 }
 ```
 
-### Insert Relations (Edges)
+### Insert relations (edges)
 
 ```ts
 const likes = await db.insert([
@@ -298,7 +298,7 @@ const likes = await db.insert([
 ]).relation();
 ```
 
-### Optimized Insertion
+### Optimised insertion
 
 ```ts
 // Don't wait for return values
@@ -307,14 +307,14 @@ await db.insert(logEntries)
 // Faster execution when you don't need the results
 ```
 
-### Insert with Timeout
+### Insert with timeout
 
 ```ts
 const users = await db.insert(largeDataset)
     .timeout(Duration.parse('30s'));
 ```
 
-### Error Handling
+### Error handling
 
 ```ts
 try {
@@ -333,7 +333,7 @@ try {
 }
 ```
 
-### Batch Processing
+### Batch processing
 
 ```ts
 const BATCH_SIZE = 100;
@@ -346,7 +346,7 @@ for (let i = 0; i < allUsers.length; i += BATCH_SIZE) {
 }
 ```
 
-## vs CREATE
+## INSERT vs CREATE
 
 ### When to use INSERT vs CREATE
 
@@ -363,7 +363,7 @@ const users = await db.insert([
 ]);
 ```
 
-## Chaining Pattern
+## Chaining pattern
 
 ```ts
 const result = await db.insert(records)
@@ -372,9 +372,9 @@ const result = await db.insert(records)
     .timeout(Duration.parse('10s'));
 ```
 
-## See Also
+## See also
 
 - [SurrealQueryable.insert()](/docs/languages/javascript/api/core/surreal-queryable#insert) - Method that returns InsertPromise
 - [CreatePromise](/docs/languages/javascript/api/queries/create-promise) - Single record creation
 - [UpsertPromise](/docs/languages/javascript/api/queries/upsert-promise) - Insert or update
-- [Query Overview](/docs/languages/javascript/api/queries/) - All query builder classes
+- [Query overview](/docs/languages/javascript/api/queries/) - All query builder classes

--- a/src/content/index/languages/javascript/api/queries/live-promise.mdx
+++ b/src/content/index/languages/javascript/api/queries/live-promise.mdx
@@ -5,7 +5,7 @@ description: LivePromise variants for managing real-time live query subscription
 ---
 
 
-# Live Query Promises {#livepromise}
+# Live query promises {#livepromise}
 
 Live query promises provide interfaces for subscribing to real-time updates from SurrealDB. There are two variants: `ManagedLivePromise` for new subscriptions and `UnmanagedLivePromise` for existing ones.
 
@@ -19,7 +19,7 @@ A managed live query subscription that the SDK automatically creates and manages
 
 **Returned by:** [`SurrealQueryable.live()`](/docs/languages/javascript/api/core/surreal-queryable#live)
 
-### Configuration Methods
+### Configuration methods
 
 #### `.diff()` {#diff}
 
@@ -217,7 +217,7 @@ livePromise.compile()
 
 ---
 
-### Live Subscription Methods
+### Live subscription methods
 
 Once awaited, a `ManagedLivePromise` returns a `LiveSubscription` object:
 
@@ -255,9 +255,9 @@ for await (const update of subscription) {
 }
 ```
 
-## Complete Examples
+## Complete examples
 
-### Basic Live Query
+### Basic live query
 
 ```ts
 import { Surreal, Table } from 'surrealdb';
@@ -276,7 +276,7 @@ for await (const update of subscription) {
 await subscription.kill();
 ```
 
-### Filtered Live Query
+### Filtered live query
 
 ```ts
 // Only receive updates for active users
@@ -294,7 +294,7 @@ for await (const update of subscription) {
 }
 ```
 
-### Live Query with Specific Fields
+### Live query with specific fields
 
 ```ts
 const subscription = await db.live(new Table('users'))
@@ -309,7 +309,7 @@ for await (const update of subscription) {
 await subscription.kill();
 ```
 
-### Diff-Based Updates
+### Diff-based updates
 
 ```ts
 // Get only changes, not full records
@@ -323,7 +323,7 @@ for await (const update of subscription) {
 }
 ```
 
-### Live Query with Relations
+### Live query with relations
 
 ```ts
 const subscription = await db.live(new Table('posts'))
@@ -337,7 +337,7 @@ for await (const update of subscription) {
 }
 ```
 
-### Real-time Dashboard
+### Real-time dashboard
 
 ```ts
 async function monitorUsers(callback: (stats: any) => void) {
@@ -363,7 +363,7 @@ monitorUsers((stats) => {
 });
 ```
 
-### Watch Specific Record
+### Watch specific record
 
 ```ts
 // Subscribe to changes on a specific record
@@ -379,7 +379,7 @@ for await (const update of subscription) {
 }
 ```
 
-### Auto-reconnect Live Query
+### Auto-reconnect live query
 
 ```ts
 let subscription: LiveSubscription | null = null;
@@ -405,7 +405,7 @@ db.subscribe('connected', async () => {
 await setupLiveQuery();
 ```
 
-### Cleanup Pattern
+### Cleanup pattern
 
 ```ts
 const subscriptions: LiveSubscription[] = [];
@@ -428,7 +428,7 @@ async function cleanup() {
 await cleanup();
 ```
 
-### Error Handling
+### Error handling
 
 ```ts
 try {
@@ -450,11 +450,11 @@ try {
 }
 ```
 
-## Update Message Structure
+## Update message structure
 
 Each update message conforms to the [`LiveMessage<T>`](/docs/languages/javascript/api/types/#livemessage) interface with `action`, `result`, and optional `diff` properties.
 
-### Processing Updates
+### Processing updates
 
 ```ts
 for await (const update of subscription) {
@@ -472,9 +472,9 @@ for await (const update of subscription) {
 }
 ```
 
-## See Also
+## See also
 
 - [SurrealQueryable.live()](/docs/languages/javascript/api/core/surreal-queryable#live) - Create managed live subscription
 - [SurrealQueryable.liveOf()](/docs/languages/javascript/api/core/surreal-queryable#liveof) - Subscribe to existing live query
-- [Live Queries Guide](/docs/reference/query-language/statements/live-select) - SurrealQL LIVE documentation
-- [Query Overview](/docs/languages/javascript/api/queries/) - All query builder classes
+- [Live queries guide](/docs/reference/query-language/statements/live-select) - SurrealQL LIVE documentation
+- [Query overview](/docs/languages/javascript/api/queries/) - All query builder classes

--- a/src/content/index/languages/javascript/api/queries/query.mdx
+++ b/src/content/index/languages/javascript/api/queries/query.mdx
@@ -13,7 +13,7 @@ The `Query` class provides a configurable interface for executing raw SurrealQL 
 
 **Source:** [query/query.ts](https://github.com/surrealdb/surrealdb.js/blob/main/packages/sdk/src/query/query.ts)
 
-## Type Parameters
+## Type parameters
 
 - `R extends unknown[]` - Array of result types for each query statement
 - `J extends boolean` - Boolean indicating if result is JSON (default: `false`)
@@ -48,7 +48,7 @@ query.collect<T>(...queryIndexes?)
     </tbody>
 </table>
 
-#### Type Parameters
+#### Type parameters
 - `T extends unknown[]` - Override result types
 
 #### Returns
@@ -166,7 +166,7 @@ query.responses<T>(...queries?)
     </tbody>
 </table>
 
-#### Type Parameters
+#### Type parameters
 - `T extends unknown[]` - Override result types
 
 #### Returns
@@ -221,9 +221,9 @@ const jsonResults = await db.query('SELECT * FROM users').json().collect();
 console.log(typeof jsonResults[0]); // 'string'
 ```
 
-## Complete Examples
+## Complete examples
 
-### Basic Query Execution
+### Basic query execution
 
 ```ts
 import { Surreal } from 'surrealdb';
@@ -239,7 +239,7 @@ console.log(result[0]); // Array of users
 const result = await db.query('SELECT * FROM users');
 ```
 
-### Parameterized Queries
+### Parameterised queries
 
 ```ts
 // Using bindings object
@@ -257,7 +257,7 @@ const result = await db.query(
 ).collect();
 ```
 
-### Multiple Statements
+### Multiple statements
 
 ```ts
 const [users, posts, comments] = await db.query<[User[], Post[], Comment[]]>(`
@@ -271,7 +271,7 @@ console.log('Posts:', posts);
 console.log('Comments:', comments);
 ```
 
-### Streaming Large Results
+### Streaming large results
 
 ```ts
 const query = db.query('SELECT * FROM large_table');
@@ -287,7 +287,7 @@ for await (const frame of query.stream()) {
 }
 ```
 
-### Error Handling with Responses
+### Error handling with responses
 
 ```ts
 const responses = await db.query(`
@@ -305,7 +305,7 @@ for (const [i, response] of responses.entries()) {
 }
 ```
 
-### Transaction Queries
+### Transaction queries
 
 ```ts
 const txn = await db.beginTransaction();
@@ -322,7 +322,7 @@ try {
 }
 ```
 
-### Complex Query with Statistics
+### Complex query with statistics
 
 ```ts
 const responses = await db.query(`
@@ -339,7 +339,7 @@ for (const response of responses) {
 }
 ```
 
-### Conditional Logic
+### Conditional logic
 
 ```ts
 const status = 'active';
@@ -358,7 +358,7 @@ const result = await db.query(
 ).collect();
 ```
 
-### Data Migration
+### Data migration
 
 ```ts
 // Batch update with query
@@ -379,7 +379,7 @@ const migration = await db.query(`
 console.log('Migration complete');
 ```
 
-### Streaming with Progress
+### Streaming with progress
 
 ```ts
 let totalRecords = 0;
@@ -398,9 +398,9 @@ for await (const frame of db.query('SELECT * FROM users; SELECT * FROM posts;').
 console.log(`Total: ${totalRecords} records from ${queriesCompleted} queries`);
 ```
 
-## Best Practices
+## Best practices
 
-### 1. Use Parameterization
+### 1. Use parameterisation
 
 ```ts
 // Good: Parameterized
@@ -420,7 +420,7 @@ const result = await db.query(
 ).collect();
 ```
 
-### 2. Handle Errors Appropriately
+### 2. Handle errors appropriately
 
 ```ts
 // Good: Check individual responses
@@ -440,7 +440,7 @@ try {
 }
 ```
 
-### 3. Use Streaming for Large Results
+### 3. Use streaming for large results
 
 ```ts
 // Good: Stream large datasets
@@ -455,7 +455,7 @@ const [large] = await db.query('SELECT * FROM large_table').collect();
 // May cause memory issues
 ```
 
-### 4. Leverage Type Parameters
+### 4. Leverage type parameters
 
 ```ts
 // Good: Type-safe results
@@ -469,9 +469,9 @@ users[0].name; // string
 posts[0].title; // string
 ```
 
-## See Also
+## See also
 
 - [SurrealQueryable.query()](/docs/languages/javascript/api/core/surreal-queryable#query) - Method that returns Query
 - [BoundQuery](/docs/languages/javascript/api/utilities/#boundquery) - Parameterized queries
 - [surql](/docs/languages/javascript/api/utilities/#surql) - Template tag for queries
-- [Query Overview](/docs/languages/javascript/api/queries/) - All query builder classes
+- [Query overview](/docs/languages/javascript/api/queries/) - All query builder classes

--- a/src/content/index/languages/javascript/api/queries/query.mdx
+++ b/src/content/index/languages/javascript/api/queries/query.mdx
@@ -403,7 +403,7 @@ console.log(`Total: ${totalRecords} records from ${queriesCompleted} queries`);
 ### 1. Use parameterisation
 
 ```ts
-// Good: Parameterized
+// Good: Parameterised
 const result = await db.query(
     'SELECT * FROM users WHERE name = $name',
     { name: userName }
@@ -472,6 +472,6 @@ posts[0].title; // string
 ## See also
 
 - [SurrealQueryable.query()](/docs/languages/javascript/api/core/surreal-queryable#query) - Method that returns Query
-- [BoundQuery](/docs/languages/javascript/api/utilities/#boundquery) - Parameterized queries
+- [BoundQuery](/docs/languages/javascript/api/utilities/#boundquery) - Parameterised queries
 - [surql](/docs/languages/javascript/api/utilities/#surql) - Template tag for queries
 - [Query overview](/docs/languages/javascript/api/queries/) - All query builder classes

--- a/src/content/index/languages/javascript/api/queries/relate-promise.mdx
+++ b/src/content/index/languages/javascript/api/queries/relate-promise.mdx
@@ -454,6 +454,6 @@ As of SurrealDB 3.1.5, when the edge ID already exists, `INSERT RELATION` return
 ## See also
 
 - [SurrealQueryable.relate()](/docs/languages/javascript/api/core/surreal-queryable#relate) - Method that returns RelatePromise
-- [Graph Relationships](/docs/reference/query-language/statements/relate) - SurrealQL RELATE documentation
+- [Graph relationships](/docs/reference/query-language/statements/relate) - SurrealQL RELATE documentation
 - [RecordId](/docs/languages/javascript/api/values/#recordid) - Record identifier type
-- [Query Overview](/docs/languages/javascript/api/queries/) - All query builder classes
+- [Query overview](/docs/languages/javascript/api/queries/) - All query builder classes

--- a/src/content/index/languages/javascript/api/queries/run-promise.mdx
+++ b/src/content/index/languages/javascript/api/queries/run-promise.mdx
@@ -13,12 +13,12 @@ The `RunPromise` class provides an interface for executing SurrealDB functions a
 
 **Source:** [query/run.ts](https://github.com/surrealdb/surrealdb.js/blob/main/packages/sdk/src/query/run.ts)
 
-## Type Parameters
+## Type parameters
 
 - `T` - The return type of the function
 - `J` - Boolean indicating if result is JSON (default: `false`)
 
-## Configuration Methods
+## Configuration methods
 
 ### `.json()` {#json}
 
@@ -64,9 +64,9 @@ runPromise.stream()
 #### Returns
 `AsyncIterableIterator<Frame<T, J>>` - Async iterator
 
-## Complete Examples
+## Complete examples
 
-### Built-in Functions
+### Built-in functions
 
 ```ts
 import { Surreal } from 'surrealdb';
@@ -98,7 +98,7 @@ const hash = await db.run('crypto::md5', ['password123']);
 console.log('Hash:', hash);
 ```
 
-### Custom Functions
+### Custom functions
 
 ```ts
 // First, define a custom function in SurrealDB
@@ -118,7 +118,7 @@ const total = await db.run('fn::calculate_total', [items]);
 console.log('Total:', total); // 35
 ```
 
-### SurrealML Models
+### SurrealML models
 
 ```ts
 // Run a machine learning model
@@ -131,7 +131,7 @@ const prediction = await db.run(
 console.log('Sentiment:', prediction);
 ```
 
-### With Type Safety
+### With type safety
 
 ```ts
 interface CalculationResult {
@@ -150,7 +150,7 @@ console.log('Average:', result.average);
 console.log('Count:', result.count);
 ```
 
-### Complex Function Arguments
+### Complex function arguments
 
 ```ts
 // Function with multiple arguments
@@ -165,7 +165,7 @@ const result = await db.run('fn::process_order', [
 ]);
 ```
 
-### Parameterized Functions
+### Parameterized functions
 
 ```ts
 // Function that uses session variables
@@ -177,7 +177,7 @@ const total = await db.run('fn::calculate_price', [
 ]);
 ```
 
-### Error Handling
+### Error handling
 
 ```ts
 try {
@@ -189,7 +189,7 @@ try {
 }
 ```
 
-### Batch Function Calls
+### Batch function calls
 
 ```ts
 const results = await db.query(`
@@ -201,7 +201,7 @@ const results = await db.query(`
 console.log('Batch results:', results);
 ```
 
-### With Transaction
+### With transaction
 
 ```ts
 const txn = await db.beginTransaction();
@@ -225,7 +225,7 @@ try {
 }
 ```
 
-### Scheduled Functions
+### Scheduled functions
 
 ```ts
 // Define a scheduled function
@@ -239,7 +239,7 @@ await db.query(`
 await db.run('fn::cleanup_old_records');
 ```
 
-### Recursive Functions
+### Recursive functions
 
 ```ts
 await db.query(`
@@ -256,7 +256,7 @@ const result = await db.run('fn::factorial', [5]);
 console.log('5! =', result); // 120
 ```
 
-### Data Transformation
+### Data transformation
 
 ```ts
 // Define transformation function
@@ -276,7 +276,7 @@ const formatted = await db.run('fn::format_user', [user]);
 console.log(formatted);
 ```
 
-### ML Model Versions
+### ML model versions
 
 ```ts
 // Run specific model version
@@ -287,7 +287,7 @@ console.log('v1 prediction:', v1Result);
 console.log('v2 prediction:', v2Result);
 ```
 
-### Validation Functions
+### Validation functions
 
 ```ts
 await db.query(`
@@ -303,9 +303,9 @@ if (isValid) {
 }
 ```
 
-## Best Practices
+## Best practices
 
-### 1. Type Function Results
+### 1. Type function results
 
 ```ts
 // Good: Type the result
@@ -322,7 +322,7 @@ const stats = await db.run('fn::calculate_stats', [data]);
 stats.count; // No type safety
 ```
 
-### 2. Handle Function Errors
+### 2. Handle function errors
 
 ```ts
 // Good: Handle errors
@@ -344,7 +344,7 @@ await db.query(`
 `).collect();
 ```
 
-### 3. Validate Function Names
+### 3. Validate function names
 
 Function names must follow the pattern: `namespace::function_name`
 
@@ -359,8 +359,8 @@ await db.run('invalid name', []); // No namespace
 await db.run('fn:bad-name', []); // Invalid characters
 ```
 
-## See Also
+## See also
 
 - [SurrealQueryable.run()](/docs/languages/javascript/api/core/surreal-queryable#run) - Method that returns RunPromise
 - [Functions](/docs/reference/query-language/statements/define/function) - SurrealQL function definitions
-- [Query Overview](/docs/languages/javascript/api/queries/) - All query builder classes
+- [Query overview](/docs/languages/javascript/api/queries/) - All query builder classes

--- a/src/content/index/languages/javascript/api/queries/run-promise.mdx
+++ b/src/content/index/languages/javascript/api/queries/run-promise.mdx
@@ -165,7 +165,7 @@ const result = await db.run('fn::process_order', [
 ]);
 ```
 
-### Parameterized functions
+### Parameterised functions
 
 ```ts
 // Function that uses session variables

--- a/src/content/index/languages/javascript/api/queries/select-promise.mdx
+++ b/src/content/index/languages/javascript/api/queries/select-promise.mdx
@@ -159,7 +159,7 @@ const activeUsers = await db.select(new Table('users'))
     ));
 ```
 
-```ts title="Parameterized Condition"
+```ts title="Parameterised condition"
 const users = await db.query(
     surql`SELECT * FROM users WHERE age >= ${minAge}`
 ).collect();

--- a/src/content/index/languages/javascript/api/queries/select-promise.mdx
+++ b/src/content/index/languages/javascript/api/queries/select-promise.mdx
@@ -13,13 +13,13 @@ The `SelectPromise` class provides a chainable interface for configuring SELECT 
 
 **Source:** [query/select.ts](https://github.com/surrealdb/surrealdb.js/blob/main/packages/sdk/src/query/select.ts)
 
-## Type Parameters
+## Type parameters
 
 - `T` - The result type
 - `I` - The input type for field selection
 - `J` - Boolean indicating if result is JSON (default: `false`)
 
-## Configuration Methods
+## Configuration methods
 
 ### `.fields()` {#fields}
 
@@ -433,9 +433,9 @@ for await (const user of db.select(new Table('users')).stream()) {
 }
 ```
 
-## Complete Examples
+## Complete examples
 
-### Basic Selection
+### Basic selection
 
 ```ts
 import { Surreal, Table } from 'surrealdb';
@@ -450,7 +450,7 @@ const allUsers = await db.select(new Table('users'));
 const user = await db.select(new RecordId('users', 'john'));
 ```
 
-### Filtered Selection
+### Filtered selection
 
 ```ts
 const activeAdults = await db.select(new Table('users'))
@@ -458,7 +458,7 @@ const activeAdults = await db.select(new Table('users'))
     .fields('name', 'email', 'age');
 ```
 
-### Paginated Selection
+### Paginated selection
 
 ```ts
 function getPage(page: number, pageSize: number) {
@@ -471,7 +471,7 @@ const page1 = await getPage(1, 20);
 const page2 = await getPage(2, 20);
 ```
 
-### Complex Query with Relations
+### Complex query with relations
 
 ```ts
 const posts = await db.select(new Table('posts'))
@@ -494,7 +494,7 @@ const stats = await db.select(new Table('orders'))
     .fields('count() as total_orders', 'sum(amount) as total_revenue', 'avg(amount) as avg_order');
 ```
 
-### Streaming Large Results
+### Streaming large results
 
 ```ts
 let count = 0;
@@ -507,7 +507,7 @@ for await (const user of db.select(new Table('users')).stream()) {
 }
 ```
 
-## Chaining Pattern
+## Chaining pattern
 
 All configuration methods return a new `SelectPromise`, allowing you to chain them in any order:
 
@@ -521,8 +521,8 @@ const result = await db.select(new Table('users'))
     .timeout(Duration.parse('5s'));
 ```
 
-## See Also
+## See also
 
 - [SurrealQueryable.select()](/docs/languages/javascript/api/core/surreal-queryable#select) - Method that returns SelectPromise
-- [Query Overview](/docs/languages/javascript/api/queries/) - All query builder classes
-- [Expression Builders](/docs/languages/javascript/api/utilities/#expr) - Building complex conditions
+- [Query overview](/docs/languages/javascript/api/queries/) - All query builder classes
+- [Expression builders](/docs/languages/javascript/api/utilities/#expr) - Building complex conditions

--- a/src/content/index/languages/javascript/api/queries/update-promise.mdx
+++ b/src/content/index/languages/javascript/api/queries/update-promise.mdx
@@ -13,13 +13,13 @@ The `UpdatePromise` class provides a chainable interface for configuring UPDATE 
 
 **Source:** [query/update.ts](https://github.com/surrealdb/surrealdb.js/blob/main/packages/sdk/src/query/update.ts)
 
-## Type Parameters
+## Type parameters
 
 - `T` - The result type
 - `I` - The input type for record data
 - `J` - Boolean indicating if result is JSON (default: `false`)
 
-## Configuration Methods
+## Configuration methods
 
 ### `.content()` {#content}
 
@@ -371,9 +371,9 @@ updatePromise.stream()
 #### Returns
 `AsyncIterableIterator` - Async iterator
 
-## Complete Examples
+## Complete examples
 
-### Basic Updates
+### Basic updates
 
 ```ts
 import { Surreal, RecordId, Table } from 'surrealdb';
@@ -395,7 +395,7 @@ const user = await db.update(new RecordId('users', 'john'))
     });
 ```
 
-### Bulk Updates
+### Bulk updates
 
 ```ts
 // Update all users matching condition
@@ -406,7 +406,7 @@ const updated = await db.update(new Table('users'))
 console.log(`Updated ${updated.length} users`);
 ```
 
-### Conditional Updates
+### Conditional updates
 
 ```ts
 // Update only if condition is met
@@ -417,7 +417,7 @@ const users = await db.update(new Table('users'))
     });
 ```
 
-### Complex Merge
+### Complex merge
 
 ```ts
 const user = await db.update(new RecordId('users', 'john'))
@@ -434,7 +434,7 @@ const user = await db.update(new RecordId('users', 'john'))
     });
 ```
 
-### Tracking Changes
+### Tracking changes
 
 ```ts
 const diff = await db.update(new RecordId('users', 'john'))
@@ -448,7 +448,7 @@ console.log('Changed fields:', diff);
 // { email: 'new@example.com', age: 31 }
 ```
 
-### Batch Update with Stream
+### Batch update with stream
 
 ```ts
 const updates = db.update(new Table('users'))
@@ -460,7 +460,7 @@ for await (const user of updates.stream()) {
 }
 ```
 
-## Difference Between Methods
+## Difference between methods
 
 ### `.content()` vs `.merge()` vs `.replace()`
 
@@ -485,7 +485,7 @@ await db.update(recordId).replace({
 // Result: Replaces specified fields
 ```
 
-## Chaining Pattern
+## Chaining pattern
 
 ```ts
 const result = await db.update(new Table('users'))
@@ -495,9 +495,9 @@ const result = await db.update(new Table('users'))
     .timeout(Duration.parse('5s'));
 ```
 
-## See Also
+## See also
 
 - [SurrealQueryable.update()](/docs/languages/javascript/api/core/surreal-queryable#update) - Method that returns UpdatePromise
 - [UpsertPromise](/docs/languages/javascript/api/queries/upsert-promise) - Insert or update
 - [CreatePromise](/docs/languages/javascript/api/queries/create-promise) - Create records
-- [Query Overview](/docs/languages/javascript/api/queries/) - All query builder classes
+- [Query overview](/docs/languages/javascript/api/queries/) - All query builder classes

--- a/src/content/index/languages/javascript/api/queries/upsert-promise.mdx
+++ b/src/content/index/languages/javascript/api/queries/upsert-promise.mdx
@@ -16,13 +16,13 @@ The `UpsertPromise` class provides a chainable interface for configuring UPSERT 
 
 **Source:** [query/upsert.ts](https://github.com/surrealdb/surrealdb.js/blob/main/packages/sdk/src/query/upsert.ts)
 
-## Type Parameters
+## Type parameters
 
 - `T` - The result type
 - `I` - The input type for record data
 - `J` - Boolean indicating if result is JSON (default: `false`)
 
-## Configuration Methods
+## Configuration methods
 
 ### `.content()` {#content}
 
@@ -291,9 +291,9 @@ upsertPromise.stream()
 #### Returns
 `AsyncIterableIterator` - Async iterator
 
-## Complete Examples
+## Complete examples
 
-### Basic Upsert
+### Basic upsert
 
 ```ts
 import { Surreal, RecordId } from 'surrealdb';
@@ -310,7 +310,7 @@ const user = await db.upsert(new RecordId('users', 'john'))
     });
 ```
 
-### Upsert with Merge
+### Upsert with merge
 
 ```ts
 // Safer: merge instead of replace
@@ -323,14 +323,14 @@ const user = await db.upsert(new RecordId('users', 'john'))
 // If not: creates user with these fields
 ```
 
-### Bulk Upsert
+### Bulk upsert
 
 ```ts
 const users = await db.upsert(new Table('users'))
     .content(userDataArray);
 ```
 
-### Track Changes
+### Track changes
 
 ```ts
 const result = await db.upsert(new RecordId('users', 'john'))
@@ -342,7 +342,7 @@ if (result) {
 }
 ```
 
-### Conditional Upsert
+### Conditional upsert
 
 ```ts
 const user = await db.upsert(new RecordId('users', 'john'))
@@ -372,9 +372,9 @@ await db.upsert(recordId).content(data);
 // Always succeeds
 ```
 
-## Use Cases
+## Use cases
 
-### Session Management
+### Session management
 
 ```ts
 // Update session or create new one
@@ -387,7 +387,7 @@ async function updateSession(sessionId: string, data: SessionData) {
 }
 ```
 
-### Cache Pattern
+### Cache pattern
 
 ```ts
 // Write-through cache
@@ -400,7 +400,7 @@ async function cacheSet(key: string, value: unknown) {
 }
 ```
 
-### Counter Pattern
+### Counter pattern
 
 ```ts
 // Increment counter or initialize
@@ -411,7 +411,7 @@ const counter = await db.upsert(new RecordId('counters', 'page_views'))
     });
 ```
 
-## Chaining Pattern
+## Chaining pattern
 
 ```ts
 const result = await db.upsert(new RecordId('users', 'john'))
@@ -420,9 +420,9 @@ const result = await db.upsert(new RecordId('users', 'john'))
     .timeout(Duration.parse('5s'));
 ```
 
-## See Also
+## See also
 
 - [SurrealQueryable.upsert()](/docs/languages/javascript/api/core/surreal-queryable#upsert) - Method that returns UpsertPromise
 - [CreatePromise](/docs/languages/javascript/api/queries/create-promise) - Create only
 - [UpdatePromise](/docs/languages/javascript/api/queries/update-promise) - Update only
-- [Query Overview](/docs/languages/javascript/api/queries/) - All query builder classes
+- [Query overview](/docs/languages/javascript/api/queries/) - All query builder classes

--- a/src/content/index/languages/javascript/api/types/index.mdx
+++ b/src/content/index/languages/javascript/api/types/index.mdx
@@ -8,7 +8,7 @@ description: TypeScript type definitions and interfaces used throughout the SDK.
 
 The SDK provides comprehensive TypeScript type definitions for type-safe development. This page documents the key types and interfaces used throughout the SDK.
 
-## Connection Types
+## Connection types
 
 ### `ConnectionStatus` {#connectionstatus}
 
@@ -143,7 +143,7 @@ const info = await db.version();
 console.log(info.version); // "surrealdb-2.1.0"
 ```
 
-## Authentication Types
+## Authentication types
 
 ### `AnyAuth` {#anyauth}
 
@@ -353,7 +353,7 @@ await db.connect('ws://localhost:8000', {
 });
 ```
 
-## Session Types
+## Session types
 
 ### `Session` {#session}
 
@@ -413,7 +413,7 @@ type SurrealEvents = SessionEvents & {
 }
 ```
 
-## Query Types
+## Query types
 
 ### `RecordResult<T>` {#recordresult}
 
@@ -548,7 +548,7 @@ for await (const message of subscription) {
 }
 ```
 
-## Value Types
+## Value types
 
 ### `RecordIdValue` {#recordidvalue}
 
@@ -611,7 +611,7 @@ type Nullable<T> = {
 }
 ```
 
-## Codec Types
+## Codec types
 
 ### `CodecOptions` {#codecoptions}
 
@@ -643,7 +643,7 @@ const db = new Surreal({
 });
 ```
 
-## Export/Import Types
+## Export/import types
 
 ### `SqlExportOptions` {#sqlexportoptions}
 
@@ -696,7 +696,7 @@ const model = await db.export({
 });
 ```
 
-## Utility Types
+## Utility types
 
 ### `Prettify<T>` {#prettify}
 
@@ -753,9 +753,9 @@ const result = await api.invoke('/custom', {
 });
 ```
 
-## Best Practices
+## Best practices
 
-### 1. Use Generic Type Parameters
+### 1. Use generic type parameters
 
 Leverage generics for type-safe operations:
 
@@ -770,7 +770,7 @@ const users = await db.select<User>(new Table('users'));
 users[0].name; // TypeScript knows this is a string
 ```
 
-### 2. Define Custom Types
+### 2. Define custom types
 
 Create types for your data models:
 
@@ -785,7 +785,7 @@ interface Post {
 const posts = await db.select<Post>(new Table('posts'));
 ```
 
-### 3. Use Type Guards
+### 3. Use type guards
 
 Implement type guards for runtime type checking:
 
@@ -804,7 +804,7 @@ if (isUser(data)) {
 }
 ```
 
-### 4. Handle Union Types
+### 4. Handle union types
 
 Properly handle discriminated unions:
 
@@ -820,10 +820,10 @@ for (const r of response) {
 }
 ```
 
-## See Also
+## See also
 
-- [Core Classes](/docs/languages/javascript/api/core/) - Classes using these types
-- [Value Types](/docs/languages/javascript/api/values/) - Value type classes
-- [Query Builders](/docs/languages/javascript/api/queries/) - Query builder types
+- [Core classes](/docs/languages/javascript/api/core/) - Classes using these types
+- [Value types](/docs/languages/javascript/api/values/) - Value type classes
+- [Query builders](/docs/languages/javascript/api/queries/) - Query builder types
 
 **Source:** [types/](https://github.com/surrealdb/surrealdb.js/tree/main/packages/sdk/src/types)

--- a/src/content/index/languages/javascript/api/utilities/bound-query.mdx
+++ b/src/content/index/languages/javascript/api/utilities/bound-query.mdx
@@ -16,7 +16,7 @@ import { BoundQuery } from 'surrealdb';
 
 **Source:** [utils/bound-query.ts](https://github.com/surrealdb/surrealdb.js/blob/main/packages/sdk/src/utils/bound-query.ts)
 
-## Type Parameters
+## Type parameters
 
 - `R extends unknown[]` - Array of result types for the query
 
@@ -176,9 +176,9 @@ query.toString()
 #### Returns
 `string` - The query string
 
-## Complete Examples
+## Complete examples
 
-### Basic Parameterized Query
+### Basic parameterized query
 
 ```ts
 import { BoundQuery } from 'surrealdb';
@@ -194,7 +194,7 @@ const query = new BoundQuery(
 const [users] = await db.query(query).collect();
 ```
 
-### Building Queries Incrementally
+### Building queries incrementally
 
 ```ts
 // Start with base query
@@ -218,7 +218,7 @@ query.append(' ORDER BY created_at DESC LIMIT $limit', { limit: 10 });
 const [products] = await db.query(query).collect();
 ```
 
-### Query Builder Pattern
+### Query builder pattern
 
 ```ts
 class QueryBuilder {
@@ -255,7 +255,7 @@ const query = builder
 const [users] = await db.query(query).collect();
 ```
 
-### Reusable Query Fragments
+### Reusable query fragments
 
 ```ts
 // Define reusable fragments
@@ -273,7 +273,7 @@ query.append(verifiedFilter);
 const [users] = await db.query(query).collect();
 ```
 
-### Complex Multi-Statement Query
+### Complex multi-statement query
 
 ```ts
 const userId = new RecordId('users', 'john');
@@ -306,7 +306,7 @@ query.append('COMMIT TRANSACTION;');
 await db.query(query).collect();
 ```
 
-### Pagination Helper
+### Pagination helper
 
 ```ts
 function paginatedQuery(
@@ -337,9 +337,9 @@ const query = paginatedQuery('users', 2, 20, { status: 'active' });
 const [users] = await db.query(query).collect();
 ```
 
-## Best Practices
+## Best practices
 
-### 1. Use surql Template Instead
+### 1. Use surql template instead
 
 For most cases, the `surql` template is easier:
 
@@ -354,7 +354,7 @@ const query = new BoundQuery(
 );
 ```
 
-### 2. Validate Parameter Names
+### 2. Validate parameter names
 
 ```ts
 // Good: Consistent parameter naming
@@ -370,7 +370,7 @@ const query = new BoundQuery(
 );
 ```
 
-### 3. Use append() for Dynamic Queries
+### 3. Use append() for dynamic queries
 
 ```ts
 // Good: Incremental building
@@ -386,7 +386,7 @@ if (filter) {
 }
 ```
 
-## See Also
+## See also
 
 - [surql](/docs/languages/javascript/api/utilities/surql) - Template tag for queries
 - [Query](/docs/languages/javascript/api/queries/query) - Query execution class

--- a/src/content/index/languages/javascript/api/utilities/bound-query.mdx
+++ b/src/content/index/languages/javascript/api/utilities/bound-query.mdx
@@ -1,13 +1,13 @@
 ---
 position: 4
 title: BoundQuery
-description: Parameterized query class for safe query composition.
+description: Parameterised query class for safe query composition.
 ---
 
 
 # `BoundQuery<R>` {#boundquery}
 
-The `BoundQuery` class represents a parameterized SurrealQL query with bound variables, providing safe query composition and preventing SQL injection.
+The `BoundQuery` class represents a parameterised SurrealQL query with bound variables, providing safe query composition and preventing SQL injection.
 
 **Import:**
 ```ts
@@ -178,7 +178,7 @@ query.toString()
 
 ## Complete examples
 
-### Basic parameterized query
+### Basic parameterised query
 
 ```ts
 import { BoundQuery } from 'surrealdb';

--- a/src/content/index/languages/javascript/api/utilities/equals.mdx
+++ b/src/content/index/languages/javascript/api/utilities/equals.mdx
@@ -16,7 +16,7 @@ import { equals } from 'surrealdb';
 
 **Source:** [utils/equals.ts](https://github.com/surrealdb/surrealdb.js/blob/main/packages/sdk/src/utils/equals.ts)
 
-## Function Signature
+## Function signature
 
 ```ts
 function equals(x: unknown, y: unknown): boolean
@@ -48,7 +48,7 @@ function equals(x: unknown, y: unknown): boolean
 #### Returns
 `boolean` - `true` if values are deeply equal, `false` otherwise
 
-## What It Compares
+## What it compares
 
 The `equals()` function correctly handles:
 - **Primitives** - strings, numbers, booleans, null, undefined
@@ -61,7 +61,7 @@ The `equals()` function correctly handles:
 
 ## Examples
 
-### Primitive Comparisons
+### Primitive comparisons
 
 ```ts
 import { equals } from 'surrealdb';
@@ -72,7 +72,7 @@ console.log(equals(true, false)); // false
 console.log(equals(null, null)); // true
 ```
 
-### SurrealDB Type Comparisons
+### SurrealDB type comparisons
 
 ```ts
 import { RecordId, DateTime, Uuid, Decimal, equals } from 'surrealdb';
@@ -104,7 +104,7 @@ const dec2 = new Decimal('19.99');
 console.log(equals(dec1, dec2)); // true
 ```
 
-### Object Comparisons
+### Object comparisons
 
 ```ts
 const obj1 = { name: 'John', age: 30 };
@@ -133,7 +133,7 @@ const deep2 = {
 console.log(equals(deep1, deep2)); // true
 ```
 
-### Array Comparisons
+### Array comparisons
 
 ```ts
 const arr1 = [1, 2, 3];
@@ -156,7 +156,7 @@ const ids2 = [
 console.log(equals(ids1, ids2)); // true
 ```
 
-### Mixed Type Comparisons
+### Mixed type comparisons
 
 ```ts
 // bigint and number comparison
@@ -170,9 +170,9 @@ const date2 = new Date('2024-01-15');
 console.log(equals(date1, date2)); // true
 ```
 
-## Use Cases
+## Use cases
 
-### Checking Record Existence
+### Checking record existence
 
 ```ts
 async function hasRecord(recordId: RecordId): Promise<boolean> {
@@ -209,7 +209,7 @@ const uniqueIds = deduplicate(recordIds);
 console.log(uniqueIds.length); // 2
 ```
 
-### Change Detection
+### Change detection
 
 ```ts
 function hasChanged<T>(before: T, after: T): boolean {
@@ -225,7 +225,7 @@ if (hasChanged(originalUser, updatedUser)) {
 }
 ```
 
-### Array Difference
+### Array difference
 
 ```ts
 function findNewItems<T>(oldList: T[], newList: T[]): T[] {
@@ -241,7 +241,7 @@ const added = findNewItems(oldTags, newTags);
 console.log(added); // ['react']
 ```
 
-### Caching / Memoization
+### Caching / memoization
 
 ```ts
 class Cache<K, V> {
@@ -270,7 +270,7 @@ cache.set(userId, userData);
 const cached = cache.get(new RecordId('users', 'john')); // Found!
 ```
 
-### Record Comparison
+### Record comparison
 
 ```ts
 interface User {
@@ -290,7 +290,7 @@ const user2: User = await db.select(new RecordId('users', 'john'));
 console.log(equals(user1, user2)); // true
 ```
 
-## Why Not Use `===` or `==`?
+## Why not use `===` or `==`?
 
 JavaScript's equality operators don't work correctly for:
 
@@ -320,9 +320,9 @@ console.log(arr1 === arr2); // false
 console.log(equals(arr1, arr2)); // true
 ```
 
-## Best Practices
+## Best practices
 
-### 1. Use for Value Comparisons
+### 1. Use for value comparisons
 
 ```ts
 // Good: Deep equality
@@ -336,7 +336,7 @@ if (recordId1 === recordId2) {
 }
 ```
 
-### 2. Use for Complex Type Comparisons
+### 2. Use for complex type comparisons
 
 ```ts
 // Good: Proper comparison
@@ -349,7 +349,7 @@ const sameDateTime = equals(
 const wrong = dt1 === dt2; // false (different instances)
 ```
 
-### 3. Prefer Built-in `.equals()` for Single Types
+### 3. Prefer built-in `.equals()` for single types
 
 ```ts
 const id1 = new RecordId('users', 'john');
@@ -363,7 +363,7 @@ console.log(id1.equals(id2)); // true
 // Use equals(id1, id2) for generic comparisons
 ```
 
-## See Also
+## See also
 
 - [Data types](/docs/languages/javascript/api/values/) - SurrealDB data types
 - [RecordId.equals()](/docs/languages/javascript/api/values/record-id#equals) - RecordId-specific comparison

--- a/src/content/index/languages/javascript/api/utilities/equals.mdx
+++ b/src/content/index/languages/javascript/api/utilities/equals.mdx
@@ -365,6 +365,6 @@ console.log(id1.equals(id2)); // true
 
 ## See Also
 
-- [Data Types](/docs/languages/javascript/api/values/) - SurrealDB data types
+- [Data types](/docs/languages/javascript/api/values/) - SurrealDB data types
 - [RecordId.equals()](/docs/languages/javascript/api/values/record-id#equals) - RecordId-specific comparison
 - [DateTime.equals()](/docs/languages/javascript/api/values/datetime#equals) - DateTime-specific comparison

--- a/src/content/index/languages/javascript/api/utilities/escape.mdx
+++ b/src/content/index/languages/javascript/api/utilities/escape.mdx
@@ -192,9 +192,9 @@ function escapeRangeBound<T>(bound: Bound<T>): string
 #### Returns
 `string` - Escaped range bound representation
 
-## Complete Examples
+## Complete examples
 
-### Dynamic Table Names
+### Dynamic table names
 
 ```ts
 import { escapeIdent } from 'surrealdb';
@@ -213,7 +213,7 @@ async function selectFromTable(tableName: string) {
 await selectFromTable('user-sessions'); // Safe
 ```
 
-### Dynamic Field Selection
+### Dynamic field selection
 
 ```ts
 import { escapeIdent } from 'surrealdb';
@@ -231,7 +231,7 @@ async function selectFields(table: string, fields: string[]) {
 await selectFields('users', ['first-name', 'last-name', 'email']);
 ```
 
-### Using surql Instead (Recommended)
+### Using surql instead (recommended)
 
 ```ts
 // Prefer surql for safe parameterization
@@ -243,23 +243,23 @@ const query = surql`
 `;
 ```
 
-## When to Use
+## When to use
 
-### ✅ Use Escape Functions When:
+### ✅ Use escape functions when:
 - Constructing queries with user-provided table/field names
 - Working with identifiers that have special characters
 - Building dynamic schema definitions
 - Interfacing with external query builders
 
-### ❌ Prefer Other Solutions:
+### ❌ Prefer other solutions:
 - **For values:** Use [`surql`](/docs/languages/javascript/api/utilities/surql) or [`BoundQuery`](/docs/languages/javascript/api/utilities/bound-query)
 - **For tables:** Use [`Table`](/docs/languages/javascript/api/values/table) class
 - **For record IDs:** Use [`RecordId`](/docs/languages/javascript/api/values/record-id) class
 - **For conditions:** Use [`expr`](/docs/languages/javascript/api/utilities/expr)
 
-## Best Practices
+## Best practices
 
-### 1. Prefer Type-Safe Alternatives
+### 1. Prefer type-safe alternatives
 
 ```ts
 // Good: Type-safe
@@ -271,7 +271,7 @@ const escaped = escapeIdent('users');
 const users = await db.query(`SELECT * FROM ${escaped}`).collect();
 ```
 
-### 2. Validate Before Escaping
+### 2. Validate before escaping
 
 ```ts
 // Good: Validate first
@@ -290,7 +290,7 @@ function unsafeQuery(tableName: string) {
 }
 ```
 
-### 3. Use surql for Complex Queries
+### 3. Use surql for complex queries
 
 ```ts
 // Good: Automatic parameterization
@@ -300,7 +300,7 @@ const query = surql`SELECT * FROM users WHERE name = ${name}`;
 const query = `SELECT * FROM users WHERE name = '${name}'`;
 ```
 
-## Security Considerations
+## Security considerations
 
 > [!WARNING]
 > Escaping functions are NOT a complete defense against SQL injection. Always prefer parameterized queries using `surql` or `BoundQuery`.
@@ -313,7 +313,7 @@ const query = surql`SELECT * FROM users WHERE name = ${userInput}`;
 const query = `SELECT * FROM users WHERE name = '${userInput}'`;
 ```
 
-## See Also
+## See also
 
 - [surql](/docs/languages/javascript/api/utilities/surql) - Recommended for parameterized queries
 - [BoundQuery](/docs/languages/javascript/api/utilities/bound-query) - Parameterized query class

--- a/src/content/index/languages/javascript/api/utilities/escape.mdx
+++ b/src/content/index/languages/javascript/api/utilities/escape.mdx
@@ -10,7 +10,7 @@ description: Functions for escaping identifiers and values in SurrealQL queries.
 Escape functions provide safe handling of identifiers and values in SurrealQL queries when you need to construct queries manually.
 
 > [!NOTE: Tip]
-> Prefer using [`surql`](/docs/languages/javascript/api/utilities/surql) or [`BoundQuery`](/docs/languages/javascript/api/utilities/bound-query) for automatic parameterization. Use escape functions only when absolutely necessary.
+> Prefer using [`surql`](/docs/languages/javascript/api/utilities/surql) or [`BoundQuery`](/docs/languages/javascript/api/utilities/bound-query) for automatic parameterisation. Use escape functions only when absolutely necessary.
 
 **Import:**
 ```ts
@@ -234,7 +234,7 @@ await selectFields('users', ['first-name', 'last-name', 'email']);
 ### Using surql instead (recommended)
 
 ```ts
-// Prefer surql for safe parameterization
+// Prefer surql for safe parameterisation
 const filters = { status: 'active', age: 18 };
 const query = surql`
     SELECT * FROM users 
@@ -293,7 +293,7 @@ function unsafeQuery(tableName: string) {
 ### 3. Use surql for complex queries
 
 ```ts
-// Good: Automatic parameterization
+// Good: Automatic parameterisation
 const query = surql`SELECT * FROM users WHERE name = ${name}`;
 
 // Avoid: Manual string construction
@@ -303,10 +303,10 @@ const query = `SELECT * FROM users WHERE name = '${name}'`;
 ## Security considerations
 
 > [!WARNING]
-> Escaping functions are NOT a complete defense against SQL injection. Always prefer parameterized queries using `surql` or `BoundQuery`.
+> Escaping functions are NOT a complete defense against SQL injection. Always prefer parameterised queries using `surql` or `BoundQuery`.
 
 ```ts
-// Secure: Parameterized
+// Secure: Parameterised
 const query = surql`SELECT * FROM users WHERE name = ${userInput}`;
 
 // Insecure: No escaping
@@ -315,7 +315,7 @@ const query = `SELECT * FROM users WHERE name = '${userInput}'`;
 
 ## See also
 
-- [surql](/docs/languages/javascript/api/utilities/surql) - Recommended for parameterized queries
-- [BoundQuery](/docs/languages/javascript/api/utilities/bound-query) - Parameterized query class
+- [surql](/docs/languages/javascript/api/utilities/surql) - Recommended for parameterised queries
+- [BoundQuery](/docs/languages/javascript/api/utilities/bound-query) - Parameterised query class
 - [Table](/docs/languages/javascript/api/values/table) - Type-safe table references
 - [RecordId](/docs/languages/javascript/api/values/record-id) - Type-safe record identifiers

--- a/src/content/index/languages/javascript/api/utilities/expr.mdx
+++ b/src/content/index/languages/javascript/api/utilities/expr.mdx
@@ -26,7 +26,7 @@ import {
 
 **Source:** [utils/expr.ts](https://github.com/surrealdb/surrealdb.js/blob/main/packages/sdk/src/utils/expr.ts)
 
-## Function Signature
+## Function signature
 
 ```ts
 function expr(expression: ExprLike): BoundQuery
@@ -53,7 +53,7 @@ function expr(expression: ExprLike): BoundQuery
 #### Returns
 `BoundQuery` - Compiled query with bindings
 
-## Comparison Operators
+## Comparison operators
 
 ### `eq(field, value)` {#eq}
 
@@ -109,7 +109,7 @@ const young = expr(lt('age', 30));
 const youngInclusive = expr(lte('age', 29));
 ```
 
-## Logical Operators
+## Logical operators
 
 ### `and(...conditions)` {#and}
 
@@ -148,7 +148,7 @@ const notBanned = expr(not(eq('status', 'banned')));
 // WHERE NOT status = 'banned'
 ```
 
-## Collection Operators
+## Collection operators
 
 ### `contains(field, value)` {#contains}
 
@@ -192,7 +192,7 @@ const noBadTags = expr(containsNone('tags', ['spam', 'banned']));
 // WHERE tags CONTAINSNONE ['spam', 'banned']
 ```
 
-## Geometry Operators
+## Geometry operators
 
 ### `inside(field, geometry)` {#inside}
 
@@ -225,7 +225,7 @@ const overlaps = expr(intersects('area', otherArea));
 // WHERE area INTERSECTS $otherArea
 ```
 
-## Search Operators
+## Search operators
 
 ### `matches(field, query, ref?)` {#matches}
 
@@ -252,7 +252,7 @@ const similar = expr(knn('embedding', [0.1, 0.2, 0.3], 10, 'cosine'));
 // WHERE embedding <|10,COSINE|> [0.1, 0.2, 0.3]
 ```
 
-## Range Operator
+## Range operator
 
 ### `between(field, a, b)` {#between}
 
@@ -263,7 +263,7 @@ const midRange = expr(between('price', 10, 50));
 // WHERE price >= 10 AND price <= 50
 ```
 
-## Raw Expressions
+## Raw expressions
 
 ### `raw(sql)` {#raw}
 
@@ -276,9 +276,9 @@ Create raw SurrealQL expressions.
 const custom = expr(raw('custom_function()'));
 ```
 
-## Complete Examples
+## Complete examples
 
-### Basic Filtering
+### Basic filtering
 
 ```ts
 import { expr, eq, gte } from 'surrealdb';
@@ -297,7 +297,7 @@ const premiumAdults = expr(and(
 const results = await db.select(new Table('users')).where(premiumAdults);
 ```
 
-### Complex Conditions
+### Complex conditions
 
 ```ts
 // Nested OR and AND
@@ -315,7 +315,7 @@ const eligibleUsers = expr(or(
 const users = await db.select(new Table('users')).where(eligibleUsers);
 ```
 
-### Date Filtering
+### Date filtering
 
 ```ts
 import { DateTime, Duration } from 'surrealdb';
@@ -326,7 +326,7 @@ const recentUsers = expr(gte('created_at', cutoffDate));
 const users = await db.select(new Table('users')).where(recentUsers);
 ```
 
-### Array Operations
+### Array operations
 
 ```ts
 // Check if user has specific tags
@@ -342,7 +342,7 @@ const fullyVerified = expr(containsAll('badges', ['email-verified', 'phone-verif
 const cleanContent = expr(containsNone('flags', ['spam', 'inappropriate']));
 ```
 
-### Geospatial Queries
+### Geospatial queries
 
 ```ts
 import { GeometryPoint } from 'surrealdb';
@@ -358,7 +358,7 @@ const overlapping = expr(intersects('coverage_area', searchArea));
 const zones = await db.select(new Table('zones')).where(overlapping);
 ```
 
-### Full-Text Search
+### Full-text search
 
 ```ts
 // Basic text search
@@ -373,7 +373,7 @@ const multiField = expr(or(
 ));
 ```
 
-### Vector Search
+### Vector search
 
 ```ts
 // Find similar items using KNN
@@ -383,7 +383,7 @@ const similar = expr(knn('embedding', queryVector, 10, 'cosine'));
 const results = await db.select(new Table('items')).where(similar);
 ```
 
-### Reusable Expressions
+### Reusable expressions
 
 ```ts
 // Define reusable filters
@@ -400,7 +400,7 @@ const users1 = await db.select(new Table('users')).where(premiumActive);
 const users2 = await db.select(new Table('users')).where(verifiedActive);
 ```
 
-### Update with Expressions
+### Update with expressions
 
 ```ts
 const condition = expr(and(
@@ -413,7 +413,7 @@ const updated = await db.update(new Table('orders'))
     .where(condition);
 ```
 
-### Delete with Expressions
+### Delete with expressions
 
 ```ts
 const oldInactive = expr(and(
@@ -424,9 +424,9 @@ const oldInactive = expr(and(
 const deleted = await db.delete(new Table('users')).where(oldInactive);
 ```
 
-## Best Practices
+## Best practices
 
-### 1. Use Expressions for Complex Conditions
+### 1. Use expressions for complex conditions
 
 ```ts
 // Good: Type-safe and reusable
@@ -439,7 +439,7 @@ const condition = expr(and(
 const condition = 'age >= 18 AND verified = true';
 ```
 
-### 2. Build Expressions Compositionally
+### 2. Build expressions compositionally
 
 ```ts
 // Good: Compose small expressions
@@ -453,7 +453,7 @@ const eligibleUsers = expr(and(isAdult, isVerified, isActive));
 const premiumEligible = expr(and(isAdult, isVerified));
 ```
 
-### 3. Avoid `raw()` When Possible
+### 3. Avoid `raw()` when possible
 
 ```ts
 // Good: Use typed operators
@@ -463,7 +463,7 @@ const condition = expr(gte('score', 80));
 const condition = expr(raw(`score >= ${userInput}`));
 ```
 
-### 4. Parameterize Dynamic Values
+### 4. Parameterize dynamic values
 
 ```ts
 // Good: Values are automatically parameterized
@@ -473,9 +473,9 @@ const condition = expr(gte('age', minAge));
 // Safe: minAge is bound as a parameter, not concatenated
 ```
 
-## Common Patterns
+## Common patterns
 
-### Dynamic Filter Builder
+### Dynamic filter builder
 
 ```ts
 function buildUserFilter(options: {
@@ -505,7 +505,7 @@ if (filter) {
 }
 ```
 
-### Search with Multiple Criteria
+### Search with multiple criteria
 
 ```ts
 function searchProducts(criteria: {
@@ -533,9 +533,9 @@ function searchProducts(criteria: {
 }
 ```
 
-## See Also
+## See also
 
-- [Query Builders](/docs/languages/javascript/api/queries/) - Using expressions in queries
+- [Query builders](/docs/languages/javascript/api/queries/) - Using expressions in queries
 - [surql](/docs/languages/javascript/api/utilities/surql) - Template tag for queries
 - [BoundQuery](/docs/languages/javascript/api/utilities/bound-query) - Parameterized queries
 - [SelectPromise.where()](/docs/languages/javascript/api/queries/select-promise#where) - Using expressions with WHERE

--- a/src/content/index/languages/javascript/api/utilities/expr.mdx
+++ b/src/content/index/languages/javascript/api/utilities/expr.mdx
@@ -463,10 +463,10 @@ const condition = expr(gte('score', 80));
 const condition = expr(raw(`score >= ${userInput}`));
 ```
 
-### 4. Parameterize dynamic values
+### 4. Parameterise dynamic values
 
 ```ts
-// Good: Values are automatically parameterized
+// Good: Values are automatically parameterised
 const minAge = getUserInput();
 const condition = expr(gte('age', minAge));
 
@@ -537,5 +537,5 @@ function searchProducts(criteria: {
 
 - [Query builders](/docs/languages/javascript/api/queries/) - Using expressions in queries
 - [surql](/docs/languages/javascript/api/utilities/surql) - Template tag for queries
-- [BoundQuery](/docs/languages/javascript/api/utilities/bound-query) - Parameterized queries
+- [BoundQuery](/docs/languages/javascript/api/utilities/bound-query) - Parameterised queries
 - [SelectPromise.where()](/docs/languages/javascript/api/queries/select-promise#where) - Using expressions with WHERE

--- a/src/content/index/languages/javascript/api/utilities/surql.mdx
+++ b/src/content/index/languages/javascript/api/utilities/surql.mdx
@@ -1,13 +1,13 @@
 ---
 position: 3
 title: surql
-description: Tagged template for composing parameterized SurrealQL queries.
+description: Tagged template for composing parameterised SurrealQL queries.
 ---
 
 
 # `surql` {#surql}
 
-The `surql` tagged template function creates parameterized SurrealQL queries with automatic value binding and SQL injection prevention.
+The `surql` tagged template function creates parameterised SurrealQL queries with automatic value binding and SQL injection prevention.
 
 **Import:**
 ```ts
@@ -49,7 +49,7 @@ function surql(
 </table>
 
 #### Returns
-`BoundQuery` - Parameterized query with automatic bindings
+`BoundQuery` - Parameterised query with automatic bindings
 
 ## How it works
 
@@ -70,7 +70,7 @@ const query = surql`SELECT * FROM users WHERE age > ${age}`;
 
 ## Basic examples
 
-### Simple parameterized query
+### Simple parameterised query
 
 ```ts
 import { surql } from 'surrealdb';
@@ -273,7 +273,7 @@ const [users] = await db.query(query).collect();
 
 ## SQL injection prevention
 
-The `surql` template prevents SQL injection by automatically parameterizing all values:
+The `surql` template prevents SQL injection by automatically parameterising all values:
 
 ```ts
 // User input
@@ -292,7 +292,7 @@ const query = surql`SELECT * FROM users WHERE name = ${userInput}`;
 ### 1. Always use surql for user input
 
 ```ts
-// Good: Safe parameterization
+// Good: Safe parameterisation
 const userName = getUserInput();
 const query = surql`SELECT * FROM users WHERE name = ${userName}`;
 
@@ -355,7 +355,7 @@ query.append(surql` ORDER BY created_at DESC LIMIT ${limit}`);
 ### 1. Identifier interpolation
 
 ```ts
-// Problem: Table names can't be parameterized
+// Problem: Table names can't be parameterised
 const tableName = 'users';
 const wrong = surql`SELECT * FROM ${tableName}`; // Creates $bind__1
 
@@ -379,7 +379,7 @@ const correct = surql`SELECT * FROM users WHERE ${raw(validated)} > 18`;
 
 ## See also
 
-- [BoundQuery](/docs/languages/javascript/api/utilities/bound-query) - Parameterized query class
+- [BoundQuery](/docs/languages/javascript/api/utilities/bound-query) - Parameterised query class
 - [expr](/docs/languages/javascript/api/utilities/expr) - Expression builder
 - [Query](/docs/languages/javascript/api/queries/query) - Executing queries
 - [SurrealQueryable.query()](/docs/languages/javascript/api/core/surreal-queryable#query) - Query method

--- a/src/content/index/languages/javascript/api/values/__category.json
+++ b/src/content/index/languages/javascript/api/values/__category.json
@@ -1,4 +1,4 @@
 {
-    "title": "Data Types",
+    "title": "Data types",
     "position": 3
 }

--- a/src/content/index/languages/javascript/api/values/datetime.mdx
+++ b/src/content/index/languages/javascript/api/values/datetime.mdx
@@ -71,7 +71,7 @@ const precise = new DateTime([1705320000n, 500000000n]);
 const clone = new DateTime(now);
 ```
 
-## Static Methods
+## Static methods
 
 ### `DateTime.now()` {#now}
 
@@ -270,7 +270,7 @@ const dt = DateTime.fromEpochSeconds(1705320000);
 console.log(dt.toString()); // '2024-01-15T12:00:00.000000000Z'
 ```
 
-## Instance Methods
+## Instance methods
 
 ### `.toDate()` {#todate}
 
@@ -620,9 +620,9 @@ const dt = new DateTime('2024-01-15T12:00:00.123456789Z');
 console.log(dt.seconds); // 1705320000
 ```
 
-## Complete Examples
+## Complete examples
 
-### Event Timestamps
+### Event timestamps
 
 ```ts
 import { Surreal, DateTime, Table } from 'surrealdb';
@@ -641,7 +641,7 @@ const event = await db.create(new Table('events')).content({
 console.log('Event created at:', event.timestamp.toString());
 ```
 
-### Date Arithmetic
+### Date arithmetic
 
 ```ts
 import { DateTime, Duration } from 'surrealdb';
@@ -657,7 +657,7 @@ const past = now.sub(Duration.parse('30d')); // 30 days ago
 const recentCutoff = now.sub(Duration.parse('1h')); // Last hour
 ```
 
-### Query with Date Ranges
+### Query with date ranges
 
 ```ts
 const startDate = new DateTime('2024-01-01T00:00:00Z');
@@ -672,7 +672,7 @@ const events = await db.query(`
 }).collect();
 ```
 
-### Time-series Data
+### Time-series data
 
 ```ts
 // Record metrics with precise timestamps
@@ -697,7 +697,7 @@ const recent = await db.query(`
 }).collect();
 ```
 
-### Conversion Examples
+### Conversion examples
 
 ```ts
 // From JavaScript Date
@@ -725,7 +725,7 @@ const fromMs = DateTime.fromEpochMilliseconds(1705320000123);
 const fromSecs = DateTime.fromEpochSeconds(1705320000);
 ```
 
-### Scheduled Tasks
+### Scheduled tasks
 
 ```ts
 // Schedule future task
@@ -746,7 +746,7 @@ const overdue = await db.query(`
 `, { now }).collect();
 ```
 
-### Expiration Handling
+### Expiration handling
 
 ```ts
 // Set expiration time
@@ -766,7 +766,7 @@ if (isExpired(session.expires_at)) {
 }
 ```
 
-### Timezone Handling
+### Timezone handling
 
 ```ts
 // DateTime is always stored in UTC
@@ -780,9 +780,9 @@ console.log('UTC:', utcTime.toString());
 console.log('Local:', localString);
 ```
 
-## Best Practices
+## Best practices
 
-### 1. Use DateTime for Database Timestamps
+### 1. Use DateTime for database timestamps
 
 ```ts
 // Good: Nanosecond precision preserved
@@ -798,7 +798,7 @@ await db.create(new Table('logs')).content({
 });
 ```
 
-### 2. Be Aware of Precision Loss
+### 2. Be aware of precision loss
 
 ```ts
 // Good: Keep as DateTime for precision
@@ -809,7 +809,7 @@ const stored = dt.toString(); // Preserves nanoseconds
 const jsDate = dt.toDate(); // Only milliseconds
 ```
 
-### 3. Use Duration for Time Arithmetic
+### 3. Use Duration for time arithmetic
 
 ```ts
 // Good: Type-safe duration arithmetic
@@ -819,7 +819,7 @@ const future = now.add(Duration.parse('1h'));
 const future2 = DateTime.fromEpochMilliseconds(now.milliseconds + 3600000);
 ```
 
-### 4. Store as DateTime, Display as Localized
+### 4. Store as DateTime, display as localized
 
 ```ts
 // Store in UTC using DateTime
@@ -832,9 +832,9 @@ const localDisplay = timestamp.toDate().toLocaleString('en-US', {
 });
 ```
 
-## See Also
+## See also
 
 - [Duration](/docs/languages/javascript/api/values/duration) - Time duration values
 - [Data types overview](/docs/languages/javascript/api/values/) - All custom data types
-- [Query Builders](/docs/languages/javascript/api/queries/) - Using DateTime in queries
-- [SurrealQL Datetime](/docs/reference/query-language/language-primitives/data-types/datetimes) - Database datetime type
+- [Query builders](/docs/languages/javascript/api/queries/) - Using DateTime in queries
+- [SurrealQL datetimes](/docs/reference/query-language/language-primitives/data-types/datetimes) - Database datetime type

--- a/src/content/index/languages/javascript/api/values/datetime.mdx
+++ b/src/content/index/languages/javascript/api/values/datetime.mdx
@@ -835,6 +835,6 @@ const localDisplay = timestamp.toDate().toLocaleString('en-US', {
 ## See Also
 
 - [Duration](/docs/languages/javascript/api/values/duration) - Time duration values
-- [Data Types Overview](/docs/languages/javascript/api/values/) - All custom data types
+- [Data types overview](/docs/languages/javascript/api/values/) - All custom data types
 - [Query Builders](/docs/languages/javascript/api/queries/) - Using DateTime in queries
 - [SurrealQL Datetime](/docs/reference/query-language/language-primitives/data-types/datetimes) - Database datetime type

--- a/src/content/index/languages/javascript/api/values/decimal.mdx
+++ b/src/content/index/languages/javascript/api/values/decimal.mdx
@@ -16,7 +16,7 @@ import { Decimal } from 'surrealdb';
 
 **Source:** [value/decimal.ts](https://github.com/surrealdb/surrealdb.js/blob/main/packages/sdk/src/value/decimal.ts)
 
-## Why Use Decimal?
+## Why use Decimal?
 
 JavaScript's `number` type uses floating-point arithmetic, which can lead to precision errors:
 
@@ -81,7 +81,7 @@ const scientific = new Decimal('1.23e-10');
 const copy = new Decimal(price);
 ```
 
-## Static Methods
+## Static methods
 
 ### `Decimal.fromScientificNotation(input)` {#fromscientificnotation}
 
@@ -152,7 +152,7 @@ const d = new Decimal('19.99');
 console.log(d.scale); // 2
 ```
 
-## Instance Methods
+## Instance methods
 
 ### `.toString()` {#tostring}
 
@@ -673,9 +673,9 @@ const pos = new Decimal('5');
 console.log(pos.isNegative()); // false
 ```
 
-## Complete Examples
+## Complete examples
 
-### Financial Calculations
+### Financial calculations
 
 ```ts
 import { Surreal, Decimal, Table } from 'surrealdb';
@@ -701,7 +701,7 @@ console.log('Tax:', tax.toString());         // 1.49925
 console.log('Total:', total.toString());     // 21.48925
 ```
 
-### Order Total Calculation
+### Order total calculation
 
 ```ts
 interface OrderItem {
@@ -731,7 +731,7 @@ const orderTotal = calculateOrderTotal(items);
 console.log('Order total:', orderTotal.toString()); // '99.94'
 ```
 
-### Currency Exchange
+### Currency exchange
 
 ```ts
 // Exchange rate calculation
@@ -742,7 +742,7 @@ const eurAmount = usdAmount.mul(exchangeRate);
 console.log(`$${usdAmount} = €${eurAmount}`);
 ```
 
-### Interest Calculation
+### Interest calculation
 
 ```ts
 // Calculate compound interest
@@ -769,7 +769,7 @@ const finalAmount = calculateCompoundInterest(principal, annualRate, years);
 console.log('Final amount:', finalAmount.toString());
 ```
 
-### Database Storage
+### Database storage
 
 ```ts
 // Store precise financial data
@@ -792,7 +792,7 @@ for (const txn of transactions) {
 console.log('Total:', totalAmount.toString());
 ```
 
-### Percentage Calculations
+### Percentage calculations
 
 ```ts
 // Calculate percentage
@@ -810,7 +810,7 @@ console.log('Discount:', discountAmount.toString()); // '15.00'
 console.log('Final price:', finalPrice.toString()); // '85.00'
 ```
 
-### Scientific Calculations
+### Scientific calculations
 
 ```ts
 // High precision scientific value
@@ -821,9 +821,9 @@ console.log('Avogadro:', avogadroNumber.toString());
 console.log('Boltzmann:', boltzmannConstant.toString());
 ```
 
-## Best Practices
+## Best practices
 
-### 1. Use Strings for Input
+### 1. Use strings for input
 
 ```ts
 // Good: String input preserves precision
@@ -833,7 +833,7 @@ const price = new Decimal('19.99');
 const price = new Decimal(19.99); // Already has float imprecision
 ```
 
-### 2. Keep as Decimal for Calculations
+### 2. Keep as Decimal for calculations
 
 ```ts
 // Good: All calculations use Decimal
@@ -845,7 +845,7 @@ const total = subtotal.add(tax);
 const subtotal = price.toFloat() * quantity; // Loses precision
 ```
 
-### 3. Convert to String for Display
+### 3. Convert to string for display
 
 ```ts
 // Good: String preserves precision
@@ -856,7 +856,7 @@ console.log(`$${display}`);
 const display = price.toFloat().toFixed(2);
 ```
 
-### 4. Store Decimals in Database
+### 4. Store decimals in database
 
 ```ts
 // Good: Store as Decimal
@@ -870,9 +870,9 @@ await db.create(table).content({
 });
 ```
 
-## Common Pitfalls
+## Common pitfalls
 
-### Floating-Point Input
+### Floating-point input
 
 ```ts
 // Problem: Number already has floating-point error
@@ -882,7 +882,7 @@ const wrong = new Decimal(0.1 + 0.2); // 0.30000000000000004
 const correct = new Decimal('0.1').add(new Decimal('0.2')); // 0.3
 ```
 
-### Premature Conversion to Number
+### Premature conversion to number
 
 ```ts
 // Problem: Loses precision
@@ -892,8 +892,8 @@ const result = price.toFloat() + tax.toFloat();
 const result = price.add(tax);
 ```
 
-## See Also
+## See also
 
 - [Data types overview](/docs/languages/javascript/api/values/) - All custom data types
-- [Query Builders](/docs/languages/javascript/api/queries/) - Using Decimal in queries
-- [SurrealQL Decimal](/docs/reference/query-language/language-primitives/data-types/numbers) - Database decimal type
+- [Query builders](/docs/languages/javascript/api/queries/) - Using Decimal in queries
+- [SurrealQL decimal](/docs/reference/query-language/language-primitives/data-types/numbers) - Database decimal type

--- a/src/content/index/languages/javascript/api/values/decimal.mdx
+++ b/src/content/index/languages/javascript/api/values/decimal.mdx
@@ -894,6 +894,6 @@ const result = price.add(tax);
 
 ## See Also
 
-- [Data Types Overview](/docs/languages/javascript/api/values/) - All custom data types
+- [Data types overview](/docs/languages/javascript/api/values/) - All custom data types
 - [Query Builders](/docs/languages/javascript/api/queries/) - Using Decimal in queries
 - [SurrealQL Decimal](/docs/reference/query-language/language-primitives/data-types/numbers) - Database decimal type

--- a/src/content/index/languages/javascript/api/values/duration.mdx
+++ b/src/content/index/languages/javascript/api/values/duration.mdx
@@ -62,7 +62,7 @@ const duration = new Duration([300n, 0n]); // 5 minutes
 const clone = new Duration(fiveMinutes);
 ```
 
-## Supported Units
+## Supported units
 
 <table>
     <thead>
@@ -121,7 +121,7 @@ const clone = new Duration(fiveMinutes);
     </tbody>
 </table>
 
-## Static Methods
+## Static methods
 
 ### `Duration.nanoseconds(ns)` {#nanoseconds-static}
 
@@ -523,7 +523,7 @@ const duration = elapsed();
 console.log('Operation took:', duration.toString());
 ```
 
-## Property Getters
+## Property getters
 
 Property getters for accessing the total duration in specific units. All return `bigint`.
 
@@ -596,7 +596,7 @@ console.log(duration.milliseconds); // 9000000n
 console.log(duration.nanoseconds);  // 9000000000000n
 ```
 
-## Instance Methods
+## Instance methods
 
 ### `.toString()` {#tostring}
 
@@ -867,9 +867,9 @@ duration.equals(other)
 #### Returns
 `boolean` - True if equal
 
-## Complete Examples
+## Complete examples
 
-### Timeouts and Expiration
+### Timeouts and expiration
 
 ```ts
 import { Surreal, Duration, DateTime, Table } from 'surrealdb';
@@ -885,7 +885,7 @@ const session = await db.create(new Table('sessions')).content({
 });
 ```
 
-### Query Timeouts
+### Query timeouts
 
 ```ts
 // Set timeout on queries
@@ -898,7 +898,7 @@ const result = await db.query(`
 `).timeout(new Duration('30s')).collect();
 ```
 
-### Rate Limiting
+### Rate limiting
 
 ```ts
 // Define rate limit window
@@ -916,7 +916,7 @@ await db.create(new Table('rate_limits')).content({
 });
 ```
 
-### Scheduled Tasks
+### Scheduled tasks
 
 ```ts
 // Schedule task with delay
@@ -945,7 +945,7 @@ function isCacheValid(entry: typeof cacheEntry): boolean {
 }
 ```
 
-### Performance Measurement
+### Performance measurement
 
 ```ts
 // Measure operation duration
@@ -957,7 +957,7 @@ const duration = elapsed();
 console.log('Operation took:', duration.toString());
 ```
 
-### Conversion Examples
+### Conversion examples
 
 ```ts
 // Parse from string
@@ -977,7 +977,7 @@ const doubled = duration.add(duration);
 console.log(doubled.toString()); // '5h'
 ```
 
-### Complex Durations
+### Complex durations
 
 ```ts
 // Very precise timing
@@ -991,7 +991,7 @@ const extended = complex.add(new Duration('12h'));
 console.log(extended.toString()); // '1d14h30m15s'
 ```
 
-### Static Factory Methods
+### Static factory methods
 
 ```ts
 // Create durations from numeric values
@@ -1005,9 +1005,9 @@ const maxRetries = 3;
 const backoff = Duration.seconds(2).mul(maxRetries);
 ```
 
-## Best Practices
+## Best practices
 
-### 1. Use Human-Readable Formats
+### 1. Use human-readable formats
 
 ```ts
 // Good: Clear intent
@@ -1018,7 +1018,7 @@ const cacheTTL = new Duration('1h');
 const timeout = new Duration([30n, 0n]);
 ```
 
-### 2. Use Duration for Time Arithmetic
+### 2. Use Duration for time arithmetic
 
 ```ts
 // Good: Type-safe duration arithmetic
@@ -1029,7 +1029,7 @@ const extended = base.add(new Duration('30m'));
 const delay = Duration.seconds(retryCount * 2);
 ```
 
-### 3. Store Durations in Database
+### 3. Store durations in database
 
 ```ts
 // Good: Store as Duration for type safety
@@ -1043,7 +1043,7 @@ await db.create(table).content({
 });
 ```
 
-### 4. Use Appropriate Units
+### 4. Use appropriate units
 
 ```ts
 // Good: Use largest appropriate unit
@@ -1055,7 +1055,7 @@ const oneDay = new Duration('24h');
 const oneWeek = new Duration('168h');
 ```
 
-### 5. Use Duration.measure() for Timing
+### 5. Use duration.measure() for timing
 
 ```ts
 // Good: Built-in measurement
@@ -1064,9 +1064,9 @@ await performOperation();
 console.log('Took:', elapsed().toString());
 ```
 
-## See Also
+## See also
 
 - [DateTime](/docs/languages/javascript/api/values/datetime) - Datetime values
 - [Data types overview](/docs/languages/javascript/api/values/) - All custom data types
-- [Query Builders](/docs/languages/javascript/api/queries/) - Using Duration in queries
-- [SurrealQL Duration](/docs/reference/query-language/language-primitives/data-types/durations) - Database duration type
+- [Query builders](/docs/languages/javascript/api/queries/) - Using Duration in queries
+- [SurrealQL durations](/docs/reference/query-language/language-primitives/data-types/durations) - Database duration type

--- a/src/content/index/languages/javascript/api/values/duration.mdx
+++ b/src/content/index/languages/javascript/api/values/duration.mdx
@@ -1067,6 +1067,6 @@ console.log('Took:', elapsed().toString());
 ## See Also
 
 - [DateTime](/docs/languages/javascript/api/values/datetime) - Datetime values
-- [Data Types Overview](/docs/languages/javascript/api/values/) - All custom data types
+- [Data types overview](/docs/languages/javascript/api/values/) - All custom data types
 - [Query Builders](/docs/languages/javascript/api/queries/) - Using Duration in queries
 - [SurrealQL Duration](/docs/reference/query-language/language-primitives/data-types/durations) - Database duration type

--- a/src/content/index/languages/javascript/api/values/file-ref.mdx
+++ b/src/content/index/languages/javascript/api/values/file-ref.mdx
@@ -80,7 +80,7 @@ The unique key identifying the file within its bucket.
 console.log(fileRef.key); // "profile-photo.png"
 ```
 
-## Instance Methods
+## Instance methods
 
 ### `.toString()` {#tostring}
 
@@ -172,7 +172,7 @@ for (const record of records) {
 }
 ```
 
-## See Also
+## See also
 
 - [Value types](/docs/languages/javascript/concepts/value-types) - Overview of all value types
 - [File uploads](/docs/reference/query-language/language-primitives/data-types/files) - Working with files in SurrealDB

--- a/src/content/index/languages/javascript/api/values/file-ref.mdx
+++ b/src/content/index/languages/javascript/api/values/file-ref.mdx
@@ -176,4 +176,4 @@ for (const record of records) {
 
 - [Value types](/docs/languages/javascript/concepts/value-types) - Overview of all value types
 - [File uploads](/docs/reference/query-language/language-primitives/data-types/files) - Working with files in SurrealDB
-- [Data Types](/docs/languages/javascript/api/values/) - All custom data types
+- [Data types](/docs/languages/javascript/api/values/) - All custom data types

--- a/src/content/index/languages/javascript/api/values/geometry.mdx
+++ b/src/content/index/languages/javascript/api/values/geometry.mdx
@@ -24,7 +24,7 @@ import {
 
 **Source:** [value/geometry.ts](https://github.com/surrealdb/surrealdb.js/blob/main/packages/sdk/src/value/geometry.ts)
 
-## Geometry Types
+## Geometry types
 
 ### `GeometryPoint` {#geometrypoint}
 
@@ -369,7 +369,7 @@ console.log(collection.collection);  // [GeometryPoint, GeometryLine, GeometryPo
 console.log(collection.geometries);  // [GeometryPoint, GeometryLine, GeometryPolygon]
 ```
 
-## Common Methods
+## Common methods
 
 All geometry types share these methods:
 
@@ -436,9 +436,9 @@ const b = new GeometryPoint([0, 0]);
 console.log(a.equals(b)); // true
 ```
 
-## Complete Examples
+## Complete examples
 
-### Store Locations
+### Store locations
 
 ```ts
 import { Surreal, GeometryPoint, Table } from 'surrealdb';
@@ -465,7 +465,7 @@ for (const location of locations) {
 }
 ```
 
-### Delivery Routes
+### Delivery routes
 
 ```ts
 // Define delivery route
@@ -484,7 +484,7 @@ await db.create(new Table('routes')).content({
 });
 ```
 
-### Service Areas
+### Service areas
 
 ```ts
 // Define service coverage area (polygon)
@@ -505,7 +505,7 @@ await db.create(new Table('service_areas')).content({
 });
 ```
 
-### Geospatial Queries
+### Geospatial queries
 
 ```ts
 // Find locations near a point
@@ -522,7 +522,7 @@ const nearbyLocations = await db.query(`
 console.log('Nearby locations:', nearbyLocations);
 ```
 
-### Polygon Containment
+### Polygon containment
 
 ```ts
 // Check if a point is within a polygon
@@ -548,7 +548,7 @@ const result = await db.query(`
 console.log('Point is inside:', result[0]);
 ```
 
-### Multiple Locations (MultiPoint)
+### Multiple locations (MultiPoint)
 
 ```ts
 // Store multiple branch locations
@@ -567,7 +567,7 @@ await db.create(new Table('companies')).content({
 });
 ```
 
-### Distance Calculations
+### Distance calculations
 
 ```ts
 // Calculate distance between two points
@@ -584,7 +584,7 @@ const distance = await db.query(`
 console.log('Distance in meters:', distance[0]);
 ```
 
-### GeoJSON Export
+### GeoJSON export
 
 ```ts
 // Export as GeoJSON for mapping libraries
@@ -600,7 +600,7 @@ const geoJson = point.toJSON();
 */
 ```
 
-### Complex Region with Holes
+### Complex region with holes
 
 ```ts
 // Define a park with a lake (hole)
@@ -630,7 +630,7 @@ await db.create(new Table('parks')).content({
 });
 ```
 
-## GeoJSON Compatibility
+## GeoJSON compatibility
 
 All geometry types are compatible with GeoJSON format:
 
@@ -650,9 +650,9 @@ console.log(geoJson);
 // Use with any GeoJSON-compatible library
 ```
 
-## Best Practices
+## Best practices
 
-### 1. Use Correct Coordinate Order
+### 1. Use correct coordinate order
 
 ```ts
 // Good: [longitude, latitude] (GeoJSON standard)
@@ -662,7 +662,7 @@ const point = new GeometryPoint([-122.4194, 37.7749]);
 const wrong = new GeometryPoint([37.7749, -122.4194]);
 ```
 
-### 2. Close Polygons Properly
+### 2. Close polygons properly
 
 ```ts
 // Good: First and last points are the same
@@ -679,7 +679,7 @@ const polygon = new GeometryPolygon([
 // The library automatically closes polygons if needed
 ```
 
-### 3. Use Appropriate Geometry Type
+### 3. Use appropriate Geometry type
 
 ```ts
 // Good: Single location
@@ -692,7 +692,7 @@ const branches = new GeometryMultiPoint([point1, point2, point3]);
 const wrong = new GeometryMultiPoint([point1]);
 ```
 
-### 4. Validate Coordinates
+### 4. Validate coordinates
 
 ```ts
 // Good: Valid coordinates
@@ -703,7 +703,7 @@ const valid = new GeometryPoint([-122.4194, 37.7749]);
 const invalid = new GeometryPoint([200, 100]); // Will create but may cause issues
 ```
 
-## Use Cases
+## Use cases
 
 - **Location-based Services** - Store and query business locations
 - **Delivery Systems** - Define delivery routes and service areas
@@ -712,9 +712,9 @@ const invalid = new GeometryPoint([200, 100]); // Will create but may cause issu
 - **Environmental** - Conservation areas, wildlife habitats
 - **Urban Planning** - City zones, districts, infrastructure
 
-## See Also
+## See also
 
 - [Data types overview](/docs/languages/javascript/api/values/) - All custom data types
-- [Query Builders](/docs/languages/javascript/api/queries/) - Using Geometry in queries
-- [SurrealQL Geometry](/docs/reference/query-language/language-primitives/data-types/geometries) - Database geometry types
+- [Query builders](/docs/languages/javascript/api/queries/) - Using Geometry in queries
+- [SurrealQL geometry](/docs/reference/query-language/language-primitives/data-types/geometries) - Database geometry types
 - [GeoJSON Specification](https://geojson.org/) - GeoJSON format standard

--- a/src/content/index/languages/javascript/api/values/geometry.mdx
+++ b/src/content/index/languages/javascript/api/values/geometry.mdx
@@ -714,7 +714,7 @@ const invalid = new GeometryPoint([200, 100]); // Will create but may cause issu
 
 ## See Also
 
-- [Data Types Overview](/docs/languages/javascript/api/values/) - All custom data types
+- [Data types overview](/docs/languages/javascript/api/values/) - All custom data types
 - [Query Builders](/docs/languages/javascript/api/queries/) - Using Geometry in queries
 - [SurrealQL Geometry](/docs/reference/query-language/language-primitives/data-types/geometries) - Database geometry types
 - [GeoJSON Specification](https://geojson.org/) - GeoJSON format standard

--- a/src/content/index/languages/javascript/api/values/index.mdx
+++ b/src/content/index/languages/javascript/api/values/index.mdx
@@ -41,7 +41,7 @@ The JavaScript SDK provides custom classes for SurrealDB-specific data types, en
   - `.bucket` - Storage bucket name
   - `.key` - File key within the bucket
 
-## Geometric Types
+## Geometric types
 
 - [**Geometry**](/docs/languages/javascript/api/values/geometry) - Spatial/geometric data types
   - `GeometryPoint` - Single point
@@ -50,7 +50,7 @@ The JavaScript SDK provides custom classes for SurrealDB-specific data types, en
   - `GeometryMultiPoint`, `GeometryMultiLine`, `GeometryMultiPolygon`
   - `GeometryCollection` - Mixed geometry collection
 
-## See Also
+## See also
 
 - [Value types concept page](/docs/languages/javascript/concepts/value-types) - Usage guide with type mapping, examples, and best practices
 - [SurrealQL data types](/docs/reference/query-language/language-primitives/data-types) - Database data model

--- a/src/content/index/languages/javascript/api/values/index.mdx
+++ b/src/content/index/languages/javascript/api/values/index.mdx
@@ -4,11 +4,11 @@ title: Data types
 description: Type mapping between SurrealQL and JavaScript, and custom data type classes.
 ---
 
-# Data Types
+# Data types
 
 The JavaScript SDK provides custom classes for SurrealDB-specific data types, ensuring type safety and data integrity when working with the database. For a conceptual overview with usage examples and best practices, see the [Value types concept page](/docs/languages/javascript/concepts/value-types).
 
-## Custom Data Type Classes
+## Custom data type classes
 
 - [**RecordId**](/docs/languages/javascript/api/values/record-id) - Type-safe record identifiers with table and ID components
   - `new RecordId(table, id)` - Create record ID
@@ -53,5 +53,5 @@ The JavaScript SDK provides custom classes for SurrealDB-specific data types, en
 ## See Also
 
 - [Value types concept page](/docs/languages/javascript/concepts/value-types) - Usage guide with type mapping, examples, and best practices
-- [SurrealQL Data Types](/docs/reference/query-language/language-primitives/data-types) - Database data model
+- [SurrealQL data types](/docs/reference/query-language/language-primitives/data-types) - Database data model
 - [Utilities](/docs/languages/javascript/concepts/utilities) - Comparing and converting values

--- a/src/content/index/languages/javascript/api/values/range.mdx
+++ b/src/content/index/languages/javascript/api/values/range.mdx
@@ -16,12 +16,12 @@ import { Range, BoundIncluded, BoundExcluded } from 'surrealdb';
 
 **Source:** [value/range.ts](https://github.com/surrealdb/surrealdb.js/blob/main/packages/sdk/src/value/range.ts)
 
-## Type Parameters
+## Type parameters
 
 - `Beg` - The type of the beginning bound
 - `End` - The type of the ending bound
 
-## Bound Types
+## Bound types
 
 Bounds are represented using `BoundIncluded` and `BoundExcluded` classes:
 
@@ -122,7 +122,7 @@ console.log(range.end.value); // 10
 console.log(range.end instanceof BoundIncluded); // true
 ```
 
-## Instance Methods
+## Instance methods
 
 ### `.toString()` {#tostring}
 
@@ -186,9 +186,9 @@ range.equals(other)
 #### Returns
 `boolean` - True if equal
 
-## Complete Examples
+## Complete examples
 
-### Numeric Ranges
+### Numeric ranges
 
 ```ts
 import { Surreal, Range, BoundIncluded } from 'surrealdb';
@@ -211,7 +211,7 @@ const adults = await db.query(`
 }).collect();
 ```
 
-### Date Ranges
+### Date ranges
 
 ```ts
 import { DateTime, Range, BoundIncluded } from 'surrealdb';
@@ -231,7 +231,7 @@ const events = await db.query(`
 }).collect();
 ```
 
-### Price Ranges
+### Price ranges
 
 ```ts
 import { Decimal, Range, BoundIncluded } from 'surrealdb';
@@ -250,7 +250,7 @@ const products = await db.query(`
 }).collect();
 ```
 
-### Score Ranges
+### Score ranges
 
 ```ts
 import { Range, BoundIncluded } from 'surrealdb';
@@ -281,7 +281,7 @@ const students = await db.query(`
 }).collect();
 ```
 
-### Time-based Filtering
+### Time-based filtering
 
 ```ts
 import { DateTime, Duration, Range, BoundIncluded } from 'surrealdb';
@@ -304,7 +304,7 @@ const recentActivity = await db.query(`
 }).collect();
 ```
 
-### Pagination with ID Ranges
+### Pagination with ID ranges
 
 ```ts
 import { RecordId, Range, BoundIncluded, BoundExcluded } from 'surrealdb';
@@ -323,7 +323,7 @@ const users = await db.query(`
 }).collect();
 ```
 
-### Exclusive Ranges
+### Exclusive ranges
 
 ```ts
 import { Range, BoundExcluded } from 'surrealdb';
@@ -343,7 +343,7 @@ const results = await db.query(`
 }).collect();
 ```
 
-### Half-Open Ranges
+### Half-open ranges
 
 ```ts
 import { Range, BoundIncluded, BoundExcluded } from 'surrealdb';
@@ -364,7 +364,7 @@ const items = await db.query(`
 }).collect();
 ```
 
-### Multiple Ranges
+### Multiple ranges
 
 ```ts
 import { Range, BoundIncluded } from 'surrealdb';
@@ -394,7 +394,7 @@ const criticalIssues = await db.query(`
 }).collect();
 ```
 
-### Range Queries in Application
+### Range queries in application
 
 ```ts
 import { Range, BoundIncluded, BoundExcluded, DateTime } from 'surrealdb';
@@ -424,7 +424,7 @@ const orders = await db.query(`
 }).collect();
 ```
 
-## Range Notation
+## Range notation
 
 SurrealDB uses specific notation for ranges:
 
@@ -435,9 +435,9 @@ SurrealDB uses specific notation for ranges:
 | `a>..b` | Exclusive start, exclusive end `(a, b)` | `1>..10` |
 | `a>..=b` | Exclusive start, inclusive end `(a, b]` | `1>..=10` |
 
-## Best Practices
+## Best practices
 
-### 1. Use Appropriate Inclusivity
+### 1. Use appropriate inclusivity
 
 ```ts
 // Good: Inclusive for dates (including full days)
@@ -453,7 +453,7 @@ const arrayRange = new Range(
 ); // [0, 10)
 ```
 
-### 2. Type Safety
+### 2. Type safety
 
 ```ts
 // Good: Explicit types
@@ -469,7 +469,7 @@ const dateRange: Range<DateTime, DateTime> = new Range(
 );
 ```
 
-### 3. Validate Bounds
+### 3. Validate bounds
 
 ```ts
 // Good: Ensure start <= end
@@ -486,7 +486,7 @@ function createRange<T>(start: T, end: T): Range<T, T> | null {
 }
 ```
 
-## Use Cases
+## Use cases
 
 - **Filtering** - Filter records by numeric, date, or other ordered values
 - **Pagination** - Query records in ID ranges
@@ -495,7 +495,7 @@ function createRange<T>(start: T, end: T): Range<T, T> | null {
 - **Score Categorization** - Categorize by score ranges (grades, ratings)
 - **Geographic Bounds** - Coordinate ranges for maps
 
-## See Also
+## See also
 
 - [RecordIdRange](/docs/languages/javascript/api/values/record-id#recordidrange) - Range of record IDs
 - [DateTime](/docs/languages/javascript/api/values/datetime) - Datetime values for date ranges

--- a/src/content/index/languages/javascript/api/values/range.mdx
+++ b/src/content/index/languages/javascript/api/values/range.mdx
@@ -500,5 +500,5 @@ function createRange<T>(start: T, end: T): Range<T, T> | null {
 - [RecordIdRange](/docs/languages/javascript/api/values/record-id#recordidrange) - Range of record IDs
 - [DateTime](/docs/languages/javascript/api/values/datetime) - Datetime values for date ranges
 - [Decimal](/docs/languages/javascript/api/values/decimal) - Precise numbers for price ranges
-- [Data Types Overview](/docs/languages/javascript/api/values/) - All custom data types
+- [Data types overview](/docs/languages/javascript/api/values/) - All custom data types
 - [SurrealQL Ranges](/docs/reference/query-language/language-primitives/data-types/ranges) - Database range syntax

--- a/src/content/index/languages/javascript/api/values/record-id.mdx
+++ b/src/content/index/languages/javascript/api/values/record-id.mdx
@@ -463,7 +463,7 @@ try {
 
 ## See Also
 
-- [Data Types Overview](/docs/languages/javascript/api/values/) - All custom data types
+- [Data types overview](/docs/languages/javascript/api/values/) - All custom data types
 - [Table](/docs/languages/javascript/api/values/table) - Table references
 - [Query Builders](/docs/languages/javascript/api/queries/) - Using RecordId in queries
 - [SurrealQL Record IDs](/docs/reference/query-language/language-primitives/data-types/record-ids) - Database record ID documentation

--- a/src/content/index/languages/javascript/api/values/record-id.mdx
+++ b/src/content/index/languages/javascript/api/values/record-id.mdx
@@ -16,7 +16,7 @@ import { RecordId } from 'surrealdb';
 
 **Source:** [value/record-id.ts](https://github.com/surrealdb/surrealdb.js/blob/main/packages/sdk/src/value/record-id.ts)
 
-## Type Parameters
+## Type parameters
 
 - `Tb extends string` - The table name (string literal type for type safety)
 - `Id` - The ID value type (string, number, object, etc.)
@@ -110,7 +110,7 @@ const productId = new RecordId('products', 42);
 console.log(productId.id); // 42
 ```
 
-## Instance Methods
+## Instance methods
 
 ### `.toString()` {#tostring}
 
@@ -194,9 +194,9 @@ console.log(a.equals(b)); // true
 console.log(a.equals(c)); // false
 ```
 
-## Complete Examples
+## Complete examples
 
-### Basic Usage
+### Basic usage
 
 ```ts
 import { Surreal, RecordId } from 'surrealdb';
@@ -222,7 +222,7 @@ await db.update(new RecordId('users', 'john'))
 await db.delete(new RecordId('users', 'john'));
 ```
 
-### Type-Safe Record IDs
+### Type-safe record IDs
 
 ```ts
 interface User {
@@ -240,7 +240,7 @@ const userId: RecordId<'users', string> = new RecordId('users', 'alice');
 const user = await db.select<User>(userId);
 ```
 
-### Complex ID Structures
+### Complex ID structures
 
 ```ts
 // Time-series data with structured IDs
@@ -262,7 +262,7 @@ const sessionId = new RecordId('sessions', {
 });
 ```
 
-### Parsing from Strings
+### Parsing from strings
 
 Use `StringRecordId` to pass a record ID string directly without parsing it into table and ID components. The string is sent as-is to SurrealDB.
 
@@ -279,7 +279,7 @@ const recordId = new StringRecordId('users:alice');
 const result = await db.select(recordId);
 ```
 
-### Working with Relations
+### Working with relations
 
 ```ts
 // Create relationship using record IDs
@@ -297,7 +297,7 @@ console.log('Edge from:', edge.in);  // RecordId('users', 'john')
 console.log('Edge to:', edge.out);   // RecordId('posts', '123')
 ```
 
-### UUID-based Record IDs
+### UUID-based record IDs
 
 ```ts
 import { Uuid } from 'surrealdb';
@@ -411,9 +411,9 @@ await db.delete(new RecordIdRange(
 ));
 ```
 
-## Best Practices
+## Best practices
 
-### 1. Use Type Parameters
+### 1. Use type parameters
 
 ```ts
 // Good: Type-safe
@@ -426,7 +426,7 @@ function getUser(id: RecordId<'users', string>) {
 }
 ```
 
-### 2. Prefer RecordId Over Strings
+### 2. Prefer RecordId over strings
 
 ```ts
 // Good: Type-safe with validation
@@ -436,7 +436,7 @@ const user = await db.select(new RecordId('users', 'john'));
 const user = await db.query('SELECT * FROM users:john').collect();
 ```
 
-### 3. Use Structured IDs for Complex Keys
+### 3. Use structured IDs for complex keys
 
 ```ts
 // Good: Structured composite key
@@ -449,7 +449,7 @@ const id = new RecordId('events', {
 const id = new RecordId('events', `john-${Date.now()}`);
 ```
 
-### 4. Handle Construction Errors
+### 4. Handle construction errors
 
 ```ts
 // Good: Safe construction
@@ -461,9 +461,9 @@ try {
 }
 ```
 
-## See Also
+## See also
 
 - [Data types overview](/docs/languages/javascript/api/values/) - All custom data types
 - [Table](/docs/languages/javascript/api/values/table) - Table references
-- [Query Builders](/docs/languages/javascript/api/queries/) - Using RecordId in queries
-- [SurrealQL Record IDs](/docs/reference/query-language/language-primitives/data-types/record-ids) - Database record ID documentation
+- [Query builders](/docs/languages/javascript/api/queries/) - Using RecordId in queries
+- [SurrealQL record IDs](/docs/reference/query-language/language-primitives/data-types/record-ids) - Database record ID documentation

--- a/src/content/index/languages/javascript/api/values/table.mdx
+++ b/src/content/index/languages/javascript/api/values/table.mdx
@@ -521,5 +521,5 @@ const posts = createTable<Post>('posts');
 
 - [RecordId](/docs/languages/javascript/api/values/record-id) - Record identifiers
 - [Data types overview](/docs/languages/javascript/api/values/) - All custom data types
-- [Query Builders](/docs/languages/javascript/api/queries/) - Using Table in queries
-- [SurrealQL Tables](/docs/reference/query-language/statements/define/table) - Database table definitions
+- [Query builders](/docs/languages/javascript/api/queries/) - Using Table in queries
+- [SurrealQL tables](/docs/reference/query-language/statements/define/table) - Database table definitions

--- a/src/content/index/languages/javascript/api/values/table.mdx
+++ b/src/content/index/languages/javascript/api/values/table.mdx
@@ -520,6 +520,6 @@ const posts = createTable<Post>('posts');
 ## See also
 
 - [RecordId](/docs/languages/javascript/api/values/record-id) - Record identifiers
-- [Data Types Overview](/docs/languages/javascript/api/values/) - All custom data types
+- [Data types overview](/docs/languages/javascript/api/values/) - All custom data types
 - [Query Builders](/docs/languages/javascript/api/queries/) - Using Table in queries
 - [SurrealQL Tables](/docs/reference/query-language/statements/define/table) - Database table definitions

--- a/src/content/index/languages/javascript/api/values/uuid.mdx
+++ b/src/content/index/languages/javascript/api/values/uuid.mdx
@@ -426,6 +426,6 @@ await db.create(table).content({
 ## See Also
 
 - [RecordId](/docs/languages/javascript/api/values/record-id) - Record identifiers
-- [Data Types Overview](/docs/languages/javascript/api/values/) - All custom data types
+- [Data types overview](/docs/languages/javascript/api/values/) - All custom data types
 - [Query Builders](/docs/languages/javascript/api/queries/) - Using Uuid in queries
 - [SurrealQL UUID](/docs/reference/query-language/language-primitives/data-types/uuids) - Database UUID type

--- a/src/content/index/languages/javascript/api/values/uuid.mdx
+++ b/src/content/index/languages/javascript/api/values/uuid.mdx
@@ -60,7 +60,7 @@ const uuid = new Uuid(bytes);
 const copy = new Uuid(uuid);
 ```
 
-## Static Methods
+## Static methods
 
 ### `Uuid.v4()` {#v4}
 
@@ -114,7 +114,7 @@ const id2 = Uuid.v7();
 // id1 < id2 (lexicographically)
 ```
 
-## Instance Methods
+## Instance methods
 
 ### `.toString()` {#tostring}
 
@@ -195,9 +195,9 @@ uuid.equals(other)
 #### Returns
 `boolean` - True if equal
 
-## Complete Examples
+## Complete examples
 
-### Session Management
+### Session management
 
 ```ts
 import { Surreal, Uuid, RecordId, DateTime, Duration, Table } from 'surrealdb';
@@ -218,7 +218,7 @@ const session = await db.create(new RecordId('sessions', sessionId))
 console.log('Session ID:', sessionId.toString());
 ```
 
-### Time-Ordered Records
+### Time-ordered records
 
 ```ts
 // Use v7 for time-series data
@@ -239,7 +239,7 @@ for (let i = 0; i < 100; i++) {
 // Events are naturally sorted by creation time
 ```
 
-### Unique Identifiers
+### Unique identifiers
 
 ```ts
 // Generate unique IDs for various purposes
@@ -255,7 +255,7 @@ await db.create(new Table('requests')).content({
 });
 ```
 
-### API Keys
+### API keys
 
 ```ts
 // Generate API keys
@@ -273,7 +273,7 @@ await db.create(new Table('api_keys')).content({
 });
 ```
 
-### Distributed System IDs
+### Distributed system IDs
 
 ```ts
 // Use UUID v7 for distributed systems (sortable)
@@ -295,7 +295,7 @@ const orderId = IdGenerator.generateOrderId();
 const txnId = IdGenerator.generateTransactionId();
 ```
 
-### File Upload Tracking
+### File upload tracking
 
 ```ts
 // Track file uploads with UUIDs
@@ -314,7 +314,7 @@ async function uploadFile(file: File): Promise<string> {
 }
 ```
 
-### Parsing and Validation
+### Parsing and validation
 
 ```ts
 // Parse UUID from user input
@@ -335,7 +335,7 @@ if (uuid) {
 }
 ```
 
-### Batch ID Generation
+### Batch ID generation
 
 ```ts
 // Generate multiple UUIDs
@@ -355,7 +355,7 @@ const sortableIds = generateBatchIds(100, true); // 100 time-ordered UUIDs
 
 ## UUID v4 vs UUID v7
 
-### UUID v4 (Random)
+### UUID v4 (random)
 
 - **Pros:** Truly random, no predictability
 - **Cons:** Not sortable, no time information
@@ -365,7 +365,7 @@ const sortableIds = generateBatchIds(100, true); // 100 time-ordered UUIDs
 const randomId = Uuid.v4();
 ```
 
-### UUID v7 (Time-ordered)
+### UUID v7 (time-ordered)
 
 - **Pros:** Sortable, includes timestamp, better for database indexes
 - **Cons:** Slightly predictable (timestamp component)
@@ -375,9 +375,9 @@ const randomId = Uuid.v4();
 const timeOrderedId = Uuid.v7();
 ```
 
-## Best Practices
+## Best practices
 
-### 1. Choose the Right Version
+### 1. Choose the right version
 
 ```ts
 // Good: v7 for time-series and events
@@ -397,7 +397,7 @@ const userId = new RecordId('users', Uuid.v7());
 await db.create(userId).content(userData);
 ```
 
-### 3. Validate User Input
+### 3. Validate user input
 
 ```ts
 // Good: Validate before use
@@ -409,7 +409,7 @@ try {
 }
 ```
 
-### 4. Store as UUID Type
+### 4. Store as UUID type
 
 ```ts
 // Good: Store as UUID
@@ -423,9 +423,9 @@ await db.create(table).content({
 });
 ```
 
-## See Also
+## See also
 
 - [RecordId](/docs/languages/javascript/api/values/record-id) - Record identifiers
 - [Data types overview](/docs/languages/javascript/api/values/) - All custom data types
-- [Query Builders](/docs/languages/javascript/api/queries/) - Using Uuid in queries
+- [Query builders](/docs/languages/javascript/api/queries/) - Using Uuid in queries
 - [SurrealQL UUID](/docs/reference/query-language/language-primitives/data-types/uuids) - Database UUID type

--- a/src/content/index/languages/javascript/concepts/bound-queries.mdx
+++ b/src/content/index/languages/javascript/concepts/bound-queries.mdx
@@ -1,12 +1,12 @@
 ---
 position: 7
 title: Bound queries
-description: The JavaScript SDK provides bound queries and template tags for safely composing parameterized SurrealQL queries.
+description: The JavaScript SDK provides bound queries and template tags for safely composing parameterised SurrealQL queries.
 ---
 
 # Bound queries
 
-When composing dynamic queries, it is important to avoid string interpolation to prevent injection vulnerabilities. The JavaScript SDK provides bound queries and the `surql` template tag to safely parameterize values, along with an expressions API for composing dynamic conditions.
+When composing dynamic queries, it is important to avoid string interpolation to prevent injection vulnerabilities. The JavaScript SDK provides bound queries and the `surql` template tag to safely parameterise values, along with an expressions API for composing dynamic conditions.
 
 ## API references
 
@@ -20,11 +20,11 @@ When composing dynamic queries, it is important to avoid string interpolation to
 	<tbody>
 		<tr>
 			<td scope="row" data-label="Utility"><a href="/docs/languages/javascript/api/utilities/surql"> <code> surql </code></a></td>
-			<td scope="row" data-label="Description">Tagged template literal for composing parameterized queries</td>
+			<td scope="row" data-label="Description">Tagged template literal for composing parameterised queries</td>
 		</tr>
 		<tr>
 			<td scope="row" data-label="Utility"><a href="/docs/languages/javascript/api/utilities/bound-query"> <code> BoundQuery </code></a></td>
-			<td scope="row" data-label="Description">Class for manually building parameterized queries</td>
+			<td scope="row" data-label="Description">Class for manually building parameterised queries</td>
 		</tr>
 		<tr>
 			<td scope="row" data-label="Utility"><a href="/docs/languages/javascript/api/utilities/expr"> <code> expr() </code></a></td>
@@ -35,7 +35,7 @@ When composing dynamic queries, it is important to avoid string interpolation to
 
 ## Using the surql template tag
 
-The `surql` tagged template literal is the recommended way to compose parameterized queries. Interpolated values are automatically bound as parameters, preventing injection and preserving type safety.
+The `surql` tagged template literal is the recommended way to compose parameterised queries. Interpolated values are automatically bound as parameters, preventing injection and preserving type safety.
 
 ```ts
 import { surql } from 'surrealdb';

--- a/src/content/index/languages/javascript/concepts/embedded-engines.mdx
+++ b/src/content/index/languages/javascript/concepts/embedded-engines.mdx
@@ -43,7 +43,7 @@ await db.connect('mem://');
 await db.connect('indxdb://myapp');
 ```
 
-### Running in a Web Worker
+### Running in a web worker
 
 Offload database operations from the main thread to keep your interface responsive:
 

--- a/src/content/index/languages/javascript/concepts/executing-queries.mdx
+++ b/src/content/index/languages/javascript/concepts/executing-queries.mdx
@@ -85,7 +85,7 @@ const [users, posts] = await db.query<[User[], Post[]]>(`
 `);
 ```
 
-You can also pass a [bound query](/docs/languages/javascript/concepts/bound-queries) for automatic parameterization using the `surql` template tag.
+You can also pass a [bound query](/docs/languages/javascript/concepts/bound-queries) for automatic parameterisation using the `surql` template tag.
 
 ```ts
 import { surql } from 'surrealdb';
@@ -323,7 +323,7 @@ for (const response of responses) {
 
 ## Learn more
 
-- [Bound queries](/docs/languages/javascript/concepts/bound-queries) for parameterized query building with `surql` and `BoundQuery`
+- [Bound queries](/docs/languages/javascript/concepts/bound-queries) for parameterised query building with `surql` and `BoundQuery`
 - [Live queries](/docs/languages/javascript/concepts/live-queries) for real-time subscriptions
 - [Transactions](/docs/languages/javascript/concepts/transactions) for atomic multi-query operations
 - [Query builders API reference](/docs/languages/javascript/api/queries/) for detailed method signatures

--- a/src/content/index/languages/javascript/concepts/executing-queries.mdx
+++ b/src/content/index/languages/javascript/concepts/executing-queries.mdx
@@ -326,5 +326,5 @@ for (const response of responses) {
 - [Bound queries](/docs/languages/javascript/concepts/bound-queries) for parameterized query building with `surql` and `BoundQuery`
 - [Live queries](/docs/languages/javascript/concepts/live-queries) for real-time subscriptions
 - [Transactions](/docs/languages/javascript/concepts/transactions) for atomic multi-query operations
-- [Query Builders API reference](/docs/languages/javascript/api/queries/) for detailed method signatures
+- [Query builders API reference](/docs/languages/javascript/api/queries/) for detailed method signatures
 - [SurrealQL statements](/docs/reference/query-language/statements/overview) for the query language reference

--- a/src/content/index/languages/javascript/concepts/utilities.mdx
+++ b/src/content/index/languages/javascript/concepts/utilities.mdx
@@ -171,11 +171,11 @@ These ship with the `surrealdb` driver and tie into its query engine. They are n
 		</tr>
 		<tr>
 			<td scope="row" data-label="Utility"><a href="/docs/languages/javascript/api/utilities/surql"> <code> surql </code></a></td>
-			<td scope="row" data-label="Description">Tagged template for composing parameterized queries</td>
+			<td scope="row" data-label="Description">Tagged template for composing parameterised queries</td>
 		</tr>
 		<tr>
 			<td scope="row" data-label="Utility"><a href="/docs/languages/javascript/api/utilities/bound-query"> <code> BoundQuery </code></a></td>
-			<td scope="row" data-label="Description">Parameterized query class with manual control</td>
+			<td scope="row" data-label="Description">Parameterised query class with manual control</td>
 		</tr>
 		<tr>
 			<td scope="row" data-label="Utility"><code> s, d, r, u </code></td>
@@ -201,7 +201,7 @@ const users = await db.select(new Table('users')).where(premiumAdults);
 
 Operators cover comparisons (`eq`, `ne`, `gt`, `gte`, `lt`, `lte`), logic (`and`, `or`, `not`), strings and arrays (`contains`, `containsAny`, `containsAll`), geometry (`inside`, `outside`, `intersects`), and search (`matches`, `knn`).
 
-### Composing parameterized queries
+### Composing parameterised queries
 
 `surql` and `BoundQuery` bind parameters so you do not splice user input into query strings. See [Bound queries](/docs/languages/javascript/concepts/bound-queries).
 
@@ -226,7 +226,7 @@ The `s`, `d`, `r`, and `u` templates build typed literals with SurrealQL's strin
 
 ## Best practices
 
-### Use surql for parameterization
+### Use surql for parameterisation
 
 ```ts
 const query = surql`SELECT * FROM users WHERE name = ${userName}`;

--- a/src/content/index/languages/javascript/concepts/value-types.mdx
+++ b/src/content/index/languages/javascript/concepts/value-types.mdx
@@ -348,7 +348,7 @@ try {
 
 ## Learn more
 
-- [Data Types API reference](/docs/languages/javascript/api/values/) for the full list of value class documentation
+- [Data types API reference](/docs/languages/javascript/api/values/) for the full list of value class documentation
 - [Codecs](/docs/languages/javascript/concepts/codecs) for serialising and deserialising value types
 - [SurrealQL data model](/docs/reference/query-language/datamodel) for the database-level type system
 - [Utilities](/docs/languages/javascript/concepts/utilities) for comparing and converting values

--- a/src/content/index/languages/kotlin/api/values/__category.json
+++ b/src/content/index/languages/kotlin/api/values/__category.json
@@ -1,4 +1,4 @@
 {
-    "title": "Data Types",
+    "title": "Data types",
     "position": 4
 }

--- a/src/content/index/languages/php/data-types.mdx
+++ b/src/content/index/languages/php/data-types.mdx
@@ -4,11 +4,11 @@ title: Data types
 description: The SurrealDB SDK for PHP enables simple and advanced querying of a remote database.
 ---
 
-# Data Types
+# Data types
 
 The PHP SDK translates all SurrealQL datatypes into native PHP types, or a custom implementation. This document describes all datatypes, and links to their respective documentation.
 
-## Data Types overview
+## Data types overview
 
 <table>
     <thead>

--- a/src/content/index/languages/python/api/core/surreal-session.mdx
+++ b/src/content/index/languages/python/api/core/surreal-session.mdx
@@ -211,5 +211,5 @@ asyncio.run(main())
 
 - [Surreal](/docs/languages/python/api/core/surreal) — Connection reference with full method documentation
 - [SurrealTransaction](/docs/languages/python/api/core/surreal-transaction) — Transaction reference
-- [Data Types](/docs/languages/python/api/types) — Type aliases and value types
+- [Data types](/docs/languages/python/api/types) — Type aliases and value types
 - [Errors](/docs/languages/python/api/errors) — Error classes reference

--- a/src/content/index/languages/python/api/core/surreal-transaction.mdx
+++ b/src/content/index/languages/python/api/core/surreal-transaction.mdx
@@ -227,5 +227,5 @@ asyncio.run(main())
 
 - [SurrealSession](/docs/languages/python/api/core/surreal-session) — Session management reference
 - [Surreal](/docs/languages/python/api/core/surreal) — Connection reference with full method documentation
-- [Data Types](/docs/languages/python/api/types) — Type aliases and value types
+- [Data types](/docs/languages/python/api/types) — Type aliases and value types
 - [Errors](/docs/languages/python/api/errors) — Error classes reference

--- a/src/content/index/languages/python/api/core/surreal.mdx
+++ b/src/content/index/languages/python/api/core/surreal.mdx
@@ -1489,6 +1489,6 @@ asyncio.run(main())
 
 - [SurrealSession](/docs/languages/python/api/core/surreal-session) — Session management reference
 - [SurrealTransaction](/docs/languages/python/api/core/surreal-transaction) — Transaction reference
-- [Data Types](/docs/languages/python/api/types) — Type aliases and value types
+- [Data types](/docs/languages/python/api/types) — Type aliases and value types
 - [Errors](/docs/languages/python/api/errors) — Error classes reference
 - [Connecting to SurrealDB](/docs/languages/python/concepts/connecting-to-surrealdb) — Connection protocols and patterns

--- a/src/content/index/languages/python/api/types/index.mdx
+++ b/src/content/index/languages/python/api/types/index.mdx
@@ -27,7 +27,7 @@ Value = (
 )
 ```
 
-This type is recursive: dictionaries and lists can contain nested `Value` types. See the [Data Types overview](/docs/languages/python/api/values/) for details on each SurrealDB-specific type.
+This type is recursive: dictionaries and lists can contain nested `Value` types. See the [Data types overview](/docs/languages/python/api/values/) for details on each SurrealDB-specific type.
 
 ---
 
@@ -147,6 +147,6 @@ class UrlScheme(Enum):
 
 ## See also
 
-- [Data Types](/docs/languages/python/api/values/) for the SurrealDB-specific type classes
+- [Data types](/docs/languages/python/api/values/) for the SurrealDB-specific type classes
 - [Errors](/docs/languages/python/api/errors/) for error classes and constants
 - [Surreal API reference](/docs/languages/python/api/core/surreal) for methods using these types

--- a/src/content/index/languages/python/api/values/datetime.mdx
+++ b/src/content/index/languages/python/api/values/datetime.mdx
@@ -82,5 +82,5 @@ db.create("events", {
 
 ## See also
 
-- [Data Types](/docs/languages/python/api/values), All SDK data types
+- [Data types](/docs/languages/python/api/values), All SDK data types
 - [Duration](/docs/languages/python/api/values/duration), Duration type with unit conversion

--- a/src/content/index/languages/python/api/values/duration.mdx
+++ b/src/content/index/languages/python/api/values/duration.mdx
@@ -185,5 +185,5 @@ db.create("tasks", {
 
 ## See also
 
-- [Data Types](/docs/languages/python/api/values) — All SDK data types
+- [Data types](/docs/languages/python/api/values) — All SDK data types
 - [Datetime](/docs/languages/python/api/values/datetime) — Datetime wrapper

--- a/src/content/index/languages/python/api/values/geometry.mdx
+++ b/src/content/index/languages/python/api/values/geometry.mdx
@@ -341,6 +341,6 @@ result = db.query("""
 
 ## See also
 
-- [Data Types](/docs/languages/python/api/values) — All SDK data types
+- [Data types](/docs/languages/python/api/values) — All SDK data types
 - [RecordID](/docs/languages/python/api/values/record-id) — Record identifier
 - [SurrealQL Geometry Functions](/docs/reference/query-language/functions/database-functions/geo) — Geospatial query functions

--- a/src/content/index/languages/python/api/values/range.mdx
+++ b/src/content/index/languages/python/api/values/range.mdx
@@ -142,5 +142,5 @@ result = db.query(
 
 ## See also
 
-- [Data Types](/docs/languages/python/api/values) — All SDK data types
+- [Data types](/docs/languages/python/api/values) — All SDK data types
 - [RecordID](/docs/languages/python/api/values/record-id) — Record identifier

--- a/src/content/index/languages/python/api/values/record-id.mdx
+++ b/src/content/index/languages/python/api/values/record-id.mdx
@@ -160,12 +160,12 @@ Methods that accept a record or table reference use the `RecordIdType` alias, wh
 RecordIdType = str | Table | RecordID
 ```
 
-See the [Data Types overview](/docs/languages/python/api/values/#recordidtype) for details.
+See the [Data types overview](/docs/languages/python/api/values/#recordidtype) for details.
 
 ---
 
 ## See also
 
-- [Data Types](/docs/languages/python/api/values) — All SDK data types
+- [Data types](/docs/languages/python/api/values) — All SDK data types
 - [Table](/docs/languages/python/api/values/table) — Table name wrapper
 - [Surreal](/docs/languages/python/api/core/surreal) — Connection and query methods

--- a/src/content/index/languages/python/api/values/table.mdx
+++ b/src/content/index/languages/python/api/values/table.mdx
@@ -73,5 +73,5 @@ users = db.select(Table("users"))
 
 ## See also
 
-- [Data Types](/docs/languages/python/api/values) — All SDK data types
+- [Data types](/docs/languages/python/api/values) — All SDK data types
 - [RecordID](/docs/languages/python/api/values/record-id) — Record identifier with table and ID components

--- a/src/content/index/languages/python/concepts/value-types.mdx
+++ b/src/content/index/languages/python/concepts/value-types.mdx
@@ -8,7 +8,7 @@ description: The Python SDK provides custom types for representing SurrealDB-spe
 
 The Python SDK maps SurrealDB data types to Python types automatically. Standard Python types like `str`, `int`, `float`, `bool`, `None`, `dict`, and `list` map directly to their SurrealDB equivalents. For SurrealDB-specific types such as record identifiers, durations, and geometry, the SDK provides dedicated Python classes.
 
-See the [Data Types reference](/docs/languages/python/api/values/) for the full API details of each type.
+See the [Data types reference](/docs/languages/python/api/values/) for the full API details of each type.
 
 ## API references
 
@@ -225,7 +225,7 @@ More complex types compose from simpler ones — a `GeometryLine` is built from 
 
 ## Learn more
 
-- [Data Types reference](/docs/languages/python/api/values/) for complete API details
+- [Data types reference](/docs/languages/python/api/values/) for complete API details
 - [RecordID reference](/docs/languages/python/api/values/record-id) for record identifier API
 - [Duration reference](/docs/languages/python/api/values/duration) for duration API
 - [Python types](/docs/languages/python/api/types/) for Value and RecordIdType definitions

--- a/src/content/learn/schema-management/schema-design/sample-industry-schemas.mdx
+++ b/src/content/learn/schema-management/schema-design/sample-industry-schemas.mdx
@@ -605,7 +605,7 @@ SELECT * FROM transfer;
 
 ### Loans and repayments
 
-Loan management system with automated interest calculations and repayment scheduling. Features [parameterized loan terms](/docs/reference/query-language/statements/define/param), mathematical payment calculations using [custom functions](/docs/reference/query-language/statements/define/function), and status tracking. Demonstrates complex financial formulas, temporal data management, and regulatory compliance constraints.
+Loan management system with automated interest calculations and repayment scheduling. Features [parameterised loan terms](/docs/reference/query-language/statements/define/param), mathematical payment calculations using [custom functions](/docs/reference/query-language/statements/define/function), and status tracking. Demonstrates complex financial formulas, temporal data management, and regulatory compliance constraints.
 
 ```surql
 -- Some government-set maximum term for loans

--- a/src/content/reference/query-language/functions/database-functions/vector.mdx
+++ b/src/content/reference/query-language/functions/database-functions/vector.mdx
@@ -528,7 +528,7 @@ RETURN vector::distance::manhattan([10, 20, 15, 10, 5], [12, 24, 18, 8, 7]);
 
 ## `vector::distance::minkowski`
 
-The `vector::distance::minkowski` function computes the Minkowski distance between two vectors, a generalization of other distance metrics such as Euclidean and Manhattan when parameterized with different values of p.
+The `vector::distance::minkowski` function computes the Minkowski distance between two vectors, a generalization of other distance metrics such as Euclidean and Manhattan when parameterised with different values of p.
 
 
 ```surql title="API DEFINITION"

--- a/src/content/reference/query-language/language-primitives/data-types/__category.json
+++ b/src/content/reference/query-language/language-primitives/data-types/__category.json
@@ -1,4 +1,4 @@
 {
     "position": 11,
-    "title": "Data Types"
+    "title": "Data types"
 }

--- a/src/content/reference/query-language/language-primitives/parameters.mdx
+++ b/src/content/reference/query-language/language-primitives/parameters.mdx
@@ -668,7 +668,7 @@ FOR $language IN ["en", "ja", "uk", "ie"] {
 
 ### REMOVE statements
 
-Parameterization in `REMOVE` statements is particularly useful in the context of testing.
+Parameterisation in `REMOVE` statements is particularly useful in the context of testing.
 
 ```surql
 /**[test]

--- a/src/content/reference/query-language/statements/alter/__category.json
+++ b/src/content/reference/query-language/statements/alter/__category.json
@@ -1,4 +1,4 @@
 {
-    "position": 30,
+    "position": 3,
     "title": "ALTER"
 }

--- a/src/content/reference/query-language/statements/alter/access.mdx
+++ b/src/content/reference/query-language/statements/alter/access.mdx
@@ -1,6 +1,6 @@
 ---
 position: 2
-title: ACCESS
+title: ALTER ACCESS
 description: "The ALTER ACCESS statement can be used to modify an existing defined access."
 ---
 

--- a/src/content/reference/query-language/statements/alter/analyzer.mdx
+++ b/src/content/reference/query-language/statements/alter/analyzer.mdx
@@ -1,6 +1,6 @@
 ---
 position: 3
-title: ANALYZER
+title: ALTER ANALYZER
 description: "The ALTER ANALYZER statement can be used to modify an existing defined analyzer."
 ---
 

--- a/src/content/reference/query-language/statements/alter/api.mdx
+++ b/src/content/reference/query-language/statements/alter/api.mdx
@@ -1,6 +1,6 @@
 ---
 position: 4
-title: API
+title: ALTER API
 description: "The ALTER API statement can be used to modify an existing defined API."
 ---
 

--- a/src/content/reference/query-language/statements/alter/bucket.mdx
+++ b/src/content/reference/query-language/statements/alter/bucket.mdx
@@ -1,6 +1,6 @@
 ---
 position: 5
-title: BUCKET
+title: ALTER BUCKET
 description: "The ALTER BUCKET statement can be used to modify an existing defined bucket."
 ---
 

--- a/src/content/reference/query-language/statements/alter/config.mdx
+++ b/src/content/reference/query-language/statements/alter/config.mdx
@@ -1,6 +1,6 @@
 ---
 position: 6
-title: CONFIG
+title: ALTER CONFIG
 description: The ALTER statement can be used to change authentication access and behaviour, global parameters, table configurations, table events, schema definitions, and indexes.
 ---
 

--- a/src/content/reference/query-language/statements/alter/database.mdx
+++ b/src/content/reference/query-language/statements/alter/database.mdx
@@ -1,5 +1,5 @@
 ---
-position: 2
+position: 7
 title: ALTER DATABASE
 description: "The ALTER statement can be used to change authentication access and behaviour, global parameters, table configurations, table events, schema definitions, and indexes."
 ---

--- a/src/content/reference/query-language/statements/alter/event.mdx
+++ b/src/content/reference/query-language/statements/alter/event.mdx
@@ -1,6 +1,6 @@
 ---
 position: 8
-title: EVENT
+title: ALTER EVENT
 description: The ALTER statement can be used to change authentication access and behaviour, global parameters, table configurations, table events, schema definitions, and indexes.
 ---
 

--- a/src/content/reference/query-language/statements/alter/field.mdx
+++ b/src/content/reference/query-language/statements/alter/field.mdx
@@ -1,5 +1,5 @@
 ---
-position: 3
+position: 9
 title: ALTER FIELD
 description: "The ALTER statement can be used to change authentication access and behaviour, global parameters, table configurations, table events, schema definitions, and indexes."
 ---

--- a/src/content/reference/query-language/statements/alter/function.mdx
+++ b/src/content/reference/query-language/statements/alter/function.mdx
@@ -1,6 +1,6 @@
 ---
 position: 10
-title: FUNCTION
+title: ALTER FUNCTION
 description: The ALTER statement can be used to change authentication access and behaviour, global parameters, table configurations, table events, schema definitions, and indexes.
 ---
 

--- a/src/content/reference/query-language/statements/alter/indexes.mdx
+++ b/src/content/reference/query-language/statements/alter/indexes.mdx
@@ -1,6 +1,6 @@
 ---
 position: 11
-title: INDEX
+title: ALTER INDEX
 description: The ALTER statement can be used to change authentication access and behaviour, global parameters, table configurations, table events, schema definitions, and indexes.
 ---
 

--- a/src/content/reference/query-language/statements/alter/namespace.mdx
+++ b/src/content/reference/query-language/statements/alter/namespace.mdx
@@ -1,5 +1,5 @@
 ---
-position: 5
+position: 12
 title: ALTER NAMESPACE
 description: "The ALTER statement can be used to change authentication access and behaviour, global parameters, table configurations, table events, schema definitions, and indexes."
 ---

--- a/src/content/reference/query-language/statements/alter/overview.mdx
+++ b/src/content/reference/query-language/statements/alter/overview.mdx
@@ -1,6 +1,6 @@
 ---
 position: 1
-title: ALTER overview
+title: Overview
 description: "The ALTER statement can be used to change authentication access and behaviour, global parameters, table configurations, table events, schema definitions, and indexes."
 ---
 

--- a/src/content/reference/query-language/statements/alter/param.mdx
+++ b/src/content/reference/query-language/statements/alter/param.mdx
@@ -1,6 +1,6 @@
 ---
 position: 13
-title: PARAM
+title: ALTER PARAM
 description: The ALTER statement can be used to change authentication access and behaviour, global parameters, table configurations, table events, schema definitions, and indexes.
 ---
 

--- a/src/content/reference/query-language/statements/alter/sequence.mdx
+++ b/src/content/reference/query-language/statements/alter/sequence.mdx
@@ -1,5 +1,5 @@
 ---
-position: 6
+position: 14
 title: ALTER SEQUENCE
 description: "The ALTER statement can be used to change authentication access and behaviour, global parameters, table configurations, table events, schema definitions, and indexes."
 ---

--- a/src/content/reference/query-language/statements/alter/system.mdx
+++ b/src/content/reference/query-language/statements/alter/system.mdx
@@ -1,5 +1,5 @@
 ---
-position: 7
+position: 15
 title: ALTER SYSTEM
 description: "The ALTER statement can be used to change authentication access and behaviour, global parameters, table configurations, table events, schema definitions, and indexes."
 ---

--- a/src/content/reference/query-language/statements/alter/table.mdx
+++ b/src/content/reference/query-language/statements/alter/table.mdx
@@ -1,5 +1,5 @@
 ---
-position: 8
+position: 16
 title: ALTER TABLE
 description: "The ALTER TABLE statement is used to alter a defined table."
 ---

--- a/src/content/reference/query-language/statements/alter/user.mdx
+++ b/src/content/reference/query-language/statements/alter/user.mdx
@@ -1,6 +1,6 @@
 ---
 position: 17
-title: USER
+title: ALTER USER
 description: The ALTER statement can be used to change authentication access and behaviour, global parameters, table configurations, table events, schema definitions, and indexes.
 ---
 

--- a/src/content/reference/query-language/statements/begin.mdx
+++ b/src/content/reference/query-language/statements/begin.mdx
@@ -1,5 +1,5 @@
 ---
-position: 3
+position: 4
 title: BEGIN
 description: "The BEGIN statement starts a single transaction in which run multiple statements can be run, either succeeding as a whole, or failing."
 ---

--- a/src/content/reference/query-language/statements/break.mdx
+++ b/src/content/reference/query-language/statements/break.mdx
@@ -1,5 +1,5 @@
 ---
-position: 4
+position: 5
 title: BREAK
 description: "The BREAK statement can be used to break out of a loop."
 ---

--- a/src/content/reference/query-language/statements/cancel.mdx
+++ b/src/content/reference/query-language/statements/cancel.mdx
@@ -1,5 +1,5 @@
 ---
-position: 5
+position: 6
 title: CANCEL
 description: "The CANCEL statement can be used to cancel the statements within a transaction, reverting or rolling back any data modification made within the transaction as a whole."
 ---

--- a/src/content/reference/query-language/statements/commit.mdx
+++ b/src/content/reference/query-language/statements/commit.mdx
@@ -1,5 +1,5 @@
 ---
-position: 6
+position: 7
 title: COMMIT
 description: "The COMMIT statement is used to commit a set of statements within a transaction, ensuring that all data modifications become a permanent part of the database."
 ---

--- a/src/content/reference/query-language/statements/continue.mdx
+++ b/src/content/reference/query-language/statements/continue.mdx
@@ -1,5 +1,5 @@
 ---
-position: 7
+position: 8
 title: CONTINUE
 description: "The CONTINUE statement can be used to skip an iteration of a loop, like within the FOR statement"
 ---

--- a/src/content/reference/query-language/statements/create.mdx
+++ b/src/content/reference/query-language/statements/create.mdx
@@ -1,5 +1,5 @@
 ---
-position: 8
+position: 9
 title: CREATE
 description: "The CREATE statement can be used to add a record to the database if it does not already exist."
 ---

--- a/src/content/reference/query-language/statements/define/__category.json
+++ b/src/content/reference/query-language/statements/define/__category.json
@@ -1,4 +1,4 @@
 {
-    "position": 29,
+    "position": 10,
     "title": "DEFINE"
 }

--- a/src/content/reference/query-language/statements/define/overview.mdx
+++ b/src/content/reference/query-language/statements/define/overview.mdx
@@ -1,6 +1,6 @@
 ---
 position: 1
-title: DEFINE overview
+title: Overview
 description: "DEFINE declares SurrealDB schema: namespaces, tables, fields, indexes, functions, events and access in SurrealQL."
 ---
 

--- a/src/content/reference/query-language/statements/delete.mdx
+++ b/src/content/reference/query-language/statements/delete.mdx
@@ -1,5 +1,5 @@
 ---
-position: 9
+position: 11
 title: DELETE
 description: "The DELETE statement can be used to delete records from the database."
 ---

--- a/src/content/reference/query-language/statements/explain.mdx
+++ b/src/content/reference/query-language/statements/explain.mdx
@@ -1,5 +1,5 @@
 ---
-position: 10
+position: 12
 title: EXPLAIN
 description: "The EXPLAIN statement is used to display the query planner for a following statement."
 ---

--- a/src/content/reference/query-language/statements/for.mdx
+++ b/src/content/reference/query-language/statements/for.mdx
@@ -1,5 +1,5 @@
 ---
-position: 11
+position: 13
 title: FOR
 description: "The FOR statement creates a loop that iterates over the values of an array."
 ---

--- a/src/content/reference/query-language/statements/if-else.mdx
+++ b/src/content/reference/query-language/statements/if-else.mdx
@@ -1,5 +1,5 @@
 ---
-position: 12
+position: 14
 title: IF ELSE
 description: "The IF ELSE statement can be used as a main statement, or within a parent statement, to return a value depending on whether a condition, or a series of conditions match."
 ---

--- a/src/content/reference/query-language/statements/info.mdx
+++ b/src/content/reference/query-language/statements/info.mdx
@@ -1,5 +1,5 @@
 ---
-position: 13
+position: 15
 title: INFO
 description: "The INFO command outputs information about the setup of the SurrealDB system."
 ---

--- a/src/content/reference/query-language/statements/insert.mdx
+++ b/src/content/reference/query-language/statements/insert.mdx
@@ -1,5 +1,5 @@
 ---
-position: 14
+position: 16
 title: INSERT
 description: "The INSERT statement can be used to insert or update data into the database, using the same statement syntax as the traditional SQL Insert statement."
 ---

--- a/src/content/reference/query-language/statements/kill.mdx
+++ b/src/content/reference/query-language/statements/kill.mdx
@@ -1,5 +1,5 @@
 ---
-position: 15
+position: 17
 title: KILL
 description: "The KILL statement is used to terminate a running live query."
 ---

--- a/src/content/reference/query-language/statements/let.mdx
+++ b/src/content/reference/query-language/statements/let.mdx
@@ -1,5 +1,5 @@
 ---
-position: 16
+position: 18
 title: LET
 description: "The LET statement sets and stores a value which can then be used in a subsequent query."
 ---

--- a/src/content/reference/query-language/statements/live-select.mdx
+++ b/src/content/reference/query-language/statements/live-select.mdx
@@ -1,5 +1,5 @@
 ---
-position: 17
+position: 19
 title: LIVE SELECT
 description: "The LIVE SELECT statement can be used to initiate a real-time selection from a table, including the option to apply filters."
 ---

--- a/src/content/reference/query-language/statements/rebuild.mdx
+++ b/src/content/reference/query-language/statements/rebuild.mdx
@@ -1,5 +1,5 @@
 ---
-position: 18
+position: 20
 title: REBUILD
 description: "The REBUILD statement is used to rebuild indexes."
 ---

--- a/src/content/reference/query-language/statements/relate.mdx
+++ b/src/content/reference/query-language/statements/relate.mdx
@@ -1,5 +1,5 @@
 ---
-position: 19
+position: 21
 title: RELATE
 description: "The RELATE statement can be used to generate graph edges between two records in the database."
 ---

--- a/src/content/reference/query-language/statements/remove.mdx
+++ b/src/content/reference/query-language/statements/remove.mdx
@@ -1,5 +1,5 @@
 ---
-position: 20
+position: 22
 title: REMOVE
 description: "The REMOVE statement is used to remove resources such as databases, tables, indexes, events and more."
 ---

--- a/src/content/reference/query-language/statements/return.mdx
+++ b/src/content/reference/query-language/statements/return.mdx
@@ -1,5 +1,5 @@
 ---
-position: 21
+position: 23
 title: RETURN
 description: "The RETURN statement can be used to return an implicit value or the result of a query, and to set the return value for a transaction, block or function."
 ---

--- a/src/content/reference/query-language/statements/select.mdx
+++ b/src/content/reference/query-language/statements/select.mdx
@@ -1,5 +1,5 @@
 ---
-position: 22
+position: 24
 title: SELECT
 description: "The SELECT statement can be used for selecting and querying data in a database."
 ---

--- a/src/content/reference/query-language/statements/show.mdx
+++ b/src/content/reference/query-language/statements/show.mdx
@@ -1,5 +1,5 @@
 ---
-position: 23
+position: 25
 title: SHOW
 description: "The SHOW statement can be used to replay changes made to a table."
 ---

--- a/src/content/reference/query-language/statements/sleep.mdx
+++ b/src/content/reference/query-language/statements/sleep.mdx
@@ -1,5 +1,5 @@
 ---
-position: 24
+position: 26
 title: SLEEP
 description: "The SLEEP statement is used to introduce a delay or pause in the execution of a query or a batch of queries for a specific amount of time."
 ---

--- a/src/content/reference/query-language/statements/throw.mdx
+++ b/src/content/reference/query-language/statements/throw.mdx
@@ -1,5 +1,5 @@
 ---
-position: 25
+position: 27
 title: THROW
 description: "The THROW statement can be used to stop execution of a query and return information on the underlying problem"
 ---

--- a/src/content/reference/query-language/statements/update.mdx
+++ b/src/content/reference/query-language/statements/update.mdx
@@ -1,5 +1,5 @@
 ---
-position: 26
+position: 28
 title: UPDATE
 description: "The UPDATE statement can be used to update records in the database. If they already exist, they will be updated. If they do not exist, no records will be updated."
 ---

--- a/src/content/reference/query-language/statements/upsert.mdx
+++ b/src/content/reference/query-language/statements/upsert.mdx
@@ -1,5 +1,5 @@
 ---
-position: 27
+position: 29
 title: UPSERT
 description: "The UPSERT statement can be used to insert records or modify records that already exist."
 ---

--- a/src/content/reference/query-language/statements/use.mdx
+++ b/src/content/reference/query-language/statements/use.mdx
@@ -1,5 +1,5 @@
 ---
-position: 28
+position: 30
 title: USE
 description: "The USE statement specifies a namespace and / or a database to use for the subsequent SurrealQL statements when switching between namespaces and databases."
 ---


### PR DESCRIPTION
Fixes ordering and headers of ALTER/DEFINE statements, capitalisation in sub-headers, removes some more North American spelling, and updates rules.