### PR TITLE
Bump UI version

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
         "@mantine/hooks": "^9.1.1",
         "@mantine/spotlight": "^9.0.2",
         "@surrealdb/docs-search-common": "workspace:*",
-        "@surrealdb/ui": "^1.2.6",
+        "@surrealdb/ui": "^1.2.13",
         "@tanstack/react-query": "^5.100.9",
         "@vikejs/hono": "^0.2.0",
         "github-slugger": "^2.0.0",


### PR DESCRIPTION
Bump UI version to fix broken backtick rendering in places like this:

<img width="1264" height="774" alt="image" src="https://github.com/user-attachments/assets/f8db6ebc-fb20-4351-a7e9-762d60ecea1e" />
