### PR TITLE
Fix five documentation inaccuracies (each verified against SurrealDB v3.2.0)

### DIFF
--- a/src/content/index/transactions-and-isolation.mdx
+++ b/src/content/index/transactions-and-isolation.mdx
@@ -31,7 +31,7 @@ Snapshot isolation with write–write conflict detection on commit gives you str
 | Lost updates (same key) | Yes | Concurrent writes to the same key cannot both commit; one transaction must retry. |
 | Write skew | No | See [write skew](#write-skew) below. |
 
-In database terms, snapshot isolation sits between read committed and serialisable. It matches the default repeatable-read behaviour familiar from PostgreSQL and the default isolation level in MySQL (InnoDB `REPEATABLE READ`), with the important caveat that SurrealDB does not provide serialisable isolation.
+In database terms, snapshot isolation sits between read committed and serialisable. It matches the default isolation level in MySQL (InnoDB `REPEATABLE READ`) and PostgreSQL's optional `REPEATABLE READ` level (note that PostgreSQL's default is `READ COMMITTED`), with the important caveat that SurrealDB does not provide serialisable isolation.
 
 ## Default and manual transactions
 

--- a/src/content/reference/query-language/functions/database-functions/http.mdx
+++ b/src/content/reference/query-language/functions/database-functions/http.mdx
@@ -8,6 +8,9 @@ description: These functions can be used when opening and submitting remote web 
 
 These functions can be used when opening and submitting remote web requests, and webhooks.
 
+> [!IMPORTANT]
+> All `http::*` functions require network capabilities, which are **denied by default**. Start the server with `--allow-net` (optionally scoped to specific targets); otherwise calls fail with `Access to network target '…' is not allowed` (verified on v3.2.0). See [Capabilities](/docs/learn/security/capabilities).
+
 <table>
   <thead>
     <tr>

--- a/src/content/reference/query-language/functions/database-functions/search.mdx
+++ b/src/content/reference/query-language/functions/database-functions/search.mdx
@@ -159,7 +159,7 @@ Notes on the arguments and output of this function:
   - When merging field data from the per‑list rows, keeps the first non‑null value encountered in the order the lists were supplied, or the last one if there are several fields with the same key.
   - Sorts by `linear_score` descending and truncates to limit.
 - **Output:**
-  - Array of merged result objects, each containing original fields and an added fuse_score.
+  - Array of merged result objects, each containing original fields and an added `linear_score`.
 
 ```surql
 /**[test]
@@ -326,7 +326,7 @@ See [this paper](https://plg.uwaterloo.ca/~gvcormac/cormacksigir09-rrf.pdf) for 
   - When merging field data from the per‑list rows, keeps the first non‑null value encountered in the order the lists were supplied, or the last one if there are several fields with the same key.
   - Sorts by `rff_score` descending and truncates to limit.
 - **Output:**
-  - Array of merged result objects, each containing original fields and an added fuse_score.
+  - Array of merged result objects, each containing original fields and an added `rrf_score`.
 
 ```surql
 /**[test]

--- a/src/content/reference/query-language/functions/database-functions/vector.mdx
+++ b/src/content/reference/query-language/functions/database-functions/vector.mdx
@@ -257,7 +257,7 @@ RETURN vector::magnitude([ 1, 2, 3, 3, 3, 4, 5 ]);
 The `vector::multiply` function performs element-wise multiplication of two vectors, where each element in the first vector is multiplied by the corresponding element in the second vector.
 
 ```surql title="API DEFINITION"
-vector::multiply(array, $other: array) -> number
+vector::multiply(array, $other: array) -> array
 ```
 The following example shows this function, and its output, when used in a [`RETURN`](/docs/reference/query-language/statements/return) statement:
 

--- a/src/content/reference/query-language/statements/live-select.mdx
+++ b/src/content/reference/query-language/statements/live-select.mdx
@@ -130,24 +130,16 @@ LIVE SELECT * FROM person WHERE age > 18 FETCH friends;
 
 ## Other notes
 
-Currently, it is not possible to use [parameters inside of Live Queries](https://github.com/surrealdb/surrealdb/issues/4026).
+Since SurrealDB 3.0, parameters can be used inside a `LIVE SELECT` statement, including in the `WHERE` clause (see [Parameters in `LIVE SELECT` statements](#parameters-in-live-select-statements) below). Parameter values are captured when the live query is registered; changing a parameter afterwards does not affect an already-registered live query — re-register the live query to apply a new value.
+
+Note that a bare parameter cannot be used as the table reference. Use `type::table()` instead:
 
 ```surql
-/**[test]
+-- Does not work: bare parameter as the table reference
+-- LIVE SELECT * FROM $table WHERE field > 50;
 
-[[test.results]]
-value = "u'0f0d0e40-f371-4a68-8ee0-6d5eb3565b76'"
-skip-uuid = true
-
-*/
-
-LIVE SELECT * FROM person WHERE $field > $value;
-```
-
-It is possible to have parameters for the table reference.
-
-```surql
-LIVE SELECT * FROM $table WHERE field > 50;
+-- Works:
+LIVE SELECT * FROM type::table($table) WHERE field > 50;
 ```
 
 


### PR DESCRIPTION
## Summary

This PR fixes five documentation inaccuracies, each verified by reproduction against SurrealDB **v3.2.0** (official Docker image; Python SDK 2.0.0 where applicable).

| File | Fix |
|---|---|
| `reference/query-language/statements/live-select.mdx` | Removed the stale note claiming parameters are not possible in live queries (they work since 3.0 and are documented later on the same page, `<Since v="v3.0.0" />`). Replaced the bare `FROM $table` example — a bare parameter as the table reference fails on 3.x (`Cannot execute LIVE statement using value`); `type::table($table)` works. Also documented that parameter values are captured at registration. |
| `reference/query-language/functions/database-functions/vector.mdx` | `vector::multiply` API definition: `-> number` → `-> array` (element-wise multiply; the page's own example returns `[1, 4, 9]`; all sibling element-wise functions already declare `-> array`). |
| `reference/query-language/functions/database-functions/search.mdx` | Output descriptions referred to a non-existent `fuse_score` field. Actual fields (verified by running the page's own example): `linear_score` for `search::linear`, `rrf_score` for `search::rrf`. |
| `index/transactions-and-isolation.mdx` | PostgreSQL's default isolation level is `READ COMMITTED`, not repeatable read — reworded the comparison (MySQL half was correct). |
| `reference/query-language/functions/database-functions/http.mdx` | Added an IMPORTANT note that `http::*` functions require network capabilities, which are denied by default (`Access to network target '…' is not allowed` on default flags) — this was previously mentioned only on the security pages, not in the function reference. |

## Verification

Every change was validated against a live v3.2.0 instance before editing, e.g.:

```surql
RETURN vector::multiply([1, 2, 3], [1, 2, 3]);           -- [1, 4, 9]
LET $min = 18; LIVE SELECT * FROM person WHERE age > $min; -- live UUID; notifications filtered by $min
LIVE SELECT * FROM $table WHERE field > 50;               -- error: Cannot execute LIVE statement using value
RETURN http::get('http://127.0.0.1:9/x');                 -- NotAllowed: Access to network target … is not allowed
```

One commit per fix for easy review/cherry-picking. Happy to adjust wording or split further if preferred.
