### PR TITLE
Improve COMMENT examples

### DIFF
--- a/src/content/build/ai-agents/mcp/embedded.mdx
+++ b/src/content/build/ai-agents/mcp/embedded.mdx
@@ -167,6 +167,8 @@ Once connected, ask the assistant which SurrealDB tools it has. It should list `
 
 Legacy names such as `list_tables`, `use_database`, and `version` are no longer published. Use `list` and `use` instead.
 
+When an agent inspects the schema with `info` or `list`, any [`COMMENT`](/docs/reference/query-language/statements/define/overview#comments-on-definitions) on tables and fields is included. Put query-relevant detail in those comments (record-ID conventions, how to compare a field, graph paths) so the agent does not have to guess from names alone.
+
 ## Configuration
 
 MCP-specific limits are read once from the environment, with the prefix `SURREAL_MCP_`. HTTP body size uses the server-wide cap.

--- a/src/content/build/ai-agents/mcp/examples.mdx
+++ b/src/content/build/ai-agents/mcp/examples.mdx
@@ -42,7 +42,7 @@ It inspects the schema to find the right table and fields, then writes the aggre
 
 > Something looks wrong with the `customer` table. What does its schema actually say?
 
-It describes the table, its fields, and its indexes, which is often faster than opening a dashboard to check a definition.
+It describes the table, its fields, and its indexes, which is often faster than opening a dashboard to check a definition. If you have put operational detail in [`COMMENT`](/docs/reference/query-language/statements/define/overview#comments-on-definitions) clauses, that text comes back with the schema and steers the next query.
 
 ## Investigate a problem
 

--- a/src/content/learn/schema-management/tables-and-fields/fields-and-validation.mdx
+++ b/src/content/learn/schema-management/tables-and-fields/fields-and-validation.mdx
@@ -6,7 +6,7 @@ description: "Defining fields: types, defaults, VALUE, ASSERT, permissions, and 
 
 # Fields and validation
 
-Fields are where you can spell out what each table column means by using certain clauses, such as its type (`TYPE`), optional default values (`DEFAULT`), how writes are normalised (`VALUE`), what counts as valid data (`ASSERT`), or who may see or change it (`PERMISSIONS`).
+Fields are where you can spell out what each table column means by using certain clauses, such as its type (`TYPE`), optional default values (`DEFAULT`), how writes are normalised (`VALUE`), what counts as valid data (`ASSERT`), or who may see or change it (`PERMISSIONS`). A [`COMMENT`](/docs/reference/query-language/statements/define/overview#comments-on-definitions) is a good place for comparison rules and invariants that are not fully captured by the type alone.
 
 You need database-level access and an active [`USE`](/docs/reference/query-language/statements/use) scope, same as for tables.
 

--- a/src/content/learn/schema-management/tables-and-fields/tables.mdx
+++ b/src/content/learn/schema-management/tables-and-fields/tables.mdx
@@ -22,7 +22,7 @@ CREATE doesnt_exist;
 SELECT * FROM doesnt_exist;
 ```
 
