### PR TITLE
Document JS SDK retry-on-conflict logic

### DIFF
--- a/src/content/index/languages/javascript/api/queries/create-promise.mdx
+++ b/src/content/index/languages/javascript/api/queries/create-promise.mdx
@@ -245,6 +245,47 @@ const user = await db.create(new Table('users'))
 
 ---
 
+### `.retry()` {#retry}
+
+Retry the operation with exponential backoff if it fails due to a write conflict. Off by default; passing an options object (or calling with no arguments) opts the operation in.
+
+This overrides the connection-wide default set via the [`retry`](/docs/languages/javascript/api/types/#connectoptions) option on `ConnectOptions`.
+
+```ts title="Method Syntax"
+createPromise.retry(options?)
+```
+
+#### Parameters
+<table>
+    <thead>
+        <tr>
+            <th>Parameter</th>
+            <th>Type</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><code>options</code> <label label="optional" /></td>
+            <td><code>Partial&lt;<a href="/docs/languages/javascript/api/types/#retryoptions">RetryOptions</a>&gt;</code></td>
+            <td>Retry configuration. If omitted, retry is enabled with the default configuration.</td>
+        </tr>
+    </tbody>
+</table>
+
+#### Returns
+`CreatePromise<T, I, J>` - Chainable promise
+
+#### Example
+
+```ts
+const user = await db.create(new Table('users'))
+    .content(userData)
+    .retry({ attempts: 3 });
+```
+
+---
+
 ### `.json()` {#json}
 
 Return result as JSON string instead of parsed object.

--- a/src/content/index/languages/javascript/api/queries/delete-promise.mdx
+++ b/src/content/index/languages/javascript/api/queries/delete-promise.mdx
@@ -140,6 +140,45 @@ deletePromise.version(timestamp)
 
 ---
 
+### `.retry()` {#retry}
+
+Retry the operation with exponential backoff if it fails due to a write conflict. Off by default; passing an options object (or calling with no arguments) opts the operation in.
+
+This overrides the connection-wide default set via the [`retry`](/docs/languages/javascript/api/types/#connectoptions) option on `ConnectOptions`.
+
+```ts title="Method Syntax"
+deletePromise.retry(options?)
+```
+
+#### Parameters
+<table>
+    <thead>
+        <tr>
+            <th>Parameter</th>
+            <th>Type</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><code>options</code> <label label="optional" /></td>
+            <td><code>Partial&lt;<a href="/docs/languages/javascript/api/types/#retryoptions">RetryOptions</a>&gt;</code></td>
+            <td>Retry configuration. If omitted, retry is enabled with the default configuration.</td>
+        </tr>
+    </tbody>
+</table>
+
+#### Returns
+`DeletePromise<T, J>` - Chainable promise
+
+#### Example
+
+```ts
+await db.delete(new RecordId('users', 'john')).retry();
+```
+
+---
+
 ### `.json()` {#json}
 
 Return result as JSON string.

--- a/src/content/index/languages/javascript/api/queries/insert-promise.mdx
+++ b/src/content/index/languages/javascript/api/queries/insert-promise.mdx
@@ -175,6 +175,45 @@ insertPromise.version(timestamp)
 
 ---
 
+### `.retry()` {#retry}
+
+Retry the operation with exponential backoff if it fails due to a write conflict. Off by default; passing an options object (or calling with no arguments) opts the operation in.
+
+This overrides the connection-wide default set via the [`retry`](/docs/languages/javascript/api/types/#connectoptions) option on `ConnectOptions`.
+
+```ts title="Method Syntax"
+insertPromise.retry(options?)
+```
+
+#### Parameters
+<table>
+    <thead>
+        <tr>
+            <th>Parameter</th>
+            <th>Type</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><code>options</code> <label label="optional" /></td>
+            <td><code>Partial&lt;<a href="/docs/languages/javascript/api/types/#retryoptions">RetryOptions</a>&gt;</code></td>
+            <td>Retry configuration. If omitted, retry is enabled with the default configuration.</td>
+        </tr>
+    </tbody>
+</table>
+
+#### Returns
+`InsertPromise<T, J>` - Chainable promise
+
+#### Example
+
+```ts
+await db.insert(new Table('users')).content(users).retry({ attempts: 3 });
+```
+
+---
+
 ### `.json()` {#json}
 
 Return result as JSON string.

--- a/src/content/index/languages/javascript/api/queries/query.mdx
+++ b/src/content/index/languages/javascript/api/queries/query.mdx
@@ -203,6 +203,57 @@ for (const response of responses) {
 
 ---
 
+### `.retry()` {#retry}
+
+Retry the whole query with exponential backoff if it fails due to a write conflict. Only applies to `.collect()` (and awaiting the query directly) — it does not apply to `.responses()`, which returns partial results, or `.stream()`, which yields results incrementally and cannot be safely replayed mid-stream.
+
+Off by default, since auto-retrying a non-atomic multi-statement query could apply some statements more than once. Passing an options object (or calling with no arguments) opts the query in. This overrides the connection-wide default set via the [`retry`](/docs/languages/javascript/api/types/#connectoptions) option on `ConnectOptions`.
+
+```ts title="Method Syntax"
+query.retry(options?)
+```
+
+#### Parameters
+<table>
+    <thead>
+        <tr>
+            <th>Parameter</th>
+            <th>Type</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><code>options</code> <label label="optional" /></td>
+            <td><code>Partial&lt;<a href="/docs/languages/javascript/api/types/#retryoptions">RetryOptions</a>&gt;</code></td>
+            <td>Retry configuration. If omitted, retry is enabled with the default configuration.</td>
+        </tr>
+    </tbody>
+</table>
+
+#### Returns
+`Query<R, J>` - Chainable query
+
+#### Example
+
+```ts title="Retry on Conflict"
+const [n] = await db
+    .query<[number]>('UPDATE counter:c SET n += 1 RETURN n')
+    .retry({ attempts: 3 })
+    .collect();
+```
+
+By default, a conflict is detected using [`isRetryableConflict`](/docs/languages/javascript/api/utilities/is-retryable-conflict), which matches on the server's error message. You can supply a custom predicate to override this:
+
+```ts title="Custom Retry Predicate"
+const result = await db
+    .query('UPDATE counter:c SET n += 1 RETURN n')
+    .retry({ attempts: 5, retryable: (error) => error.message.includes('conflict') })
+    .collect();
+```
+
+---
+
 ### `.json()` {#json}
 
 Configure the query to return results as JSON strings.

--- a/src/content/index/languages/javascript/api/queries/relate-promise.mdx
+++ b/src/content/index/languages/javascript/api/queries/relate-promise.mdx
@@ -148,6 +148,45 @@ relatePromise.version(timestamp)
 
 ---
 
+### `.retry()` {#retry}
+
+Retry the operation with exponential backoff if it fails due to a write conflict. Off by default; passing an options object (or calling with no arguments) opts the operation in.
+
+This overrides the connection-wide default set via the [`retry`](/docs/languages/javascript/api/types/#connectoptions) option on `ConnectOptions`.
+
+```ts title="Method Syntax"
+relatePromise.retry(options?)
+```
+
+#### Parameters
+<table>
+    <thead>
+        <tr>
+            <th>Parameter</th>
+            <th>Type</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><code>options</code> <label label="optional" /></td>
+            <td><code>Partial&lt;<a href="/docs/languages/javascript/api/types/#retryoptions">RetryOptions</a>&gt;</code></td>
+            <td>Retry configuration. If omitted, retry is enabled with the default configuration.</td>
+        </tr>
+    </tbody>
+</table>
+
+#### Returns
+`RelatePromise<T, J>` - Chainable promise
+
+#### Example
+
+```ts
+await db.relate(alice, 'follows', bob).retry();
+```
+
+---
+
 ### `.json()` {#json}
 
 Return result as JSON string.

--- a/src/content/index/languages/javascript/api/queries/run-promise.mdx
+++ b/src/content/index/languages/javascript/api/queries/run-promise.mdx
@@ -40,6 +40,45 @@ console.log(typeof jsonResult); // 'string'
 
 ---
 
+### `.retry()` {#retry}
+
+Retry the operation with exponential backoff if it fails due to a write conflict. Off by default; passing an options object (or calling with no arguments) opts the operation in.
+
+This overrides the connection-wide default set via the [`retry`](/docs/languages/javascript/api/types/#connectoptions) option on `ConnectOptions`.
+
+```ts title="Method Syntax"
+runPromise.retry(options?)
+```
+
+#### Parameters
+<table>
+    <thead>
+        <tr>
+            <th>Parameter</th>
+            <th>Type</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><code>options</code> <label label="optional" /></td>
+            <td><code>Partial&lt;<a href="/docs/languages/javascript/api/types/#retryoptions">RetryOptions</a>&gt;</code></td>
+            <td>Retry configuration. If omitted, retry is enabled with the default configuration.</td>
+        </tr>
+    </tbody>
+</table>
+
+#### Returns
+`RunPromise<T, J>` - Chainable promise
+
+#### Example
+
+```ts
+await db.run('fn::allocate_inventory', [productId, 10]).retry({ attempts: 3 });
+```
+
+---
+
 ### `.compile()` {#compile}
 
 Compile the query into a BoundQuery.

--- a/src/content/index/languages/javascript/api/queries/update-promise.mdx
+++ b/src/content/index/languages/javascript/api/queries/update-promise.mdx
@@ -325,6 +325,47 @@ updatePromise.timeout(duration)
 
 ---
 
+### `.retry()` {#retry}
+
+Retry the operation with exponential backoff if it fails due to a write conflict. Off by default; passing an options object (or calling with no arguments) opts the operation in.
+
+This overrides the connection-wide default set via the [`retry`](/docs/languages/javascript/api/types/#connectoptions) option on `ConnectOptions`.
+
+```ts title="Method Syntax"
+updatePromise.retry(options?)
+```
+
+#### Parameters
+<table>
+    <thead>
+        <tr>
+            <th>Parameter</th>
+            <th>Type</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><code>options</code> <label label="optional" /></td>
+            <td><code>Partial&lt;<a href="/docs/languages/javascript/api/types/#retryoptions">RetryOptions</a>&gt;</code></td>
+            <td>Retry configuration. If omitted, retry is enabled with the default configuration.</td>
+        </tr>
+    </tbody>
+</table>
+
+#### Returns
+`UpdatePromise<T, I, J>` - Chainable promise
+
+#### Example
+
+```ts
+await db.update(new RecordId('counter', 'c'))
+    .merge({ n: 1 })
+    .retry({ attempts: 3 });
+```
+
+---
+
 ### `.json()` {#json}
 
 Return result as JSON string.

--- a/src/content/index/languages/javascript/api/queries/upsert-promise.mdx
+++ b/src/content/index/languages/javascript/api/queries/upsert-promise.mdx
@@ -246,6 +246,47 @@ upsertPromise.timeout(duration)
 
 ---
 
+### `.retry()` {#retry}
+
+Retry the operation with exponential backoff if it fails due to a write conflict. Off by default; passing an options object (or calling with no arguments) opts the operation in.
+
+This overrides the connection-wide default set via the [`retry`](/docs/languages/javascript/api/types/#connectoptions) option on `ConnectOptions`.
+
+```ts title="Method Syntax"
+upsertPromise.retry(options?)
+```
+
+#### Parameters
+<table>
+    <thead>
+        <tr>
+            <th>Parameter</th>
+            <th>Type</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><code>options</code> <label label="optional" /></td>
+            <td><code>Partial&lt;<a href="/docs/languages/javascript/api/types/#retryoptions">RetryOptions</a>&gt;</code></td>
+            <td>Retry configuration. If omitted, retry is enabled with the default configuration.</td>
+        </tr>
+    </tbody>
+</table>
+
+#### Returns
+`UpsertPromise<T, I, J>` - Chainable promise
+
+#### Example
+
+```ts
+await db.upsert(new RecordId('users', 'john'))
+    .merge({ visits: 1 })
+    .retry();
+```
+
+---
+
 ### `.json()` {#json}
 
 Return result as JSON string.

--- a/src/content/index/languages/javascript/api/types/index.mdx
+++ b/src/content/index/languages/javascript/api/types/index.mdx
@@ -71,6 +71,7 @@ interface ConnectOptions {
     versionCheck?: boolean;
     invalidateOnExpiry?: boolean;
     reconnect?: boolean | Partial<ReconnectOptions>;
+    retry?: boolean | Partial<RetryOptions>;
 }
 ```
 
@@ -81,6 +82,7 @@ interface ConnectOptions {
 - `versionCheck` - Enable version compatibility checking (default: true)
 - `invalidateOnExpiry` - Invalidate session on token expiry (default: false)
 - `reconnect` - Reconnection behavior configuration (default: true)
+- `retry` - Connection-wide default for retrying queries on write conflict (default: disabled)
 
 **Example:**
 ```ts
@@ -94,6 +96,11 @@ await db.connect('ws://localhost:8000', {
     reconnect: {
         attempts: 10,
         retryDelay: 1000
+    },
+    retry: {
+        enabled: true,
+        attempts: 5,
+        retryDelay: 100
     }
 });
 ```
@@ -124,6 +131,49 @@ interface ReconnectOptions {
 - `retryDelayMultiplier` - Multiply delay after each failed attempt
 - `retryDelayJitter` - Random offset percentage for delays
 - `catch` - Custom error handler for reconnection errors
+
+---
+
+### `RetryOptions` {#retryoptions}
+
+Configuration for retrying a query, mutation, or transaction when it fails with a write conflict. Modeled on [`ReconnectOptions`](#reconnectoptions), and applied the same way: as a connection-wide default via [`ConnectOptions.retry`](#connectoptions), or per call via `.retry()`.
+
+```ts
+interface RetryOptions {
+    enabled: boolean;
+    attempts: number;
+    retryDelay: number;
+    retryDelayMax: number;
+    retryDelayMultiplier: number;
+    retryDelayJitter: number;
+    retryable?: (error: Error) => boolean;
+}
+```
+
+**Properties:**
+- `enabled` - Enable retrying on write conflict
+- `attempts` - Maximum retry attempts
+- `retryDelay` - Initial delay before retrying (ms)
+- `retryDelayMax` - Maximum delay between attempts (ms)
+- `retryDelayMultiplier` - Multiply delay after each failed attempt
+- `retryDelayJitter` - Random offset percentage for delays
+- `retryable` - Custom predicate deciding whether an error should be retried (default: [`isRetryableConflict`](/docs/languages/javascript/api/utilities/is-retryable-conflict))
+
+Retry is off by default. Passing an options object, or calling `.retry()` with no arguments, opts a query, mutation, or transaction in. Retrying a non-atomic multi-statement query can apply some statements more than once, so it must always be enabled explicitly.
+
+**Example:**
+```ts
+// Connection-wide default
+await db.connect('ws://localhost:8000', {
+    retry: { enabled: true, attempts: 5, retryDelay: 100 }
+});
+
+// Per-query override
+const [n] = await db
+    .query<[number]>('UPDATE counter:c SET n += 1 RETURN n')
+    .retry({ attempts: 3 })
+    .collect();
+```
 
 ---
 

--- a/src/content/index/languages/javascript/api/utilities/is-retryable-conflict.mdx
+++ b/src/content/index/languages/javascript/api/utilities/is-retryable-conflict.mdx
@@ -1,0 +1,68 @@
+---
+position: 7
+title: isRetryableConflict
+description: Default predicate used to detect retryable write conflicts.
+---
+
+
+# `isRetryableConflict()` {#isretryableconflict}
+
+The `isRetryableConflict()` function is the default predicate used by [`.retry()`](/docs/languages/javascript/api/queries/query#retry) to decide whether a failed query should be retried. SurrealDB does not currently expose a structured retryable error kind, so the predicate matches on the error message.
+
+**Import:**
+```ts
+import { isRetryableConflict } from 'surrealdb';
+```
+
+**Source:** [utils/index.ts](https://github.com/surrealdb/surrealdb.js/blob/main/packages/sdk/src/utils/index.ts)
+
+## Function signature
+
+```ts
+function isRetryableConflict(error: Error): boolean
+```
+
+#### Parameters
+<table>
+    <thead>
+        <tr>
+            <th>Parameter</th>
+            <th>Type</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><code>error</code> <label label="required" /></td>
+            <td><code>Error</code></td>
+            <td>The error thrown by a failed query.</td>
+        </tr>
+    </tbody>
+</table>
+
+#### Returns
+`boolean` - `true` if the error looks like a retryable write conflict (its message contains "conflict" or "can be retried"), `false` otherwise
+
+## Overriding the default predicate
+
+Pass a custom `retryable` function in [`RetryOptions`](/docs/languages/javascript/api/types/#retryoptions) to change what counts as retryable, optionally reusing `isRetryableConflict` as a base:
+
+```ts
+import { isRetryableConflict } from 'surrealdb';
+
+await db.query('UPDATE counter:c SET n += 1 RETURN n')
+    .retry({
+        attempts: 5,
+        retryable: (error) => isRetryableConflict(error) || error.message.includes('busy')
+    })
+    .collect();
+```
+
+> [!NOTE]
+> Confirm the exact conflict message against the SurrealDB server version you target — the heuristic matches on message text rather than a structured error kind.
+
+## See also
+
+- [Query.retry()](/docs/languages/javascript/api/queries/query#retry) - Retry queries on write conflict
+- [RetryOptions](/docs/languages/javascript/api/types/#retryoptions) - Retry configuration type
+- [Error handling](/docs/languages/javascript/concepts/error-handling) - Handling SDK errors

--- a/src/content/index/languages/javascript/concepts/connecting-to-surrealdb.mdx
+++ b/src/content/index/languages/javascript/concepts/connecting-to-surrealdb.mdx
@@ -114,6 +114,27 @@ Additionally, you can configure the behavior with exponential backoff and jitter
 | `retryDelayMultiplier`| Multiply delay after each failed attempt                 |
 | `retryDelayJitter`    | Random offset percentage for delays                      |
 
+#### Retrying on write conflict
+
+Under concurrent write load, a query can fail with a read/write conflict when another transaction touched the same data. You can configure the SDK to replay the conflicting work automatically with exponential backoff, using the `retry` option. It shares the same shape as `reconnect`, and is off by default since retrying a non-atomic multi-statement query could apply some statements more than once.
+
+```ts
+await db.connect('ws://localhost:8000', {
+    namespace: 'my_namespace',
+    database: 'my_database',
+    retry: { enabled: true, attempts: 5, retryDelay: 100 }
+});
+```
+
+This sets the connection-wide default. It can be overridden per call with `.retry()` on a [`query()`](/docs/languages/javascript/concepts/executing-queries) or on [mutation methods](/docs/languages/javascript/concepts/executing-queries) like `.create()` and `.delete()` — including when called on a [transaction](/docs/languages/javascript/concepts/transactions), since it exposes the same query methods.
+
+```ts
+const [n] = await db
+    .query<[number]>('UPDATE counter:c SET n += 1 RETURN n')
+    .retry({ attempts: 3 })
+    .collect();
+```
+
 ### Waiting for a connection
 
 You can wait for the connection to the database to succeed by awaiting the `.connect()` method. If the connection fails for any reason, the promise will reject.
@@ -201,6 +222,7 @@ A complete [list of supported features](https://github.com/surrealdb/surrealdb.j
 
 - [Surreal API reference](/docs/languages/javascript/api/core/surreal) for the complete connection interface
 - [ConnectOptions type reference](/docs/languages/javascript/api/types/#connectoptions) for all connection options
+- [RetryOptions type reference](/docs/languages/javascript/api/types/#retryoptions) for retry-on-conflict configuration
 - [Authentication](/docs/languages/javascript/concepts/authentication) for signing in and managing credentials
 - [WebAssembly engine](/docs/languages/javascript/engines/wasm) for embedded browser databases
 - [Node.js engine](/docs/languages/javascript/engines/node) for embedded server-side databases

--- a/src/content/index/languages/javascript/concepts/error-handling.mdx
+++ b/src/content/index/languages/javascript/concepts/error-handling.mdx
@@ -205,8 +205,18 @@ async function withRetry<T>(fn: () => Promise<T>, maxRetries = 3): Promise<T> {
 const users = await withRetry(() => db.select(new Table('users')));
 ```
 
+For the specific case of write conflicts under concurrent load, prefer the SDK's built-in [`.retry()`](/docs/languages/javascript/api/queries/query#retry) over a hand-rolled loop — it applies exponential backoff and only replays work known to be safely retryable.
+
+```ts
+const [n] = await db
+    .query<[number]>('UPDATE counter:c SET n += 1 RETURN n')
+    .retry({ attempts: 3 })
+    .collect();
+```
+
 ## Learn more
 
 - [Errors API reference](/docs/languages/javascript/api/errors) for a complete list of error classes and their properties
 - [Connecting to SurrealDB](/docs/languages/javascript/concepts/connecting-to-surrealdb) for connection and reconnection configuration
+- [Retrying on write conflict](/docs/languages/javascript/concepts/connecting-to-surrealdb#retrying-on-write-conflict) for configuring built-in query retry
 - [Authentication](/docs/languages/javascript/concepts/authentication) for handling authentication flows

--- a/src/content/index/languages/javascript/concepts/executing-queries.mdx
+++ b/src/content/index/languages/javascript/concepts/executing-queries.mdx
@@ -321,10 +321,28 @@ for (const response of responses) {
 }
 ```
 
+## Retrying on write conflict
+
+Under concurrent write load, a query can fail with a read/write conflict when another transaction touched the same data. Chain `.retry()` onto `.query()` or any query builder method to replay the operation automatically with exponential backoff.
+
+```ts
+const [n] = await db
+    .query<[number]>('UPDATE counter:c SET n += 1 RETURN n')
+    .retry({ attempts: 3 })
+    .collect();
+
+await db.delete(new RecordId('users', 'john')).retry();
+```
+
+Retry is off by default, and only applies to `.collect()` (or awaiting the query directly) — not `.responses()` or `.stream()`. For raw queries with multiple statements, only enable it when the statements are safe to apply more than once, since a retried query re-sends the whole thing.
+
+You can also set a connection-wide default with the `retry` option on [`.connect()`](/docs/languages/javascript/concepts/connecting-to-surrealdb#retrying-on-write-conflict), which `.retry()` overrides per call.
+
 ## Learn more
 
 - [Bound queries](/docs/languages/javascript/concepts/bound-queries) for parameterised query building with `surql` and `BoundQuery`
 - [Live queries](/docs/languages/javascript/concepts/live-queries) for real-time subscriptions
 - [Transactions](/docs/languages/javascript/concepts/transactions) for atomic multi-query operations
+- [Connecting to SurrealDB](/docs/languages/javascript/concepts/connecting-to-surrealdb#retrying-on-write-conflict) for connection-wide retry configuration
 - [Query builders API reference](/docs/languages/javascript/api/queries/) for detailed method signatures
 - [SurrealQL statements](/docs/reference/query-language/statements/overview) for the query language reference

--- a/src/content/index/languages/javascript/concepts/transactions.mdx
+++ b/src/content/index/languages/javascript/concepts/transactions.mdx
@@ -71,6 +71,22 @@ Call `.cancel()` to discard all pending changes. This is typically done when an 
 await txn.cancel();
 ```
 
+## Retrying on write conflict
+
+Queries executed within a transaction can fail with a write conflict under concurrent load, just like queries outside a transaction. Since `SurrealTransaction` exposes the same query methods as a regular session, you can chain [`.retry()`](/docs/languages/javascript/api/queries/query#retry) onto any statement inside the transaction to replay it with exponential backoff.
+
+```ts
+const txn = await db.beginTransaction();
+
+await txn.update(new RecordId('accounts', 'alice'))
+    .merge({ balance: from.balance - 100 })
+    .retry({ attempts: 3 });
+
+await txn.commit();
+```
+
+See [Retrying on write conflict](/docs/languages/javascript/concepts/connecting-to-surrealdb#retrying-on-write-conflict) for how to configure a connection-wide default.
+
 ## Handling errors in transactions
 
 Always wrap transaction logic in a try-catch block to ensure the transaction is cancelled if any operation fails. This prevents partial changes from being committed.

--- a/src/content/index/languages/javascript/concepts/utilities.mdx
+++ b/src/content/index/languages/javascript/concepts/utilities.mdx
@@ -181,6 +181,10 @@ These ship with the `surrealdb` driver and tie into its query engine. They are n
 			<td scope="row" data-label="Utility"><code> s, d, r, u </code></td>
 			<td scope="row" data-label="Description">Tagged templates for SurrealQL string, datetime, record, and UUID prefixes</td>
 		</tr>
+		<tr>
+			<td scope="row" data-label="Utility"><a href="/docs/languages/javascript/api/utilities/is-retryable-conflict"> <code> isRetryableConflict(error) </code></a></td>
+			<td scope="row" data-label="Description">Default predicate used by <code>.retry()</code> to detect retryable write conflicts</td>
+		</tr>
 	</tbody>
 </table>
 


### PR DESCRIPTION
## Summary

- Documents the retry-on-write-conflict feature added to the JS SDK in [surrealdb/surrealdb.js#628](https://github.com/surrealdb/surrealdb.js/pull/628), which was previously undocumented (only reconnect-on-disconnect retry was covered).
- Adds `.retry()` reference docs to the `Query` class and all mutation query builders (`create`, `delete`, `insert`, `relate`, `run`, `update`, `upsert`).
- Adds a `RetryOptions` type reference and a `retry` field on `ConnectOptions` in the TypeScript types page.
- Adds a new `isRetryableConflict()` utility reference page.
- Adds concept-level coverage: a "Retrying on write conflict" section in Connecting to SurrealDB, a section in Transactions, and a pointer from Error handling toward the built-in retry instead of hand-rolled loops.

## Test plan

- [x] `bun run qc` (biome check) passes with no new issues
- [x] Verified balanced JSX tags/code fences across all edited MDX files
- [ ] Visual review of rendered pages in the deploy preview