### PR TITLE
fix: remove stray backslashes in vector index query syntax table

### DIFF
--- a/src/content/learn/data-models/vector-search/vector-indexes.mdx
+++ b/src/content/learn/data-models/vector-search/vector-indexes.mdx
@@ -127,14 +127,14 @@ With a DISKANN index defined on `point`, the same `<|K, EF|>` approximate form a
 
 | Query                   | HNSW index | DISKANN index |
 | ----------------------- | ---------- | --------------- |
-| `<\|2\|>`               | uses distance function defined in index | same when the index distance matches |
-| `<\|2, EUCLIDEAN\|>`    | brute force method | brute force method |
-| `<\|2, COSINE\|>`       | brute force method | brute force method |
-| `<\|2, MANHATTAN\|>`    | brute force method | brute force method |
-| `<\|2, MINKOWSKI, 3\|>` | brute force method (third param is [𝑝](#notes)) | brute force method |
-| `<\|2, CHEBYSHEV\|>`    | brute force method | brute force method |
-| `<\|2, HAMMING\|>`      | brute force method | brute force method |
-| `<\|2, 10\|>`           | second param is effort* | same approximate form — second value bounds the candidate list |
+| `<|2|>`               | uses distance function defined in index | same when the index distance matches |
+| `<|2, EUCLIDEAN|>`    | brute force method | brute force method |
+| `<|2, COSINE|>`       | brute force method | brute force method |
+| `<|2, MANHATTAN|>`    | brute force method | brute force method |
+| `<|2, MINKOWSKI, 3|>` | brute force method (third param is [𝑝](#notes)) | brute force method |
+| `<|2, CHEBYSHEV|>`    | brute force method | brute force method |
+| `<|2, HAMMING|>`      | brute force method | brute force method |
+| `<|2, 10|>`           | second param is effort* | same approximate form — second value bounds the candidate list |
 
 \* **effort** — for HNSW and DISKANN, the second number in `<|K, N|>` tells the engine how far to search along the graph. Both algorithms are approximate and may miss some vectors.
 


### PR DESCRIPTION
## Summary
- The `Query` column in the "WHERE statement" table on the vector indexes doc rendered literal backslashes (e.g. `<\|2\|>`) instead of the correct KNN operator syntax `<|2|>`.
- Removed the unnecessary `\` escaping before each `|` across all rows in the table.

## Test plan
- [x] `bun run qa` / `bun run qc` pass
- [x] Visually confirmed the table now reads `<|2|>`, `<|2, EUCLIDEAN|>`, etc.