### PR TITLE
Python SDK: correct the v3 query() return contract

### DIFF
--- a/src/content/reference/python/api/core/surreal-session.mdx
+++ b/src/content/reference/python/api/core/surreal-session.mdx
@@ -59,7 +59,7 @@ A session exposes the same interface as the parent connection. All methods below
 | Method | Returns | Description |
 |---|---|---|
 | [`.use(namespace, database)`](/docs/reference/python/api/core/surreal#use) | `None` | Switch namespace and database for this session. |
-| [`.query(query, vars)`](/docs/reference/python/api/core/surreal#query) | Awaitable / lazy `Value` or `tuple[Value, ...]` builder | Execute one or more SurrealQL statements. |
+| [`.query(query, vars)`](/docs/reference/python/api/core/surreal#query) | Awaitable / lazy builder -> `list[Value]`, one entry per statement (`.execute()`), or the first statement's result (`.first()`) | Execute one or more SurrealQL statements. |
 | [`.signin(vars)`](/docs/reference/python/api/core/surreal#signin) | [`Tokens`](/docs/reference/python/api/types/#tokens) | Sign in within this session. |
 | [`.signup(vars)`](/docs/reference/python/api/core/surreal#signup) | [`Tokens`](/docs/reference/python/api/types/#tokens) | Sign up within this session. |
 | [`.authenticate(token)`](/docs/reference/python/api/core/surreal#authenticate) | `None` | Authenticate this session with a JWT. |

--- a/src/content/reference/python/api/core/surreal-transaction.mdx
+++ b/src/content/reference/python/api/core/surreal-transaction.mdx
@@ -68,7 +68,7 @@ A transaction exposes query and CRUD methods that mirror the parent connection's
 
 | Method | Returns | Description |
 |---|---|---|
-| [`.query(query, vars)`](/docs/reference/python/api/core/surreal#query) | Awaitable / lazy `Value` or `tuple[Value, ...]` builder | Execute one or more SurrealQL statements within the transaction. |
+| [`.query(query, vars)`](/docs/reference/python/api/core/surreal#query) | Awaitable / lazy builder -> `list[Value]`, one entry per statement (`.execute()`), or the first statement's result (`.first()`) | Execute one or more SurrealQL statements within the transaction. |
 | [`.select(record)`](/docs/reference/python/api/core/surreal#select) | [`Value`](/docs/reference/python/api/types/#value) | Select records. |
 | [`.create(record, data)`](/docs/reference/python/api/core/surreal#create) | CRUD builder -> `dict[str, Value]` | Create a record (chain `.content/.replace/.merge/.patch`). |
 | [`.update(record, data)`](/docs/reference/python/api/core/surreal#update) | CRUD builder -> `dict` or `list` | Update records (chain `.content/.replace/.merge/.patch`). |
@@ -165,11 +165,11 @@ with Surreal("ws://localhost:8000") as db:
         txn.query(
             "UPDATE accounts:alice SET balance = balance - $amount",
             {"amount": 200},
-        )
+        ).execute()
         txn.query(
             "UPDATE accounts:bob SET balance = balance + $amount",
             {"amount": 200},
-        )
+        ).execute()
         txn.commit()
         print("Transfer committed")
     except Exception:
@@ -202,11 +202,11 @@ async def main():
             await txn.query(
                 "UPDATE accounts:alice SET balance = balance - $amount",
                 {"amount": 200},
-            )
+            ).execute()
             await txn.query(
                 "UPDATE accounts:bob SET balance = balance + $amount",
                 {"amount": 200},
-            )
+            ).execute()
             await txn.commit()
             print("Transfer committed")
         except Exception:

--- a/src/content/reference/python/api/core/surreal.mdx
+++ b/src/content/reference/python/api/core/surreal.mdx
@@ -473,12 +473,12 @@ db.let(key, value)
 
 ```python title="Synchronous"
 db.let("user_id", RecordID("users", "john"))
-result = db.query("SELECT * FROM users WHERE id = $user_id")
+result = db.query("SELECT * FROM users WHERE id = $user_id").first()
 ```
 
 ```python title="Asynchronous"
 await db.let("user_id", RecordID("users", "john"))
-result = await db.query("SELECT * FROM users WHERE id = $user_id")
+result = await db.query("SELECT * FROM users WHERE id = $user_id").first()
 ```
 
 ### `.unset()` {#unset}
@@ -524,14 +524,14 @@ await db.unset("user_id")
 
 ### `.query()` {#query}
 
-Runs a set of [SurrealQL](/docs/reference/query-language) statements against the database. Returns an awaitable (async) or lazy (sync) builder.
+Builds a set of [SurrealQL](/docs/reference/query-language) statements to run against the database. Returns an awaitable (async) or lazy (sync) builder — nothing is sent until you trigger it.
 
 ```python title="Method Syntax"
 db.query(query, vars)
 ```
 
 > [!IMPORTANT]
-> **Behaviour change in v3.0.** `.query()` now surfaces every statement result. When the server returns a single statement result it returns the result directly; when it returns multiple results it returns a `tuple[Value, ...]`. This fixes the silent-discard behaviour reported in [issue #232](https://github.com/surrealdb/surrealdb.py/issues/232).
+> **Behaviour change in v3.0.** `.query()` no longer returns a result directly — it returns a builder that you trigger explicitly with `.execute()`, `.first()` or `.into(cls)`. `.execute()` returns a `list[Value]` with **one entry per statement, always** — even when the query contains a single statement. This surfaces every statement result, fixing the silent-discard behaviour reported in [issue #232](https://github.com/surrealdb/surrealdb.py/issues/232). Use `.first()` when you only care about the first statement's result.
 
 <table>
     <thead>
@@ -555,9 +555,27 @@ db.query(query, vars)
     </tbody>
 </table>
 
-**Returns:** [`Value`](/docs/reference/python/api/types/#value) for a single-statement query, otherwise `tuple[Value, ...]` of statement results.
+**Returns:** a builder. Nothing is sent to the database until you trigger it with one of the accessors below.
 
-The returned object also exposes `.into(cls)` which maps the N statement results positionally onto the fields of a dataclass (or any class accepting keyword arguments).
+| Accessor | Returns |
+|---|---|
+| `.execute()` | `list[Value]` — one entry per statement, **always a list**, even for a single statement. See [Value](/docs/reference/python/api/types/#value). |
+| `.first()` | The first statement's result, or `None` when the query contains no statements. |
+| `.into(cls)` | The N statement results mapped positionally onto the fields of a dataclass (or any class accepting keyword arguments). |
+| `.into(cls, rows=True)` | `list[cls]` — each **row** of the first statement's result mapped onto `cls`. |
+
+On an async connection every accessor is awaitable — `await db.query(...).execute()`, `await db.query(...).first()`, `await db.query(...).into(Stats)` — and the builder itself is too, so `await db.query(...)` is shorthand for `await db.query(...).execute()`. The sync builder has no such shortcut: you must call an accessor.
+
+> [!NOTE]
+> A single-statement `SELECT` without `ONLY` produces **two** levels of nesting, and only the outer one comes from the SDK. The outer list is the per-statement envelope described above; the inner list is SurrealQL's own result set, because `SELECT ... FROM person:tobie` returns an *array of matching rows* even when it targets one record. Use [`ONLY`](/docs/reference/query-language/statements/select#the-only-clause) to collapse the inner list server-side, and `.first()` to peel the outer one.
+>
+> ```python
+> db.query("SELECT name FROM person:tobie").execute()            # [[{'name': 'Tobie'}]]
+> db.query("SELECT name FROM person:tobie").first()              # [{'name': 'Tobie'}]
+> db.query("SELECT VALUE name FROM person:tobie").first()        # ['Tobie']
+> db.query("SELECT name FROM ONLY person:tobie").first()         # {'name': 'Tobie'}
+> db.query("SELECT VALUE name FROM ONLY person:tobie").first()   # 'Tobie'
+> ```
 
 #### Examples
 
@@ -565,13 +583,21 @@ The returned object also exposes `.into(cls)` which maps the N statement results
 result = await db.query(
     "SELECT * FROM users WHERE age > $min_age",
     {"min_age": 18},
-)
+).execute()
+# [[{'id': RecordID(table_name=users, record_id='tobie'), 'age': 30}]]
+#  ^ one entry, because the query has one statement
+
+users = await db.query(
+    "SELECT * FROM users WHERE age > $min_age",
+    {"min_age": 18},
+).first()
+# [{'id': RecordID(table_name=users, record_id='tobie'), 'age': 30}]
 ```
 
-```python title="Multi-statement returns tuple"
+```python title="Multi-statement: one entry per statement"
 people, count = await db.query(
     "SELECT * FROM person; SELECT count() FROM person GROUP ALL"
-)
+).execute()
 ```
 
 ```python title="Map results onto a dataclass"
@@ -588,10 +614,13 @@ stats = await db.query(
 ```
 
 ```python title="Synchronous lazy builder"
-# The sync builder auto-executes when consumed (indexed, iterated, compared, etc.).
-# For fire-and-forget statements call .execute() explicitly.
-people = db.query("SELECT * FROM users")
+# The sync builder never auto-executes - it has no __len__, __iter__ or
+# __getitem__. Always call an accessor, including for fire-and-forget
+# statements.
+builder = db.query("SELECT * FROM users")   # nothing has run yet
+people = builder.first()
 print(len(people))
+
 db.query("DELETE temp_data;").execute()
 ```
 
@@ -600,7 +629,7 @@ db.query("DELETE temp_data;").execute()
 Runs a set of SurrealQL statements and returns the raw RPC response, including per-statement results, statuses, and execution times. Unlike `.query()`, errors in individual statements are returned in the response rather than raised as exceptions.
 
 ```python title="Method Syntax"
-db.query_raw(query, params)
+db.query_raw(query, vars)
 ```
 
 <table>
@@ -618,14 +647,14 @@ db.query_raw(query, params)
             <td>The SurrealQL query string to execute.</td>
         </tr>
         <tr>
-            <td><code>params</code> <Label label="optional" /></td>
+            <td><code>vars</code> <Label label="optional" /></td>
             <td><code>dict[str, <a href="/docs/reference/python/api/types/#value">Value</a>] | None</code></td>
             <td>Variables to bind into the query. Defaults to <code>None</code>.</td>
         </tr>
     </tbody>
 </table>
 
-**Returns:** `dict[str, Any]`
+**Returns:** `dict[str, Any]` — the RPC envelope. Its `result` key holds one entry per statement, each with `status`, `time`, and `result`.
 
 #### Examples
 
@@ -1354,13 +1383,13 @@ db.commit(txn_id, session_id)
 
 ```python title="Synchronous"
 txn_id = db.begin()
-db.query("CREATE users SET name = 'Alice'")
+db.query("CREATE users SET name = 'Alice'").execute()
 db.commit(txn_id)
 ```
 
 ```python title="Asynchronous"
 txn_id = await db.begin()
-await db.query("CREATE users SET name = 'Alice'")
+await db.query("CREATE users SET name = 'Alice'").execute()
 await db.commit(txn_id)
 ```
 
@@ -1400,13 +1429,13 @@ db.cancel(txn_id, session_id)
 
 ```python title="Synchronous"
 txn_id = db.begin()
-db.query("DELETE users")
+db.query("DELETE users").execute()
 db.cancel(txn_id)
 ```
 
 ```python title="Asynchronous"
 txn_id = await db.begin()
-await db.query("DELETE users")
+await db.query("DELETE users").execute()
 await db.cancel(txn_id)
 ```
 
@@ -1458,7 +1487,7 @@ with Surreal("ws://localhost:8000") as db:
     cheap = db.query(
         "SELECT * FROM products WHERE price < $max",
         {"max": 100},
-    )
+    ).first()
     print("Affordable:", cheap)
 
     db.update(RecordID("products", products[0]["id"].id)).merge({"stock": 50})

--- a/src/content/reference/python/api/errors/index.mdx
+++ b/src/content/reference/python/api/errors/index.mdx
@@ -83,7 +83,7 @@ has_kind(kind: str) -> bool
 from surrealdb import ErrorKind
 
 try:
-    db.query("INVALID")
+    db.query("INVALID").execute()
 except ServerError as e:
     if e.has_kind(ErrorKind.VALIDATION):
         print("Validation error")

--- a/src/content/reference/python/api/values/geometry.mdx
+++ b/src/content/reference/python/api/values/geometry.mdx
@@ -319,22 +319,21 @@ collection = GeometryCollection([
 ```python
 from surrealdb import Surreal, GeometryPoint
 
-db = Surreal("ws://localhost:8000")
-db.connect()
-db.use("my_ns", "my_db")
-db.signin({"username": "root", "password": "root"})
+with Surreal("ws://localhost:8000") as db:
+    db.use("my_ns", "my_db")
+    db.signin({"username": "root", "password": "root"})
 
-db.create("locations", {
-    "name": "London",
-    "coordinates": GeometryPoint(-0.1278, 51.5074),
-})
+    db.create("locations", {
+        "name": "London",
+        "coordinates": GeometryPoint(-0.1278, 51.5074),
+    })
 
-result = db.query("""
-    SELECT * FROM locations
-    WHERE geo::distance(coordinates, $point) < 50000
-""", {
-    "point": GeometryPoint(-0.1180, 51.5099),
-})
+    locations = db.query("""
+        SELECT * FROM locations
+        WHERE geo::distance(coordinates, $point) < 50000
+    """, {
+        "point": GeometryPoint(-0.1180, 51.5099),
+    }).first()
 ```
 
 ---

--- a/src/content/reference/python/api/values/range.mdx
+++ b/src/content/reference/python/api/values/range.mdx
@@ -127,15 +127,14 @@ r = Range(
 from surrealdb import Surreal, Range
 from surrealdb.data.types.range import BoundIncluded
 
-db = Surreal("ws://localhost:8000")
-db.connect()
-db.use("my_ns", "my_db")
-db.signin({"username": "root", "password": "root"})
+with Surreal("ws://localhost:8000") as db:
+    db.use("my_ns", "my_db")
+    db.signin({"username": "root", "password": "root"})
 
-result = db.query(
-    "SELECT * FROM events WHERE year IN $range",
-    {"range": Range(BoundIncluded(2020), BoundIncluded(2025))},
-)
+    events = db.query(
+        "SELECT * FROM events WHERE year IN $range",
+        {"range": Range(BoundIncluded(2020), BoundIncluded(2025))},
+    ).first()
 ```
 
 ---

--- a/src/content/reference/python/concepts/error-handling.mdx
+++ b/src/content/reference/python/concepts/error-handling.mdx
@@ -59,7 +59,7 @@ with Surreal("ws://localhost:8000") as db:
     db.signin({"username": "root", "password": "root"})
 
     try:
-        result = db.query("SELECT * FROM users")
+        result = db.query("SELECT * FROM users").execute()
     except SurrealError as e:
         print("SDK error:", e)
 ```
@@ -76,7 +76,7 @@ You can check whether an error is a `ServerError` and then inspect its kind usin
 from surrealdb import ServerError, ErrorKind
 
 try:
-    result = db.query("INVALID QUERY")
+    result = db.query("INVALID QUERY").execute()
 except ServerError as e:
     print("Kind:", e.kind)
     print("Details:", e.details)

--- a/src/content/reference/python/concepts/executing-queries.mdx
+++ b/src/content/reference/python/concepts/executing-queries.mdx
@@ -22,10 +22,10 @@ This page covers how to run queries, bind variables, and work with raw results.
 	<tbody>
 		<tr>
 			<td scope="row" data-label="Method"><a href="/docs/reference/python/api/core/surreal#query"><code>db.query(query, vars?)</code></a></td>
-			<td scope="row" data-label="Description">Executes a SurrealQL query and returns the processed result</td>
+			<td scope="row" data-label="Description">Builds a SurrealQL query; trigger it with <code>.execute()</code>, <code>.first()</code> or <code>.into(cls)</code></td>
 		</tr>
 		<tr>
-			<td scope="row" data-label="Method"><a href="/docs/reference/python/api/core/surreal#query-raw"><code>db.query_raw(query, params?)</code></a></td>
+			<td scope="row" data-label="Method"><a href="/docs/reference/python/api/core/surreal#query-raw"><code>db.query_raw(query, vars?)</code></a></td>
 			<td scope="row" data-label="Description">Executes a SurrealQL query and returns the full raw response</td>
 		</tr>
 	</tbody>
@@ -33,7 +33,12 @@ This page covers how to run queries, bind variables, and work with raw results.
 
 ## Running a query
 
-The `.query()` method executes a SurrealQL statement and returns the result directly as a [Value](/docs/reference/python/api/types/#value). This is the simplest way to run queries when you need only the result data.
+The `.query()` method builds a SurrealQL query. It does not talk to the database on its own — you trigger it explicitly:
+
+- `.execute()` returns a `list` of [Value](/docs/reference/python/api/types/#value) with **one entry per statement**, always a list, even when the query contains a single statement.
+- `.first()` returns just the first statement's result, which is what you usually want for a one-statement query.
+
+On an async connection you can also `await` the builder directly, which is the same as awaiting `.execute()`.
 
 <Tabs syncKey="python-sync-async">
 	<TabItem value="sync" label="Synchronous" default>
@@ -44,8 +49,11 @@ The `.query()` method executes a SurrealQL statement and returns the result dire
 		    db.use("surrealdb", "docs")
 		    db.signin({"username": "root", "password": "root"})
 
-		    result = db.query("SELECT * FROM users")
-		    print(result)
+		    statements = db.query("SELECT * FROM users").execute()
+		    print(statements)  # [[{...}, {...}]] - one entry, one statement
+
+		    users = db.query("SELECT * FROM users").first()
+		    print(users)       # [{...}, {...}]
 		```
 	</TabItem>
 	<TabItem value="async" label="Asynchronous">
@@ -56,8 +64,11 @@ The `.query()` method executes a SurrealQL statement and returns the result dire
 		    await db.use("surrealdb", "docs")
 		    await db.signin({"username": "root", "password": "root"})
 
-		    result = await db.query("SELECT * FROM users")
-		    print(result)
+		    statements = await db.query("SELECT * FROM users").execute()
+		    print(statements)  # [[{...}, {...}]] - one entry, one statement
+
+		    users = await db.query("SELECT * FROM users").first()
+		    print(users)       # [{...}, {...}]
 		```
 	</TabItem>
 </Tabs>
@@ -69,18 +80,18 @@ You can pass a dictionary of variables as the second argument to `.query()`. Var
 <Tabs syncKey="python-sync-async">
 	<TabItem value="sync" label="Synchronous" default>
 		```python
-		result = db.query(
+		users = db.query(
 		    "SELECT * FROM users WHERE age > $min_age AND active = $active",
 		    {"min_age": 18, "active": True},
-		)
+		).first()
 		```
 	</TabItem>
 	<TabItem value="async" label="Asynchronous">
 		```python
-		result = await db.query(
+		users = await db.query(
 		    "SELECT * FROM users WHERE age > $min_age AND active = $active",
 		    {"min_age": 18, "active": True},
-		)
+		).first()
 		```
 	</TabItem>
 </Tabs>
@@ -90,10 +101,10 @@ You can bind any Python value supported by the SDK, including strings, numbers, 
 ```python
 from surrealdb import RecordID
 
-result = db.query(
+users = db.query(
     "SELECT * FROM users WHERE id = $user_id",
     {"user_id": RecordID("users", "tobie")},
-)
+).first()
 ```
 
 ## Getting raw query results
@@ -105,7 +116,7 @@ The `.query_raw()` method returns the full response from the server, including m
 		```python
 		response = db.query_raw("SELECT * FROM users; SELECT * FROM products")
 
-		for statement in response:
+		for statement in response["result"]:
 		    print(statement["status"])
 		    print(statement["time"])
 		    print(statement["result"])
@@ -115,7 +126,7 @@ The `.query_raw()` method returns the full response from the server, including m
 		```python
 		response = await db.query_raw("SELECT * FROM users; SELECT * FROM products")
 
-		for statement in response:
+		for statement in response["result"]:
 		    print(statement["status"])
 		    print(statement["time"])
 		    print(statement["result"])
@@ -123,44 +134,36 @@ The `.query_raw()` method returns the full response from the server, including m
 	</TabItem>
 </Tabs>
 
-Each element in the response corresponds to one statement in the query and contains the `status`, `time`, and `result` fields.
+The response is a `dict` containing the RPC envelope. Its `result` key holds one entry per statement in the query, each with `status`, `time`, and `result` fields. Unlike `.query()`, a failed statement is reported as `"status": "ERR"` rather than raised.
 
 ## Handling multiple statements
 
-When a query string contains multiple semicolon-separated statements, `.query()` returns only the result of the **last** statement. If you need the results from every statement, use `.query_raw()` instead.
-
-The following example demonstrates the difference between the two methods for multi-statement queries.
+When a query string contains multiple semicolon-separated statements, `.execute()` returns one entry per statement, in order. Nothing is discarded, so you can unpack the results directly.
 
 <Tabs syncKey="python-sync-async">
 	<TabItem value="sync" label="Synchronous" default>
 		```python
-		last_result = db.query("""
+		created, users = db.query("""
 		    CREATE users CONTENT {"name": "Alice", "age": 30};
 		    SELECT * FROM users;
-		""")
+		""").execute()
 
-		all_results = db.query_raw("""
-		    CREATE users CONTENT {"name": "Alice", "age": 30};
-		    SELECT * FROM users;
-		""")
+		# .first() would return only the CREATE result
 		```
 	</TabItem>
 	<TabItem value="async" label="Asynchronous">
 		```python
-		last_result = await db.query("""
+		created, users = await db.query("""
 		    CREATE users CONTENT {"name": "Alice", "age": 30};
 		    SELECT * FROM users;
-		""")
+		""").execute()
 
-		all_results = await db.query_raw("""
-		    CREATE users CONTENT {"name": "Alice", "age": 30};
-		    SELECT * FROM users;
-		""")
+		# .first() would return only the CREATE result
 		```
 	</TabItem>
 </Tabs>
 
-In the example above, `last_result` contains only the `SELECT` output, while `all_results` contains the full response for both the `CREATE` and `SELECT` statements.
+`.query_raw()` returns those same per-statement results wrapped in the raw RPC envelope, with each statement's `status` and `time` alongside its `result`. Reach for it when you need that metadata, or when you want failed statements reported rather than raised.
 
 ## Learn more
 

--- a/src/content/reference/python/concepts/live-queries.mdx
+++ b/src/content/reference/python/concepts/live-queries.mdx
@@ -131,7 +131,7 @@ When you no longer need to receive notifications, call `.kill()` with the query 
 
 ## Subscribing to live queries from SurrealQL
 
-You can also initiate a live query using a [`LIVE SELECT`](/docs/reference/query-language/statements/live-select) statement through the `.query()` method. The query returns a UUID that can be passed to `.subscribe_live()` in the same way as a UUID returned by `.live()`.
+You can also initiate a live query using a [`LIVE SELECT`](/docs/reference/query-language/statements/live-select) statement through the `.query()` method. Because `.query()` returns a builder whose `.execute()` yields one entry per statement, use `.first()` to get the bare UUID, which can then be passed to `.subscribe_live()` in the same way as a UUID returned by `.live()`.
 
 This approach is useful when you need the filtering capabilities of SurrealQL, such as selecting specific fields or applying `WHERE` clauses.
 
@@ -144,7 +144,7 @@ This approach is useful when you need the filtering capabilities of SurrealQL, s
 		    db.use("surrealdb", "docs")
 		    db.signin({"username": "root", "password": "root"})
 
-		    query_uuid = db.query("LIVE SELECT * FROM users WHERE age > 18")
+		    query_uuid = db.query("LIVE SELECT * FROM users WHERE age > 18").first()
 
 		    for notification in db.subscribe_live(query_uuid):
 		        print(notification["action"])
@@ -159,7 +159,7 @@ This approach is useful when you need the filtering capabilities of SurrealQL, s
 		    await db.use("surrealdb", "docs")
 		    await db.signin({"username": "root", "password": "root"})
 
-		    query_uuid = await db.query("LIVE SELECT * FROM users WHERE age > 18")
+		    query_uuid = await db.query("LIVE SELECT * FROM users WHERE age > 18").first()
 
 		    async for notification in db.subscribe_live(query_uuid):
 		        print(notification["action"])

--- a/src/content/reference/python/concepts/transactions.mdx
+++ b/src/content/reference/python/concepts/transactions.mdx
@@ -75,7 +75,7 @@ To create a transaction, first open a session with `.new_session()` on the conne
 
 ## Executing operations within a transaction
 
-Once a transaction is created, use its methods — such as `.query()`, `.create()`, `.select()`, `.update()`, and `.delete()` — to perform operations. These operations are buffered within the transaction scope and are not visible to other connections or sessions until the transaction is committed.
+Once a transaction is created, use its methods — such as `.query()`, `.create()`, `.select()`, `.update()`, and `.delete()` — to perform operations. `.query()` returns a lazy builder, so remember to finish it with `.execute()` or `.first()`; nothing is sent to the server until you do. These operations are buffered within the transaction scope and are not visible to other connections or sessions until the transaction is committed.
 
 <Tabs syncKey="python-sync-async">
 	<TabItem value="sync" label="Synchronous" default>
@@ -92,7 +92,7 @@ Once a transaction is created, use its methods — such as `.query()`, `.create(
 		    "age": 25,
 		})
 
-		result = txn.query("SELECT * FROM users")
+		users = txn.query("SELECT * FROM users").first()
 		```
 	</TabItem>
 	<TabItem value="async" label="Asynchronous">
@@ -109,7 +109,7 @@ Once a transaction is created, use its methods — such as `.query()`, `.create(
 		    "age": 25,
 		})
 
-		result = await txn.query("SELECT * FROM users")
+		users = await txn.query("SELECT * FROM users").first()
 		```
 	</TabItem>
 </Tabs>

--- a/src/content/reference/python/concepts/value-types.mdx
+++ b/src/content/reference/python/concepts/value-types.mdx
@@ -194,10 +194,10 @@ with Surreal("ws://localhost:8000") as db:
     db.use("my_ns", "my_db")
     db.signin({"username": "root", "password": "root"})
 
-    result = db.query(
+    events = db.query(
         "SELECT * FROM events WHERE year IN $range",
         {"range": Range(BoundIncluded(2020), BoundIncluded(2025))},
-    )
+    ).first()
 ```
 
 See the [Range reference](/docs/reference/python/api/values/range) for the full API and bound types.


### PR DESCRIPTION
Closes the docs half of https://github.com/surrealdb/surrealdb.py/issues/299.

## The reported problem

The `.query()` reference states:

> **Returns:** `Value` for a single-statement query, otherwise `tuple[Value, ...]` of statement results.

That was the 3.0.0-alpha.1 contract. [surrealdb.py#285](https://github.com/surrealdb/surrealdb.py/pull/285) removed the single-statement unwrap in alpha.2, because a return shape that depends on how many statements the user's SQL string happens to contain isn't statically typeable. The shipped contract is:

- `.query(sql)` returns a **builder** — nothing is sent until you trigger it.
- `.execute()` returns `list[Value]`, one entry per statement, **always a list**.
- `.first()` returns the first statement's result. This was documented nowhere in `src/content/reference/python/`.

The page was written when the old contract was correct and was never revised. It also carried an `[!IMPORTANT] Behaviour change in v3.0` callout restating the superseded behaviour as authoritative.

## What this changes

**The return contract** — `surreal.mdx` Returns line, the v3 callout, and the `.query()` rows in `surreal-session.mdx` / `surreal-transaction.mdx`. Adds an accessor table covering `.execute()`, `.first()`, `.into(cls)` and `.into(cls, rows=True)`.

Adds a note on the two independent nesting layers, since that is what actually confused the reporter: the SDK's per-statement envelope, and SurrealQL's own array of rows that any `SELECT` without `ONLY` returns. `SELECT VALUE` collapses neither — it only replaces the row object with a scalar.

`concepts/executing-queries.mdx` was further behind still, claiming `.query()` returns only the **last** statement's result — the pre-[surrealdb.py#232](https://github.com/surrealdb/surrealdb.py/issues/232) v2 behaviour.

**Examples that never ran.** The sync builder has no `__len__`, `__iter__` or `__getitem__`, so a bare `db.query(...)` is a no-op. Several examples predating the builder were silently broken:

- `live-queries.mdx` handed a builder to `subscribe_live()` instead of the UUID
- `error-handling.mdx` and `api/errors/index.mdx` had `except` blocks that could never fire — including one whose whole purpose was to trigger a `ServerError`
- `surreal-transaction.mdx` printed `"Transfer committed"` while neither `UPDATE` was ever sent
- `query_raw` examples iterated the response dict's *keys*; the per-statement entries are under `response["result"]`. Its parameter is also `vars`, not `params` — `params=` raises `TypeError`
- plus `transactions.mdx`, `value-types.mdx`, `geometry.mdx`, `range.mdx`, and four call sites in `surreal.mdx`

## Verification

Checked against a live SurrealDB 3.2.3 server over both WebSocket and HTTP, not just read off the source: the accessor shapes, `LIVE SELECT ... .first()` yielding a bare `UUID`, `.execute()` raising where the untriggered builder doesn't, the `query_raw` envelope, and `vars` vs `params`.

## Deliberately out of scope

- **Pages outside `src/content/reference/python/`** (integrations, tutorials, `index/languages/python.mdx`, `learn/`). These target the **2.x stable** SDK — unpinned `pip install surrealdb`, and `db.connect()`. Under v2 `query()` does return results directly, so changing them would break them. They need a sweep once 3.0.0 ships stable.
- **`.query_raw()` / `.info()` / `.version()` rows** missing from the session and transaction tables — added in [surrealdb.py#300](https://github.com/surrealdb/surrealdb.py/pull/300), and they want their own parameter tables and examples.
- **Remaining v2-era `db.connect()`** in `authentication.mdx`, `connecting-to-surrealdb.mdx`, `api/types/index.mdx`, `datetime.mdx`, `duration.mdx`, `table.mdx` and `surreal-transaction.mdx`. Fixed only in the two snippets this PR was already editing. Worth noting `connect()` exists on `AsyncSurreal` but not `Surreal`, so every sync example using it raises `AttributeError` — that may be an SDK asymmetry rather than a docs problem.