### PR TITLE
Clarify why PERMISSIONS NONE for tables and PERMISSIONS FULL for fields

### DIFF
--- a/src/content/learn/schema-management/tables-and-fields/fields-and-validation.mdx
+++ b/src/content/learn/schema-management/tables-and-fields/fields-and-validation.mdx
@@ -286,7 +286,7 @@ DEFINE FIELD created ON resource VALUE time::now() READONLY;
 
 ## Setting permissions on fields
 
-By default, the permissions on a field will be set to FULL unless otherwise specified.
+By default, the permissions on a field are set to `FULL` unless otherwise specified. That means once a [table](/docs/learn/schema-management/tables-and-fields/tables#defining-permissions) allows an operation for a record user, the field is included unless you narrow it with your own `PERMISSIONS` clause. Tables default the other way: omitting table `PERMISSIONS` stores `PERMISSIONS NONE`.
 
 ```surql
 DEFINE FIELD some_info ON TABLE some_table TYPE string;
@@ -306,6 +306,8 @@ INFO FOR TABLE some_table;
 ```
 
 You can set permissions on fields to control who can perform operations on them using the `PERMISSIONS` clause. The `PERMISSIONS` clause can be used to set permissions for `SELECT`, `CREATE`, and `UPDATE` operations. The `DELETE` operation only relates to records and, as such, is not available for fields.
+
+Like table permissions, field permissions apply to [record users](/docs/learn/security/authentication/authentication#record-users) (and guests when enabled), not to system users.
 
 ```surql
 /[test]

--- a/src/content/learn/schema-management/tables-and-fields/tables.mdx
+++ b/src/content/learn/schema-management/tables-and-fields/tables.mdx
@@ -22,7 +22,7 @@ CREATE doesnt_exist;
 SELECT * FROM doesnt_exist;
 ```
 
-`DEFINE TABLE` can also set high-level rules, such as whether new fields are allowed without a definition, whether rows are normal documents or graph edges, whether the table is a pre-computed view, and who may select / create / update / delete.
+`DEFINE TABLE` can also set high-level rules, such as whether new fields are allowed without a definition, whether records are normal documents or graph edges, whether the table is a pre-computed view, and who may select / create / update / delete.
 
 Individual columns still use [`DEFINE FIELD`](/docs/reference/query-language/statements/define/field); the table statement does not replace that.
 
@@ -125,7 +125,9 @@ SELECT * FROM avg_product_review;
 
 ## Defining permissions
 
-By default, the permissions on a table will be set to NONE unless otherwise specified.
+Table `PERMISSIONS` control what [record users](/docs/learn/security/authentication/authentication#record-users) (and [guests](/docs/learn/security/authorization/capabilities#guest-access), when guest access is enabled) may do with records in that table. They do not restrict [system users](/docs/learn/security/authentication/authentication#system-users) at the root, namespace, or database level, as those users are governed by roles instead.
+
+If you omit the clause, SurrealDB will default to `PERMISSIONS NONE` which denies `SELECT`, `CREATE`, `UPDATE`, and `DELETE` for record users until you grant access explicitly. The opposite shorthand is `PERMISSIONS FULL`, which allows all four operations.
 
 ```surql
 CREATE some_table;
@@ -150,7 +152,7 @@ INFO FOR DB;
 }
 ```
 
-The following shows how to set table level `PERMISSIONS` using the `DEFINE TABLE` statement. This allows you to set independent permissions for selecting, creating, updating, and deleting data.
+You can also set independent rules for selecting, creating, updating, and deleting data. Each `FOR` clause is a SurrealQL expression evaluated in the context of the current authentication (often using the [`$auth`](/docs/learn/security/authorization/permissions-and-row-level-security) parameter which is set when a record user authenticates).
 
 ```surql
 -- Specify access permissions for the 'post' table
@@ -171,6 +173,8 @@ DEFINE TABLE post SCHEMALESS
 			OR $auth.admin = true
 ;
 ```
+
+Field permissions work the same way but default to `PERMISSIONS FULL` instead of `NONE`. The table is the main access gate, while field permissions only narrow further when you need to (for example hiding a password). With `FULL`, a field follows the table's rules without adding its own. See [Setting permissions on fields](/docs/learn/schema-management/tables-and-fields/fields-and-validation#setting-permissions-on-fields) and [Permissions & row-level security](/docs/learn/security/authorization/permissions-and-row-level-security).
 
 ## Table with specialized `TYPE` clause
 

--- a/src/content/learn/security/authentication/summary.mdx
+++ b/src/content/learn/security/authentication/summary.mdx
@@ -33,9 +33,10 @@ SurrealDB allows the creation of users that can be easily signed up but with no 
 - [Security: Authentication (Record Users)](/docs/learn/security/authentication/authentication#record-users)
 
 #### Permissions
-SurrealDB enforces table and field permissions for record users. Those permissions ensure that record users can only perform explicitly defined actions over explicitly defined data. Permissions are specified when defining a table or a field and use SurrealQL syntax to establish the conditions under which the table or the field can be queried with SELECT, UPDATE, CREATE and DELETE operations individually. No table permissions are defined by default, thus preventing a record user from querying any data unless explicitly allowed.
-- [Statement: DEFINE TABLE](/docs/reference/query-language/statements/define/table)
-- [Statement: DEFINE FIELD](/docs/reference/query-language/statements/define/field)
+SurrealDB enforces table and field permissions for record users. Those permissions ensure that record users can only perform explicitly defined actions over explicitly defined data. Permissions are specified when defining a table or a field and use SurrealQL syntax to establish the conditions under which the table or the field can be queried with SELECT, UPDATE, CREATE and DELETE operations individually. Tables default to `PERMISSIONS NONE`, so a record user cannot query any data unless you grant access; fields default to `PERMISSIONS FULL`.
+- [Statement: DEFINE TABLE](/docs/reference/query-language/statements/define/table#defining-permissions)
+- [Statement: DEFINE FIELD](/docs/reference/query-language/statements/define/field#setting-permissions-on-fields)
+- [Permissions & row-level security](/docs/learn/security/authorization/permissions-and-row-level-security)
 
 ### JSON web tokens
 SurrealDB internally uses JWTs to perform and manage authentication for both system and record users. It also supports accepting tokens issued by third party authentication providers in order to authenticate as a system user on any level as well as a record user for an application. This ensures that advanced authentication features not present in SurrealDB can be integrated through a third party provider. This integration is simple and reliable thanks to JSON Web Key Set (JWKS) support implemented by SurrealDB.

--- a/src/content/learn/security/authorization/permissions-and-row-level-security.mdx
+++ b/src/content/learn/security/authorization/permissions-and-row-level-security.mdx
@@ -1,16 +1,26 @@
 ---
 position: 2
 title: Permissions & row-level security
-description: "How SurrealDB's PERMISSIONS clause on tables and fields controls create, select, update, and delete, including row-level and field-level rules using $auth."
+description: "How SurrealDB's PERMISSIONS clause on tables and fields controls create, select, update, and delete, including per-record and field-level rules using $auth."
 ---
 
 # Permissions & row-level security
 
-SurrealDB lets you declare **permissions** alongside your schema so access is enforced in the database, not only in application code. You attach a `PERMISSIONS` clause to [`DEFINE TABLE`](/docs/reference/query-language/statements/define/table) and [`DEFINE FIELD`](/docs/reference/query-language/statements/define/field) to describe which operations are allowed under which conditions.
+SurrealDB lets you declare permissions alongside your schema so access is enforced in the database, not only in application code. You attach a `PERMISSIONS` clause to [`DEFINE TABLE`](/docs/reference/query-language/statements/define/table) and [`DEFINE FIELD`](/docs/reference/query-language/statements/define/field) to describe which operations are allowed under which conditions.
 
-For each table, you set independent rules for **create**, **select**, **update**, and **delete**. Each clause is a SurrealQL expression that must succeed for that operation to proceed; if it fails, the operation is rejected for the affected rows. **Field-level permissions** refine this: you can constrain **select**, **create**, and **update** on individual columns—useful for sensitive fields that should not be readable or writable under the same rules as the rest of the row.
+These clauses apply to [record users](/docs/learn/security/authentication/authentication#record-users) and to [guests](/docs/learn/security/authorization/capabilities#guest-access) when guest access is enabled. [System users](/docs/learn/security/authentication/authentication#system-users) are not restricted by table or field `PERMISSIONS`, using roles instead.
 
-**Row-level security** is implemented by writing expressions that depend on the authenticated context. The **`$auth`** variable holds the current identity and claims after sign-in, so you can compare it to columns on the row (for example `owner = $auth.id`) and ensure each user only sees or changes their own data.
+## Defaults: `NONE` and `FULL`
+
+On a table, omitting `PERMISSIONS` results in a `PERMISSIONS NONE` in the actual statement passed to the database: record users cannot `SELECT`, `CREATE`, `UPDATE`, or `DELETE` records in that table until you grant access. `PERMISSIONS FULL` allows all four operations.
+
+Field permissions default the other way. A field without an explicit clause is stored as `PERMISSIONS FULL`. The table is the main access gate, while field permissions only narrow further when you need to (for example hiding a password). With `FULL`, a field follows the table's rules without adding its own.
+
+## Record and field rules
+
+For each table, you set independent rules for **create**, **select**, **update**, and **delete**. Each clause is a SurrealQL expression that must succeed for that operation to proceed; if it fails, the operation is rejected for the affected records. **Field-level permissions** refine this: you can constrain **select**, **create**, and **update** on individual fields—useful for sensitive data that should not be readable or writable under the same rules as the rest of the record.
+
+What the wider industry calls **row-level security** is implemented here by writing expressions that depend on the authenticated context. The **`$auth`** variable holds the current identity and claims after sign-in, so you can compare it to fields on the record (for example `owner = $auth.id`) and ensure each user only sees or changes their own data.
 
 ### Example: users read only their own records
 
@@ -36,4 +46,4 @@ DEFINE FIELD internal_note ON order TYPE string
 ;
 ```
 
-Together, table- and field-level `PERMISSIONS` give you flexible **authorisation** without duplicating policy in every client. For full syntax and options, see [`DEFINE TABLE`](/docs/reference/query-language/statements/define/table) and [`DEFINE FIELD`](/docs/reference/query-language/statements/define/field).
+Together, table- and field-level `PERMISSIONS` give you flexible authorisation without duplicating policy in every client. For full syntax and options, see [`DEFINE TABLE`](/docs/reference/query-language/statements/define/table#defining-permissions) and [`DEFINE FIELD`](/docs/reference/query-language/statements/define/field#setting-permissions-on-fields).

--- a/src/content/reference/query-language/statements/define/field.mdx
+++ b/src/content/reference/query-language/statements/define/field.mdx
@@ -711,7 +711,7 @@ DEFINE FIELD OVERWRITE example ON TABLE user TYPE string;
 
 ## Setting permissions on fields
 
-By default, the permissions on a field will be set to FULL unless otherwise specified.
+By default, the permissions on a field will be set to `FULL` unless otherwise specified. The table is the main access gate, while field permissions only narrow further when you need to (for example, when hiding a password). With `FULL`, a field follows the [table](/docs/reference/query-language/statements/define/table#defining-permissions)'s rules without adding its own. Tables default the other way: omitting table `PERMISSIONS` in a `DEFINE` statement stores `PERMISSIONS NONE`.
 
 ```surql
 /**[test]
@@ -741,6 +741,8 @@ INFO FOR TABLE some_table;
 ```
 
 You can set permissions on fields to control who can perform operations on them using the `PERMISSIONS` clause. The `PERMISSIONS` clause can be used to set permissions for `SELECT`, `CREATE`, and `UPDATE` operations. The `DELETE` operation only relates to records and, as such, is not available for fields.
+
+Like table permissions, field permissions apply to [record users](/docs/learn/security/authentication/authentication#record-users) (and guests when enabled), not to system users.
 
 ```surql
 /**[test]

--- a/src/content/reference/query-language/statements/define/table.mdx
+++ b/src/content/reference/query-language/statements/define/table.mdx
@@ -465,7 +465,9 @@ Also note that table views are not triggered when importing data.
 
 ## Defining permissions
 
-By default, the permissions on a table will be set to NONE unless otherwise specified.
+Table `PERMISSIONS` control what [record users](/docs/learn/security/authentication/authentication#record-users) (and [guests](/docs/learn/security/authorization/capabilities#guest-access), when guest access is enabled) may do with records in that table. They do not restrict [system users](/docs/learn/security/authentication/authentication#system-users) at the root, namespace, or database level, as those users are governed by roles instead.
+
+If you omit the clause, SurrealDB stores `PERMISSIONS NONE`. That denies `SELECT`, `CREATE`, `UPDATE`, and `DELETE` for record users until you grant access explicitly. The opposite shorthand is `PERMISSIONS FULL`, which allows all four operations.
 
 ```surql
 /**[test]
@@ -503,7 +505,7 @@ INFO FOR DB;
 }
 ```
 
-The following shows how to set table level `PERMISSIONS` using the `DEFINE TABLE` statement. This allows you to set independent permissions for selecting, creating, updating, and deleting data.
+You can also set independent rules for selecting, creating, updating, and deleting data. Each `FOR` clause is a SurrealQL expression evaluated in the context of the current authentication (often using [`$auth`](/docs/learn/security/authorization/permissions-and-row-level-security)).
 
 ```surql
 /**[test]
@@ -531,6 +533,8 @@ DEFINE TABLE post SCHEMALESS
 			OR $auth.admin = true
 ;
 ```
+
+Field permissions work the same way but default to `PERMISSIONS FULL` instead of `NONE`. This is because the table is the main access gate, while field permissions only narrow further when you need to (for example hiding a password). With `FULL`, a field follows the table's rules without adding its own. See [`DEFINE FIELD`](/docs/reference/query-language/statements/define/field#setting-permissions-on-fields) and [Permissions & row-level security](/docs/learn/security/authorization/permissions-and-row-level-security).
 
 ## Using `IF NOT EXISTS` clause
 


### PR DESCRIPTION
Makes it clearer why you have the NONE default for one and FULL for the other.