### PR TITLE
Count index update

### DIFF
--- a/src/content/learn/schema-management/indexes/index-types-and-strategies.mdx
+++ b/src/content/learn/schema-management/indexes/index-types-and-strategies.mdx
@@ -83,7 +83,14 @@ DEFINE INDEX test ON user FIELDS account, email UNIQUE;
 
 ### Count index
 
-An index using the `COUNT` clause is used to maintain a count of the number of records in a table. This is used together with the `count()` function and `GROUP ALL` inside a query. Without a count index, the `count()` function will iterate through the records of a table when it is called.
+<Since v="v3.0.0" />
+
+A count index maintains a running count of records on a table. Use it with `count()` and `GROUP ALL`.
+
+- **`COUNT`** — full-table counts: `SELECT count() FROM <table> GROUP ALL`.
+- **`COUNT WHERE <condition>`** — filtered counts when the query `WHERE` exactly matches the index condition.
+
+An unconditional count index is optional for full-table counts; SurrealDB already uses a `CountScan` fast path that counts keys without deserialising rows. `COUNT WHERE` is most useful for repeated filtered counts without scanning the whole table.
 
 ```surql
 DEFINE INDEX idx ON indexed_reading COUNT;
@@ -101,6 +108,16 @@ FOR $_ IN 0..100000 {
 SELECT count() FROM reading GROUP ALL;
 SELECT count() FROM indexed_reading GROUP ALL;
 ```
