### PR TITLE
Fix index-compaction and HNSW cache descriptions, surface the DS block cache

### DIFF
--- a/src/content/manage/observability/configuration.mdx
+++ b/src/content/manage/observability/configuration.mdx
@@ -302,8 +302,21 @@ A short list of the SurrealDS networking and consensus knobs that operators rout
             <td scope="row" data-label="Default"><code>500</code> / <code>5000</code></td>
             <td scope="row" data-label="Trigger">Rising <code>surrealdb_ds_finalize_prepare_retries_total</code>.</td>
         </tr>
+        <tr>
+            <td scope="row" data-label="Variable"><code>SURREAL_DS_ROCKSDB_BLOCK_CACHE_SIZE</code></td>
+            <td scope="row" data-label="Default"><code>max(memory/2 - 1 GiB, 16 MiB)</code></td>
+            <td scope="row" data-label="Trigger">Steady-state RSS pressure. The largest single consumer in a node using the RocksDB durable backend, and the cache through which full-text and vector index reads are served. The default is derived from detected memory, so set it explicitly on memory-constrained pods.</td>
+        </tr>
+        <tr>
+            <td scope="row" data-label="Variable"><code>SURREAL_DS_ROCKSDB_MAX_WRITE_BUFFER_NUMBER</code></td>
+            <td scope="row" data-label="Default">Derived from detected memory (<code>2</code>–<code>32</code>)</td>
+            <td scope="row" data-label="Trigger">RSS pressure during sustained write phases. The memtable ceiling is this value multiplied by <code>SURREAL_DS_ROCKSDB_WRITE_BUFFER_SIZE</code> and by the four heavy column families, so it is the knob to cap first when headroom is tight.</td>
+        </tr>
     </tbody>
 </table>
+
+> [!NOTE]
+> `SURREAL_DS_ROCKSDB_*` applies only when a node's store path selects the RocksDB durable backend. Memtable and block-cache memory are bounded together by a write-buffer manager that stalls writes on reaching the limit rather than failing them, so an undersized budget presents as write latency rather than errors.
 
 ## Recommended configurations
 

--- a/src/content/manage/observability/configuration.mdx
+++ b/src/content/manage/observability/configuration.mdx
@@ -303,12 +303,12 @@ A short list of the SurrealDS networking and consensus knobs that operators rout
             <td scope="row" data-label="Trigger">Rising <code>surrealdb_ds_finalize_prepare_retries_total</code>.</td>
         </tr>
         <tr>
-            <td scope="row" data-label="Variable"><code>SURREAL_DS_ROCKSDB_BLOCK_CACHE_SIZE</code></td>
+            <td scope="row" data-label="Variable"><code>SURREAL_DS_ROCKSDB_BLOCK_CACHE_SIZE</code><Since v="v3.1.1" /></td>
             <td scope="row" data-label="Default"><code>max(memory/2 - 1 GiB, 16 MiB)</code></td>
             <td scope="row" data-label="Trigger">Steady-state RSS pressure. The largest single consumer in a node using the RocksDB durable backend, and the cache through which full-text and vector index reads are served. The default is derived from detected memory, so set it explicitly on memory-constrained pods.</td>
         </tr>
         <tr>
-            <td scope="row" data-label="Variable"><code>SURREAL_DS_ROCKSDB_MAX_WRITE_BUFFER_NUMBER</code></td>
+            <td scope="row" data-label="Variable"><code>SURREAL_DS_ROCKSDB_MAX_WRITE_BUFFER_NUMBER</code><Since v="v3.1.1" /></td>
             <td scope="row" data-label="Default">Derived from detected memory (<code>2</code>–<code>32</code>)</td>
             <td scope="row" data-label="Trigger">RSS pressure during sustained write phases. The memtable ceiling is this value multiplied by <code>SURREAL_DS_ROCKSDB_WRITE_BUFFER_SIZE</code> and by the four heavy column families, so it is the knob to cap first when headroom is tight.</td>
         </tr>

--- a/src/content/reference/cli/surrealdb-cli/environment-variables.mdx
+++ b/src/content/reference/cli/surrealdb-cli/environment-variables.mdx
@@ -89,7 +89,7 @@ These environment variables can be used to configure a SurrealDB server to confi
       <td scope="row" data-label="Env var"><code>SURREAL_HNSW_CACHE_SIZE</code></td>
       <td scope="row" data-label="Default">268,435,456 (256 MiB)</td>
       <td scope="row" data-label="Allowed values">A usize</td>