-`DEFINE TABLE` can also set high-level rules, such as whether new fields are allowed without a definition, whether records are normal documents or graph edges, whether the table is a pre-computed view, and who may select / create / update / delete.
+`DEFINE TABLE` can also set high-level rules, such as whether new fields are allowed without a definition, whether records are normal documents or graph edges, whether the table is a pre-computed view, and who may select / create / update / delete. A [`COMMENT`](/docs/reference/query-language/statements/define/overview#comments-on-definitions) is optional but worth adding when the table's role, record-ID convention, or graph edges would otherwise be unclear to readers or to agents that load the schema via [`INFO`](/docs/reference/query-language/statements/info) or MCP.
 
 Individual columns still use [`DEFINE FIELD`](/docs/reference/query-language/statements/define/field); the table statement does not replace that.
 

--- a/src/content/reference/query-language/statements/define/field.mdx
+++ b/src/content/reference/query-language/statements/define/field.mdx
@@ -612,6 +612,21 @@ DEFINE FIELD email ON TABLE user TYPE string
   VALUE string::lowercase($value);
 ```
 
+## Comments
+
+A `COMMENT` documents how the field is meant to be used. Comments can be useful when describing how someone (or an agent) would write a query: comparison rules, units, allowed values, or invariants. The comment is stored with the definition and shown by [`INFO`](/docs/reference/query-language/statements/info). See also [Comments on definitions](/docs/reference/query-language/statements/define/overview#comments-on-definitions).
+
+```surql
+DEFINE FIELD time ON meeting TYPE string
+	COMMENT "Meeting date as an ISO string, 'YYYY-MM-DD'. It is a string, not a datetime: compare and sort lexicographically (time >= '2026-07-10').";
+
+DEFINE FIELD is_organizer ON attended TYPE bool
+	COMMENT "True if this person ran the meeting, false if they only attended. Exactly one attendee per meeting has it true.";
+
+DEFINE FIELD score ON review TYPE float
+	COMMENT "Rating from 0.0 to 5.0 inclusive. Always assert score >= 0 AND score <= 5.";
+```
+
 ## Asserting rules on fields
 
 You can take your field definitions even further by using asserts. Assert can be used to ensure that your data remains consistent. For example you can use asserts to ensure that a field is always a valid email address, or that a number is always positive.

--- a/src/content/reference/query-language/statements/define/overview.mdx
+++ b/src/content/reference/query-language/statements/define/overview.mdx
@@ -66,6 +66,32 @@ DEFINE [
 
 The [INFO](/docs/reference/query-language/statements/info) statement can be used to see which definition statements currently exist in a database connection. All `DEFINE` statements can be followed up with a `COMMENT`.
 
+### Comments on definitions
+
+A `COMMENT` is stored with the definition and returned by [`INFO`](/docs/reference/query-language/statements/info) (and by schema tools such as MCP `info` / `list`). Short, concrete comments help people and agents alike: they explain what a table or field is for, how values should be compared, and which graph edges or record-ID conventions matter.
+
+Useful comments tend to include:
+
+- What the entity represents, and what it deliberately does not store
+- How to read the record ID or field (for example `record::id(id)` when the ID is the canonical name)
+- How to compare or sort unusual types (ISO date strings vs datetimes)
+- Cardinality or invariants ("exactly one organiser per meeting")
+- The main graph paths to related tables
+
+```surql
+DEFINE TABLE person TYPE NORMAL SCHEMAFULL
+	COMMENT "A person, deduplicated across notes. Has no fields: the record id IS the canonical full name, e.g. person:`Alice Chen`. Read the name with record::id(id). Meetings: person->attended->meeting.";
+
+DEFINE TABLE meeting TYPE NORMAL SCHEMAFULL
+	COMMENT "A calendar meeting. Link attendees with RELATE person->attended->meeting.";
+
+DEFINE TABLE attended TYPE RELATION IN person OUT meeting SCHEMAFULL
+	COMMENT "Attendance edge. Exactly one attendee per meeting has is_organizer = true.";
+
+DEFINE FIELD is_organizer ON attended TYPE bool
+	COMMENT "True if this person ran the meeting, false if they only attended.";
+```
+
 An example of defining a field on a table, followed by an `INFO` command for the same table:
 
 ```surql

--- a/src/content/reference/query-language/statements/define/table.mdx
+++ b/src/content/reference/query-language/statements/define/table.mdx
@@ -66,6 +66,15 @@ value = "NONE"
 DEFINE TABLE reading;
 ```
 
+### Comments
+
+Add a `COMMENT` when the table's role is not obvious from the name alone. The text is returned by [`INFO`](/docs/reference/query-language/statements/info) and by agent-facing schema tools, so prefer operational detail (record-ID conventions, graph paths, invariants) over a one-line restatement of the table name. See [Comments on definitions](/docs/reference/query-language/statements/define/overview#comments-on-definitions) for a fuller pattern.
+
+```surql
+DEFINE TABLE person TYPE NORMAL SCHEMAFULL
+	COMMENT "Deduplicated person. The record id is the canonical full name (person:`Alice Chen`); use record::id(id) to read it. Edges: person->attended->meeting.";
+```
+
 The following example uses the `DROP` portion of the `DEFINE TABLE` statement. Marking a table as `DROP` disallows creating or updating records.
 
 `DROP` tables are useful in combination with events or foreign (view) tables, as you can compute a record and essentially drop the input.


### PR DESCRIPTION
Make it clearer that the COMMENT clause can be quite useful, especially when passing on info to agents.