+
+Filtered example:
+
+```surql
+DEFINE INDEX item_active_count ON item COUNT WHERE status = "active";
+
+SELECT count() FROM item WHERE status = "active" GROUP ALL;
+```
+
+A regular index (a B-tree index) on the same field can also accelerate filtered counts when it fully covers the `WHERE` clause; you typically choose one approach, not both. For counting several statuses (`IN` lists vs per-status totals), see [Multiple conditions](/docs/reference/query-language/statements/define/indexes#multiple-conditions) in the reference. See [`DEFINE INDEX`](/docs/reference/query-language/statements/define/indexes#count-index) for requirements, `EXPLAIN` output, and comparison with B-tree indexes.
 
 ### Full-text search (`FULLTEXT`) index
 

--- a/src/content/learn/schema-management/indexes/index-types-and-strategies.mdx
+++ b/src/content/learn/schema-management/indexes/index-types-and-strategies.mdx
@@ -16,7 +16,7 @@ SurrealDB offers a range of indexing capabilities designed to optimize data retr
 
 ### Standard (non-unique) index
 
-An index without any special clauses allows for the indexing of attributes that may have non-unique values, facilitating efficient data retrieval. Non-unique indexes help index frequently appearing data in queries that do not require uniqueness, such as categorization tags or status indicators.
+An index with `FIELDS` or `COLUMNS` and no special clause (`UNIQUE`, `COUNT`, `FULLTEXT`, etc.) is a **standard B-tree index** — the default secondary index type.
 
 Let's create a non-unique index for an age field on a user table.
 
@@ -85,7 +85,7 @@ DEFINE INDEX test ON user FIELDS account, email UNIQUE;
 
 <Since v="v3.0.0" />
 
-A count index maintains a running count of records on a table. Use it with `count()` and `GROUP ALL`.
+A count index uses the `COUNT` special clause instead of the usual `FIELDS` / `COLUMNS` form (which defines a standard B-tree index). Use it with `count()` and `GROUP ALL`.
 
 - **`COUNT`** — full-table counts: `SELECT count() FROM <table> GROUP ALL`.
 - **`COUNT WHERE <condition>`** — filtered counts when the query `WHERE` exactly matches the index condition.
@@ -117,7 +117,7 @@ DEFINE INDEX item_active_count ON item COUNT WHERE status = "active";
 SELECT count() FROM item WHERE status = "active" GROUP ALL;
 ```
 
-A regular index (a B-tree index) on the same field can also accelerate filtered counts when it fully covers the `WHERE` clause; you typically choose one approach, not both. For counting several statuses (`IN` lists vs per-status totals), see [Multiple conditions](/docs/reference/query-language/statements/define/indexes#multiple-conditions) in the reference. See [`DEFINE INDEX`](/docs/reference/query-language/statements/define/indexes#count-index) for requirements, `EXPLAIN` output, and comparison with B-tree indexes.
+A **standard index** (`DEFINE INDEX … FIELDS …` on the same field) can also accelerate filtered counts when it fully covers the `WHERE` clause; you typically choose one approach, not both. For choosing between standard and count indexes (including storage tradeoffs), see [When to use which](/docs/reference/query-language/statements/define/indexes#when-to-use-which). For counting several statuses (`IN` lists vs per-status totals), see [Multiple conditions](/docs/reference/query-language/statements/define/indexes#multiple-conditions).
 
 ### Full-text search (`FULLTEXT`) index
 

--- a/src/content/reference/query-language/statements/define/indexes.mdx
+++ b/src/content/reference/query-language/statements/define/indexes.mdx
@@ -239,11 +239,36 @@ Requirements for the filtered fast path:
 
 If the `WHERE` clause is not an exact match, SurrealDB falls back to a full table scan, filter, and count.
 
-#### Count index vs standard index for counts
+#### When to use which
 
-A standard index (a B-tree index) can also accelerate filtered counts when it fully covers the `WHERE` clause — for example, `DEFINE INDEX … FIELDS status` for `WHERE status = "active" GROUP ALL`. You do not need both a B-tree and a `COUNT WHERE` index for the same predicate; either can enable `IndexCountScan`.
+For many applications, a **standard B-tree index** (`FIELDS` / `COLUMNS`) is the default for filtered counts. Recent planner improvements let a covering B-tree use the same `IndexCountScan` fast path as a `COUNT WHERE` index, so the two often perform similarly at query time.
 
-Choose `COUNT WHERE` when you want fast filtered counts without maintaining a separate B-tree on that field. Choose a B-tree when you also need the field for lookups, sorting, or other predicates.
+That does **not** make count indexes obsolete, however, as they solve a narrower problem and have a smaller storage footprint.
+
+* If you would add `DEFINE INDEX … FIELDS status` anyway, a separate `COUNT WHERE status = "active"` index is usually redundant. In this case, a standard B-tree is preferred.
+
+* When to use `COUNT WHERE` instead: materialised cardinality for a fixed condition you do not want to back with a B-tree; compound predicates without a covering index; or a dedicated counter separate from lookup indexes.
+
+The following chart sums up a few use cases and when to prefer one vs. the other.
+
+| Goal | Prefer |
+| --- | --- |
+| `count() … GROUP ALL` with no `WHERE` | Nothing extra required; `CountScan` counts record keys. Unconditional `COUNT` is optional. |
+| `count() … WHERE field = value GROUP ALL` on a field you already filter on | `FIELDS field` B-tree (also supports `SELECT`, `ORDER BY`, and other predicates) |
+| Many per-value counts on the same field | One B-tree on that field |
+| One fixed combined predicate (`IN`, `AND`, etc.) counted repeatedly | `COUNT WHERE` with the **exact** same expression in the query |
+| Fast counts for a predicate but **no** B-tree on those fields | `COUNT WHERE` |
+| Compound `WHERE` with no covering composite B-tree | `COUNT WHERE` with the exact compound condition |
+
+#### Storage footprint
+
+Count indexes and B-tree indexes store different shapes of data, so size is not the same even when query performance is similar.
+
+A **B-tree index** stores one entry per indexed record: encoded field value(s) plus the record id in the key. Storage grows **with the number of rows** in the table (O(n) for that index).
+
+A **`COUNT WHERE` index** does not store per-row field keys. It appends small **delta entries** (`IndexCountKey`) when rows enter or leave the predicate, then **compacts** them into a single aggregate entry in the background. In steady state, footprint is usually **much smaller** than a B-tree on the same field, often a handful of keys rather than one per row.
+
+So `COUNT WHERE` can be attractive when you need fast filtered counts **without** paying the per-row storage of a B-tree if it will not be used for anything else.
 
 To compare indexed and non-indexed performance, the `WITH NOINDEX` clause can be used.
 
@@ -271,7 +296,33 @@ SELECT count() FROM person
 
 In the above example, it does not also speed up `WHERE status = "active" GROUP ALL` or other subsets.
 
+For separate per-status totals, one `FIELDS status` B-tree is usually simpler than one `COUNT WHERE` index per value. See [When to use which](/docs/reference/query-language/statements/define/indexes#when-to-use-which).
+
 Use [`EXPLAIN ANALYZE`](/docs/reference/query-language/statements/explain) to confirm `IndexCountScan` is selected. If the query `WHERE` differs even slightly from the index condition, SurrealDB falls back to a full scan.
+
+#### Other `COUNT` syntax notes
+
+```surql
+-- Other clauses like `COMMENT` are fine
+DEFINE INDEX idx ON users COUNT
+    COMMENT "Users are expected to grow substantially so index the count"
+    CONCURRENTLY;
+
+-- Conditional count indexes
+DEFINE INDEX active_users ON users COUNT WHERE status = "active" CONCURRENTLY;
+
+-- But not `FIELD`
+DEFINE INDEX idx2 ON person FIELD name;
+```
+
+```surql title="Output"
+'There was a problem with the database: Parse error: Unexpected token `FIELD`, expected Eof
+ --> [1:29]
+  |
+1 | DEFINE INDEX idx2 ON person FIELD name;
+  |                             ^^^^^ 
+'
+```
 
 ### Full-text search (`FULLTEXT`) index
 

--- a/src/content/reference/query-language/statements/define/indexes.mdx
+++ b/src/content/reference/query-language/statements/define/indexes.mdx
@@ -35,7 +35,7 @@ The `@special_clause` part of the statement is an optional part in which an inde
 
 ```syntax title="Special index clauses"
 UNIQUE
-| COUNT
+| COUNT [ WHERE @condition ]
 | FULLTEXT ANALYZER @analyzer [ BM25 [(@k1, @b)] ] [ HIGHLIGHTS ]
 | HNSW DIMENSION @dimension [ TYPE @type ] [ DIST @distance ] [ EFC @efc ] [ M @m ]
 | DISKANN DIMENSION @dimension [ TYPE @type ] [ DIST @distance ] [ DEGREE @degree ] [ L_BUILD @l_build ] [ ALPHA @alpha ] [ HASHED_VECTOR ]
@@ -183,7 +183,18 @@ LIMIT 10;
 
 <Since v="v3.0.0" />
 
-An index using the `COUNT` clause is used to maintain a count of the number of records in a table. This is used together with the `count()` function and `GROUP ALL` inside a query. Without a count index, the `count()` function will iterate through the records of a table when it is called.
+A count index maintains a running count of records on a table. It is used with `count()` and `GROUP ALL` in a query. SurrealDB stores incremental count deltas and compacts them in the background.
+
+Count indexes come in two forms:
+
+- **`COUNT`** — counts every record in the table. Used with `SELECT count() FROM <table> GROUP ALL` (no `WHERE`).
+- **`COUNT WHERE <condition>`** — counts only records that match the condition. Used with `SELECT count() FROM <table> WHERE <condition> GROUP ALL` when the query `WHERE` clause **exactly matches** the index condition.
+
+As a count index is declared on a table as a whole, it cannot use the `FIELDS` / `COLUMNS` clause.
+
+#### Full-table counts
+
+For `SELECT count() FROM <table> GROUP ALL`, SurrealDB already uses a `CountScan` fast path that counts record keys in storage without deserialising every row. An unconditional `COUNT` index is optional here; it can reduce work further once count deltas have been compacted, but a freshly built index on a large existing table may hold millions of delta entries until compaction runs.
 
 ```surql
 DEFINE INDEX idx ON indexed_reading COUNT;
@@ -202,26 +213,65 @@ SELECT count() FROM reading GROUP ALL;
 SELECT count() FROM indexed_reading GROUP ALL;
 ```
 
-As a count index is declared on a table as a whole, it cannot use the `FIELDS` / `COLUMNS` clause.
+#### Filtered counts (`COUNT WHERE`)
+
+Use `COUNT WHERE` when you repeatedly need `SELECT count() … WHERE … GROUP ALL` and do not want to scan and deserialise every record. The planner uses `IndexCountScan` when the query `WHERE` matches the index condition exactly (same expression as written in `DEFINE INDEX`).
 
 ```surql
--- Other clauses like `COMMENT` are fine
-DEFINE INDEX idx ON users COUNT
-    COMMENT "Users are expected to grow substantially so index the count"
-    CONCURRENTLY;
+DEFINE TABLE item SCHEMALESS;
+DEFINE INDEX item_active_count ON item COUNT WHERE status = "active";
 
--- But not `FIELD`
-DEFINE INDEX idx2 ON person FIELD name;
+CREATE item:a SET status = "active";
+CREATE item:b SET status = "active";
+CREATE item:c SET status = "inactive";
+
+SELECT count() FROM item WHERE status = "active" GROUP ALL;
+
+EXPLAIN ANALYZE SELECT count() FROM item WHERE status = "active" GROUP ALL;
 ```
 
-```surql title="Output"
-'There was a problem with the database: Parse error: Unexpected token `FIELD`, expected Eof
- --> [1:29]
-  |
-1 | DEFINE INDEX idx2 ON person FIELD name;
-  |                             ^^^^^ 
-'
+Requirements for the filtered fast path:
+
+- `GROUP ALL` must be present.
+- The query `WHERE` must match the index condition exactly (not a broader or different predicate).
+- The index build must be complete (`INFO FOR INDEX …` shows `ready`).
+- Field-level `SELECT` permissions on fields in the condition must not block index-only counting.
+
+If the `WHERE` clause is not an exact match, SurrealDB falls back to a full table scan, filter, and count.
+
+#### Count index vs standard index for counts
+
+A standard index (a B-tree index) can also accelerate filtered counts when it fully covers the `WHERE` clause — for example, `DEFINE INDEX … FIELDS status` for `WHERE status = "active" GROUP ALL`. You do not need both a B-tree and a `COUNT WHERE` index for the same predicate; either can enable `IndexCountScan`.
+
+Choose `COUNT WHERE` when you want fast filtered counts without maintaining a separate B-tree on that field. Choose a B-tree when you also need the field for lookups, sorting, or other predicates.
+
+To compare indexed and non-indexed performance, the `WITH NOINDEX` clause can be used.
+
+```surql
+-- Slow path: scan every record
+SELECT count() FROM item WITH NOINDEX WHERE status = "active" GROUP ALL;
+
+-- Fast path: count index deltas (or B-tree keys if a covering index exists)
+SELECT count() FROM item WHERE status = "active" GROUP ALL;
 ```
+
+#### Multiple conditions
+
+As each `COUNT WHERE` index tracks one fixed predicate, it does not accelerate several different counts unless each query repeats the **exact** condition stored in the index.
+
+```surql
+DEFINE INDEX openish_count ON person COUNT
+    WHERE status IN ["active", "non-active", "delayed"];
+
+-- Fast only when the WHERE matches the index exactly
+SELECT count() FROM person
+    WHERE status IN ["active", "non-active", "delayed"]
+    GROUP ALL;
+```
+
+In the above example, it does not also speed up `WHERE status = "active" GROUP ALL` or other subsets.
+
+Use [`EXPLAIN ANALYZE`](/docs/reference/query-language/statements/explain) to confirm `IndexCountScan` is selected. If the query `WHERE` differs even slightly from the index condition, SurrealDB falls back to a full scan.
 
 ### Full-text search (`FULLTEXT`) index
 


### PR DESCRIPTION
Updates on COUNT indexes and indexes in general:

- Adds WHERE syntax to COUNT (was not documented anywhere)
- Notes on when to use regular B-tree index vs. COUNT WHERE