### PR TITLE
Old wording cleanup

### DIFF
--- a/src/content/build/integrations/ai-frameworks/kreuzberg.mdx
+++ b/src/content/build/integrations/ai-frameworks/kreuzberg.mdx
@@ -94,7 +94,7 @@ For more ideas on how to redo this example to suit your own needs, see the [API 
 ```rust
 // Required features to run:
 // kreuzberg = { version = "4.9.4", default-features = true, features = ["hwpx", "language-detection"] }
-// surrealdb = { version = "3.1.0-beta.1", default-features = true, features = ["protocol-ws", "kv-mem"] }
+// surrealdb = { version = "3.2.0", default-features = true, features = ["protocol-ws", "kv-mem"] }
 use anyhow::{Context, Result};
 use kreuzberg::{extract_file, ExtractionConfig, LanguageDetectionConfig};
 use sha2::{Digest, Sha256};

--- a/src/content/explore/surrealist/getting-started.mdx
+++ b/src/content/explore/surrealist/getting-started.mdx
@@ -38,7 +38,7 @@ When creating a new connection you will be prompted with a dialog to enter your 
 - **Authentication method**: The auth method determines how you want to authenticate with your database.
 
 > [!IMPORTANT]
-> In the new Surrealist redesign, the namespace and database fields are now configured per connection before you can [send queries to the database](/docs/explore/surrealist/concepts/sending-queries).
+> You must configure namespace and database on each connection before you can [send queries to the database](/docs/explore/surrealist/concepts/sending-queries).
 
 Depending on the selected authentication method, you will be prompted to enter additional details such as a username and password, or a token.
 

--- a/src/content/index/languages/rust/frameworks/axum.mdx
+++ b/src/content/index/languages/rust/frameworks/axum.mdx
@@ -50,7 +50,7 @@ The `serde` crate will also need a feature flag for its `Serialize` and `Deseria
 axum = "0.8.8"
 fake = "4.4.0"
 serde = { version = "1.0.228", features = ["derive"] }
-surrealdb = "3.0.0-beta.2"
+surrealdb = "3.2.0"
 thiserror = "2.0.18"
 tokio = "1.49.0"
 ```

--- a/src/content/index/languages/rust/frameworks/rocket.mdx
+++ b/src/content/index/languages/rust/frameworks/rocket.mdx
@@ -49,7 +49,7 @@ The `serde` crate will need the `derive` flag, and `rocket` will need the `json`
 fake = "4.4.0"
 rocket = { version = "0.5.1", features = ["json"] }
 serde = { version = "1.0.228", features = ["derive"] }
-surrealdb = "3.0.0-beta.2"
+surrealdb = "3.2.0"
 thiserror = "2.0.18"
 ```
 

--- a/src/content/index/languages/rust/methods/export.mdx
+++ b/src/content/index/languages/rust/methods/export.mdx
@@ -322,8 +322,6 @@ INSERT [ { id: person:bgq0b0rblnozrufizdjm } ];
 
 ### Export configuration
 
-<Since v="v2.1.0" />
-
 The [`Export`](https://docs.rs/surrealdb/2/surrealdb/method/struct.Export.html) struct has a method called `.with_config()` that gives access to the configuration parameters for the export. These can be chained one after another inside a single line of code. The majority of these functions take a single `bool`:
 
 * `.versions()`: whether to include [version information](/docs/reference/query-language/statements/select#the-version-clause) for backends with versioning enabled

--- a/src/content/index/languages/rust/start.mdx
+++ b/src/content/index/languages/rust/start.mdx
@@ -84,7 +84,7 @@ async fn main() -> surrealdb::Result<()> {
 }
 ```
 
-Note that the `.query()` method is able to hold more than one statement, in this case three statements; i.e. two [`RETURN`](/docs/reference/query-language/statements/return) statements and one [`SELECT`](/docs/reference/query-language/statements/select) statement. The [`IndexedResults`](https://docs.rs/surrealdb/3.0.0-beta.2/surrealdb/struct.IndexedResults.html) struct returned contains a field called `results` which holds the output of each statement. Note that each result has its own index. This will become useful when using the `.take()` method in the example to follow, which can access a result by its index number.
+Note that the `.query()` method is able to hold more than one statement, in this case three statements; i.e. two [`RETURN`](/docs/reference/query-language/statements/return) statements and one [`SELECT`](/docs/reference/query-language/statements/select) statement. The [`IndexedResults`](https://docs.rs/surrealdb/latest/surrealdb/struct.IndexedResults.html) struct returned contains a field called `results` which holds the output of each statement. Note that each result has its own index. This will become useful when using the `.take()` method in the example to follow, which can access a result by its index number.
 
 ```surql title="Example output"
 results: {
@@ -152,7 +152,7 @@ results: {
     }
 ```
 
-Now that we have the basics down, it is time to try out some other methods like [`CREATE`](/docs/reference/query-language/statements/create) and [`UPDATE`](/docs/reference/query-language/statements/update). The most ergonomic way to do this is to use a struct that implements [`SurrealValue`](https://docs.rs/surrealdb/3.0.0-beta.2/surrealdb/types/trait.SurrealValue.html) which allows for both serialization and deserialization between the Rust code and the database.
+Now that we have the basics down, it is time to try out some other methods like [`CREATE`](/docs/reference/query-language/statements/create) and [`UPDATE`](/docs/reference/query-language/statements/update). The most ergonomic way to do this is to use a struct that implements [`SurrealValue`](https://docs.rs/surrealdb/latest/surrealdb/types/trait.SurrealValue.html) which allows for both serialization and deserialization between the Rust code and the database.
 
 ```rust
 use surrealdb::Surreal;

--- a/src/content/learn/data-models/full-text-search/scoring-and-ranking.mdx
+++ b/src/content/learn/data-models/full-text-search/scoring-and-ranking.mdx
@@ -10,7 +10,7 @@ After you have [defined analyzers](/docs/learn/data-models/full-text-search/anal
 
 ## Querying
 
-Once an index that uses a full-text analyzer is in place, it is now possible to use the `@@` operator (the `MATCHES` operator).
+Once an index that uses a full-text analyzer is in place, use the `@@` operator (the `MATCHES` operator) to query it.
 
 - **Ranking / Scoring**: Once matches are found, an FTS engine ranks them to show the most relevant results first. Algorithms such as BM25 or TF-IDF look at how often terms appear in a document, or whether those terms appear in the title vs. the body, etc.
 

--- a/src/content/learn/schema-management/indexes/index-types-and-strategies.mdx
+++ b/src/content/learn/schema-management/indexes/index-types-and-strategies.mdx
@@ -130,7 +130,7 @@ Let's create a full-text search index for a `name` field on a `user` table.
 ```surql
 -- Define the an analyzer with
 DEFINE ANALYZER example_ascii TOKENIZERS class FILTERS ascii;
--- Since 3.0.0-beta: only FULLTEXT used to benefit from concurrent full-text search
+-- Since 3.0.0: only FULLTEXT used to benefit from concurrent full-text search
 DEFINE INDEX userNameIndex ON TABLE user FIELDS name FULLTEXT ANALYZER example_ascii BM25 HIGHLIGHTS;
 ```
 

--- a/src/content/learn/schema-management/schema-design/sample-industry-schemas.mdx
+++ b/src/content/learn/schema-management/schema-design/sample-industry-schemas.mdx
@@ -9,7 +9,7 @@ description: "Copy-paste starter schemas for energy, finance, retail, medical, a
 These snippets are starting points that are realistic enough to learn from, short enough to paste into Surrealist or to lift into [SurrealKit](/docs/manage/schema-migration) `.surql` schema files and then reshape. They mix **tables**, **relations**, **computed** fields, **events**, and **indexes** the way a real app might.
 
 > [!NOTE]
-> Many fields use [`COMPUTED`](/docs/reference/query-language/statements/define/field#computed-fields) (SurrealDB 3.0.0-beta onward). On older versions, replace with a [`future`](/docs/reference/query-language/language-primitives/data-types/futures) and `VALUE { … }` as in the futures documentation.
+> Many fields use [`COMPUTED`](/docs/reference/query-language/statements/define/field#computed-fields) (SurrealDB 3.0.0 onward). On older versions, replace with a [`future`](/docs/reference/query-language/language-primitives/data-types/futures) and `VALUE { … }` as in the futures documentation.
 
 ## Adding to this page
 

--- a/src/content/learn/security/authentication/authentication.mdx
+++ b/src/content/learn/security/authentication/authentication.mdx
@@ -115,8 +115,6 @@ curl -X POST \
 
 ## Record users
 
-<Since v="v2.0.0" />
-
 Record users represent users that are defined as a record in a database instead of through the `DEFINE USER` statement. Since these users exist as regular database records, they can have associated fields containing any information required for authentication and authorization.
 
 Thanks to this, SurrealDB is able to offer mechanisms to define your own signin and signup logic as well as custom table and field permissions for record users. This feature contributes to making SurrealDB an all-in-one BaaS (Backend-as-a-Service).
@@ -261,8 +259,6 @@ curl -X POST \
 ```
 
 ## Sessions
-
-<Since v="v2.0.0" />
 
 Whenever authentication is performed with any kind of user against SurrealDB, a session is established between the client and the SurrealDB server with which the connection was established. These sessions exist only in memory on the server for the duration of the connection, whether it is a single request through the [HTTP REST API](/docs/reference/rest-api/http) or through multiple requests in the same connection using the [WebSocket API](/docs/reference/rest-api/rpc) and any of the [SDKs](/docs/reference/rest-api/sdks) that leverage it.
 

--- a/src/content/reference/cli/surrealdb-cli/commands/sql.mdx
+++ b/src/content/reference/cli/surrealdb-cli/commands/sql.mdx
@@ -143,8 +143,6 @@ For more on the environment variables available for CLI commands or SurrealDB in
 
 ## `--auth-level` option
 
-<Since v="v2.0.0" />
-
 The `--auth-level` option sets the authentication level to use when connecting to the database. The option has three possible values: `root`, `namespace`, and `database`. The `root` value is the highest level of authentication, while the `namespace` and `database` values are used for authenticating as users defined on a specific namespace or database. 
 
 There are a few things to keep in mind when using the `--auth-level` option:
@@ -168,8 +166,6 @@ surreal sql --endpoint http://localhost:8000 --namespace main --database main --
 ```
 
 ## `--token` option
-
-<Since v="v2.0.0" />
 
 The `--token` option sets the authentication token to use when connecting to the server. This option allows you to connect to SurrealDB using a JWT instead of user credentials. The token is used to authenticate the user and provide access to the database server which means it cannot be provided at the same time as `--username`, `--password` or `--auth-level`.
 

--- a/src/content/reference/cli/surrealdb-cli/commands/start.mdx
+++ b/src/content/reference/cli/surrealdb-cli/commands/start.mdx
@@ -308,8 +308,6 @@ surreal start --deny-all --allow-funcs "array, string, crypto::argon2, http::get
 
 ## Unauthenticated mode
 
-<Since v="v2.0.0" />
-
 > [!NOTE]
 > We recommend enabling authentication when running SurrealDB in production or in publicly exposed ways. Failure to do so may result in unauthorized access.
 
@@ -322,8 +320,6 @@ surreal start --unauthenticated
 ```
 
 ## Identification headers
-
-<Since v="v2.0.0" />
 
 By default, SurrealDB includes headers in the HTTP response that identify the server name and version. You can suppress these headers by using the `--no-identification-headers` flag.
 

--- a/src/content/reference/cli/surrealdb-cli/environment-variables.mdx
+++ b/src/content/reference/cli/surrealdb-cli/environment-variables.mdx
@@ -80,7 +80,7 @@ These environment variables can be used to configure a SurrealDB server to confi
       <td scope="row" data-label="Notes">Specifies the number of items which can be cached within a single transaction.</td>
     </tr>
 <tr>
-      <td scope="row" data-label="Env var"><code>SURREAL_DATASTORE_CACHE_SIZE</code><Since v="v2.1.0" /></td>
+      <td scope="row" data-label="Env var"><code>SURREAL_DATASTORE_CACHE_SIZE</code></td>
       <td scope="row" data-label="Default">1,000</td>
       <td scope="row" data-label="Allowed values">A usize</td>
       <td scope="row" data-label="Notes">The number of definitions which can be cached across transactions.</td>
@@ -155,7 +155,7 @@ Server-side filesystem access for features that read paths from disk (notably th
   <tbody>
 
   <tr>
-      <td scope="row" data-label="Env var"><code>SURREAL_MAX_HTTP_REDIRECTS</code><Since v="v2.0.5" /></td>
+      <td scope="row" data-label="Env var"><code>SURREAL_MAX_HTTP_REDIRECTS</code></td>
       <td scope="row" data-label="Default">10</td>
       <td scope="row" data-label="Allowed values">A usize</td>
       <td scope="row" data-label="Notes">The maximum number of HTTP redirects allowed within http functions.</td>
@@ -419,13 +419,13 @@ Resource limits for experimental [ISO GQL](/docs/learn/querying/gql/overview) `M
       <td scope="row" data-label="Notes">Specifies how deep the parser will parse recursive queries (queries within queries).</td>
     </tr>
     <tr>
-      <td scope="row" data-label="Env var"><code>SURREAL_OPERATOR_BUFFER_SIZE</code><Since v="v2.1.5" /></td>
+      <td scope="row" data-label="Env var"><code>SURREAL_OPERATOR_BUFFER_SIZE</code></td>
       <td scope="row" data-label="Default">2</td>
       <td scope="row" data-label="Allowed values">A usize</td>
       <td scope="row" data-label="Notes">The number of batches each operator buffers ahead of downstream demand. Set to 0 to disable operator-level pipeline buffering.</td>
     </tr>
     <tr>
-      <td scope="row" data-label="Env var"><code>SURREAL_REGEX_SIZE_LIMIT</code><Since v="v2.1.5" /></td>
+      <td scope="row" data-label="Env var"><code>SURREAL_REGEX_SIZE_LIMIT</code></td>
       <td scope="row" data-label="Default">10,485,760 (10 MiB)</td>
       <td scope="row" data-label="Allowed values">A usize</td>
       <td scope="row" data-label="Notes">Limits the maximum allowed size (in bytes) for regular expressions. This prevents excessive memory consumption when building complex or very large regex patterns.</td>
@@ -491,7 +491,7 @@ Resource limits for experimental [ISO GQL](/docs/learn/querying/gql/overview) `M
       <td scope="row" data-label="Notes">Maximum memory limit of the JavaScript function runtime.</td>
     </tr>
     <tr>
-      <td scope="row" data-label="Env var"><code>SURREAL_SCRIPTING_MAX_TIME_LIMIT</code><Since v="v2.0.5" /></td>
+      <td scope="row" data-label="Env var"><code>SURREAL_SCRIPTING_MAX_TIME_LIMIT</code></td>
       <td scope="row" data-label="Default">5000 (5000 milliseconds or 5 seconds)</td>
       <td scope="row" data-label="Allowed values">A usize</td>
       <td scope="row" data-label="Notes">Maximum allowed time in milliseconds that a JavaScript function is allowed to run for.</td>
@@ -596,13 +596,13 @@ Resource limits for experimental [ISO GQL](/docs/learn/querying/gql/overview) `M
   </thead>
   <tbody>
     <tr>
-      <td scope="row" data-label="Env var"><code>SURREAL_TELEMETRY_DISABLE_METRICS</code><Since v="v2.1.3" /></td>
+      <td scope="row" data-label="Env var"><code>SURREAL_TELEMETRY_DISABLE_METRICS</code></td>
       <td scope="row" data-label="Default">false</td>
       <td scope="row" data-label="Allowed values">true, false</td>
       <td scope="row" data-label="Notes">Whether to disable sending metrics to the GRPC OTEL collector.</td>
     </tr>
     <tr>
-      <td scope="row" data-label="Env var"><code>SURREAL_TELEMETRY_DISABLE_TRACING</code><Since v="v2.1.3" /></td>
+      <td scope="row" data-label="Env var"><code>SURREAL_TELEMETRY_DISABLE_TRACING</code></td>
       <td scope="row" data-label="Default">false</td>
       <td scope="row" data-label="Allowed values">true, false</td>
       <td scope="row" data-label="Notes">Whether to disable sending traces to the GRPC OTEL collector.</td>
@@ -795,7 +795,7 @@ These settings are for operators, benchmarks, and advanced debugging — not typ
       <td scope="row" data-label="Notes">Whether MVCC versioning is enabled. Used by memory and surrealkv engines.</td>
     </tr>
     <tr>
-      <td scope="row" data-label="Env var"><code>SURREAL_MEMORY_THRESHOLD</code><Since v="v2.1.5" /></td>
+      <td scope="row" data-label="Env var"><code>SURREAL_MEMORY_THRESHOLD</code></td>
       <td scope="row" data-label="Default">0</td>
       <td scope="row" data-label="Allowed values">A usize or suffixed integer</td>
       <td scope="row" data-label="Notes">Configuring the memory threshold which can be used across the programme to check if the amount of memory available to the programme is lower than required. The value can be specified as bytes (b, or without any suffix), kibibytes (k, kb, or kib), mebibytes (m, mb, or mib), or gibibytes (g, gb, or gib). If the environment variable is not specified, then the threshold is not used, and no memory limit is enabled.</td>
@@ -1547,25 +1547,25 @@ The available environment variables for configuring a RocksDB instance are:
       <td scope="row" data-label="Notes">The readahead buffer size used during compaction.</td>
     </tr>
     <tr>
-      <td scope="row" data-label="Env var"><code>SURREAL_ROCKSDB_COMPACTION_STYLE</code> <Since v="v2.0.3" /></td>
+      <td scope="row" data-label="Env var"><code>SURREAL_ROCKSDB_COMPACTION_STYLE</code> </td>
       <td scope="row" data-label="Default">level</td>
       <td scope="row" data-label="Allowed values">level, universal</td>
       <td scope="row" data-label="Notes">Use to specify the database compaction style.</td>
     </tr>
     <tr>
-      <td scope="row" data-label="Env var"><code>SURREAL_ROCKSDB_DELETION_FACTORY_DELETE_COUNT</code><Since v="v2.0.3" /></td>
+      <td scope="row" data-label="Env var"><code>SURREAL_ROCKSDB_DELETION_FACTORY_DELETE_COUNT</code></td>
       <td scope="row" data-label="Default">50</td>
       <td scope="row" data-label="Allowed values">A usize</td>
       <td scope="row" data-label="Notes">The number of deletions to track in the window.</td>
     </tr>
     <tr>
-      <td scope="row" data-label="Env var"><code>SURREAL_ROCKSDB_DELETION_FACTORY_RATIO</code><Since v="v2.0.3" /></td>
+      <td scope="row" data-label="Env var"><code>SURREAL_ROCKSDB_DELETION_FACTORY_RATIO</code></td>
       <td scope="row" data-label="Default">0.5</td>
       <td scope="row" data-label="Allowed values">A float</td>
       <td scope="row" data-label="Notes">The ratio of deletions to track in the window.</td>
     </tr>
     <tr>
-      <td scope="row" data-label="Env var"><code>SURREAL_ROCKSDB_DELETION_FACTORY_WINDOW_SIZE</code><Since v="v2.0.3" /></td>
+      <td scope="row" data-label="Env var"><code>SURREAL_ROCKSDB_DELETION_FACTORY_WINDOW_SIZE</code></td>
       <td scope="row" data-label="Default">1000</td>
       <td scope="row" data-label="Allowed values">A usize</td>
       <td scope="row" data-label="Notes">The size of the window used to track deletions.</td>
@@ -1613,7 +1613,7 @@ The available environment variables for configuring a RocksDB instance are:
       <td scope="row" data-label="Notes">The number of files needed to trigger level 0 compaction.</td>
     </tr>
     <tr>
-      <td scope="row" data-label="Env var"><code>SURREAL_ROCKSDB_JOBS_COUNT</code> <Since v="v2.0.3" /></td>
+      <td scope="row" data-label="Env var"><code>SURREAL_ROCKSDB_JOBS_COUNT</code></td>
       <td scope="row" data-label="Default">Number of CPUs * 2</td>
       <td scope="row" data-label="Allowed values">A usize</td>
       <td scope="row" data-label="Notes">The maximum number of threads to use for flushing and compaction.</td>
@@ -1805,7 +1805,7 @@ The available environment variables for configuring a RocksDB instance are:
       <td scope="row" data-label="Notes">A string specifying the keyspace identifier for data isolation.</td>
     </tr>
     <tr>
-      <td scope="row" data-label="Env var"><code>SURREAL_TIKV_GRPC_MAX_DECODING_MESSAGE_SIZE</code><Since v="v2.1.8" /></td>
+      <td scope="row" data-label="Env var"><code>SURREAL_TIKV_GRPC_MAX_DECODING_MESSAGE_SIZE</code></td>
       <td scope="row" data-label="Default">4,194,304 (4 MiB)</td>
       <td scope="row" data-label="Allowed values">A usize</td>
       <td scope="row" data-label="Notes">Sets the maximum decoding size of a gRPC message.</td>

--- a/src/content/reference/query-language/functions/database-functions/array.mdx
+++ b/src/content/reference/query-language/functions/database-functions/array.mdx
@@ -865,8 +865,6 @@ RETURN array::distinct([ 1, 2, 1, 3, 3, 4 ]);
 
 ## `array::fill`
 
-<Since v="v2.0.0" />
-
 The `array::fill` function replaces all values of an array with a new value.
 
 ```surql title="API DEFINITION"
@@ -1290,8 +1288,6 @@ RETURN array::flatten([ [1,
 
 ## `array::fold`
 
-<Since v="v2.1.0" />
-
 The `array::fold` function returns a final value from the elements of an array by allowing an operation to be performed at each step of the way as each subsequent item in the array is encountered. To use `array::fold`, pass in an initial value, followed by parameter names for the current value and the next value and an operation to perform on them. If you only want to perform an operation on each item and do not need an initial value, use the [`array::reduce`](#arrayreduce) function instead.
 
 ```surql title="API DEFINITION"
@@ -1563,8 +1559,6 @@ RETURN array::intersect([1, 2, 3, 4], [3, 4, 5, 6]);
 <br />
 
 ## `array::is_empty`
-
-<Since v="v2.0.0" />
 
 The `array::is_empty` function checks whether the array contains values.
 
@@ -2216,8 +2210,6 @@ RETURN array::push([1, 2, 3, 4], 5);
 
 ## `array::range`
 
-<Since v="v2.0.0" />
-
 The `array::range` function creates an array of numbers from a given range.
 
 ```surql title="API DEFINITION"
@@ -2257,8 +2249,6 @@ RETURN array::range(1..=5);
 <br />
 
 ## `array::reduce`
-
-<Since v="v2.1.0" />
 
 The `array::reduce` function reduces the elements of an array to a single final value by allowing an operation to be performed at each step of the way as each subsequent item in the array is encountered. To use `array::reduce`, pass in parameter names for the current value and the next value and an operation to perform on them. If you need an initial value to pass in before the other items are operated on, use the [`array::fold`](#arrayfold) function instead.
 
@@ -2407,8 +2397,6 @@ RETURN array::remove([1, 2, 3, 4, 5], -2);
 
 ## `array::repeat`
 
-<Since v="v2.0.0" />
-
 The `array::repeat` function creates an array of a given size contain the specified value for each element. The `count` argument must be non-negative; negative values return an error.
 
 ```surql title="API DEFINITION"
@@ -2496,8 +2484,6 @@ array::sequence(-5, 6);
 ```
 
 ## `array::shuffle`
-
-<Since v="v2.0.0" />
 
 The `array::shuffle` function randomly shuffles the items of an array.
 
@@ -2894,8 +2880,6 @@ RETURN array::sort::desc([ 1, 2, 1, null, "something", 3, 3, 4, 0 ]);
 
 ## `array::swap`
 
-<Since v="v2.0.0" />
-
 The `array::swap` function swaps two values of an array based on indexes.
 
 ```surql title="API DEFINITION"
@@ -3203,8 +3187,6 @@ RETURN array::union([1, 2, 1, 6], [1, 3, 4, 5, 6]);
 
 ## `array::windows`
 
-<Since v="v2.0.0" />
-
 ```surql title="API DEFINITION"
 array::windows(array, $window_size: int) -> array
 ```
@@ -3269,8 +3251,6 @@ FROM person;
 ```
 
 ## Method chaining
-
-<Since v="v2.0.0" />
 
 Method chaining allows functions to be called using the `.` dot operator on a value of a certain type instead of the full path of the function followed by the value.
 

--- a/src/content/reference/query-language/functions/database-functions/array.mdx
+++ b/src/content/reference/query-language/functions/database-functions/array.mdx
@@ -760,7 +760,7 @@ RETURN [1,2].concat([3,4], [4,3])
 -- [1, 2, 3, 4, 4, 3]
 ```
 
-As of SurrealDB 3.0.0-beta, the behaviour of this function can also be achieved using the `+` operator.
+As of SurrealDB 3.0.0, the behaviour of this function can also be achieved using the `+` operator.
 
 ```surql
 /**[test]
@@ -2214,7 +2214,7 @@ The `array::range` function creates an array of numbers from a given range.
 
 ```surql title="API DEFINITION"
 array::range($start: int, $end: int) -> array
--- Also since 3.0.0-beta
+-- Also since 3.0.0
 array::range(range) -> array;
 ```
 
@@ -2514,7 +2514,7 @@ The `array::slice` function returns a slice of an array, based on a starting pos
 
 ```surql title="API DEFINITION"
 array::slice(array, $start: int, $len: int) -> array
--- Also since 3.0.0-beta
+-- Also since 3.0.0
 array::slice(array, $slice: range) -> array;
 ```
 

--- a/src/content/reference/query-language/functions/database-functions/crypto.mdx
+++ b/src/content/reference/query-language/functions/database-functions/crypto.mdx
@@ -78,8 +78,6 @@ These functions can be used when hashing data, encrypting data, and for securely
 
 ## `crypto::blake3`
 
-<Since v="v2.0.0" />
-
 The `crypto::blake3` function returns the blake3 hash of the input value.
 
 ```surql title="API DEFINITION"

--- a/src/content/reference/query-language/functions/database-functions/duration.mdx
+++ b/src/content/reference/query-language/functions/database-functions/duration.mdx
@@ -9,7 +9,7 @@ description: Functions and constants for working with duration-related data.
 This page contains built-in functions and constants for converting between numeric and [duration](/docs/reference/query-language/language-primitives/data-types/durations) data.
 
 > [!NOTE]
-> Since version 3.0.0-beta, the `::from::` functions (e.g. `duration::from::millis()`) now use underscores (e.g. `duration::from_millis()`) to better match the intent of the function and method syntax.
+> Since version 3.0.0, the `::from::` functions (e.g. `duration::from::millis()`) now use underscores (e.g. `duration::from_millis()`) to better match the intent of the function and method syntax.
 
 ## Duration functions
 

--- a/src/content/reference/query-language/functions/database-functions/duration.mdx
+++ b/src/content/reference/query-language/functions/database-functions/duration.mdx
@@ -574,8 +574,6 @@ RETURN duration::from_weeks(3);
 
 ## Method chaining
 
-<Since v="v2.0.0" />
-
 Method chaining allows functions to be called using the `.` dot operator on a value of a certain type instead of the full path of the function followed by the value.
 
 ```surql

--- a/src/content/reference/query-language/functions/database-functions/http.mdx
+++ b/src/content/reference/query-language/functions/database-functions/http.mdx
@@ -44,20 +44,17 @@ These functions can be used when opening and submitting remote web requests, and
 </table>
 
 
-## Before you begin
+## Response encoding and errors
 
-<Since v="v2.2.0" />
+Failed requests return descriptive errors with the relevant HTTP status code when the remote server provides one.
 
-From version `2.2` of SurrealDB, the HTTP functions have been improved to provide a more consistent and user-friendly experience. These improvements include:
+Response bodies encode SurrealQL values as follows:
 
-- **Enhanced HTTP error messages**: The server provides more descriptive error responses, including relevant HTTP status codes and detailed error information when available.
+- **Bytes**, sent as raw bytes (not base64- or JSON-encoded).
+- **Strings**, sent as raw strings.
+- **Other values** (numbers, arrays, objects, booleans, and so on), JSON-encoded.
 
-- **Raw SurrealQL data encoding**: Data types are preserved more faithfully in responses through improved encoding.
-  - SurrealQL **byte values** are now sent as raw bytes (not base64-encoded or JSON-encoded).  
-  - SurrealQL **string values** are sent as raw strings.  
-  - All other SurrealQL values (numbers, arrays, objects, booleans, etc.) are automatically JSON-encoded.
-
-- **Manual Header Configuration**: SurrealDB no longer automatically adds `Content-Type: application/octet-stream` to responses when the body contains SurrealQL byte values. If you need this header, you can set it manually.
+SurrealDB does not add `Content-Type: application/octet-stream` automatically when the body contains byte values. You can set this header yourself if a client requires it.
 
 ## `http::head`
 

--- a/src/content/reference/query-language/functions/database-functions/index.mdx
+++ b/src/content/reference/query-language/functions/database-functions/index.mdx
@@ -437,8 +437,6 @@ cat:mr_meow
 
 ### Method syntax
 
-<Since v="v2.0.0" />
-
 Functions that are called on an existing value can be called using method syntax, using the `.` (dot) operator.
 
 The following functions will produce the same output as the classic syntax above. `type::record()` cannot be called with method syntax because it is used to outright create a record ID from nothing, rather than being called on an existing value.
@@ -535,8 +533,6 @@ These functions are:
 * [`time::min()`](/docs/reference/query-language/functions/database-functions/time#timemin)
 
 ## Anonymous functions
-
-<Since v="v2.0.0" />
 
 SurrealDB also allows for the creation of anonymous functions (also known as closures) that do not need to be defined on the database. See [the page on closures](/docs/reference/query-language/language-primitives/data-types/closures) for more details.
 

--- a/src/content/reference/query-language/functions/database-functions/index.mdx
+++ b/src/content/reference/query-language/functions/database-functions/index.mdx
@@ -453,7 +453,7 @@ The method syntax is particularly useful when calling a number of functions insi
 array::len(array::windows(array::distinct(array::flatten([[1,2,3],[1,4,6],[4,2,4]])), 2));
 ```
 
-Readability before `2.0` could be improved to a certain extent by moving a query of this type over multiple lines.
+Without method chaining, a query of this type is often written across multiple nested lines:
 
 ```surql
 array::len(

--- a/src/content/reference/query-language/functions/database-functions/math.mdx
+++ b/src/content/reference/query-language/functions/database-functions/math.mdx
@@ -314,8 +314,6 @@ RETURN math::abs(-13.746189);
 
 ## `math::acos`
 
-<Since v="v2.0.0" />
-
 The `math::acos` function returns the arccosine (inverse cosine) of a number, which must be in the range -1 to 1. The result is expressed in radians.
 
 ```surql title="API DEFINITION"
@@ -341,8 +339,6 @@ RETURN math::acos(0.5);
 
 ## `math::acot`
 
-<Since v="v2.0.0" />
-
 The `math::acot` function returns the arccotangent (inverse cotangent) of a number. The result is expressed in radians.
 
 ```surql title="API DEFINITION"
@@ -365,8 +361,6 @@ RETURN math::acot(1);
 ```
 
 ## `math::asin`
-
-<Since v="v2.0.0" />
 
 The `math::asin` function returns the arcsine (inverse sine) of a number, which must be in the range -1 to 1. The result is expressed in radians.
 
@@ -392,9 +386,6 @@ RETURN math::asin(0.5);
 <br />
 
 ## `math::atan`
-
-<Since v="v2.0.0" />
-
 The `math::atan` function returns the arctangent (inverse tangent) of a number. The result is expressed in radians.
 
 ```surql title="API DEFINITION"
@@ -469,8 +460,6 @@ RETURN math::ceil(13.146572);
 
 ## `math::clamp`
 
-<Since v="v2.0.0" />
-
 The `math::clamp` function constrains a number within the specified range, defined by a minimum and a maximum value. If the number is less than the minimum, it returns the minimum. If it is greater than the maximum, it returns the maximum.
 
 ```surql title="API DEFINITION"
@@ -494,8 +483,6 @@ RETURN math::clamp(1, 5, 10);
 <br />
 
 ## `math::cos`
-
-<Since v="v2.0.0" />
 
 The `math::cos` function returns the cosine of a number, which is assumed to be in radians. The result is a value between -1 and 1.
 
@@ -521,8 +508,6 @@ RETURN math::cos(1);
 
 ## `math::cot`
 
-<Since v="v2.0.0" />
-
 The `math::cot` function returns the cotangent of a number, which is assumed to be in radians. The cotangent is the reciprocal of the tangent function.
 
 ```surql title="API DEFINITION"
@@ -546,9 +531,6 @@ RETURN math::cot(1);
 <br />
 
 ## `math::deg2rad`
-
-<Since v="v2.0.0" />
-
 The `math::deg2rad` function converts an angle from degrees to radians.
 
 ```surql title="API DEFINITION"
@@ -915,8 +897,6 @@ RETURN math::interquartile([ 1, 40, 60, 10, 2, 901 ]);
 
 ## `math::lerp`
 
-<Since v="v2.0.0" />
-
 The `math::lerp` function performs a linear interpolation between two numbers based on a given fraction. The fraction will usually be between 0 and 1, where 0 returns `$num_1` and 1 returns `$num_2`.
 
 ```surql title="API DEFINITION"
@@ -955,8 +935,6 @@ RETURN math::lerp(0, 10, 2);
 
 ## `math::lerpangle`
 
-<Since v="v2.0.0" />
-
 The `math::lerpangle` function interpolates between two angles (`$num_1` and `$num_2`) by the given fraction. This is useful for smoothly transitioning between angles.
 
 ```surql title="API DEFINITION"
@@ -980,9 +958,6 @@ RETURN math::lerpangle(0, 180, 0.5);
 <br />
 
 ## `math::ln`
-
-<Since v="v2.0.0" />
-
 The `math::ln` function returns the natural logarithm (base e) of a number.
 
 ```surql title="API DEFINITION"
@@ -1055,8 +1030,6 @@ RETURN math::ln_2;
 
 ## `math::log`
 
-<Since v="v2.0.0" />
-
 The `math::log` function returns the logarithm of a number with a specified base.
 
 ```surql title="API DEFINITION"
@@ -1080,8 +1053,6 @@ RETURN math::log(100, 10);
 <br />
 
 ## `math::log10`
-
-<Since v="v2.0.0" />
 
 The `math::log10` function returns the base-10 logarithm of a number.
 
@@ -1155,8 +1126,6 @@ RETURN math::log10_e;
 <br />
 
 ## `math::log2`
-
-<Since v="v2.0.0" />
 
 The `math::log2` function returns the base-2 logarithm of a number.
 
@@ -1555,8 +1524,6 @@ RETURN math::product([ 26.164, 13.746189, 23, 16.4, 41.42 ]);
 
 ## `math::rad2deg`
 
-<Since v="v2.0.0" />
-
 The `math::rad2deg` function converts an angle from radians to degrees.
 
 ```surql title="API DEFINITION"
@@ -1605,8 +1572,6 @@ RETURN math::round(13.53124);
 
 ## `math::sign`
 
-<Since v="v2.0.0" />
-
 The `math::sign` function returns the sign of a number, indicating whether the number is positive, negative, or zero.
 It returns 1 for positive numbers, -1 for negative numbers, and 0 for zero.
 
@@ -1631,8 +1596,6 @@ RETURN math::sign(-42);
 <br />
 
 ## `math::sin`
-
-<Since v="v2.0.0" />
 
 The `math::sin` function returns the sine of a number, which is assumed to be in radians.
 
@@ -1867,8 +1830,6 @@ math::sum([0, NONE, 10dec, 10.7, NULL].map(|$num| $num ?? 0));
 <br />
 
 ## `math::tan`
-
-<Since v="v2.0.0" />
 
 The `math::tan` function returns the tangent of a number, which is assumed to be in radians.
 

--- a/src/content/reference/query-language/functions/database-functions/math.mdx
+++ b/src/content/reference/query-language/functions/database-functions/math.mdx
@@ -1713,7 +1713,7 @@ RETURN math::stddev([ 1, 40, 60, 10, 2, 901 ]);
 -- 359.37167389765153f
 ```
 
-As of SurrealDB 3.0.0-beta, this function can be used [inside a table view](/docs/reference/query-language/statements/select#mathstddev-and-mathvariance-in-table-views).
+As of SurrealDB 3.0.0, this function can be used [inside a table view](/docs/reference/query-language/statements/select#mathstddev-and-mathvariance-in-table-views).
 
 ```surql
 DEFINE TABLE person SCHEMALESS;
@@ -1947,7 +1947,7 @@ RETURN math::variance([ 1, 40, 60, 10, 2, 901 ]);
 -- 129148
 ```
 
-As of SurrealDB 3.0.0-beta, this function can be used [inside a table view](/docs/reference/query-language/statements/select#mathstddev-and-mathvariance-in-table-views).
+As of SurrealDB 3.0.0, this function can be used [inside a table view](/docs/reference/query-language/statements/select#mathstddev-and-mathvariance-in-table-views).
 
 ```surql
 DEFINE TABLE person SCHEMALESS;

--- a/src/content/reference/query-language/functions/database-functions/object.mdx
+++ b/src/content/reference/query-language/functions/database-functions/object.mdx
@@ -371,8 +371,6 @@ RETURN object::values({
 
 ## Method chaining
 
-<Since v="v2.0.0" />
-
 Method chaining allows functions to be called using the `.` dot operator on a value of a certain type instead of the full path of the function followed by the value.
 
 ```surql

--- a/src/content/reference/query-language/functions/database-functions/rand.mdx
+++ b/src/content/reference/query-language/functions/database-functions/rand.mdx
@@ -216,7 +216,7 @@ RETURN rand::float(10, 15);
 ## `rand::id`
 
 > [!NOTE]
-> This function was known as `rand::guid` in versions of SurrealDB before 3.0.0-beta. The behaviour has not changed.
+> This function was known as `rand::guid` in versions of SurrealDB before 3.0.0. The behaviour has not changed.
 
 The `rand::id` function generates a random alphanumeric ID, defaulting to a length of 20 characters.
 
@@ -384,7 +384,7 @@ RETURN rand::time(d'1970-01-01', d'2000-01-01');
 
 <Since v="v2.3.0" />
 
-Either of the arguments of this function can now be either a number or a datetime.
+Either of the arguments of this function can be either a number or a datetime.
 
 ```surql
 RETURN rand::time(0, d'1990-01-01');

--- a/src/content/reference/query-language/functions/database-functions/record.mdx
+++ b/src/content/reference/query-language/functions/database-functions/record.mdx
@@ -170,8 +170,6 @@ record::is_edge("likes:first_like");
 
 ## Method chaining
 
-<Since v="v2.0.0" />
-
 Method chaining allows functions to be called using the `.` dot operator on a value of a certain type instead of the full path of the function followed by the value.
 
 ```surql

--- a/src/content/reference/query-language/functions/database-functions/search.mdx
+++ b/src/content/reference/query-language/functions/database-functions/search.mdx
@@ -45,7 +45,7 @@ These functions are used in conjunction with the [`@@` operator (the 'matches' o
 <br/>
 
 > [!NOTE]
-> Before SurrealDB version 3.0.0-beta, the `FULLTEXT ANALYZER` clause used the syntax `SEARCH ANALYZER`.
+> Before SurrealDB version 3.0.0, the `FULLTEXT ANALYZER` clause used the syntax `SEARCH ANALYZER`.
 
 The examples below assume the following queries:
 

--- a/src/content/reference/query-language/functions/database-functions/session.mdx
+++ b/src/content/reference/query-language/functions/database-functions/session.mdx
@@ -53,8 +53,6 @@ These functions return information about the current SurrealDB session.
 
 ## `session::ac`
 
-<Since v="v2.0.0" />
-
 > [!NOTE]
 > This function was known as `session::sc` in versions of SurrealDB before 2.0. The behaviour has not changed.
 
@@ -160,8 +158,6 @@ RETURN session::origin();
 <br />
 
 ## `session::rd`
-
-<Since v="v2.0.0" />
 
 The `session::rd` function returns the current user's record authentication.
 

--- a/src/content/reference/query-language/functions/database-functions/string.mdx
+++ b/src/content/reference/query-language/functions/database-functions/string.mdx
@@ -338,8 +338,6 @@ RETURN string::contains('abcdefg', 'cde');
 
 ## `string::ends_with`
 
-<Since v="v2.0.0" />
-
 > [!NOTE]
 > This function was known as `string::endsWith` in versions of SurrealDB before 2.0. The behaviour has not changed.
 
@@ -659,8 +657,6 @@ RETURN string::split('this, is, a, list', ', ');
 
 ## `string::starts_with`
 
-<Since v="v2.0.0" />
-
 > [!NOTE]
 > This function was known as `string::startsWith` in versions of SurrealDB before 2.0. The behaviour has not changed.
 
@@ -760,8 +756,6 @@ RETURN string::words('this is a test');
 
 ## `string::distance::damerau_levenshtein`
 
-<Since v="v2.1.0" />
-
 The `string::distance::damerau_levenshtein` function returns the Damerau-Levenshtein distance between two strings.
 
 ```surql title="API DEFINITION"
@@ -819,8 +813,6 @@ string::distance::damerau_levenshtein($first, $short);
 ```
 
 ## `string::distance::normalized_damerau_levenshtein`
-
-<Since v="v2.1.0" />
 
 The `string::distance::normalized_damerau_levenshtein` function returns the normalized Damerau-Levenshtein distance between two strings. Normalized means that identical strings will return a score of 1, with less similar strings returning lower numbers as the distance grows.
 
@@ -880,8 +872,6 @@ string::distance::normalized_damerau_levenshtein($first, $short);
 
 ## `string::distance::hamming`
 
-<Since v="v2.1.0" />
-
 The `string::distance::hamming` function returns the Hamming distance between two strings of equal length.
 
 ```surql title="API DEFINITION"
@@ -940,8 +930,6 @@ string::distance::hamming($first, $short);
 
 ## `string::distance::levenshtein`
 
-<Since v="v2.1.0" />
-
 The `string::distance::levenshtein` function returns the Levenshtein distance between two strings.
 
 ```surql title="API DEFINITION"
@@ -999,8 +987,6 @@ string::distance::levenshtein($first, $short);
 ```
 
 ## `string::distance::normalized_levenshtein`
-
-<Since v="v2.1.0" />
 
 The `string::distance::normalized_levenshtein` function returns the normalized Levenshtein distance between two strings. Normalized means that identical strings will return a score of 1, with less similar strings returning lower numbers as the distance grows.
 
@@ -1063,8 +1049,6 @@ string::distance::normalized_levenshtein($first, $short);
 > [!NOTE]
 > This function was known as `string::distance::osa_distance` in versions of SurrealDB before 3.0.0-beta. The behaviour has not changed.
 
-<Since v="v2.1.0" />
-
 The `string::distance::osa_distance` function returns the OSA (Optimal String Alignment) distance between two strings.
 
 ```surql title="API DEFINITION"
@@ -1123,8 +1107,6 @@ string::distance::osa($first, $short);
 
 ## `string::html::encode`
 
-<Since v="v2.0.0" />
-
 The `string::html::encode` function encodes special characters into HTML entities to prevent HTML injection. It is recommended to use this function in most cases when retrieving any untrusted content that may be rendered inside of an HTML document. You can learn more about its behavior from the [original implementation](https://docs.rs/ammonia/latest/ammonia/fn.clean_text.html).
 
 ```surql title="API DEFINITION"
@@ -1148,8 +1130,6 @@ RETURN string::html::encode("<h1>Safe Title</h1><script>alert('XSS')</script><p>
 <br />
 
 ## `string::html::sanitize`
-
-<Since v="v2.0.0" />
 
 The `string::html::sanitize` function sanitizes HTML code to prevent the most dangerous subset of HTML injection that can lead to attacks like cross-site scripting, layout breaking or clickjacking. This function will keep any other HTML syntax intact in order to support user-generated content that needs to contain HTML styling. It is only recommended to rely on this function if you want to allow the creators of the content to have some control over its HTML styling. You can learn more about its behavior from the [original implementation](https://docs.rs/ammonia/latest/ammonia/fn.clean.html).
 
@@ -1418,8 +1398,6 @@ RETURN string::is_hexadecimal("ff009e");
 > [!NOTE]
 > This function was known as `string::is::ip` in versions of SurrealDB before 3.0.0-beta. The behaviour has not changed.
 
-<Since v="v2.0.0" />
-
 The `string::is_ip` function checks whether a value is an IP address.
 
 ```surql title="API DEFINITION"
@@ -1448,8 +1426,6 @@ RETURN string::is_ip("192.168.0.1");
 > [!NOTE]
 > This function was known as `string::is::ipv4` in versions of SurrealDB before 3.0.0-beta. The behaviour has not changed.
 
-<Since v="v2.0.0" />
-
 The `string::is_ipv4` function checks whether a value is an IP v4 address.
 
 ```surql title="API DEFINITION"
@@ -1477,8 +1453,6 @@ RETURN string::is_ipv4("192.168.0.1");
 
 > [!NOTE]
 > This function was known as `string::is::ipv6` in versions of SurrealDB before 3.0.0-beta. The behaviour has not changed.
-
-<Since v="v2.0.0" />
 
 The `string::is_ipv6` function checks whether a value is an IP v6 address.
 
@@ -2119,8 +2093,6 @@ SELECT of, score FROM comparison ORDER BY score DESC;
 
 ## `string::similarity::jaro`
 
-<Since v="v2.1.0" />
-
 The `string::similarity::jaro` function returns the Jaro similarity between two strings. Two strings that are identical have a score of 1, while less similar strings will have lower scores as the distance between them increases.
 
 ```surql title="API DEFINITION"
@@ -2179,8 +2151,6 @@ string::similarity::jaro($first, $short);
 
 ## `string::similarity::jaro_winkler`
 
-<Since v="v2.1.0" />
-
 The `string::similarity::jaro_winkler` function returns the Jaro-Winkler similarity between two strings. Two strings that are identical have a score of 1, while less similar strings will have lower scores as the distance between them increases.
 
 ```surql title="API DEFINITION"
@@ -2238,8 +2208,6 @@ string::similarity::jaro_winkler($first, $short);
 ```
 
 ## Method chaining
-
-<Since v="v2.0.0" />
 
 Method chaining allows functions to be called using the `.` dot operator on a value of a certain type instead of the full path of the function followed by the value.
 

--- a/src/content/reference/query-language/functions/database-functions/string.mdx
+++ b/src/content/reference/query-language/functions/database-functions/string.mdx
@@ -1047,7 +1047,7 @@ string::distance::normalized_levenshtein($first, $short);
 ## `string::distance::osa`
 
 > [!NOTE]
-> This function was known as `string::distance::osa_distance` in versions of SurrealDB before 3.0.0-beta. The behaviour has not changed.
+> This function was known as `string::distance::osa_distance` in versions of SurrealDB before 3.0.0. The behaviour has not changed.
 
 The `string::distance::osa_distance` function returns the OSA (Optimal String Alignment) distance between two strings.
 
@@ -1155,7 +1155,7 @@ RETURN string::html::sanitize("<h1>Safe Title</h1><script>alert('XSS')</script><
 ## `string::is_alphanum`
 
 > [!NOTE]
-> This function was known as `string::is::alphanum` in versions of SurrealDB before 3.0.0-beta. The behaviour has not changed.
+> This function was known as `string::is::alphanum` in versions of SurrealDB before 3.0.0. The behaviour has not changed.
 
 The `string::is_alphanum` function checks whether a value has only alphanumeric characters.
 
@@ -1183,7 +1183,7 @@ RETURN string::is_alphanum("ABC123");
 ## `string::is_alpha`
 
 > [!NOTE]
-> This function was known as `string::is::alpha` in versions of SurrealDB before 3.0.0-beta. The behaviour has not changed.
+> This function was known as `string::is::alpha` in versions of SurrealDB before 3.0.0. The behaviour has not changed.
 
 The `string::is_alpha` function checks whether a value has only alpha characters.
 
@@ -1210,7 +1210,7 @@ RETURN string::is_alpha("ABCDEF");
 ## `string::is_ascii`
 
 > [!NOTE]
-> This function was known as `string::is::ascii` in versions of SurrealDB before 3.0.0-beta. The behaviour has not changed.
+> This function was known as `string::is::ascii` in versions of SurrealDB before 3.0.0. The behaviour has not changed.
 
 The `string::is_ascii` function checks whether a value has only ascii characters.
 
@@ -1239,7 +1239,7 @@ RETURN string::is_ascii("ABC123"); -- true
 ## `string::is_datetime`
 
 > [!NOTE]
-> This function was known as `string::is::datetime` in versions of SurrealDB before 3.0.0-beta. The behaviour has not changed.
+> This function was known as `string::is::datetime` in versions of SurrealDB before 3.0.0. The behaviour has not changed.
 
 The `string::is_datetime` function checks whether a string representation of a date and time matches either the [datetime](/docs/reference/query-language/language-primitives/data-types/datetimes) format or a user-specified format.
 
@@ -1313,7 +1313,7 @@ false
 ## `string::is_domain`
 
 > [!NOTE]
-> This function was known as `string::is::domain` in versions of SurrealDB before 3.0.0-beta. The behaviour has not changed.
+> This function was known as `string::is::domain` in versions of SurrealDB before 3.0.0. The behaviour has not changed.
 
 The `string::is_domain` function checks whether a value is a domain.
 
@@ -1340,7 +1340,7 @@ RETURN string::is_domain("surrealdb.com");
 ## `string::is_email`
 
 > [!NOTE]
-> This function was known as `string::is::email` in versions of SurrealDB before 3.0.0-beta. The behaviour has not changed.
+> This function was known as `string::is::email` in versions of SurrealDB before 3.0.0. The behaviour has not changed.
 
 The `string::is_email` function checks whether a value is an email.
 
@@ -1368,7 +1368,7 @@ RETURN string::is_email("info@surrealdb.com");
 ## `string::is_hexadecimal`
 
 > [!NOTE]
-> This function was known as `string::is::hexadecimal` in versions of SurrealDB before 3.0.0-beta. The behaviour has not changed.
+> This function was known as `string::is::hexadecimal` in versions of SurrealDB before 3.0.0. The behaviour has not changed.
 
 The `string::is_hexadecimal` function checks whether a value is hexadecimal.
 
@@ -1396,7 +1396,7 @@ RETURN string::is_hexadecimal("ff009e");
 ## `string::is_ip`
 
 > [!NOTE]
-> This function was known as `string::is::ip` in versions of SurrealDB before 3.0.0-beta. The behaviour has not changed.
+> This function was known as `string::is::ip` in versions of SurrealDB before 3.0.0. The behaviour has not changed.
 
 The `string::is_ip` function checks whether a value is an IP address.
 
@@ -1424,7 +1424,7 @@ RETURN string::is_ip("192.168.0.1");
 ## `string::is_ipv4`
 
 > [!NOTE]
-> This function was known as `string::is::ipv4` in versions of SurrealDB before 3.0.0-beta. The behaviour has not changed.
+> This function was known as `string::is::ipv4` in versions of SurrealDB before 3.0.0. The behaviour has not changed.
 
 The `string::is_ipv4` function checks whether a value is an IP v4 address.
 
@@ -1452,7 +1452,7 @@ RETURN string::is_ipv4("192.168.0.1");
 ## `string::is_ipv6`
 
 > [!NOTE]
-> This function was known as `string::is::ipv6` in versions of SurrealDB before 3.0.0-beta. The behaviour has not changed.
+> This function was known as `string::is::ipv6` in versions of SurrealDB before 3.0.0. The behaviour has not changed.
 
 The `string::is_ipv6` function checks whether a value is an IP v6 address.
 
@@ -1480,7 +1480,7 @@ RETURN string::is_ipv6("2001:0db8:85a3:0000:0000:8a2e:0370:7334");
 ## `string::is_latitude`
 
 > [!NOTE]
-> This function was known as `string::is::latitude` in versions of SurrealDB before 3.0.0-beta. The behaviour has not changed.
+> This function was known as `string::is::latitude` in versions of SurrealDB before 3.0.0. The behaviour has not changed.
 
 The `string::is_latitude` function checks whether a value is a latitude value.
 
@@ -1508,7 +1508,7 @@ RETURN string::is_latitude("-0.118092");
 ## `string::is_longitude`
 
 > [!NOTE]
-> This function was known as `string::is::longitude` in versions of SurrealDB before 3.0.0-beta. The behaviour has not changed.
+> This function was known as `string::is::longitude` in versions of SurrealDB before 3.0.0. The behaviour has not changed.
 
 The `string::is_longitude` function checks whether a value is a longitude value.
 
@@ -1536,7 +1536,7 @@ RETURN string::is_longitude("51.509865");
 ## `string::is_numeric`
 
 > [!NOTE]
-> This function was known as `string::is::numeric` in versions of SurrealDB before 3.0.0-beta. The behaviour has not changed.
+> This function was known as `string::is::numeric` in versions of SurrealDB before 3.0.0. The behaviour has not changed.
 
 The `string::is_numeric` function checks whether a value has only numeric characters.
 
@@ -1563,7 +1563,7 @@ RETURN string::is_numeric("1484091748");
 ## `string::is_semver`
 
 > [!NOTE]
-> This function was known as `string::is::semver` in versions of SurrealDB before 3.0.0-beta. The behaviour has not changed.
+> This function was known as `string::is::semver` in versions of SurrealDB before 3.0.0. The behaviour has not changed.
 
 The `string::is_semver` function checks whether a value matches a semver version.
 
@@ -1591,7 +1591,7 @@ RETURN string::is_semver("1.0.0");
 ## `string::is_ulid`
 
 > [!NOTE]
-> This function was known as `string::is::ulid` in versions of SurrealDB before 3.0.0-beta. The behaviour has not changed.
+> This function was known as `string::is::ulid` in versions of SurrealDB before 3.0.0. The behaviour has not changed.
 
 The `string::is_ulid` function checks whether a string is a ULID.
 
@@ -1619,7 +1619,7 @@ RETURN string::is_ulid("01JCJB3TPQ50XTG32WM088NKJD");
 ## `string::is_url`
 
 > [!NOTE]
-> This function was known as `string::is::url` in versions of SurrealDB before 3.0.0-beta. The behaviour has not changed.
+> This function was known as `string::is::url` in versions of SurrealDB before 3.0.0. The behaviour has not changed.
 
 The `string::is_url` function checks whether a value is a valid URL.
 
@@ -1647,7 +1647,7 @@ RETURN string::is_url("https://surrealdb.com");
 ## `string::is_record`
 
 > [!NOTE]
-> This function was known as `string::is::record` in versions of SurrealDB before 3.0.0-beta. The behaviour has not changed.
+> This function was known as `string::is::record` in versions of SurrealDB before 3.0.0. The behaviour has not changed.
 
 The `string::is_record` function checks whether a string is a Record ID.
 
@@ -1689,7 +1689,7 @@ RETURN string::is_record("not a record id");       -- false
 ## `string::is_uuid`
 
 > [!NOTE]
-> This function was known as `string::is::uuid` in versions of SurrealDB before 3.0.0-beta. The behaviour has not changed.
+> This function was known as `string::is::uuid` in versions of SurrealDB before 3.0.0. The behaviour has not changed.
 
 The `string::is_uuid` function checks whether a string is a UUID.
 

--- a/src/content/reference/query-language/functions/database-functions/type.mdx
+++ b/src/content/reference/query-language/functions/database-functions/type.mdx
@@ -730,8 +730,6 @@ RETURN type::point([ 51.509865, -0.118092 ]);
 
 ## `type::range`
 
-<Since v="v2.0.0" />
-
 The `type::range` function converts a value into a [range](/docs/reference/query-language/language-primitives/data-types/ranges). It accepts a single argument, either a range or an array with two values. If the argument is an array, it will be converted into a range, similar to [casting](/docs/reference/query-language/language-primitives/data-types/casting).
 
 ```surql title="API DEFINITION"
@@ -1744,8 +1742,6 @@ RETURN type::is_uuid(u"018a6680-bef9-701b-9025-e1754f296a0f");
 <br /><br />
 
 ## Method chaining
-
-<Since v="v2.0.0" />
 
 Method chaining allows functions to be called using the `.` dot operator on a value of a certain type instead of the full path of the function followed by the value.
 

--- a/src/content/reference/query-language/functions/database-functions/type.mdx
+++ b/src/content/reference/query-language/functions/database-functions/type.mdx
@@ -770,7 +770,7 @@ RETURN type::range([1,9,4]);
 <TabItem label="3.x">
 
 > [!NOTE]
-> This function was known as `type::thing` in versions of SurrealDB before 3.0.0-beta. The behaviour has not changed.
+> This function was known as `type::thing` in versions of SurrealDB before 3.0.0. The behaviour has not changed.
 
 The `type::record` function converts a value into a record pointer definition.
 
@@ -1058,7 +1058,7 @@ RETURN type::uuid("0191f946-936f-7223-bef5-aebbc527ad80");
 ## `type::is_array`
 
 > [!NOTE]
-> This function was known as `type::is::array` in versions of SurrealDB before 3.0.0-beta. The behaviour has not changed.
+> This function was known as `type::is::array` in versions of SurrealDB before 3.0.0. The behaviour has not changed.
 
 The `type::is_array` function checks if the passed value is of type `array`.
 
@@ -1086,7 +1086,7 @@ RETURN type::is_array([ 'a', 'b', 'c' ]);
 ## `type::is_bool`
 
 > [!NOTE]
-> This function was known as `type::is::bool` in versions of SurrealDB before 3.0.0-beta. The behaviour has not changed.
+> This function was known as `type::is::bool` in versions of SurrealDB before 3.0.0. The behaviour has not changed.
 
 The `type::is_bool` function checks if the passed value is of type `bool`.
 
@@ -1114,7 +1114,7 @@ RETURN type::is_bool(true);
 ## `type::is_bytes`
 
 > [!NOTE]
-> This function was known as `type::is::bytes` in versions of SurrealDB before 3.0.0-beta. The behaviour has not changed.
+> This function was known as `type::is::bytes` in versions of SurrealDB before 3.0.0. The behaviour has not changed.
 
 The `type::is_bytes` function checks if the passed value is of type `bytes`.
 
@@ -1142,7 +1142,7 @@ RETURN type::is_bytes("I am not bytes");
 ## `type::is_collection`
 
 > [!NOTE]
-> This function was known as `type::is::collection` in versions of SurrealDB before 3.0.0-beta. The behaviour has not changed.
+> This function was known as `type::is::collection` in versions of SurrealDB before 3.0.0. The behaviour has not changed.
 
 The `type::is_collection` function checks if the passed value is of type `collection`.
 
@@ -1171,7 +1171,7 @@ RETURN type::is_collection("I am not a collection");
 ## `type::is_datetime`
 
 > [!NOTE]
-> This function was known as `type::is::datetime` in versions of SurrealDB before 3.0.0-beta. The behaviour has not changed.
+> This function was known as `type::is::datetime` in versions of SurrealDB before 3.0.0. The behaviour has not changed.
 
 The `type::is_datetime` function checks if the passed value is of type `datetime`.
 
@@ -1198,7 +1198,7 @@ RETURN type::is_datetime(time::now());
 ## `type::is_decimal`
 
 > [!NOTE]
-> This function was known as `type::is::decimal` in versions of SurrealDB before 3.0.0-beta. The behaviour has not changed.
+> This function was known as `type::is::decimal` in versions of SurrealDB before 3.0.0. The behaviour has not changed.
 
 The `type::is_decimal` function checks if the passed value is of type `decimal`.
 
@@ -1227,7 +1227,7 @@ RETURN type::is_decimal(<decimal>
 ## `type::is_duration`
 
 > [!NOTE]
-> This function was known as `type::is::duration` in versions of SurrealDB before 3.0.0-beta. The behaviour has not changed.
+> This function was known as `type::is::duration` in versions of SurrealDB before 3.0.0. The behaviour has not changed.
 
 The `type::is_duration` function checks if the passed value is of type `duration`.
 
@@ -1254,7 +1254,7 @@ RETURN type::is_duration('1970-01-01T00:00:00');
 ## `type::is_float`
 
 > [!NOTE]
-> This function was known as `type::is::float` in versions of SurrealDB before 3.0.0-beta. The behaviour has not changed.
+> This function was known as `type::is::float` in versions of SurrealDB before 3.0.0. The behaviour has not changed.
 
 The `type::is_float` function checks if the passed value is of type ` float`.
 
@@ -1281,7 +1281,7 @@ RETURN type::is_float(<float> 41.5);
 ## `type::is_geometry`
 
 > [!NOTE]
-> This function was known as `type::is::geometry` in versions of SurrealDB before 3.0.0-beta. The behaviour has not changed.
+> This function was known as `type::is::geometry` in versions of SurrealDB before 3.0.0. The behaviour has not changed.
 
 The `type::is_geometry` function checks if the passed value is of type `geometry`.
 
@@ -1308,7 +1308,7 @@ RETURN type::is_geometry((-0.118092, 51.509865));
 ## `type::is_int`
 
 > [!NOTE]
-> This function was known as `type::is::int` in versions of SurrealDB before 3.0.0-beta. The behaviour has not changed.
+> This function was known as `type::is::int` in versions of SurrealDB before 3.0.0. The behaviour has not changed.
 
 The `type::is_int` function checks if the passed value is of type `int`.
 
@@ -1335,7 +1335,7 @@ RETURN type::is_int(<int> 123);
 ## `type::is_line`
 
 > [!NOTE]
-> This function was known as `type::is::line` in versions of SurrealDB before 3.0.0-beta. The behaviour has not changed.
+> This function was known as `type::is::line` in versions of SurrealDB before 3.0.0. The behaviour has not changed.
 
 The `type::is_line` function checks if the passed value is of type `line`.
 
@@ -1363,7 +1363,7 @@ RETURN type::is_line("I am not a line");
 ## `type::is_none`
 
 > [!NOTE]
-> This function was known as `type::is::none` in versions of SurrealDB before 3.0.0-beta. The behaviour has not changed.
+> This function was known as `type::is::none` in versions of SurrealDB before 3.0.0. The behaviour has not changed.
 
 
 The `type::is_none` function checks if the passed value is of type `none`.
@@ -1391,7 +1391,7 @@ RETURN type::is_none(NONE);
 ## `type::is_null`
 
 > [!NOTE]
-> This function was known as `type::is::null` in versions of SurrealDB before 3.0.0-beta. The behaviour has not changed.
+> This function was known as `type::is::null` in versions of SurrealDB before 3.0.0. The behaviour has not changed.
 
 The `type::is_null` function checks if the passed value is of type `null`.
 
@@ -1419,7 +1419,7 @@ RETURN type::is_null(NULL);
 ## `type::is_multiline`
 
 > [!NOTE]
-> This function was known as `type::is::multiline` in versions of SurrealDB before 3.0.0-beta. The behaviour has not changed.
+> This function was known as `type::is::multiline` in versions of SurrealDB before 3.0.0. The behaviour has not changed.
 
 The `type::is_multiline` function checks if the passed value is of type `multiline`.
 
@@ -1447,7 +1447,7 @@ RETURN type::is_multiline("I am not a multiline");
 ## `type::is_multipoint`
 
 > [!NOTE]
-> This function was known as `type::is::multipoint` in versions of SurrealDB before 3.0.0-beta. The behaviour has not changed.
+> This function was known as `type::is::multipoint` in versions of SurrealDB before 3.0.0. The behaviour has not changed.
 
 The `type::is_multipoint` function checks if the passed value is of type `multipoint`.
 
@@ -1475,7 +1475,7 @@ RETURN type::is_multipoint("I am not a multipoint");
 ## `type::is_multipolygon`
 
 > [!NOTE]
-> This function was known as `type::is::multipolygon` in versions of SurrealDB before 3.0.0-beta. The behaviour has not changed.
+> This function was known as `type::is::multipolygon` in versions of SurrealDB before 3.0.0. The behaviour has not changed.
 
 The `type::is_multipolygon` function checks if the passed value is of type `multipolygon`.
 
@@ -1503,7 +1503,7 @@ RETURN type::is_multipolygon("I am not a multipolygon");
 ## `type::is_number`
 
 > [!NOTE]
-> This function was known as `type::is::number` in versions of SurrealDB before 3.0.0-beta. The behaviour has not changed.
+> This function was known as `type::is::number` in versions of SurrealDB before 3.0.0. The behaviour has not changed.
 
 The `type::is_number` function checks if the passed value is of type `number`.
 
@@ -1531,7 +1531,7 @@ RETURN type::is_number(123);
 ## `type::is_object`
 
 > [!NOTE]
-> This function was known as `type::is::object` in versions of SurrealDB before 3.0.0-beta. The behaviour has not changed.
+> This function was known as `type::is::object` in versions of SurrealDB before 3.0.0. The behaviour has not changed.
 
 The `type::is_object` function checks if the passed value is of type `object`.
 
@@ -1559,7 +1559,7 @@ RETURN type::is_object({ hello: 'world' });
 ## `type::is_point`
 
 > [!NOTE]
-> This function was known as `type::is::point` in versions of SurrealDB before 3.0.0-beta. The behaviour has not changed.
+> This function was known as `type::is::point` in versions of SurrealDB before 3.0.0. The behaviour has not changed.
 
 The `type::is_point` function checks if the passed value is of type `point`.
 
@@ -1587,7 +1587,7 @@ RETURN type::is_point((-0.118092, 51.509865));
 ## `type::is_polygon`
 
 > [!NOTE]
-> This function was known as `type::is::polygon` in versions of SurrealDB before 3.0.0-beta. The behaviour has not changed.
+> This function was known as `type::is::polygon` in versions of SurrealDB before 3.0.0. The behaviour has not changed.
 
 The `type::is_polygon` function checks if the passed value is of type `polygon`.
 
@@ -1613,7 +1613,7 @@ RETURN type::is_polygon("I am not a polygon");
 ## `type::is_range`
 
 > [!NOTE]
-> This function was known as `type::is::range` in versions of SurrealDB before 3.0.0-beta. The behaviour has not changed.
+> This function was known as `type::is::range` in versions of SurrealDB before 3.0.0. The behaviour has not changed.
 
 The `type::is_range` function checks if the passed value is of type `range`.
 
@@ -1643,7 +1643,7 @@ type::is_range(0..1);
 ## `type::is_record`
 
 > [!NOTE]
-> This function was known as `type::is::record` in versions of SurrealDB before 3.0.0-beta. The behaviour has not changed.
+> This function was known as `type::is::record` in versions of SurrealDB before 3.0.0. The behaviour has not changed.
 
 The `type::is_record` function checks if the passed value is of type `record`.
 
@@ -1688,7 +1688,7 @@ RETURN type::is_record(user:tobie, 'test');
 ## `type::is_string`
 
 > [!NOTE]
-> This function was known as `type::is::string` in versions of SurrealDB before 3.0.0-beta. The behaviour has not changed.
+> This function was known as `type::is::string` in versions of SurrealDB before 3.0.0. The behaviour has not changed.
 
 The `type::is_string` function checks if the passed value is of type `string`.
 
@@ -1716,7 +1716,7 @@ RETURN type::is_string("abc");
 ## `type::is_uuid`
 
 > [!NOTE]
-> This function was known as `type::is::uuid` in versions of SurrealDB before 3.0.0-beta. The behaviour has not changed.
+> This function was known as `type::is::uuid` in versions of SurrealDB before 3.0.0. The behaviour has not changed.
 
 The `type::is_uuid` function checks if the passed value is of type `uuid`.
 

--- a/src/content/reference/query-language/functions/database-functions/value.mdx
+++ b/src/content/reference/query-language/functions/database-functions/value.mdx
@@ -38,8 +38,6 @@ This module contains several miscellaneous functions that can be used with value
 
 ## `.chain()`
 
-<Since v="v2.0.0" />
-
 The `.chain()` method passes a value into a [closure](/docs/reference/query-language/language-primitives/data-types/closures) through which an operation can be performed to return any value.
 
 ```surql title="API DEFINITION"
@@ -87,8 +85,6 @@ value = ""{ company: 'SURREALDB!!!!!', latest_version: '3.1' }""
 For a similar function that allows using a closure on each item in an array instead of a value as a whole, see [array::map](/docs/reference/query-language/functions/database-functions/array#arraymap).
 
 ## `value::diff`
-
-<Since v="v2.0.0" />
 
 The `value::diff` function returns an object that shows the [JSON Patch](https://jsonpatch.com/) operation(s) required for the first value to equal the second one.
 
@@ -218,8 +214,6 @@ This method is most conveniently used when chaining methods to make assertions a
 As closures in SurrealDB take ownership of the values of their arguments, this function clones the original value in order to return it. It is thus only recommended to use when debugging or when the assertion is a simple one.
 
 ## `value::patch`
-
-<Since v="v2.0.0" />
 
 The `value::patch` function applies an array of [JSON Patch](https://jsonpatch.com/) operations to a value. Patches produced by [`value::diff()`](/docs/reference/query-language/functions/database-functions/value#valuediff) round-trip correctly, including when the value is a top-level scalar (the empty path `""` refers to the root value per RFC 6901).
 

--- a/src/content/reference/query-language/functions/database-functions/vector.mdx
+++ b/src/content/reference/query-language/functions/database-functions/vector.mdx
@@ -329,8 +329,6 @@ RETURN vector::project([1, 2, 3], [4, 5, 6]);
 
 ## `vector::scale`
 
-<Since v="v2.0.0" />
-
 The `vector::scale` function multiplies each item in a vector by a number.
 
 ```surql title="API DEFINITION"

--- a/src/content/reference/query-language/language-primitives/data-types/arrays.mdx
+++ b/src/content/reference/query-language/language-primitives/data-types/arrays.mdx
@@ -231,8 +231,6 @@ value = "[{ first_mayor: 'Papa Smurf', name: 'Smurfville', population: 55 }]"
 ]
 ```
 
-<Since v="v2.0.0" />
-
 ## Filtering and mapping with array functions
 
 SurrealDB also includes a number of methods for arrays that make it easier to filter and map. These methods take a closure (an anonymous function) that works in a similar way to the `$this` parameter above.

--- a/src/content/reference/query-language/language-primitives/data-types/closures.mdx
+++ b/src/content/reference/query-language/language-primitives/data-types/closures.mdx
@@ -6,8 +6,6 @@ description: "Closures (anonymous functions) in SurrealDB allow you to define sm
 
 # Closures (anonymous functions)
 
-<Since v="v2.0.0" />
-
 ```syntax title="SurrealQL Syntax"
 LET $parameter = |@parameters| @expression;
 ```

--- a/src/content/reference/query-language/language-primitives/data-types/literals.mdx
+++ b/src/content/reference/query-language/language-primitives/data-types/literals.mdx
@@ -6,8 +6,6 @@ description: "A value that may have multiple representations or formats."
 
 # Literals
 
-<Since v="v2.0.0" />
-
 A literal is a value that may have multiple representations or formats, similar to an enum or a union type. A literal can be composed of strings, numbers, objects, arrays, or durations.
 
 ## Examples

--- a/src/content/reference/query-language/language-primitives/data-types/ranges.mdx
+++ b/src/content/reference/query-language/language-primitives/data-types/ranges.mdx
@@ -6,8 +6,6 @@ description: "A range of possible values."
 
 # Ranges
 
-<Since v="v2.0.0" />
-
 A range is composed of `..` and possible delimiters to set the maximum and minimum possible values. The default syntax includes the lower limit and excludes the upper limit. A `=` can be used to make the upper limit inclusive, and `>` can be used to make the lower limit exclusive.
 
 ```surql

--- a/src/content/reference/query-language/language-primitives/data-types/sets.mdx
+++ b/src/content/reference/query-language/language-primitives/data-types/sets.mdx
@@ -7,7 +7,7 @@ description: "A set is a collection type of deduplicated and ordered values that
 # Sets
 
 > [!NOTE]
-> Before version 3.0.0-beta, sets were simply arrays that deduplicated their items. To emulate the former behaviour, add the clause `VALUE $value.distinct()` to a `DEFINE FIELD` definition.
+> Before version 3.0.0, sets were simply arrays that deduplicated their items. To emulate the former behaviour, add the clause `VALUE $value.distinct()` to a `DEFINE FIELD` definition.
 
 A set is similar to an array, but with two key differences:
 

--- a/src/content/reference/query-language/language-primitives/idioms.mdx
+++ b/src/content/reference/query-language/language-primitives/idioms.mdx
@@ -229,8 +229,6 @@ The output for `INFO FOR TABLE person` includes an automatically generated defin
 
 ### Using `.*` to return values
 
-<Since v="v2.1.0" />
-
 The `.*` idiom in SurrealDB allows you to target all values in an object or all entries in an array. It can be used in various contexts such as querying, field definitions, and data manipulation. This section explains the behaviour of `.*` with practical examples.
 
 When `.*` is applied to `NONE`, `NULL`, or a scalar value, the result is `NONE`.
@@ -443,8 +441,6 @@ SELECT results[$].score FROM student;
 
 ## Method chaining
 
-<Since v="v2.0.0" />
-
 To call a method on the current data, use a dot `.` followed by the method name and parentheses `()` with arguments. SurrealDB supports method chaining, so you can call multiple methods (functions) on the same data. Learn more about [method chaining](/docs/reference/query-language/functions/database-functions#method-syntax) in the functions section.
 
 For example, let's create a new `person` record and then call `uppercase()` on its name field.
@@ -587,8 +583,6 @@ Explanation:
 - `<->? AS involved_in`: Retrieves all relationships connected to Drake, regardless of direction, and aliases them as `involved_in`.
 
 ## Destructuring
-
-<Since v="v2.0.0" />
 
 When working with nested data, you can destructure objects using the `.` and `{ ... }` idioms.
 
@@ -770,8 +764,6 @@ RETURN {
 
 ### Destructuring the current item in a SELECT query
 
-<Since v="v2.1.0" />
-
 The current record in a `SELECT` query can be accessed and destructured using the `@` operator.
 
 ```surql
@@ -946,8 +938,6 @@ person:one.{
 
 ## Optional parts
 
-<Since v="v2.0.0" />
-
 > [!NOTE]
 > Until SurrealDB 3.0.0-beta, this operator was a single `?` question mark. Since this version, it was changed to `.?` to avoid conflicts with the `??` operator when parsing.
 
@@ -970,8 +960,6 @@ SELECT name, spouse.?.name AS spouse_name FROM person;
 This idiom will return `NONE` for `spouse_name` if the `spouse` field is not present.
 
 ## Recursive paths
-
-<Since v="v2.1.0" />
 
 A recursive path allows record link or graph traversal down to a specified depth, as opposed to manually putting together a query to navigate down each level.
 

--- a/src/content/reference/query-language/language-primitives/idioms.mdx
+++ b/src/content/reference/query-language/language-primitives/idioms.mdx
@@ -939,7 +939,7 @@ person:one.{
 ## Optional parts
 
 > [!NOTE]
-> Until SurrealDB 3.0.0-beta, this operator was a single `?` question mark. Since this version, it was changed to `.?` to avoid conflicts with the `??` operator when parsing.
+> Until SurrealDB 3.0.0, this operator was a single `?` question mark. Since this version, it was changed to `.?` to avoid conflicts with the `??` operator when parsing.
 
 The `.?` operator is used to indicate that a part is optional (it may not exist) it also allows you to safely access nested data without having to check if the nested data exists and exit an idiom path early when the result is NONE.
 

--- a/src/content/reference/query-language/language-primitives/operators.mdx
+++ b/src/content/reference/query-language/language-primitives/operators.mdx
@@ -1492,7 +1492,7 @@ ORDER BY score DESC;
 
 ### `AND`, `OR`, and numeric operators inside `@@`
 
-In addition to the `AND` keyword, the `OR` matches operator can also be used as of 3.0.0-beta. This allows a single string to be compared against instead of needing to specify individual parts of the string.
+In addition to the `AND` keyword, the `OR` matches operator can also be used. This allows a single string to be compared against instead of needing to specify individual parts of the string.
 
 ```surql
 /**[test]

--- a/src/content/reference/query-language/language-primitives/operators.mdx
+++ b/src/content/reference/query-language/language-primitives/operators.mdx
@@ -1249,8 +1249,6 @@ SELECT * FROM (-0.118092, 51.509865) INSIDE {
 true
 ```
 
-<Since v="v2.1.0" />
-
 This operator can also be used to check for the existence of a key inside an [object](/docs/reference/query-language/language-primitives/data-types/objects). To do so, precede `IN` with the field name as a string.
 
 ```surql

--- a/src/content/reference/query-language/statements/alter/overview.mdx
+++ b/src/content/reference/query-language/statements/alter/overview.mdx
@@ -6,8 +6,6 @@ description: "The ALTER statement can be used to change authentication access an
 
 # `ALTER` statement
 
-<Since v="v2.0.0" />
-
 The `ALTER` statement can be used to change the behaviour of database resources.
 
 There are two main cases in which to use an `ALTER` statement:

--- a/src/content/reference/query-language/statements/define/access/index.mdx
+++ b/src/content/reference/query-language/statements/define/access/index.mdx
@@ -6,8 +6,6 @@ description: "Defining an access method allows SurrealDB to grant access to reso
 
 # `DEFINE ACCESS` statement
 
-<Since v="v2.0.0" />
-
 Defining an access method allows SurrealDB to grant access to resources using different kinds of credentials.
 
 ## Requirements

--- a/src/content/reference/query-language/statements/define/access/jwt.mdx
+++ b/src/content/reference/query-language/statements/define/access/jwt.mdx
@@ -6,8 +6,6 @@ description: "A JWT access method allows accessing SurrealDB with a token signed
 
 # `DEFINE ACCESS ... TYPE JWT`
 
-<Since v="v2.0.0" />
-
 A JWT access method allows accessing SurrealDB with a token signed by a trusted issuer. The contents of the token will be trusted by SurrealDB as long as it has been signed with a trusted credential.
 
 SurrealDB can work with third-party authentication providers such as OpenID Connect providers, OAuth providers and other trusted parties providing JWT (JSON Web Tokens, also referred to in this page as “tokens”). Let's say that your provider issues your client (e.g. a user or a service) a JWT once it has authenticated. By using the `DEFINE ACCESS ... TYPE JWT` statement, you can set the public key or shared secret that will be used to verify the authenticity of the token.

--- a/src/content/reference/query-language/statements/define/access/record.mdx
+++ b/src/content/reference/query-language/statements/define/access/record.mdx
@@ -6,8 +6,6 @@ description: "A record access method allows accessing SurrealDB as a record user
 
 # `DEFINE ACCESS ... TYPE RECORD`
 
-<Since v="v2.0.0" />
-
 A record access method allows accessing SurrealDB as a [record user](/docs/learn/security/authentication/authentication#record-users).
 
 Record users allow SurrealDB to operate as a web database by offering mechanisms to define custom signin and signup logic as well as custom table and field permissions.

--- a/src/content/reference/query-language/statements/define/analyzer.mdx
+++ b/src/content/reference/query-language/statements/define/analyzer.mdx
@@ -530,8 +530,6 @@ DEFINE ANALYZER IF NOT EXISTS example TOKENIZERS blank;
 
 ## Using `OVERWRITE` clause
 
-<Since v="v2.0.0" />
-
 The `OVERWRITE` clause can be used to create an analyzer and overwrite an existing one if it already exists. You should use the `OVERWRITE` clause when you want to modify an existing analyzer definition. If the analyzer already exists, the `DEFINE ANALYZER` statement will overwrite the existing analyzer definition with the new one.
 
 ```surql

--- a/src/content/reference/query-language/statements/define/analyzer.mdx
+++ b/src/content/reference/query-language/statements/define/analyzer.mdx
@@ -7,7 +7,7 @@ description: "In the context of a database, an analyzer plays a crucial role in 
 # `DEFINE ANALYZER` statement
 
 > [!NOTE]
-> Before SurrealDB version 3.0.0-beta, the `FULLTEXT ANALYZER` clause used the syntax `SEARCH ANALYZER`.
+> Before SurrealDB version 3.0.0, the `FULLTEXT ANALYZER` clause used the syntax `SEARCH ANALYZER`.
 
 In the context of a database, an analyzer plays a crucial role in text processing and searching. It is defined by its name, a set of tokenizers, and a collection of filters.
 

--- a/src/content/reference/query-language/statements/define/database.mdx
+++ b/src/content/reference/query-language/statements/define/database.mdx
@@ -75,8 +75,6 @@ DEFINE DATABASE IF NOT EXISTS app_vitalsense;
 
 ## Using `OVERWRITE` clause
 
-<Since v="v2.0.0" />
-
 The `OVERWRITE` clause can be used to define a database and overwrite an existing one if it already exists. You should use the `OVERWRITE` clause when you want to modify an existing database definition. If the database already exists, the `DEFINE DATABASE` statement will overwrite the existing definition with the new one.
 
 ```surql

--- a/src/content/reference/query-language/statements/define/event.mdx
+++ b/src/content/reference/query-language/statements/define/event.mdx
@@ -53,7 +53,7 @@ DEFINE EVENT [ IF NOT EXISTS | OVERWRITE ] @name ON [ TABLE ] @table
 - **WHEN**: Conditional logic that controls whether the event is triggered. Will show up in the event definition as `WHEN true` if not specified.
 - **THEN**: Specifies the action(s) to execute when the event is triggered.
 - **COMMENT**: Optional comment for describing the event.
-- **ASYNC**: Whether to run the event outside of the transaction that triggers it. Available since SurrealDB 3.0.0-beta.
+- **ASYNC**: Whether to run the event outside of the transaction that triggers it. Available since SurrealDB 3.0.0.
 
 ## Example usage
 

--- a/src/content/reference/query-language/statements/define/event.mdx
+++ b/src/content/reference/query-language/statements/define/event.mdx
@@ -282,8 +282,6 @@ DEFINE EVENT IF NOT EXISTS example ON example THEN {};
 
 ## Using `OVERWRITE` clause
 
-<Since v="v2.0.0" />
-
 The `OVERWRITE` clause can be used to define an event and overwrite an existing one if it already exists. You should use the `OVERWRITE` clause when you want to modify an existing event definition. If the event already exists, the `DEFINE EVENT` statement will overwrite the existing event definition with the new one.
 
 ```surql

--- a/src/content/reference/query-language/statements/define/field.mdx
+++ b/src/content/reference/query-language/statements/define/field.mdx
@@ -50,7 +50,7 @@ DEFINE FIELD [ OVERWRITE | IF NOT EXISTS ] @name ON [ TABLE ] @table
 <Since v="v3.0.0" />
 
 > [!NOTE]
-> In versions of SurrealDB before 3.0.0-beta, `COMPUTED` fields were implemented using a data type called a `future`. Please see [the page on futures](/docs/reference/query-language/language-primitives/data-types/futures) in this case.
+> In versions of SurrealDB before 3.0.0, `COMPUTED` fields were implemented using a data type called a `future`. Please see [the page on futures](/docs/reference/query-language/language-primitives/data-types/futures) in this case.
 
 A `COMPUTED` field is one that is not stored but computed every time it is accessed. Such fields have a more limited set of clauses that can be used. Furthermore, a `COMPUTED` field cannot be defined on the `id` field of a record, nor any nested fields (i.e. a field `metadata` can be defined as computed, but not `medatata.can_drive`).
 
@@ -162,7 +162,7 @@ As the output shows, the `.` enclosed inside backticks in the last field results
 
 The `DEFINE FIELD` statement allows you to set the data type of a field. For a full list of supported data types, see [Data types](/docs/reference/query-language/datamodel).
 
-From version `v2.2.0`, when defining nested fields, where both the parent and the nested fields have types defined, it is no longer possible to have mismatching types, to prevent any impossible type issues once the schema is defined.
+When defining nested fields, if both the parent and the nested fields have types defined, those types must agree. Mismatching types are rejected to prevent impossible schema states.
 
 For example, the following will fail:
 
@@ -407,7 +407,7 @@ DEFINE FIELD locked ON TABLE user TYPE bool
 
 <Since v="v2.2.0" />
 
-In addition to the `DEFAULT` clause, you can use the `DEFAULT ALWAYS` clause to set a default value for a field. The `ALWAYS` keyword indicates that the `DEFAULT` clause is used not only on `CREATE`, but also on `UPDATE` if the value is empty (NONE).
+`DEFAULT ALWAYS` applies a default on `CREATE` and on `UPDATE` when the value is `NONE`. The `ALWAYS` keyword distinguishes this from plain `DEFAULT`, which only runs on `CREATE`.
 
 ```surql
 /**[test]

--- a/src/content/reference/query-language/statements/define/field.mdx
+++ b/src/content/reference/query-language/statements/define/field.mdx
@@ -679,8 +679,6 @@ DEFINE FIELD IF NOT EXISTS email ON TABLE user TYPE string;
 
 ## Using `OVERWRITE` clause
 
-<Since v="v2.0.0" />
-
 The `OVERWRITE` clause can be used to define a field and overwrite an existing one if it already exists. You should use the `OVERWRITE` clause when you want to modify an existing field definition. If the field already exists, the `DEFINE FIELD` statement will overwrite the existing definition with the new one.
 
 ```surql
@@ -963,9 +961,6 @@ CREATE person SET first_name = "Bob", last_name = "BOBSON";
 A good rule of thumb is to organise your `DEFINE FIELD` statements in alphabetical order so that the field definitions show up in the same order as that in which they are computed.
 
 ## Defining a literal on a field
-
-<Since v="v2.0.0" />
-
 A field can also be defined as a [literal type](/docs/reference/query-language/language-primitives/data-types/literals), by specifying one or more possible values and/or permitted types.
 
 ```surql

--- a/src/content/reference/query-language/statements/define/function.mdx
+++ b/src/content/reference/query-language/statements/define/function.mdx
@@ -325,8 +325,6 @@ DEFINE FUNCTION IF NOT EXISTS fn::example() {};
 
 ## Using `OVERWRITE` clause
 
-<Since v="v2.0.0" />
-
 The `OVERWRITE` clause can be used to define a function and overwrite an existing one if it already exists. You should use the `OVERWRITE` clause when you want to modify an existing user definition. If the user already exists, the `DEFINE FUNCTION` statement will overwrite the existing definition with the new one.
 
 ```surql

--- a/src/content/reference/query-language/statements/define/indexes.mdx
+++ b/src/content/reference/query-language/statements/define/indexes.mdx
@@ -5,7 +5,7 @@ description: "SurrealDB uses indexes to help optimize query performance. An inde
 ---
 
 > [!NOTE]
-> Before SurrealDB version 3.0.0-beta, the `FULLTEXT ANALYZER` clause used the syntax `SEARCH ANALYZER`.
+> Before SurrealDB version 3.0.0, the `FULLTEXT ANALYZER` clause used the syntax `SEARCH ANALYZER`.
 
 # `DEFINE INDEX` statement
 
@@ -345,7 +345,7 @@ value = "NONE"
 
 -- Define the an analyzer with
 DEFINE ANALYZER example_ascii TOKENIZERS class FILTERS ascii;
--- Since 3.0.0-beta: only FULLTEXT used to benefit from concurrent full-text search
+-- Since 3.0.0: only FULLTEXT used to benefit from concurrent full-text search
 DEFINE INDEX userNameIndex ON TABLE user COLUMNS name FULLTEXT ANALYZER example_ascii BM25 HIGHLIGHTS;
 ```
 
@@ -357,7 +357,7 @@ DEFINE INDEX userNameIndex ON TABLE user COLUMNS name FULLTEXT ANALYZER example_
 
 #### `FULLTEXT` vs. `SEARCH`
 
-Since version 3.0.0-beta, using `FULLTEXT ANALYZER` is the syntax used for a text analyzer. The `FULLTEXT` clause allows for more performant [concurrent full-text search](https://github.com/surrealdb/surrealdb/pull/5571), as well as the ability to [use the `OR` operator](https://github.com/surrealdb/surrealdb/pull/6179).
+Since version 3.0.0, using `FULLTEXT ANALYZER` is the syntax used for a text analyzer. The `FULLTEXT` clause allows for more performant [concurrent full-text search](https://github.com/surrealdb/surrealdb/pull/5571), as well as the ability to [use the `OR` operator](https://github.com/surrealdb/surrealdb/pull/6179).
 
 ## Vector search indexes
 

--- a/src/content/reference/query-language/statements/define/indexes.mdx
+++ b/src/content/reference/query-language/statements/define/indexes.mdx
@@ -558,8 +558,6 @@ DEFINE INDEX IF NOT EXISTS example ON example FIELDS example;
 
 ## Using `OVERWRITE` clause
 
-<Since v="v2.0.0" />
-
 The `OVERWRITE` clause can be used to define an index and overwrite an existing one if it already exists. You should use the `OVERWRITE` clause when you want to modify an existing index definition. If the index already exists, the `DEFINE INDEX` statement will overwrite the existing definition with the new one.
 
 ```surql
@@ -575,9 +573,6 @@ DEFINE INDEX OVERWRITE example ON example FIELDS example;
 ```
 
 ## Using `CONCURRENTLY` clause
-
-<Since v="v2.0.0" />
-
 Building indexes can be lengthy and may time out before they're completed. Without `CONCURRENTLY`, `DEFINE INDEX` blocks until the index is fully built (or the build fails). The `CONCURRENTLY` clause can be used when you need the statement to return immediately while indexing continues in the background. This allows other operations to keep running while the index builds, during which you can monitor progress with [INFO FOR INDEX](/docs/reference/query-language/statements/info#index-information).
 
 ```surql

--- a/src/content/reference/query-language/statements/define/namespace.mdx
+++ b/src/content/reference/query-language/statements/define/namespace.mdx
@@ -70,8 +70,6 @@ DEFINE NAMESPACE IF NOT EXISTS example;
 
 ## Using `OVERWRITE` clause
 
-<Since v="v2.0.0" />
-
 The `OVERWRITE` clause can be used to define a namespace and overwrite an existing one if it already exists. You should use the `OVERWRITE` clause when you want to modify an existing namespace definition. If the namespace already exists, the `DEFINE NAMESPACE` statement will overwrite the existing namespace definition with the new one.
 
 ```surql

--- a/src/content/reference/query-language/statements/define/overview.mdx
+++ b/src/content/reference/query-language/statements/define/overview.mdx
@@ -9,7 +9,7 @@ description: "DEFINE declares SurrealDB schema: namespaces, tables, fields, inde
 The DEFINE statement can be used to specify instructions to the schema such as authentication access and behaviour, global parameters, table configurations, table events, analyzers, and indexes.
 
 > [!NOTE]
-> Before SurrealDB version 3.0.0-beta, the `FULLTEXT ANALYZER` clause used the syntax `SEARCH ANALYZER`.
+> Before SurrealDB version 3.0.0, the `FULLTEXT ANALYZER` clause used the syntax `SEARCH ANALYZER`.
 
 ```syntax title="SurrealQL Syntax"
 DEFINE [

--- a/src/content/reference/query-language/statements/define/param.mdx
+++ b/src/content/reference/query-language/statements/define/param.mdx
@@ -77,8 +77,6 @@ DEFINE PARAM IF NOT EXISTS $example VALUE 123;
 
 ## Using `OVERWRITE` clause
 
-<Since v="v2.0.0" />
-
 The `OVERWRITE` clause can be used to define a param and overwrite an existing one if it already exists. You should use the `OVERWRITE` clause when you want to modify an existing param definition. If the param already exists, the `DEFINE PARAM` statement will overwrite the existing param definition with the new one.
 
 ```surql

--- a/src/content/reference/query-language/statements/define/table.mdx
+++ b/src/content/reference/query-language/statements/define/table.mdx
@@ -555,8 +555,6 @@ DEFINE TABLE IF NOT EXISTS reading;
 
 ## Using `OVERWRITE` clause
 
-<Since v="v2.0.0" />
-
 The `OVERWRITE` clause can be used to define a table and overwrite an existing one if it already exists. You should use the `OVERWRITE` clause when you want to modify an existing table definition. If the table already exists, the `DEFINE TABLE` statement will overwrite the existing table definition with the new one.
 
 ```surql
@@ -631,8 +629,6 @@ DEFINE TABLE assigned_to SCHEMAFULL TYPE RELATION IN tag OUT sticky
 ```
 
 ## Using ENFORCED to ensure that related records exist
-
-<Since v="v2.0.0" />
 
 As relations are represented by standalone tables, they can be constructed before any linked records exist.
 

--- a/src/content/reference/query-language/statements/define/user.mdx
+++ b/src/content/reference/query-language/statements/define/user.mdx
@@ -138,8 +138,6 @@ DEFINE USER IF NOT EXISTS example
 
 ## Using `OVERWRITE` clause
 
-<Since v="v2.0.0" />
-
 The `OVERWRITE` clause can be used to define a user and overwrite an existing one if it already exists. You should use the `OVERWRITE` clause when you want to modify an existing user definition. If the user already exists, the `DEFINE USER` statement will overwrite the existing user definition with the new one.
 
 ```surql
@@ -182,7 +180,5 @@ Currently, only the built-in roles OWNER, EDITOR and VIEWER are available.
 </table>
 
 ## Duration
-
-<Since v="v2.0.0" />
 
 The duration clause specifies the duration of the token returned after successful authentication with a password or passhash as well as the duration of the session established both using a password or passhash and the aforementioned token. The difference between these concepts is explained in the [expiration](/docs/learn/security/authentication/authentication#expiration) documentation.

--- a/src/content/reference/query-language/statements/for.mdx
+++ b/src/content/reference/query-language/statements/for.mdx
@@ -67,8 +67,6 @@ FOR $person IN (SELECT VALUE id FROM person WHERE age >= 18) {
 
 ## Ranges in FOR loops
 
-<Since v="v2.0.0" />
-
 A `FOR` loop can also be made out of a [range UUID](/docs/reference/query-language/language-primitives/data-types/ranges) of integers.
 
 ```surql

--- a/src/content/reference/query-language/statements/insert.mdx
+++ b/src/content/reference/query-language/statements/insert.mdx
@@ -220,8 +220,6 @@ INSERT IGNORE INTO person [
 
 ### Return values
 
-<Since v="v2.0.0" />
-
 By default, the `INSERT` statement returns the record once it has been inserted. To change what is returned, we can use the `RETURN` clause, specifying either `NONE`, `BEFORE`, `AFTER`, `DIFF`, or a comma-separated list of specific fields to return.
 
 `RETURN NONE` can be useful to avoid excess output:
@@ -385,8 +383,6 @@ INSERT INTO planet [
 ```
 
 ## Bulk insert
-
-<Since v="v2.0.0" />
 
 The `INSERT` statement supports bulk insert, which allows multiple records to be inserted in a single query. The `@what` part of the syntax can be either a single object or an array of objects.
 

--- a/src/content/reference/query-language/statements/let.mdx
+++ b/src/content/reference/query-language/statements/let.mdx
@@ -171,8 +171,6 @@ LET $session = 10;
 
 ## Typed LET statements
 
-<Since v="v2.0.0" />
-
 Type safety in a `LET` statement can be ensured by adding a `:` (a colon) and the type name after the `LET` keyword.
 
 ```surql

--- a/src/content/reference/query-language/statements/relate.mdx
+++ b/src/content/reference/query-language/statements/relate.mdx
@@ -1615,8 +1615,6 @@ SELECT id, ->knows[WHERE same_high_school
 
 ### Recursive graph queries
 
-<Since v="v2.1.0" />
-
 Graph edges can also be queried recursively. For a full explanation of this syntax, see the page on [recursive paths](/docs/reference/query-language/language-primitives/idioms#recursive-paths).
 
 Take the following example which creates five cities, each of which is connected to the next by some type of road of random length.

--- a/src/content/reference/query-language/statements/select.mdx
+++ b/src/content/reference/query-language/statements/select.mdx
@@ -242,8 +242,6 @@ SELECT *, (SELECT * FROM events
 
 ## Numeric ranges in a `WHERE` clause
 
-<Since v="v2.0.0" />
-
 A numeric range inside a `WHERE` clause can improve performance if the range is able to replace multiple checks on a certain condition. The following code should show a modest but measurable improvement in performance between the first and second `SELECT` statement, as only one condition needs to be checked instead of two.
 
 ```surql
@@ -774,8 +772,6 @@ SELECT * FROM person
 
 ## The `TEMPFILES` clause
 
-<Since v="v2.0.0" />
-
 When processing a large result set with many records, it is possible to use the `TEMPFILES` clause to specify that the statement should be processed in temporary files rather than memory.
 
 This significantly reduces memory usage in exchange for slower performance.
@@ -981,8 +977,6 @@ SELECT * FROM ONLY table_name LIMIT 1;
 ```
 
 ## The `VERSION` clause
-
-<Since v="v2.0.0" />
 
 If you are using a versioned storage engine (in-memory SurrealMX, RocksDB where supported, or beta SurrealKV) with versioning enabled, write operations on a table will track the state of each record at the time at which the operation was performed. 
 

--- a/src/content/reference/query-language/statements/select.mdx
+++ b/src/content/reference/query-language/statements/select.mdx
@@ -555,7 +555,7 @@ To return the most recently modified record per group instead of aggregate total
 
 The `GROUP` and `SPLIT` clauses are incompatible with each other due to opposing behaviour: while `SPLIT` is a post-processing clause that multiplies the output of a query, `GROUP` works in the other way by collapsing the output.
 
-Versions before 3.0.0-beta allowed these two clauses to be used together, after which attempting to do so results in a parsing error.
+Versions before 3.0.0 allowed these two clauses to be used together, after which attempting to do so results in a parsing error.
 
 ```surql
 SELECT * FROM person SPLIT name GROUP BY name;

--- a/src/content/reference/query-language/statements/upsert.mdx
+++ b/src/content/reference/query-language/statements/upsert.mdx
@@ -6,8 +6,6 @@ description: "The UPSERT statement can be used to insert records or modify recor
 
 # `UPSERT` statement
 
-<Since v="v2.0.0" />
-
 The `UPSERT` statement can be used to insert records into the database, or to update them if they exist.
 
 > [!NOTE]

--- a/src/content/reference/query-language/statements/use.mdx
+++ b/src/content/reference/query-language/statements/use.mdx
@@ -100,7 +100,7 @@ USE NS ns; -- Now defined, no error
 
 <Since v="v3.0.0" />
 
-Before SurrealDB 3.0.0-beta, the output of a `USE` statement was `NONE`. Since then, each `USE` statement returns an object containing the current namespace and database.
+Before SurrealDB 3.0.0, the output of a `USE` statement was `NONE`. Since then, each `USE` statement returns an object containing the current namespace and database.
 
 ```surql
 USE NS main;

--- a/src/content/reference/rest-api/http-protocol.mdx
+++ b/src/content/reference/rest-api/http-protocol.mdx
@@ -156,7 +156,7 @@ curl -I http://localhost:8000/status
 HTTP/1.1 200 OK
 vary: origin, access-control-request-method, access-control-request-headers
 access-control-allow-origin: *
-surreal-version: surrealdb/3.0.0-beta
+surreal-version: surrealdb/3.0.0
 server: SurrealDB
 x-request-id: fdb9bcdb-b085-4da0-80ef-a61105c432f9
 content-length: 0
@@ -179,7 +179,7 @@ curl -I http://localhost:8000/health
 HTTP/1.1 200 OK
 vary: origin, access-control-request-method, access-control-request-headers
 access-control-allow-origin: *
-surreal-version: surrealdb/3.0.0-beta
+surreal-version: surrealdb/3.0.0
 server: SurrealDB
 x-request-id: 66938ec2-ad7c-4afb-928d-683e7a75433a
 content-length: 0
@@ -230,7 +230,7 @@ curl http://localhost:8000/version
 ```
 
 ```bash title="Sample output"
-surrealdb-3.0.0-beta
+surrealdb-3.0.0
 ```
 
 

--- a/src/content/reference/rest-api/http-protocol.mdx
+++ b/src/content/reference/rest-api/http-protocol.mdx
@@ -1864,8 +1864,6 @@ Parse errors return **HTTP 400** with an error payload. See [GQL via HTTP](/docs
 
 ## `POST /graphql` {#graphql}
 
-<Since v="v2.0.0" />
-
 The GraphQL endpoint enables use of GraphQL queries to interact with your data.
 
 > [!NOTE]

--- a/src/content/reference/rest-api/rpc-protocol.mdx
+++ b/src/content/reference/rest-api/rpc-protocol.mdx
@@ -1849,7 +1849,7 @@ This method does not accept any parameters.
 {
     "id": 1,
     "result": {
-        "version": "2.0.0-beta.2",
+        "version": "3.2.0",
         "build": "abc123",
         "timestamp": "2024-09-15T12:34:56Z"
     }


### PR DESCRIPTION

* Removes Since tags for 2.0.x and 2.1.x features
* Removes -beta in many places
* Changes wording for 2.x features that imply that they are new.