### PR TITLE
Add advanced grouping example

### DIFF
--- a/.agents/skills/seo-audit/evals/evals.json
+++ b/.agents/skills/seo-audit/evals/evals.json
@@ -56,11 +56,11 @@
         {
             "id": 4,
             "prompt": "Review the technical SEO of our e-commerce site. We have about 50,000 products and use faceted navigation.",
-            "expected_output": "Should focus on e-commerce-specific technical issues: faceted navigation creating duplicate content, crawl budget management for large product catalog, parameterized URLs, product schema markup (with the caveat about detection limitations). Should check for thin category pages, duplicate product descriptions, out-of-stock page handling. Should address crawl budget issues: pagination, infinite scroll handling, session IDs in URLs. Should provide structured findings with Impact ratings and specific fixes.",
+            "expected_output": "Should focus on e-commerce-specific technical issues: faceted navigation creating duplicate content, crawl budget management for large product catalog, parameterised URLs, product schema markup (with the caveat about detection limitations). Should check for thin category pages, duplicate product descriptions, out-of-stock page handling. Should address crawl budget issues: pagination, infinite scroll handling, session IDs in URLs. Should provide structured findings with Impact ratings and specific fixes.",
             "assertions": [
                 "Addresses faceted navigation duplicate content",
                 "Addresses crawl budget for large catalog",
-                "Checks for parameterized URL issues",
+                "Checks for parameterised URL issues",
                 "Mentions product schema with detection limitation caveat",
                 "Checks for thin category pages",
                 "Checks for duplicate product descriptions",

--- a/src/content/learn/querying/concepts-and-guides/subqueries-and-advanced-patterns.mdx
+++ b/src/content/learn/querying/concepts-and-guides/subqueries-and-advanced-patterns.mdx
@@ -1,7 +1,7 @@
 ---
 position: 4
 title: Subqueries and advanced patterns
-description: "Nested SELECTs, CREATE as a value, $parent and $this, and graph paths that behave like inner queries."
+description: "Nested SELECTs, CREATE as a value, $parent and $this, latest record per group, and graph paths that behave like inner queries."
 ---
 
 # Subqueries and advanced patterns
@@ -77,6 +77,52 @@ FROM person;
 ```
 
 Full detail: [Reserved variables — `$parent`, `$this`](/docs/reference/query-language/language-primitives/parameters#parent-this).
+
+## Latest record per group
+
+A common pattern is to return the **most recently modified record** for each distinct value of a field — the equivalent of a `ROW_NUMBER() OVER (PARTITION BY … ORDER BY …)` window in SQL. In SurrealQL you can combine [`GROUP BY`](/docs/reference/query-language/clauses/group-by), [`.map()`](/docs/reference/query-language/functions/database-functions/array#arraymap), and a nested [`SELECT`](/docs/reference/query-language/statements/select):
+
+```surql
+CREATE person:1 SET role = "user", modified_at = d'1970-01-01';
+CREATE person:2 SET role = "admin", modified_at = d'1990-01-01';
+CREATE person:3 SET role = "user", modified_at = d'1999-01-01';
+CREATE person:4 SET role = "admin", modified_at = d'2999-01-01';
+
+(SELECT id, role FROM person GROUP BY role).map(|$o| {
+    SELECT * FROM ONLY $o.id ORDER BY modified_at DESC LIMIT 1
+});
+```
+
+```surql title="Output"
+[
+	{
+		id: person:4,
+		modified_at: d'2999-01-01T00:00:00Z',
+		role: 'admin'
+	},
+	{
+		id: person:3,
+		modified_at: d'1999-01-01T00:00:00Z',
+		role: 'user'
+	}
+]
+```
+
+How it works:
+
+1. **`GROUP BY role`** collapses records into one row per role. Non-aggregated fields such as `id` become arrays of the grouped record ids.
+2. **`.map(|$o| { … })`** runs the nested query once per grouped record.
+3. **`SELECT * FROM ONLY $o.id ORDER BY modified_at DESC LIMIT 1`** fetches all of the records in that group, orders by `modified_at`, and returns the latest one.
+
+To partition by more than one field, include every non-aggregated field in both the projection and the `GROUP BY` clause:
+
+```surql
+(SELECT id, role, status FROM person GROUP BY role, status).map(|$o| {
+    SELECT * FROM ONLY $o.id ORDER BY modified_at DESC LIMIT 1
+});
+```
+
+See also the [`GROUP` clause](/docs/reference/query-language/clauses/group-by#latest-record-per-group) reference for a shorter summary.
 
 ## Graph paths and inner queries
 

--- a/src/content/reference/query-language/clauses/group.mdx
+++ b/src/content/reference/query-language/clauses/group.mdx
@@ -137,3 +137,16 @@ GROUP BY gender, country;
 	" />
 
 
+## Latest record per group
+
+When you need the most recently modified record for each value of a field, group by that field and use [`.map()`](/docs/reference/query-language/functions/database-functions/array#arraymap) to run a nested `SELECT` per group:
+
+```surql
+(SELECT id, role FROM person GROUP BY role).map(|$o| {
+    SELECT * FROM ONLY $o.id ORDER BY modified_at DESC LIMIT 1
+});
+```
+
+`GROUP BY` collects record ids into an array, after which the inner query orders those records and returns the latest. For a worked example with sample data, see [Latest record per group](/docs/learn/querying/concepts-and-guides/subqueries-and-advanced-patterns#latest-record-per-group).
+
+

--- a/src/content/reference/query-language/statements/select.mdx
+++ b/src/content/reference/query-language/statements/select.mdx
@@ -551,6 +551,8 @@ SELECT count() AS number_of_records FROM person GROUP ALL;
 ]
 ```
 
+To return the most recently modified record per group instead of aggregate totals, see [Latest record per group](/docs/learn/querying/concepts-and-guides/subqueries-and-advanced-patterns#latest-record-per-group).
+
 ### `GROUP` and `SPLIT` incompatibility
 
 The `GROUP` and `SPLIT` clauses are incompatible with each other due to opposing behaviour: while `SPLIT` is a post-processing clause that multiplies the output of a query, `GROUP` works in the other way by collapsing the output.


### PR DESCRIPTION
Adds an example showing how to first group and then map to query against each grouped part. e.g. to group by type and then return the latest modified record from each one.