### PR TITLE
Clarify id on TYPE JWT vs. WITH JWT

### DIFF
--- a/src/content/reference/query-language/statements/define/access/jwt.mdx
+++ b/src/content/reference/query-language/statements/define/access/jwt.mdx
@@ -161,16 +161,18 @@ The following claims should be added to the JWT payload by the issuer of the tok
 
 The names of these claims can be in all lowercase (i.e. `ac`) or all uppercase (i.e. `AC`), and can be optionally prefaced with the `https://surrealdb.com` namespace (e.g. `https://surrealdb.com/ac`) in order to separate claims directed to SurrealDB from claims directed to other services. When using a namespace, the claim name can also be used without abbreviation, such as in `https://surrealdb.com/access`, `https://surrealdb.com/database`...
 
-The following optional claims are also processed by SurrealDB:
+The following optional claim is also processed by SurrealDB:
 
-- `id`: The identifier of the resource (e.g. user) associated with the token.
 - `nbf`: The token acceptance Unix time. The token will not be valid before.
 
 The expected claims depend on the level at which the token was defined:
 
 - For tokens defined `ON ROOT`: `exp`, `ac`.
 - For tokens defined `ON NAMESPACE`: `exp`, `ac`, `ns`.
-- For tokens defined `ON DATABASE`: `exp`, `ac`,`ns`,`db`.
+- For tokens defined `ON DATABASE`: `exp`, `ac`, `ns`, `db`.
+
+> [!NOTE]
+> An `id` claim is **not** required for `TYPE JWT`. That claim identifies a [record user](/docs/learn/security/authentication/authentication#record-users) and belongs to [`DEFINE ACCESS ... TYPE RECORD ... WITH JWT`](/docs/reference/query-language/statements/define/access/record#with-json-web-token). A `TYPE JWT` token without `id` authenticates as a [system user](/docs/learn/security/authentication/authentication#system-users) session.
 
 For tokens defined for [system users](/docs/learn/security/authentication/authentication#system-users), the optional `rl` claim containing an array of capitalized [system user roles](/docs/reference/query-language/statements/define/user#roles) (e.g. `["Viewer", "Editor", "Owner"]`) can be provided. Doing so will apply the access policy for those roles to any action made using the token. By default, sessions established with tokens without the `rl` claim will only have the `Viewer` role.
 

--- a/src/content/reference/query-language/statements/define/access/record.mdx
+++ b/src/content/reference/query-language/statements/define/access/record.mdx
@@ -123,6 +123,9 @@ The token payload should at least include the following claims when used to auth
 }
 ```
 
+> [!IMPORTANT]
+> For `TYPE RECORD ... WITH JWT`, the `id` claim must identify the record user, unless an [`AUTHENTICATE`](#with-authenticate-clause) clause resolves that record from other claims (for example an email address). This differs from [`TYPE JWT`](/docs/reference/query-language/statements/define/access/jwt#using-tokens), where `id` is not required and the session is a system user.
+
 When the `id` claim is present in the token, the fields of the record matching the identifier specified will be accessible through the `$auth` reserved parameter. For example, if the value of the `id` claim is `user:73q1bl039y6k8z80v55d`, and user records have fields such as “name” or “email”, then `$auth.name` and `$auth.email` can be used to access those values for the `user:73q1bl039y6k8z80v55d` record specifically, without them being present in the JWT.
 
 #### With issuer


### PR DESCRIPTION
Makes it easier to see how TYPE RECORD ... WITH JWT and TYPE JWT are not the same thing with regards to the `id` field.