### PR TITLE
Spectron package names & MCP

### DIFF
--- a/src/content/spectron/cookbooks/build/coding-agent-with-project-memory.mdx
+++ b/src/content/spectron/cookbooks/build/coding-agent-with-project-memory.mdx
@@ -24,20 +24,17 @@ Without persistent memory, every new session starts from scratch. With Spectron,
 
 ## Installing the MCP server
 
-Spectron provides an MCP server that exposes memory operations as tools. Install it into your editor using the MCP installer:
+Spectron serves MCP at `/mcp` on your instance (SurrealDB Cloud: your context host from Surrealist **API keys**; self-hosted: your server's base URL). Install it into your editor with [`install-mcp`](https://github.com/supermemoryai/install-mcp) — the `/mcp` URL is the first argument, auth goes through `--header`, and `--oauth no` skips the OAuth prompt:
 
 ```bash
 # Install for Cursor
-npx install-mcp spectron --client cursor --context my-project
-
-# With repository-scoped memory
-npx install-mcp spectron \
+npx install-mcp https://<your-context-host>/mcp \
     --client cursor \
-    --context my-project \
-    --scope org/acme/project/my-repo
+    --header "Authorization: Bearer <your-api-key>" \
+    --oauth no
 ```
 
-This registers the Spectron MCP server in your editor's MCP configuration. You will be prompted for your Spectron API key during installation.
+This registers the Spectron MCP server in your editor's MCP configuration. Memory is scoped per tool call with a `scope` argument (for example `["org/acme/project/my-repo"]`), not at install time.
 
 ### Manual configuration
 
@@ -47,12 +44,10 @@ If you prefer to configure the MCP server manually, add it to your editor's MCP 
 {
   "mcpServers": {
     "spectron": {
-      "command": "npx",
-      "args": ["@spectron/mcp"],
-      "env": {
-        "SPECTRON_API_KEY": "sk-…",
-        "SPECTRON_SCOPE": "{\"project\": \"my-repo\"}",
-        "SPECTRON_SERVER": "https://spectron.acme.com"
+      "url": "https://<your-context-host>/mcp",
+      "headers": {
+        "Authorization": "Bearer <your-api-key>",
+        "X-Spectron-Context": "my-project"
       }
     }
   }

--- a/src/content/spectron/index/quickstarts/self-hosted.mdx
+++ b/src/content/spectron/index/quickstarts/self-hosted.mdx
@@ -106,11 +106,17 @@ spectron recall "What is Alice's role at Acme?" --json \
 spectron chat "Summarise what you know about Alice at Acme" \
   --url "$SPECTRON_URL" --api-key "$SPECTRON_API_KEY" --context-id \
     "$SPECTRON_CONTEXT_ID"
-
-spectron mcp
 ```
 
-Paste the printed MCP config into Claude Desktop, Cursor, or Claude Code.
+The MCP server is served at `/mcp` on the same host and port as the REST API. Point a client at `$SPECTRON_URL/mcp`, or install it with [`install-mcp`](https://github.com/supermemoryai/install-mcp):
+
+```bash
+npx install-mcp "$SPECTRON_URL/mcp" \
+  --client cursor \
+  --header "Authorization: Bearer $SPECTRON_API_KEY" --oauth no
+```
+
+See the [MCP server install guide](/docs/spectron/integrations/mcp-server/install) for per-client setup.
 
 ## Next steps
 

--- a/src/content/spectron/integrations/ai-sdks/vercel-ai-sdk.mdx
+++ b/src/content/spectron/integrations/ai-sdks/vercel-ai-sdk.mdx
@@ -6,7 +6,7 @@ description: "Spectron memory for the Vercel AI SDK, via language-model middlewa
 
 # Vercel AI SDK
 
-`@surrealdb/vercel-ai` integrates Spectron with the [Vercel AI SDK](https://ai-sdk.dev). Keep using your own model provider (`@ai-sdk/openai`, `@ai-sdk/anthropic`, and so on) with `generateText` / `streamText`, and let Spectron transparently:
+`@surrealdb/spectron-vercel-ai` integrates Spectron with the [Vercel AI SDK](https://ai-sdk.dev). Keep using your own model provider (`@ai-sdk/openai`, `@ai-sdk/anthropic`, and so on) with `generateText` / `streamText`, and let Spectron transparently:
 
 - **inject** relevant long-term memory (and the user's profile) into the prompt before generation, and
 - **store** each user and assistant exchange afterwards,
@@ -18,7 +18,7 @@ The API is `createSpectron()` → `.middleware()` / `.tools()`.
 ## Installation
 
 ```bash
-npm i @surrealdb/vercel-ai ai @surrealdb/spectron
+npm i @surrealdb/spectron-vercel-ai ai @surrealdb/spectron
 # plus your model provider, e.g.
 npm i @ai-sdk/openai
 ```
@@ -36,13 +36,13 @@ npm i @ai-sdk/openai
 | `SPECTRON_CONTEXT` | Context id |
 
 ```typescript
-import { createSpectron } from "@surrealdb/vercel-ai";
+import { createSpectron } from "@surrealdb/spectron-vercel-ai";
 
 // From the environment, bound to one user by default.
 const spectron = createSpectron({ defaultScopes: "user/tobie" });
 
 // Or pass config / a preconstructed client explicitly:
-import { Spectron } from "@surrealdb/vercel-ai";
+import { Spectron } from "@surrealdb/spectron-vercel-ai";
 const spectron = createSpectron({
     client: new Spectron({ endpoint, apiKey, context }),
 });
@@ -55,7 +55,7 @@ Wrap your model with `wrapLanguageModel`. The middleware fetches memory for the 
 ```typescript
 import { openai } from "@ai-sdk/openai";
 import { generateText, wrapLanguageModel } from "ai";
-import { createSpectron } from "@surrealdb/vercel-ai";
+import { createSpectron } from "@surrealdb/spectron-vercel-ai";
 
 const spectron = createSpectron({ defaultScopes: "user/tobie" });
 

--- a/src/content/spectron/integrations/frameworks/crewai.mdx
+++ b/src/content/spectron/integrations/frameworks/crewai.mdx
@@ -8,7 +8,7 @@ description: "CrewAI integration for Spectron, with memory tools and automatic p
 
 Spectron gives [CrewAI](https://www.crewai.com/) agents persistent, provenance-first memory. The integration offers two approaches that compose: tools an agent calls explicitly, and automatic memory that recalls before each task, writes back after it, and consolidates when the crew finishes, without changing your agents or tasks.
 
-Package: **`spectron-crew-ai`** (PyPI). It pulls in CrewAI and the Spectron SDK (`surrealdb[spectron]`).
+Package: **`spectron-crew-ai`** (PyPI). It pulls in CrewAI and the SurrealDB SDK (`surrealdb` v3, which bundles Spectron).
 
 ## Requirements
 

--- a/src/content/spectron/integrations/frameworks/crewai.mdx
+++ b/src/content/spectron/integrations/frameworks/crewai.mdx
@@ -8,7 +8,7 @@ description: "CrewAI integration for Spectron, with memory tools and automatic p
 
 Spectron gives [CrewAI](https://www.crewai.com/) agents persistent, provenance-first memory. The integration offers two approaches that compose: tools an agent calls explicitly, and automatic memory that recalls before each task, writes back after it, and consolidates when the crew finishes, without changing your agents or tasks.
 
-Package: **`spectron-crewai`** (PyPI). It pulls in CrewAI and the Spectron SDK (`surrealdb[spectron]`).
+Package: **`spectron-crew-ai`** (PyPI). It pulls in CrewAI and the Spectron SDK (`surrealdb[spectron]`).
 
 ## Requirements
 
@@ -19,7 +19,7 @@ Package: **`spectron-crewai`** (PyPI). It pulls in CrewAI and the Spectron SDK (
 ## Installation
 
 ```bash
-pip install spectron-crewai
+pip install spectron-crew-ai
 ```
 
 ## Environment

--- a/src/content/spectron/integrations/frameworks/google-adk.mdx
+++ b/src/content/spectron/integrations/frameworks/google-adk.mdx
@@ -16,11 +16,7 @@ Package: **`spectron-google-adk`** (PyPI). It pulls in `google-adk` and `surreal
 pip install spectron-google-adk
 ```
 
-To run against a live Spectron instance:
-
-```bash
-pip install "spectron-google-adk" "surrealdb[spectron]"
-```
+This pulls in `google-adk` and `surrealdb` (the Spectron client ships in `surrealdb` 3.0.0a1 and later, installed automatically).
 
 ## Environment
 

--- a/src/content/spectron/integrations/frameworks/hermes.mdx
+++ b/src/content/spectron/integrations/frameworks/hermes.mdx
@@ -8,7 +8,7 @@ description: "Spectron memory provider for the Hermes Agent."
 
 Spectron is a memory provider for the [Hermes Agent](https://github.com/NousResearch/hermes-agent). Once installed and selected, the agent recalls relevant memories before each turn, writes each completed turn back to Spectron asynchronously, and consolidates memory when a session ends. It also gains explicit memory tools it can call directly.
 
-Package: **`spectron-hermes-agent`** (PyPI). It pulls in the Spectron SDK (`surrealdb[spectron]`) and registers the plugin with Hermes through the `hermes_agent.plugins` entry point.
+Package: **`spectron-hermes`** (PyPI). It pulls in the SurrealDB SDK (`surrealdb` v3, which bundles Spectron) and registers the plugin with Hermes through the `hermes_agent.plugins` entry point.
 
 ## Requirements
 
@@ -19,7 +19,7 @@ Package: **`spectron-hermes-agent`** (PyPI). It pulls in the Spectron SDK (`surr
 ## Installation
 
 ```bash
-pip install spectron-hermes-agent
+pip install spectron-hermes
 ```
 
 ## Environment

--- a/src/content/spectron/integrations/frameworks/openai-agents.mdx
+++ b/src/content/spectron/integrations/frameworks/openai-agents.mdx
@@ -8,12 +8,12 @@ description: "Spectron memory for agents built with the OpenAI Agents SDK."
 
 Spectron gives agents built with the [OpenAI Agents SDK](https://openai.github.io/openai-agents-python/) a durable, shared memory. An agent can remember across runs, recall what it needs before answering, and share memory with other agents through a common scope.
 
-Package: **`spectron-openai-agents`** (PyPI). Memory works two ways, and they compose: function tools the agent calls itself, and automatic memory wrapped around a run.
+Package: **`spectron-openai-agents-sdk`** (PyPI). Memory works two ways, and they compose: function tools the agent calls itself, and automatic memory wrapped around a run.
 
 ## Installation
 
 ```bash
-pip install spectron-openai-agents
+pip install spectron-openai-agents-sdk
 ```
 
 ## Environment
@@ -32,7 +32,7 @@ The agent decides when to `remember`, `recall`, `context`, `reflect`, or `forget
 
 ```python
 from agents import Agent, Runner
-from spectron_openai_agents import get_spectron_tools
+from spectron_openai_agents_sdk import get_spectron_tools
 
 agent = Agent(
     name="assistant",
@@ -56,7 +56,7 @@ print(result.final_output)
 ```python
 import asyncio
 from agents import Agent
-from spectron_openai_agents import MemoryScope, run_with_memory
+from spectron_openai_agents_sdk import MemoryScope, run_with_memory
 
 agent = Agent(name="assistant", instructions="You are a helpful assistant.")
 scope = MemoryScope(session_id="user-123")
@@ -76,7 +76,7 @@ To save an agent's output while running it yourself, attach `SpectronMemoryHooks
 
 ```python
 from agents import Runner
-from spectron_openai_agents import SpectronClient, SpectronMemoryHooks, MemoryScope
+from spectron_openai_agents_sdk import SpectronClient, SpectronMemoryHooks, MemoryScope
 
 client = SpectronClient.from_env()
 hooks = SpectronMemoryHooks(client, MemoryScope(session_id="user-123"))

--- a/src/content/spectron/integrations/frameworks/pydantic-ai.mdx
+++ b/src/content/spectron/integrations/frameworks/pydantic-ai.mdx
@@ -23,7 +23,7 @@ pip install spectron-pydantic-ai
 To run against a live Spectron instance and a model provider:
 
 ```bash
-pip install "spectron-pydantic-ai" "pydantic-ai-slim[openai]" "surrealdb[spectron]"
+pip install "spectron-pydantic-ai" "pydantic-ai-slim[openai]"
 ```
 
 ## Quickstart

--- a/src/content/spectron/integrations/frameworks/strands-agents.mdx
+++ b/src/content/spectron/integrations/frameworks/strands-agents.mdx
@@ -8,7 +8,7 @@ description: "Spectron memory as tools for the Strands Agents SDK."
 
 Spectron exposes its memory operations as [Strands Agents](https://strandsagents.com) tools, so any Strands agent can store and retrieve long-term memory with a single line of setup.
 
-Package: **`spectron-strands`** (PyPI). It pulls in `strands-agents` and `surrealdb` (which provides the Spectron client).
+Package: **`spectron-strands-agents`** (PyPI). It pulls in `strands-agents` and `surrealdb` (which provides the Spectron client).
 
 ```python
 from strands import Agent
@@ -23,13 +23,13 @@ print(agent("What is the value of the Meditech Solutions contract?"))
 ## Installation
 
 ```bash
-pip install spectron-strands
+pip install spectron-strands-agents
 ```
 
 To run the examples with Amazon Bedrock (Strands' default model provider):
 
 ```bash
-pip install "spectron-strands[bedrock]"
+pip install "spectron-strands-agents[bedrock]"
 ```
 
 Requires Python 3.10+.

--- a/src/content/spectron/integrations/index.mdx
+++ b/src/content/spectron/integrations/index.mdx
@@ -43,7 +43,7 @@ Call Spectron directly from application code.
 
 Drop-in memory for the popular TypeScript AI SDKs, with recall and storage wrapped around your model calls.
 
-- **Vercel AI SDK**: `@surrealdb/vercel-ai`, via `wrapLanguageModel` middleware and a tool set.
+- **Vercel AI SDK**: `@surrealdb/spectron-vercel-ai`, via `wrapLanguageModel` middleware and a tool set.
 - **TanStack AI**: the `@surrealdb/spectron` client in TanStack Start server routes.
 - **Cloudflare Workers AI**: the client inside a Worker, alongside Workers AI models.
 
@@ -57,7 +57,7 @@ Harness adapters expose Spectron as agent tools and add automatic per-turn memor
 | --- | --- | --- |
 | LangChain / LangGraph | `@surrealdb/langchain`, `@surrealdb/langgraph` | TypeScript |
 | CrewAI | `spectron-crew-ai` | Python |
-| OpenAI Agents SDK | `spectron-openai-agents` | Python |
+| OpenAI Agents SDK | `spectron-openai-agents-sdk` | Python |
 | Pydantic AI | `spectron-pydantic-ai` | Python |
 | Google ADK | `spectron-google-adk` | Python |
 | Strands Agents | `spectron-strands-agents` | Python |

--- a/src/content/spectron/integrations/index.mdx
+++ b/src/content/spectron/integrations/index.mdx
@@ -12,10 +12,12 @@ The REST surface is described by an OpenAPI specification. The Python, TypeScrip
 
 ## MCP server (coding assistants)
 
-Native MCP at `/mcp` on the api port, with the same **`Authorization: Bearer`** auth as REST. Prefer this when the client already speaks MCP.
+Native MCP at `/mcp` on the api port, with the same **`Authorization: Bearer`** auth as REST. Prefer this when the client already speaks MCP. Point the client at your instance's `/mcp` endpoint, or install it with [`install-mcp`](https://github.com/supermemoryai/install-mcp):
 
 ```bash
-spectron mcp
+npx install-mcp https://<your-context-host>/mcp \
+  --client cursor \
+  --header "Authorization: Bearer <your-api-key>" --oauth no
 ```
 
 → [MCP server install](/docs/spectron/integrations/mcp-server/install) · Per-client guides: [Claude](/docs/spectron/integrations/mcp-server/coding-assistants/claude-desktop-and-code) · [Cursor](/docs/spectron/integrations/mcp-server/coding-assistants/cursor) · [VS Code](/docs/spectron/integrations/mcp-server/coding-assistants/vscode) · [JetBrains](/docs/spectron/integrations/mcp-server/coding-assistants/jetbrains) · [Zed](/docs/spectron/integrations/mcp-server/coding-assistants/zed) · [Windsurf](/docs/spectron/integrations/mcp-server/coding-assistants/windsurf) · [Codex](/docs/spectron/integrations/mcp-server/coding-assistants/codex) · [Antigravity](/docs/spectron/integrations/mcp-server/coding-assistants/antigravity) · [OpenCode](/docs/spectron/integrations/mcp-server/coding-assistants/opencode)
@@ -54,13 +56,13 @@ Harness adapters expose Spectron as agent tools and add automatic per-turn memor
 | Framework | Package | Language |
 | --- | --- | --- |
 | LangChain / LangGraph | `@surrealdb/langchain`, `@surrealdb/langgraph` | TypeScript |
-| CrewAI | `spectron-crewai` | Python |
+| CrewAI | `spectron-crew-ai` | Python |
 | OpenAI Agents SDK | `spectron-openai-agents` | Python |
 | Pydantic AI | `spectron-pydantic-ai` | Python |
 | Google ADK | `spectron-google-adk` | Python |
-| Strands Agents | `spectron-strands` | Python |
+| Strands Agents | `spectron-strands-agents` | Python |
 | Mastra | `@surrealdb/mastra-ai` | TypeScript |
-| Hermes Agent | `spectron-hermes-agent` | Python |
+| Hermes Agent | `spectron-hermes` | Python |
 | OpenClaw | `@surrealdb/spectron-openclaw` | TypeScript |
 | Eve | `@surrealdb/spectron-eve` | TypeScript |
 

--- a/src/content/spectron/integrations/mcp-server/coding-assistants/antigravity.mdx
+++ b/src/content/spectron/integrations/mcp-server/coding-assistants/antigravity.mdx
@@ -12,7 +12,7 @@ For integration rules your agent should follow (auth, scope, endpoints, common m
 
 ## Configure
 
-Antigravity's IDE and CLI share a central MCP configuration at `~/.gemini/config/mcp_config.json`. In the IDE you can reach it through **Manage MCP servers → View raw config**.
+The `install-mcp` helper does not cover Antigravity, so configure the server by hand. Antigravity's IDE and CLI share a central MCP configuration at `~/.gemini/config/mcp_config.json`. In the IDE you can reach it through **Manage MCP servers → View raw config**.
 
 > [!NOTE]
 > Antigravity uses a stricter schema than most MCP clients: remote Streamable HTTP servers use **`serverUrl`**, not `url`.

--- a/src/content/spectron/integrations/mcp-server/coding-assistants/claude-desktop-and-code.mdx
+++ b/src/content/spectron/integrations/mcp-server/coding-assistants/claude-desktop-and-code.mdx
@@ -1,126 +1,60 @@
 ---
 position: 2
 title: Claude
-description: "Installing Spectron as an MCP server in Claude Desktop and Claude Code."
+description: "Connecting Spectron to Claude Code, Cowork, and Claude Desktop."
 ---
 
 # Claude
 
-Spectron can be installed as an MCP server in both Claude Desktop (the macOS and Windows application) and Claude Code (the CLI-based agentic coding tool). Once installed, Claude gains access to all seven Spectron tools and can persist and retrieve memory across conversations.
+The official [SurrealDB plugin marketplace for Claude](https://github.com/surrealdb/ai-claude-plugin) ships a **`spectron`** plugin that connects Claude to your Spectron instance's `/mcp` endpoint and installs a usage skill. It supports **Claude Code**, **Cowork**, and **Claude Desktop**. There is no default URL — point it at your own instance (SurrealDB Cloud: your context host from Surrealist **API keys**; self-hosted: your server's base URL).
 
-## Claude Desktop
+## Claude Code and Cowork
 
-### Install
+### Install the plugin
+
+Add the marketplace, then install the `spectron` plugin:
 
 ```bash
-npx install-mcp spectron --client claude-desktop --context acme-prod
+/plugin marketplace add surrealdb/ai-claude-plugin
+/plugin install spectron@surrealdb
 ```
 
-The installer writes the Spectron MCP configuration to Claude Desktop's config file and merges it with any existing MCP server entries.
+Claude Code reads the plugin directly — the MCP server and the usage skill load automatically.
 
-### Config file location
+### Configure
 
-| Platform | Path |
-|---|---|
-| macOS | `~/Library/Application Support/Claude/claude_desktop_config.json` |
-| Windows | `%APPDATA%\Claude\claude_desktop_config.json` |
+The Spectron MCP has no default URL. Set your instance endpoint and a bearer token before launching Claude Code, then restart:
 
-### What gets written
+```bash
+export SPECTRON_MCP_URL="https://<your-spectron-instance>/mcp"
+export SPECTRON_MCP_TOKEN="<your-api-key>"
+```
+
+If `SPECTRON_MCP_URL` is unset, the server will not connect. The plugin's MCP entry expands these variables:
 
 ```json
 {
   "mcpServers": {
     "spectron": {
-      "url": "https://<your-context-host>/mcp",
+      "type": "http",
+      "url": "${SPECTRON_MCP_URL}",
       "headers": {
-        "Authorization": "Bearer <your-api-key>",
-        "X-Spectron-Context": "acme-prod"
+        "Authorization": "Bearer ${SPECTRON_MCP_TOKEN}"
       }
     }
   }
 }
 ```
 
-### Verify the installation
-
-1. Restart Claude Desktop completely (quit and reopen)
-2. Start a new conversation
-3. Click the tools icon (the hammer symbol) in the composer – you should see the seven Spectron tools listed: `remember`, `recall`, `context`, `reflect`, `forget`, `upload`, `inspect`
-4. Send the message: "What MCP tools do you have?" – Claude should describe the Spectron tools
-
-If the tools do not appear, check that the config file is valid JSON and that the Spectron API key is correct. You can validate the file with `cat ~/Library/Application\ Support/Claude/claude_desktop_config.json | python3 -m json.tool`.
-
-### Usage examples
-
-**Storing a preference:**
-> "Remember that I prefer responses in British English and that I work in the fintech industry."
-
-Claude calls `remember` and the preference is available in all future conversations.
-
-**Retrieving a profile at the start of a session:**
-
-You can instruct Claude (via its system prompt in Claude Desktop projects) to call `context` at the start of every conversation:
-
-> "At the start of every conversation, call context to retrieve my current context and apply my preferences and instructions to your responses."
-
-**Searching your knowledge base:**
-> "What does our compliance documentation say about KYC requirements?"
-
-Claude calls `recall` against the Spectron knowledge base and returns the relevant policy content.
-
----
-
-## Claude Code
-
-Claude Code is Anthropic's CLI-based agentic coding assistant. It uses the same MCP protocol as Claude Desktop, with a different config file path.
-
-### Install
-
-```bash
-npx install-mcp spectron --client claude-code --context acme-prod
-```
-
-### Config file location
-
-Claude Code stores its MCP configuration at:
-
-```
-~/.claude/mcp.json
-```
-
-If the file does not exist, the installer creates it. If it exists, the `spectron` entry is merged in.
-
-### What gets written
-
-```json
-{
-  "mcpServers": {
-    "spectron": {
-      "url": "https://<your-context-host>/mcp",
-      "headers": {
-        "Authorization": "Bearer <your-api-key>",
-        "X-Spectron-Context": "acme-prod"
-      }
-    }
-  }
-}
-```
+The bearer token is your Spectron context API key. Each key is bound to one Context, so `context_id` is optional on every tool call.
 
 ### Verify the installation
-
-Run Claude Code and ask:
-
-```bash
-claude "What MCP tools do you have access to?"
-```
-
-Claude Code should list the seven Spectron tools. You can also run:
 
 ```bash
 claude mcp list
 ```
 
-to see all configured MCP servers and their status.
+You should see **spectron** connected. In a session, ask "What MCP tools do you have access to?" and Claude should list the Spectron tools: `remember`, `recall`, `context`, `reflect`, `forget`, `upload`, `inspect`.
 
 ### Usage examples
 
@@ -130,7 +64,7 @@ to see all configured MCP servers and their status.
 claude "Remember that we have decided to use event sourcing for the orders service and that the aggregate root is OrderAggregate."
 ```
 
-Claude Code calls `remember`. The next time you start a Claude Code session in this project, `recall` surfaces this decision before Claude answers questions about the orders service.
+Claude Code calls `remember`. The next time you start a session in this project, `recall` surfaces this decision before Claude answers questions about the orders service.
 
 **Recall context before a coding task:**
 
@@ -138,18 +72,60 @@ Claude Code calls `remember`. The next time you start a Claude Code session in t
 claude "What do you remember about our database schema decisions?"
 ```
 
-**Scope per project:**
+## Claude Desktop
 
-Pass a `scope` argument on each MCP tool call (slash paths, for example `["org/acme/project/orders-service"]`). The install helper does not set a default scope; use separate contexts or distinct scope paths per repository.
+Claude Desktop has no plugin/marketplace format, so set it up manually. Both options use your instance's `/mcp` URL and a bearer token; there is no default.
 
----
+### Option A — Connectors UI (recommended)
+
+Open **Settings → Connectors → Add custom connector** and add:
+
+| Name | URL | Header |
+|---|---|---|
+| `spectron` | your Spectron `/mcp` endpoint (for example `https://<your-spectron-instance>/mcp`) | `Authorization: Bearer <your-api-key>` |
+
+### Option B — Manual config
+
+Merge the following into `claude_desktop_config.json`, then restart Claude Desktop:
+
+| Platform | Path |
+|---|---|
+| macOS | `~/Library/Application Support/Claude/claude_desktop_config.json` |
+| Windows | `%APPDATA%\Claude\claude_desktop_config.json` |
+
+```json
+{
+  "mcpServers": {
+    "spectron": {
+      "type": "http",
+      "url": "https://<your-spectron-instance>/mcp",
+      "headers": {
+        "Authorization": "Bearer <your-api-key>"
+      }
+    }
+  }
+}
+```
+
+You can validate the file with `cat ~/Library/Application\ Support/Claude/claude_desktop_config.json | python3 -m json.tool`.
+
+### Skill (optional)
+
+Claude Desktop cannot load plugins, but you can add the Spectron usage skill by hand: open **Settings → Skills → Upload skill** and upload the `plugins/spectron/skills/mcp/` folder from the [plugin repo](https://github.com/surrealdb/ai-claude-plugin).
+
+### Verify the installation
+
+1. Restart Claude Desktop completely (quit and reopen)
+2. Start a new conversation
+3. Click the tools icon (the hammer symbol) in the composer — the seven Spectron tools should appear
+4. Ask "What MCP tools do you have?" and Claude should describe the Spectron tools
 
 ## Scope on tool calls
 
-Narrow reads and writes with the per-tool **`scope`** argument (for example `["org/acme/user/alice"]`). Register paths with `spectron scopes create` before first use. On **SurrealDB Cloud**, use your context host from Surrealist **API keys** in the MCP URL.
+Narrow reads and writes with the per-tool **`scope`** argument (slash paths, for example `["org/acme/user/alice"]` or `["org/acme/project/orders-service"]`). Register paths with `spectron scopes create` before first use. Use separate contexts or distinct scope paths to keep memory isolated per repository.
 
 ## Removing Spectron
 
-**Claude Desktop:** Open the config file and delete the `"spectron"` key, then restart Claude Desktop.
+**Claude Code / Cowork:** remove the `spectron` plugin from the `/plugin` menu, or run `claude mcp remove spectron`.
 
-**Claude Code:** Run `claude mcp remove spectron`, or edit `~/.claude/mcp.json` directly and remove the `"spectron"` entry.
+**Claude Desktop:** remove the `spectron` connector, or delete the `"spectron"` key from `claude_desktop_config.json`, then restart Claude Desktop.

--- a/src/content/spectron/integrations/mcp-server/coding-assistants/codex.mdx
+++ b/src/content/spectron/integrations/mcp-server/coding-assistants/codex.mdx
@@ -10,6 +10,9 @@ Installing Spectron in the [OpenAI Codex CLI](https://developers.openai.com/code
 
 For integration rules your agent should follow (auth, scope, endpoints, common mistakes), see **[Agent guide (AGENTS.md)](/docs/spectron/reference/agents)**. You can add it to your project's `AGENTS.md`, which Codex reads automatically.
 
+> [!NOTE]
+> SurrealDB also publishes a [Codex plugin](https://github.com/surrealdb/ai-codex-plugin) that adds a Spectron usage skill. It is a local marketplace for now — clone the repo, then run `codex plugin marketplace add "$PWD"` and `codex plugin add spectron@surrealdb`. The manual MCP configuration below works with or without it.
+
 ## Configure
 
 Codex reads MCP servers from `~/.codex/config.toml` (or `.codex/config.toml` in a trusted project). Add a Streamable HTTP entry with a `url` and a bearer token sourced from an environment variable:

--- a/src/content/spectron/integrations/mcp-server/coding-assistants/cursor.mdx
+++ b/src/content/spectron/integrations/mcp-server/coding-assistants/cursor.mdx
@@ -12,13 +12,16 @@ For integration rules your agent should follow (auth, scope, endpoints, common m
 
 ## Install
 
-Run the following command in your terminal, replacing `acme-prod` with your context ID:
+The MCP server lives at `/mcp` on your Spectron instance. On **SurrealDB Cloud** the base is your context host from Surrealist **API keys**; self-hosted, it is your server's base URL. Point Cursor at it with [`install-mcp`](https://github.com/supermemoryai/install-mcp):
 
 ```bash
-npx install-mcp spectron --client cursor --context acme-prod
+npx install-mcp https://<your-context-host>/mcp \
+  --client cursor \
+  --header "Authorization: Bearer <your-api-key>" \
+  --oauth no
 ```
 
-The installer prompts for your Spectron API key and writes the MCP configuration to `~/.cursor/mcp.json`. If that file already exists, the `spectron` entry is merged in without disturbing other MCP servers.
+The URL is the first argument; auth is passed with `--header`, and `--oauth no` skips the OAuth prompt (Spectron uses a static Bearer key). The command writes the configuration to `~/.cursor/mcp.json`. If that file already exists, the `spectron` entry is merged in without disturbing other MCP servers.
 
 ### What gets written
 
@@ -89,7 +92,10 @@ Cursor calls `recall` against the knowledge base and incorporates the retrieved 
 To change the API key or context host after installation, edit `~/.cursor/mcp.json` directly or re-run the install command. Re-running merges the new values over the existing entry:
 
 ```bash
-npx install-mcp spectron --client cursor --context acme-prod
+npx install-mcp https://<your-context-host>/mcp \
+  --client cursor \
+  --header "Authorization: Bearer <your-api-key>" \
+  --oauth no
 ```
 
 ## Removing Spectron from Cursor

--- a/src/content/spectron/integrations/mcp-server/coding-assistants/jetbrains.mdx
+++ b/src/content/spectron/integrations/mcp-server/coding-assistants/jetbrains.mdx
@@ -12,7 +12,7 @@ For integration rules your agent should follow (auth, scope, endpoints, common m
 
 ## Configure
 
-Open **Settings → Tools → AI Assistant → Model Context Protocol (MCP)**, click **Add**, and paste a JSON configuration. AI Assistant connects to remote servers over Streamable HTTP:
+The `install-mcp` helper does not cover JetBrains IDEs, so configure the server by hand. Open **Settings → Tools → AI Assistant → Model Context Protocol (MCP)**, click **Add**, and paste a JSON configuration. AI Assistant connects to remote servers over Streamable HTTP:
 
 ```json
 {

--- a/src/content/spectron/integrations/mcp-server/coding-assistants/opencode.mdx
+++ b/src/content/spectron/integrations/mcp-server/coding-assistants/opencode.mdx
@@ -10,6 +10,19 @@ Installing Spectron in [OpenCode](https://opencode.ai/) gives the agent persiste
 
 For integration rules your agent should follow (auth, scope, endpoints, common mistakes), see **[Agent guide (AGENTS.md)](/docs/spectron/reference/agents)**. OpenCode reads a project `AGENTS.md` automatically.
 
+## Quick install
+
+Install with [`install-mcp`](https://github.com/supermemoryai/install-mcp) — the `/mcp` URL is the first argument, auth goes through `--header`, and `--oauth no` skips the OAuth prompt (Spectron uses a static Bearer key):
+
+```bash
+npx install-mcp https://<your-context-host>/mcp \
+  --client opencode \
+  --header "Authorization: Bearer <your-api-key>" \
+  --oauth no
+```
+
+Or configure it by hand, as below.
+
 ## Configure
 
 OpenCode reads configuration from `opencode.json` in your workspace root (or `~/.config/opencode/opencode.json` for a global entry). Add Spectron as a remote MCP server:

--- a/src/content/spectron/integrations/mcp-server/coding-assistants/vscode.mdx
+++ b/src/content/spectron/integrations/mcp-server/coding-assistants/vscode.mdx
@@ -17,19 +17,18 @@ To enable Copilot agent mode: open VS Code settings, search for `github.copilot.
 
 ## Install
 
-```bash
-npx install-mcp spectron --client vscode --context acme-prod
-```
-
-The installer writes the Spectron configuration to `.vscode/mcp.json` in your current working directory. This makes the MCP server available to all contributors who open the workspace, which is suitable for shared team projects.
-
-To install globally for all VS Code workspaces instead, pass `--global`:
+The MCP server lives at `/mcp` on your Spectron instance. On **SurrealDB Cloud** the base is your context host from Surrealist **API keys**; self-hosted, it is your server's base URL. Point VS Code at it with [`install-mcp`](https://github.com/supermemoryai/install-mcp):
 
 ```bash
-npx install-mcp spectron --client vscode --context acme-prod --global
+npx install-mcp https://<your-context-host>/mcp \
+  --client vscode \
+  --header "Authorization: Bearer <your-api-key>" \
+  --oauth no
 ```
 
-The global config is written to your VS Code user settings directory.
+The URL is the first argument; auth is passed with `--header`, and `--oauth no` skips the OAuth prompt (Spectron uses a static Bearer key). The installer writes the configuration to `.vscode/mcp.json` in your current working directory, which makes the MCP server available to everyone who opens the workspace — suitable for shared team projects.
+
+To make the server available in every workspace instead, add the same entry to your global VS Code config by hand (see the paths below).
 
 ### Config file locations
 

--- a/src/content/spectron/integrations/mcp-server/coding-assistants/windsurf.mdx
+++ b/src/content/spectron/integrations/mcp-server/coding-assistants/windsurf.mdx
@@ -10,11 +10,16 @@ Windsurf's Cascade agent supports MCP servers natively. Installing Spectron give
 
 ## Install
 
+The MCP server lives at `/mcp` on your Spectron instance. On **SurrealDB Cloud** the base is your context host from Surrealist **API keys**; self-hosted, it is your server's base URL. Point Windsurf at it with [`install-mcp`](https://github.com/supermemoryai/install-mcp):
+
 ```bash
-npx install-mcp spectron --client windsurf --context acme-prod
+npx install-mcp https://<your-context-host>/mcp \
+  --client windsurf \
+  --header "Authorization: Bearer <your-api-key>" \
+  --oauth no
 ```
 
-The installer writes the Spectron MCP configuration to Windsurf's global MCP config file and merges it with any existing entries.
+The URL is the first argument; auth is passed with `--header`, and `--oauth no` skips the OAuth prompt (Spectron uses a static Bearer key). The installer writes the configuration to Windsurf's global MCP config file and merges it with any existing entries.
 
 ### Config file location
 
@@ -96,7 +101,10 @@ Cascade calls `remember` with the full brief. Subsequent sessions recall this co
 To change the API key or context host, edit `~/.codeium/windsurf/mcp_config.json` directly or re-run the install command:
 
 ```bash
-npx install-mcp spectron --client windsurf --context acme-prod
+npx install-mcp https://<your-context-host>/mcp \
+  --client windsurf \
+  --header "Authorization: Bearer <your-api-key>" \
+  --oauth no
 ```
 
 Re-running the command merges the updated values over the existing configuration entry.

--- a/src/content/spectron/integrations/mcp-server/coding-assistants/zed.mdx
+++ b/src/content/spectron/integrations/mcp-server/coding-assistants/zed.mdx
@@ -10,6 +10,19 @@ Zed calls MCP servers **context servers**. Installing Spectron gives Zed's assis
 
 For integration rules your agent should follow (auth, scope, endpoints, common mistakes), see **[Agent guide (AGENTS.md)](/docs/spectron/reference/agents)**. Zed reads a project `AGENTS.md` automatically.
 
+## Quick install
+
+Install with [`install-mcp`](https://github.com/supermemoryai/install-mcp) — the `/mcp` URL is the first argument, auth goes through `--header`, and `--oauth no` skips the OAuth prompt (Spectron uses a static Bearer key):
+
+```bash
+npx install-mcp https://<your-context-host>/mcp \
+  --client zed \
+  --header "Authorization: Bearer <your-api-key>" \
+  --oauth no
+```
+
+Or configure it by hand, as below.
+
 ## Configure
 
 Open Zed settings (`cmd`/`ctrl` `,`), which edits `~/.config/zed/settings.json`, and add Spectron under `context_servers`. Recent Zed versions connect to a remote server directly from a `url`:

--- a/src/content/spectron/integrations/mcp-server/install.mdx
+++ b/src/content/spectron/integrations/mcp-server/install.mdx
@@ -6,40 +6,44 @@ description: "Connect Spectron to Claude, Cursor, Windsurf, VS Code, and other M
 
 # Installing the MCP server
 
-Spectron serves MCP (Streamable HTTP) at **`/mcp`** on the same host and port as the REST API (default `http://localhost:9090/mcp`). Tools map to the unified substrate: remember, recall, documents, reflect, and related operations.
+Spectron serves MCP (Streamable HTTP) at **`/mcp`** on the same host and port as the REST API. Point any MCP client at that endpoint:
 
-## Generate config
+- **SurrealDB Cloud** — your context host from Surrealist **API keys** with `/mcp` appended, for example `https://abc123.spectron.cloud/mcp`.
+- **Self-hosted** — your server's base URL plus `/mcp`, for example `http://localhost:9090/mcp`.
 
-Run on a machine that has the **`spectron`** CLI and your env vars set:
+Authentication uses **`Authorization: Bearer`**, the same as REST. Each key is bound to one Context, so `context_id` is optional on every tool call. The tools map to the unified substrate: `remember`, `recall`, `context`, `reflect`, `forget`, `upload`, `inspect`.
+
+## Quick install
+
+[`install-mcp`](https://github.com/supermemoryai/install-mcp) writes the correct config for most clients. Pass the `/mcp` URL as the first argument, your key with `--header`, and `--oauth no` to skip the OAuth prompt (Spectron uses a static Bearer key, not OAuth):
 
 ```bash
-export SPECTRON_URL=http://localhost:9090
-export SPECTRON_API_KEY=<context-key>
-export SPECTRON_CONTEXT_ID=<context-id>
-
-spectron mcp
+npx install-mcp https://<your-context-host>/mcp \
+  --client cursor \
+  --header "Authorization: Bearer <your-api-key>" \
+  --oauth no
 ```
 
-The command prints an `mcpServers` JSON block for Claude Desktop, Cursor, and Claude Code, plus a `claude mcp add` one-liner where applicable.
+Use this for `cursor`, `vscode`, `windsurf`, `zed`, and `opencode`. **Claude** (Code, Cowork, Desktop) and **Codex** have a dedicated SurrealDB plugin — see the [Claude](/docs/spectron/integrations/mcp-server/coding-assistants/claude-desktop-and-code) and [Codex](/docs/spectron/integrations/mcp-server/coding-assistants/codex) guides. JetBrains and Antigravity use the manual configuration below.
 
-## Example configuration
+## Manual configuration
+
+Any MCP client can be configured by hand:
 
 ```json
 {
   "mcpServers": {
     "spectron": {
-      "url": "http://localhost:9090/mcp",
+      "url": "https://<your-context-host>/mcp",
       "headers": {
-        "Authorization": "Bearer <your-context-api-key>"
+        "Authorization": "Bearer <your-api-key>"
       }
     }
   }
 }
 ```
 
-Context is usually encoded in the key or passed per tool; follow the snippet `spectron mcp` prints for your client version.
-
-Authentication uses **`Authorization: Bearer`**, the same as REST. Run `spectron mcp` to print an install snippet with the correct headers.
+Some clients use a different key or shape — `serverUrl` in Windsurf and Antigravity, a `servers` object with a `type` field in VS Code. The per-client guides show each one.
 
 ## Per-client guides
 
@@ -52,9 +56,9 @@ Authentication uses **`Authorization: Bearer`**, the same as REST. Run `spectron
 
 | Situation | Use |
 | --- | --- |
-| Coding assistant with native MCP | `spectron mcp` config |
+| Coding assistant with native MCP | `install-mcp` or manual `/mcp` config |
 | Application code (Python/TS) | `surrealdb` / `@surrealdb/spectron` |
-| Agent framework with harness adapter | `spectron-crewai`, `@surrealdb/vercel-ai`, … |
+| Agent framework with harness adapter | `spectron-crew-ai`, `@surrealdb/vercel-ai`, … |
 | Custom infrastructure | [REST API](/docs/spectron/reference/rest-api) |
 
 Tool schemas: [MCP tools reference](/docs/spectron/reference/mcp-tools).

--- a/src/content/spectron/integrations/mcp-server/install.mdx
+++ b/src/content/spectron/integrations/mcp-server/install.mdx
@@ -58,7 +58,7 @@ Some clients use a different key or shape — `serverUrl` in Windsurf and Antigr
 | --- | --- |
 | Coding assistant with native MCP | `install-mcp` or manual `/mcp` config |
 | Application code (Python/TS) | `surrealdb` / `@surrealdb/spectron` |
-| Agent framework with harness adapter | `spectron-crew-ai`, `@surrealdb/vercel-ai`, … |
+| Agent framework with harness adapter | `spectron-crew-ai`, `@surrealdb/spectron-vercel-ai`, … |
 | Custom infrastructure | [REST API](/docs/spectron/reference/rest-api) |
 
 Tool schemas: [MCP tools reference](/docs/spectron/reference/mcp-tools).

--- a/src/content/spectron/integrations/sdks/javascript-and-typescript.mdx
+++ b/src/content/spectron/integrations/sdks/javascript-and-typescript.mdx
@@ -147,7 +147,7 @@ The default timeout is 30,000 ms; streaming chat disables the read timeout while
 ## Vercel AI SDK adapter
 
 ```bash
-npm install @surrealdb/vercel-ai
+npm install @surrealdb/spectron-vercel-ai
 ```
 
 → [Vercel AI SDK](/docs/spectron/integrations/ai-sdks/vercel-ai-sdk)

--- a/src/content/spectron/integrations/sdks/python.mdx
+++ b/src/content/spectron/integrations/sdks/python.mdx
@@ -188,7 +188,7 @@ For agent frameworks that should auto-record every turn, Spectron ships Python a
 
 ```bash
 pip install spectron-crew-ai              # CrewAI
-pip install spectron-openai-agents        # OpenAI Agents SDK
+pip install spectron-openai-agents-sdk    # OpenAI Agents SDK
 pip install spectron-strands-agents       # Strands Agents
 pip install spectron-google-adk           # Google ADK
 ```

--- a/src/content/spectron/integrations/sdks/python.mdx
+++ b/src/content/spectron/integrations/sdks/python.mdx
@@ -187,9 +187,9 @@ from surrealdb.spectron import RecallResponse, RecallHit
 For agent frameworks that should auto-record every turn, Spectron ships Python adapters that build on this SDK:
 
 ```bash
-pip install spectron-crewai   # CrewAI
+pip install spectron-crew-ai              # CrewAI
 pip install spectron-openai-agents        # OpenAI Agents SDK
-pip install spectron-strands              # Strands Agents
+pip install spectron-strands-agents       # Strands Agents
 pip install spectron-google-adk           # Google ADK
 ```
 

--- a/src/content/spectron/reference/agents.mdx
+++ b/src/content/spectron/reference/agents.mdx
@@ -125,7 +125,7 @@ Use **`session.turn()` + `session.context()`** when you need your own LLM, tools
 
 ## MCP (Cursor, Claude Desktop, …)
 
-Remote MCP endpoint: `https://<your-context-host>/mcp` (SurrealDB Cloud: host from Surrealist **API keys**; self-hosted: your server URL).
+Remote MCP endpoint: your instance base URL plus `/mcp` — for example `https://abc123.spectron.cloud/mcp` (SurrealDB Cloud: host from Surrealist **API keys**) or `http://localhost:9090/mcp` (self-hosted).
 
 Headers:
 
@@ -144,10 +144,12 @@ Seven tools: `remember`, `recall`, `context`, `reflect`, `forget`, `upload`, `in
 
 **Errors:** operation failures use `isError: true` with `structuredContent.error.status` (same codes as REST). JSON-RPC `error` is for protocol faults only. See [MCP error handling](/docs/spectron/reference/mcp-tools#error-handling).
 
-Install helper:
+Install helper ([`install-mcp`](https://github.com/supermemoryai/install-mcp) — pass the `/mcp` URL as the first argument, auth via `--header`):
 
 ```bash
-npx install-mcp spectron --client cursor --context <context_id>
+npx install-mcp https://<your-context-host>/mcp \
+  --client cursor \
+  --header "Authorization: Bearer <api-key>" --oauth no
 ```
 
 See [Cursor](/docs/spectron/integrations/mcp-server/coding-assistants/cursor).

--- a/src/content/spectron/reference/cli.mdx
+++ b/src/content/spectron/reference/cli.mdx
@@ -132,13 +132,9 @@ spectron entities show Person/alice
 spectron traces show <trace_id>
 ```
 
-### MCP install helper
+### MCP server
 
-```bash
-spectron mcp
-```
-
-Prints JSON for Claude Desktop / Cursor and a Claude Code one-liner.
+The MCP server is served at `/mcp` on the same host and port as the REST API — no CLI step is needed. Point your client at that endpoint, or run [`install-mcp`](https://github.com/supermemoryai/install-mcp). See the [MCP server install guide](/docs/spectron/integrations/mcp-server/install).
 
 ### Operator provisioning
 

--- a/src/content/spectron/reference/sdk-javascript.mdx
+++ b/src/content/spectron/reference/sdk-javascript.mdx
@@ -86,7 +86,7 @@ Python names `query_context` as `context` here. Python exposes `whoami()` and `k
 ## Harness adapter
 
 ```bash
-npm install @surrealdb/vercel-ai
+npm install @surrealdb/spectron-vercel-ai
 ```
 
 → [Vercel AI SDK](/docs/spectron/integrations/ai-sdks/vercel-ai-sdk)

--- a/src/content/spectron/self-hosting/security/authentication.mdx
+++ b/src/content/spectron/self-hosting/security/authentication.mdx
@@ -54,7 +54,7 @@ Harness adapters also accept `SPECTRON_BASE_URL` and `SPECTRON_CONTEXT` per pack
 
 ## MCP
 
-MCP clients (Claude Desktop, Cursor, Claude Code) send the same Bearer token in the MCP transport config (`Authorization: Bearer …`). Run `spectron mcp` to print an install snippet.
+MCP clients (Claude Desktop, Cursor, Claude Code) send the same Bearer token in the MCP transport config (`Authorization: Bearer …`). Point the client at your instance's `/mcp` endpoint — see the [MCP server install guide](/docs/spectron/integrations/mcp-server/install).
 
 ## Key rotation
 


### PR DESCRIPTION
Fixes MCP focused  instructions and Spectron integration package names.