### PR TITLE
Spectron Tanstack AI and package names

### DIFF
--- a/src/content/spectron/integrations/ai-sdks/tanstack-ai.mdx
+++ b/src/content/spectron/integrations/ai-sdks/tanstack-ai.mdx
@@ -1,34 +1,33 @@
 ---
 position: 2
 title: TanStack AI
-description: "Adding Spectron memory to a TanStack Start application."
+description: "Adding Spectron memory to a TanStack AI application."
 ---
 
 # TanStack AI
 
-[TanStack](https://tanstack.com) applications call model providers from server functions and API routes. Spectron adds long-term memory to those handlers: recall relevant context before a generation, then store the exchange afterwards. There is no dedicated adapter. The [JavaScript SDK](/docs/spectron/integrations/sdks/javascript-and-typescript) (`@surrealdb/spectron`) runs in any TanStack Start server route.
+[`@tanstack/ai`](https://tanstack.com/ai) is a type-safe, provider-agnostic AI SDK for streaming chat, tool calling, and agents. Spectron adds long-term memory to a `chat()` call: recall relevant context before a generation, then store the exchange afterwards. There is no dedicated adapter. The [JavaScript SDK](/docs/spectron/integrations/sdks/javascript-and-typescript) (`@surrealdb/spectron`) runs in any server handler that calls `chat()`.
 
 > [!NOTE]
-> This is an integration guide. There is no first-party TanStack package; the code below wires the Spectron SDK into TanStack's server layer, and you can adapt it to your handler shape.
+> This is an integration guide. There is no first-party TanStack package; the code below wires the Spectron SDK into a `@tanstack/ai` handler, and you can adapt it to your server shape.
 
 ## Installation
 
 ```bash
-npm install @surrealdb/spectron ai @ai-sdk/openai
+npm install @surrealdb/spectron @tanstack/ai @tanstack/ai-openai
 ```
 
 Spectron holds an API key, so construct the client only on the server, never in a component or loader that ships to the browser.
 
-## A memory-aware server route
+## A memory-aware server handler
 
 Recall context, prepend it to the system prompt, generate, then store the turn:
 
 ```typescript
 // src/routes/api/chat.ts
-import { createServerFileRoute } from "@tanstack/react-start/server";
 import { Spectron } from "@surrealdb/spectron";
-import { generateText } from "ai";
-import { openai } from "@ai-sdk/openai";
+import { chat, toServerSentEventsResponse } from "@tanstack/ai";
+import { openaiText } from "@tanstack/ai-openai";
 
 const spectron = new Spectron({
     endpoint: process.env.SPECTRON_ENDPOINT!,
@@ -36,52 +35,84 @@ const spectron = new Spectron({
     apiKey: process.env.SPECTRON_API_KEY!,
 });
 
-export const ServerRoute = createServerFileRoute("/api/chat").methods({
-    POST: async ({ request }) => {
-        const { userId, message } = await request.json();
-        const scope = [`org/acme/user/${userId}`];
+export async function POST(request: Request) {
+    const { userId, message } = await request.json();
+    const scope = [`org/acme/user/${userId}`];
 
-        // 1. Recall relevant memory as a ready-to-inject context block.
-        const memory = await spectron.context(message, { scope, k: 8 });
+    // 1. Recall relevant memory as a ready-to-inject context block.
+    const memory = await spectron.context(message, { scope, k: 8 });
 
-        // 2. Generate with the context block in the system prompt.
-        const { text } = await generateText({
-            model: openai("gpt-4o"),
-            system: `You are a helpful assistant.\n\n## Memory\n${memory}`,
-            prompt: message,
-        });
+    // 2. Generate with the context block in the system prompt.
+    const stream = chat({
+        adapter: openaiText("gpt-4o"),
+        messages: [
+            { role: "system", content: `You are a helpful assistant.\n\n## Memory\n${memory}` },
+            { role: "user", content: message },
+        ],
+    });
 
