### PR TITLE
Fix light-mode flash on load in dark mode

### DIFF
--- a/src/assets/styles/global.scss
+++ b/src/assets/styles/global.scss
@@ -13,6 +13,20 @@ html {
 	-moz-osx-font-smoothing: grayscale;
 }
 
+// Paint the theme background on the first frame to avoid a light-mode flash
+// before Mantine's layered styles resolve.
+body {
+	--mantine-color-text: var(--mantine-color-slate-2);
+
+	background-color: var(--mantine-color-obsidian-9) !important;
+
+	@include light {
+		--mantine-color-text: var(--mantine-color-slate-7);
+
+		background-color: var(--mantine-color-white) !important;
+	}
+}
+
 input::-ms-reveal,
 input::-ms-clear {
 	display: none;


### PR DESCRIPTION
## Problem

On dark-mode devices, the page briefly flashes light on load.

## Root cause

#1849 removed the `body` rule from `global.scss` that painted an explicit background colour. Without it, nothing paints the page background on the first frame, so it falls back to the browser default (white) until Mantine's `@layer`-scoped styles resolve — producing a light flash on dark-mode devices.

## Fix

Restored the rule. Because `ColorSchemeScript` sets `data-mantine-color-scheme` on `<html>` in the head (before the body renders), the `background-color` / `@include light` mixin resolves to the correct colour on the very first paint.

## Verification

Checked in-browser:
- Dark scheme → body background `rgb(13, 13, 18)` (obsidian-9) ✓
- Light scheme → body background `rgb(255, 255, 255)` ✓