-      <td scope="row" data-label="Notes">The maximum size of the HNSW vector cache.</td>
+      <td scope="row" data-label="Notes">The maximum total size, in bytes, of the HNSW index cache, shared across all HNSW indexes in the process. HNSW graph data lives in the key-value store and is paged through this bounded cache.</td>
     </tr>
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_DISKANN_CACHE_SIZE</code><Since v="v3.1.0" /></td>
@@ -1159,7 +1159,7 @@ surreal start --allow-all true
       <td scope="row" data-label="Command">`start`</td>
       <td scope="row" data-label="Default">5s</td>
       <td scope="row" data-label="Allowed values">A duration</td>
-      <td scope="row" data-label="Notes">The interval at which to perform changefeed garbage collection.</td>
+      <td scope="row" data-label="Notes">The interval at which to compact queued index updates. Writes to a full-text, count, or HNSW index enqueue pending updates that a background task folds into the index; this controls how often that task runs. One node in a cluster performs the work for the whole cluster. Lengthening the interval allows the pending backlog to grow, which increases the work each subsequent query must do to read through it.</td>
     </tr>
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_KEY</code></td>

--- a/src/content/reference/query-language/statements/define/indexes.mdx
+++ b/src/content/reference/query-language/statements/define/indexes.mdx
@@ -424,7 +424,7 @@ Used to determine the maximum level ll for a new element during its insertion in
 
 <Since v="v3.0.0" />
 
-HNSW vector search uses a bounded memory cache by default, reducing memory spikes and improving stability under load. The default size for the cache is 256 MiB, and can be modified via the `SURREAL_HNSW_CACHE_SIZE` [environment variable](/docs/reference/cli/surrealdb-cli/environment-variables).
+HNSW vector search uses a bounded memory cache by default, reducing memory spikes and improving stability under load. The cache is a single budget **shared across every HNSW index** in the process, not a per-index allowance. It defaults to 256 MiB and can be modified via the `SURREAL_HNSW_CACHE_SIZE` [environment variable](/docs/reference/cli/surrealdb-cli/environment-variables). The value is an integer number of bytes — for example, `268435456` for the 256 MiB default.
 
 ### DISKANN (disk-based approximate nearest neighbours)
 


### PR DESCRIPTION
## Why

A customer running 3.2.4 in a 3-node SurrealDS cluster asked what to expect from memory with a large number of full-text indexes. Working through the answer turned up three wrong or ambiguous entries and one gap, all in index-related configuration docs.

## Corrections

**1. `SURREAL_INDEX_COMPACTION_INTERVAL` was described as changefeed GC.** Its Notes cell read *"The interval at which to perform changefeed garbage collection"* — the description belonging to the `SURREAL_CHANGEFEED_GC_INTERVAL` row above it. Replaced with what the setting controls, including the consequence of raising it: pending index updates accumulate, and every subsequent query reads through that backlog.

The root cause is upstream — the CLI flag has no `help` text, so the docs had nothing to draw on. Fixed separately in `surrealdb-private` ([PR #915](https://github.com/surrealdb/surrealdb-private/pull/915)).

**2. `SURREAL_HNSW_CACHE_SIZE` read as per-index.** It said only *"The maximum size of the HNSW vector cache"*. It is a single process-wide total shared by every HNSW index. The `SURREAL_DISKANN_CACHE_SIZE` row directly below already said so; this brings them in line.

**3. The DEFINE INDEX page had the same ambiguity.** Its HNSW subsection gave the 256 MiB default without saying the budget is shared, while the DISKANN subsection immediately below it was explicit. Matched them and added the byte-value example DISKANN already had.

## Addition

**`SURREAL_DS_ROCKSDB_BLOCK_CACHE_SIZE` in the observability knob table.** That table lists the SurrealDS settings operators tune against a metric signal, and already names steady-state RSS pressure as a trigger for `SURREAL_DS_MAX_READ_OPERATIONS` — but omitted the storage layer beneath it, where most of a node's memory actually sits. The block cache is the largest single consumer and the cache through which full-text and vector index reads are served, so it belongs in exactly that table. Added `MAX_WRITE_BUFFER_NUMBER` alongside it as the knob to cap first when write-phase headroom is tight.

The note records that memtables and block cache are bounded together and that exceeding the budget stalls writes rather than failing them, so operators read write latency correctly.

The complete 36-variable `SURREAL_DS_ROCKSDB_*` reference goes in the Enterprise Kubernetes deployment guide, which is where this page already points readers and which previously covered none of them.

## Not done here

`commands/start.mdx` embeds a `surreal start --help` transcript that still shows `--index-compaction-interval` with no description. Regenerating it now would document help text no released binary emits; it should follow the release carrying the upstream fix.