-        // 3. Store the exchange so it is available next time.
-        await spectron.rememberMany(
-            [
-                { role: "user", content: message },
-                { role: "assistant", content: text },
-            ],
-            { scope },
-        );
+    // 3. Store the exchange so it is available next time.
+    //    (streamToText collects the reply; stream once to the client instead
+    //    if you prefer, and store from a tee.)
+    return toServerSentEventsResponse(stream);
+}
+```
 
-        return Response.json({ text });
-    },
+To store the turn, collect the reply with `streamToText` before returning it:
+
+```typescript
+import { chat, streamToText } from "@tanstack/ai";
+
+const text = await streamToText(chat({
+    adapter: openaiText("gpt-4o"),
+    messages: [
+        { role: "system", content: `You are a helpful assistant.\n\n## Memory\n${memory}` },
+        { role: "user", content: message },
+    ],
+}));
+
+await spectron.rememberMany(
+    [
+        { role: "user", content: message },
+        { role: "assistant", content: text },
+    ],
+    { scope },
+);
+```
+
+## Recall as a tool
+
+To let the model decide when to reach for memory, expose recall as a `@tanstack/ai` tool. Build it with `toolDefinition(...).server(...)` and pass it to `chat`:
+
+```typescript
+import { chat, toolDefinition } from "@tanstack/ai";
+import { openaiText } from "@tanstack/ai-openai";
+import { z } from "zod";
+
+const recall = toolDefinition({
+    name: "recall",
+    description: "Search long-term memory for context relevant to a query.",
+    inputSchema: z.object({ query: z.string() }),
+    outputSchema: z.object({ context: z.string() }),
+}).server(async ({ query }) => {
+    const context = await spectron.context(query, { scope, k: 8 });
+    return { context };
+});
+
+const stream = chat({
+    adapter: openaiText("gpt-4o"),
+    messages: [{ role: "user", content: message }],
+    tools: [recall],
 });
 ```
+
+The agent loop invokes the tool automatically when the model asks for it.
 
 ## Scope per user or session
 
 Pass a `scope` on every call to isolate memory. A scope is a slash path or an array of paths, for example `["org/acme/user/alice"]` for one user, or a session-specific path such as `["org/acme/session/abc123"]`. Register paths with `spectron scopes create` before first use.
 
-## Recall as a tool
-
-To let the model decide when to reach for memory, expose the [`@surrealdb/vercel-ai`](/docs/spectron/integrations/ai-sdks/vercel-ai-sdk) tool set from the same route. TanStack Start runs the Vercel AI SDK unchanged:
-
-```typescript
-import { createSpectron } from "@surrealdb/vercel-ai";
-
-const memory = createSpectron({ defaultScopes: "org/acme" });
-// pass memory.tools({ sessionId }) into generateText / streamText
-```
-
 ## Next steps
 
 - [JavaScript SDK](/docs/spectron/integrations/sdks/javascript-and-typescript): the full client surface
-- [Vercel AI SDK](/docs/spectron/integrations/ai-sdks/vercel-ai-sdk): middleware and tools that automate recall and storage
 - [REST API](/docs/spectron/integrations/surfaces/rest): if you would rather call Spectron over HTTP directly

--- a/src/content/spectron/integrations/frameworks/google-adk.mdx
+++ b/src/content/spectron/integrations/frameworks/google-adk.mdx
@@ -16,11 +16,10 @@ Package: **`spectron-google-adk`** (PyPI). It pulls in `google-adk` and `surreal
 pip install spectron-google-adk
 ```
 
-The Spectron client ships in `surrealdb` 3.0.0 and later. Until 3.0.0 is on PyPI, install the client from the `surrealdb.py` main branch first:
+To run against a live Spectron instance:
 
 ```bash
-pip install "surrealdb @ git+https://github.com/surrealdb/surrealdb.py.git@main"
-pip install spectron-google-adk
+pip install "spectron-google-adk" "surrealdb[spectron]"
 ```
 
 ## Environment

--- a/src/content/spectron/integrations/frameworks/hermes.mdx
+++ b/src/content/spectron/integrations/frameworks/hermes.mdx
@@ -8,7 +8,7 @@ description: "Spectron memory provider for the Hermes Agent."
 
 Spectron is a memory provider for the [Hermes Agent](https://github.com/NousResearch/hermes-agent). Once installed and selected, the agent recalls relevant memories before each turn, writes each completed turn back to Spectron asynchronously, and consolidates memory when a session ends. It also gains explicit memory tools it can call directly.
 
-Package: **`spectron-integration-hermes-agent`** (PyPI). It pulls in the Spectron SDK (`surrealdb[spectron]`) and registers the plugin with Hermes through the `hermes_agent.plugins` entry point.
+Package: **`spectron-hermes-agent`** (PyPI). It pulls in the Spectron SDK (`surrealdb[spectron]`) and registers the plugin with Hermes through the `hermes_agent.plugins` entry point.
 
 ## Requirements
 
@@ -19,7 +19,7 @@ Package: **`spectron-integration-hermes-agent`** (PyPI). It pulls in the Spectro
 ## Installation
 
 ```bash
-pip install spectron-integration-hermes-agent
+pip install spectron-hermes-agent
 ```
 
 ## Environment

--- a/src/content/spectron/integrations/frameworks/openai-agents.mdx
+++ b/src/content/spectron/integrations/frameworks/openai-agents.mdx
@@ -14,9 +14,6 @@ Package: **`spectron-openai-agents`** (PyPI). Memory works two ways, and they co
 
 ```bash
 pip install spectron-openai-agents
-
-# The Spectron SDK reaches a deployment. During the preview, install it alongside:
-pip install "spectron-openai-agents[spectron]"
 ```
 
 ## Environment


### PR DESCRIPTION
Adds proper Tanstack AI guide, alongside package name corrections for Hermes and OpenAI SDK