### PR TITLE
Spectron CrewAI package name

### DIFF
--- a/src/content/spectron/integrations/frameworks/crewai.mdx
+++ b/src/content/spectron/integrations/frameworks/crewai.mdx
@@ -8,7 +8,7 @@ description: "CrewAI integration for Spectron, with memory tools and automatic p
 
 Spectron gives [CrewAI](https://www.crewai.com/) agents persistent, provenance-first memory. The integration offers two approaches that compose: tools an agent calls explicitly, and automatic memory that recalls before each task, writes back after it, and consolidates when the crew finishes, without changing your agents or tasks.
 
-Package: **`spectron-integration-crewai`** (PyPI). It pulls in CrewAI and the Spectron SDK (`surrealdb[spectron]`).
+Package: **`spectron-crewai`** (PyPI). It pulls in CrewAI and the Spectron SDK (`surrealdb[spectron]`).
 
 ## Requirements
 
@@ -19,7 +19,7 @@ Package: **`spectron-integration-crewai`** (PyPI). It pulls in CrewAI and the Sp
 ## Installation
 
 ```bash
-pip install spectron-integration-crewai
+pip install spectron-crewai
 ```
 
 ## Environment

--- a/src/content/spectron/integrations/index.mdx
+++ b/src/content/spectron/integrations/index.mdx
@@ -54,13 +54,13 @@ Harness adapters expose Spectron as agent tools and add automatic per-turn memor
 | Framework | Package | Language |
 | --- | --- | --- |
 | LangChain / LangGraph | `@surrealdb/langchain`, `@surrealdb/langgraph` | TypeScript |
-| CrewAI | `spectron-integration-crewai` | Python |
+| CrewAI | `spectron-crewai` | Python |
 | OpenAI Agents SDK | `spectron-openai-agents` | Python |
 | Pydantic AI | `spectron-pydantic-ai` | Python |
 | Google ADK | `spectron-google-adk` | Python |
 | Strands Agents | `spectron-strands` | Python |
 | Mastra | `@surrealdb/mastra-ai` | TypeScript |
-| Hermes Agent | `spectron-integration-hermes-agent` | Python |
+| Hermes Agent | `spectron-hermes-agent` | Python |
 | OpenClaw | `@surrealdb/spectron-openclaw` | TypeScript |
 | Eve | `@surrealdb/spectron-eve` | TypeScript |
 

--- a/src/content/spectron/integrations/mcp-server/install.mdx
+++ b/src/content/spectron/integrations/mcp-server/install.mdx
@@ -54,7 +54,7 @@ Authentication uses **`Authorization: Bearer`**, the same as REST. Run `spectron
 | --- | --- |
 | Coding assistant with native MCP | `spectron mcp` config |
 | Application code (Python/TS) | `surrealdb` / `@surrealdb/spectron` |
-| Agent framework with harness adapter | `spectron-integration-crewai`, `@surrealdb/vercel-ai`, … |
+| Agent framework with harness adapter | `spectron-crewai`, `@surrealdb/vercel-ai`, … |
 | Custom infrastructure | [REST API](/docs/spectron/reference/rest-api) |
 
 Tool schemas: [MCP tools reference](/docs/spectron/reference/mcp-tools).

--- a/src/content/spectron/integrations/sdks/python.mdx
+++ b/src/content/spectron/integrations/sdks/python.mdx
@@ -187,7 +187,7 @@ from surrealdb.spectron import RecallResponse, RecallHit
 For agent frameworks that should auto-record every turn, Spectron ships Python adapters that build on this SDK:
 
 ```bash
-pip install spectron-integration-crewai   # CrewAI
+pip install spectron-crewai   # CrewAI
 pip install spectron-openai-agents        # OpenAI Agents SDK
 pip install spectron-strands              # Strands Agents
 pip install spectron-google-adk           # Google ADK


### PR DESCRIPTION
Removes `-integration` prefix from package names for CrewAI.