### PR TITLE
Bump @surrealdb/ui to 1.2.13

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "@mantine/hooks": "^9.1.1",
         "@mantine/spotlight": "^9.0.2",
         "@surrealdb/docs-search-common": "workspace:*",
-        "@surrealdb/ui": "^1.2.6",
+        "@surrealdb/ui": "^1.2.13",
         "@tanstack/react-query": "^5.100.9",
         "@vikejs/hono": "^0.2.0",
         "github-slugger": "^2.0.0",
@@ -456,7 +456,7 @@
 
     "@surrealdb/lezer": ["@surrealdb/lezer@1.0.0-beta.23", "", { "dependencies": { "@lezer/common": "^1.2.3", "@lezer/highlight": "^1.2.1", "@lezer/lr": "^1.4.2" } }, "sha512-TOF0ktFg5c6vA1G10DXVJdb2Cg+FwBf8KL2Tjl+CM662/MiXykhPmYvp8g+g7q+c2o705EymDg21vsht6nTBGw=="],
 
-    "@surrealdb/ui": ["@surrealdb/ui@1.2.6", "", { "dependencies": { "@codemirror/lang-markdown": "^6.5.0", "@codemirror/legacy-modes": "^6.4.2", "@fontsource-variable/geist": "^5.2.9", "@fontsource-variable/jetbrains-mono": "^5.2.8", "@lezer/common": "^1.2.1", "@lezer/go": "^1.0.0", "@lezer/highlight": "^1.2.1", "@lezer/html": "^1.3.10", "@lezer/javascript": "^1.4.17", "@lezer/json": "^1.0.3", "@lezer/markdown": "^1.6.3", "@lezer/php": "^1.0.2", "@lezer/python": "^1.1.14", "@lezer/rust": "^1.0.2", "@lezer/yaml": "^1.0.3", "@replit/codemirror-indentation-markers": "^6.5.3", "@surrealdb/lezer": "1.0.0-beta.23", "acorn": "^8.16.0", "github-slugger": "^2.0.0", "vite-tsconfig-paths": "^6.0.5" }, "peerDependencies": { "@codemirror/autocomplete": "^6.13.0", "@codemirror/commands": "^6.3.3", "@codemirror/language": "^6.10.1", "@codemirror/lint": "^6.5.0", "@codemirror/search": "^6.5.6", "@codemirror/state": "^6.4.1", "@codemirror/view": "^6.24.1", "@mantine/core": "^9.2.2", "@mantine/hooks": "^9.2.2", "mermaid": "^11", "react": "^19", "slate": "^0.120.0", "slate-dom": "^0.119.0", "slate-react": "^0.120.0" }, "optionalPeers": ["mermaid"] }, "sha512-IxfnvfeqezFfdVcs/l6NZzFRuHuCSjt9fD0B2Wlvz5O6EK33BaCoiqqJu7oYOLMBp/RWWbv/y74watInjFlNcg=="],
+    "@surrealdb/ui": ["@surrealdb/ui@1.2.13", "", { "dependencies": { "@codemirror/lang-markdown": "^6.5.0", "@codemirror/legacy-modes": "^6.4.2", "@fontsource-variable/geist": "^5.2.9", "@fontsource-variable/jetbrains-mono": "^5.2.8", "@lezer/common": "^1.2.1", "@lezer/go": "^1.0.0", "@lezer/highlight": "^1.2.1", "@lezer/html": "^1.3.10", "@lezer/javascript": "^1.4.17", "@lezer/json": "^1.0.3", "@lezer/markdown": "^1.6.3", "@lezer/php": "^1.0.2", "@lezer/python": "^1.1.14", "@lezer/rust": "^1.0.2", "@lezer/yaml": "^1.0.3", "@replit/codemirror-indentation-markers": "^6.5.3", "@surrealdb/lezer": "1.0.0-beta.23", "acorn": "^8.16.0", "github-slugger": "^2.0.0", "react-reverse-portal": "^2.3.0", "vite-tsconfig-paths": "^6.0.5" }, "peerDependencies": { "@codemirror/autocomplete": "^6.13.0", "@codemirror/commands": "^6.3.3", "@codemirror/language": "^6.10.1", "@codemirror/lint": "^6.5.0", "@codemirror/search": "^6.5.6", "@codemirror/state": "^6.4.1", "@codemirror/view": "^6.24.1", "@mantine/core": "^9.2.2", "@mantine/hooks": "^9.2.2", "mermaid": "^11", "react": "^19", "slate": "^0.120.0", "slate-dom": "^0.119.0", "slate-react": "^0.120.0" }, "optionalPeers": ["mermaid"] }, "sha512-QkZuiMJqOYRZRwipGZ8pFnpi5fgmp/lE4xUvbHhFqnVkmYPLi87ey0zzVmRKG36Mx1nQYTTVgD8oMSQY4Hw8qw=="],
 
     "@tanstack/query-core": ["@tanstack/query-core@5.100.14", "", {}, "sha512-5X41dGpxgeaHISCRW2oYwcSycZeULZzAunaudXT9ov1KOTj9xwt0CH6hbwqP1/z74ZWF7rYFnDpyYH07XFcZew=="],
 
@@ -1039,6 +1039,8 @@
     "react-remove-scroll": ["react-remove-scroll@2.7.2", "", { "dependencies": { "react-remove-scroll-bar": "^2.3.7", "react-style-singleton": "^2.2.3", "tslib": "^2.1.0", "use-callback-ref": "^1.3.3", "use-sidecar": "^1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q=="],
 
     "react-remove-scroll-bar": ["react-remove-scroll-bar@2.3.8", "", { "dependencies": { "react-style-singleton": "^2.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q=="],
+
+    "react-reverse-portal": ["react-reverse-portal@2.3.0", "", { "peerDependencies": { "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-kvbPfLPKg6Y3S6tVq83us2RghvDpOS4GcJxbI7cZ0V0tuzUaSzblRIhVnKLOucfqF4lN/i9oWvEmpEi6bAOYlQ=="],
 
     "react-streaming": ["react-streaming@0.4.17", "", { "dependencies": { "@brillout/import": "^0.2.3", "@brillout/json-serializer": "^0.5.1", "@brillout/picocolors": "^1.0.11", "isbot-fast": "1.2.0" }, "peerDependencies": { "react": ">=19", "react-dom": ">=19" } }, "sha512-FgY2BSqqgpLv0Gw5wrX3kPZttBW50vSHFZCirFbgz8AT6lZHFjhOqlhP+x7zdzAv57aD9gclAYCnTafobOJEJw=="],
 


### PR DESCRIPTION
## Summary
- Updates the lockfile so `@surrealdb/ui` resolves to `1.2.13` (latest)
- `package.json` already allowed `^1.2.13` from #1887, but the lockfile was still pinned to `1.2.6`

## Test plan
- [ ] Confirm `bun install` resolves `@surrealdb/ui@1.2.13`
- [ ] Spot-check docs pages that use UI kit markdown/rendering components
- [ ] Run `bun run qa` and `bun run qc`


Made with [Cursor](https://cursor.com)