### PR TITLE
Correct the HNSW cache scope and the DS write-stall mechanism

### DIFF
--- a/src/content/manage/observability/configuration.mdx
+++ b/src/content/manage/observability/configuration.mdx
@@ -254,14 +254,14 @@ Controls the [Enterprise slow-query log pipeline](/docs/manage/observability/slo
     </tbody>
 </table>
 
-## SurrealDS networking
+## SurrealDS networking, consensus and storage
 
 <Edition value="enterprise" />
 
 > [!NOTE]
 > **SurrealDS** is SurrealDB's distributed storage engine for highly available, horizontally scalable clusters. The `SURREAL_DS_*` variables below apply when that runtime is deployed — on [SurrealDB Cloud Scale](https://surrealdb.com/pricing/scale) or in self-hosted Enterprise installations.
 
-A short list of the SurrealDS networking and consensus knobs that operators routinely tune in response to a metric signal. For a product overview, see [SurrealDS](https://surrealdb.com/platform/surrealds). The complete `SURREAL_DS_*` reference is part of the Enterprise Kubernetes deployment guide.
+A short list of the SurrealDS networking, consensus and storage-memory knobs that operators routinely tune in response to a metric signal. For a product overview, see [SurrealDS](https://surrealdb.com/platform/surrealds). The complete `SURREAL_DS_*` reference is part of the Enterprise Kubernetes deployment guide.
 
 <table>
     <thead>
@@ -305,7 +305,7 @@ A short list of the SurrealDS networking and consensus knobs that operators rout
         <tr>
             <td scope="row" data-label="Variable"><code>SURREAL_DS_ROCKSDB_BLOCK_CACHE_SIZE</code><Since v="v3.1.1" /></td>
             <td scope="row" data-label="Default"><code>max(memory/2 - 1 GiB, 16 MiB)</code></td>
-            <td scope="row" data-label="Trigger">Steady-state RSS pressure. The largest single consumer in a node using the RocksDB durable backend, and the cache through which full-text and vector index reads are served. The default is derived from detected memory, so set it explicitly on memory-constrained pods.</td>
+            <td scope="row" data-label="Trigger">Steady-state RSS pressure. The largest single consumer in a node using the RocksDB durable backend. Full-text index reads are served through it entirely; vector index reads hit it on load and on cache misses. The default is derived from detected memory, so set it explicitly on memory-constrained pods.</td>
         </tr>
         <tr>
             <td scope="row" data-label="Variable"><code>SURREAL_DS_ROCKSDB_MAX_WRITE_BUFFER_NUMBER</code><Since v="v3.1.1" /></td>
@@ -316,7 +316,7 @@ A short list of the SurrealDS networking and consensus knobs that operators rout
 </table>
 
 > [!NOTE]
-> `SURREAL_DS_ROCKSDB_*` applies only when a node's store path selects the RocksDB durable backend. Memtable and block-cache memory are bounded together by a write-buffer manager that stalls writes on reaching the limit rather than failing them, so an undersized budget presents as write latency rather than errors.
+> `SURREAL_DS_ROCKSDB_*` applies only when a node's store path selects the RocksDB durable backend. Memtable and block-cache memory are accounted together, and an undersized write budget presents as write latency rather than errors — but the operative limits are the per-column-family memtable count and the L0 compaction trigger, not the combined ceiling. `SURREAL_DS_ROCKSDB_WRITE_BUFFER_SIZE` sets the per-column-family memtable size; the complete reference is in the Enterprise Kubernetes deployment guide.
 
 ## Recommended configurations
 

--- a/src/content/reference/cli/surrealdb-cli/environment-variables.mdx
+++ b/src/content/reference/cli/surrealdb-cli/environment-variables.mdx
@@ -105,7 +105,7 @@ These environment variables can be used to configure a SurrealDB server to confi
       <td scope="row" data-label="Env var"><code>SURREAL_HNSW_CACHE_SIZE</code></td>
       <td scope="row" data-label="Default">268,435,456 (256 MiB)</td>
       <td scope="row" data-label="Allowed values">A usize</td>
-      <td scope="row" data-label="Notes">The maximum total size, in bytes, of the HNSW index cache, shared across all HNSW indexes in the process. HNSW graph data lives in the key-value store and is paged through this bounded cache.</td>
+      <td scope="row" data-label="Notes">The maximum total size, in bytes, of the HNSW vector cache, shared across all HNSW indexes in the process. This bounds the cached element <em>vectors</em> used for distance computation — it is not a cap on total HNSW memory: the adjacency graph is loaded into resident memory on first use and stays there, outside this budget. Contrast <code>SURREAL_DISKANN_CACHE_SIZE</code>, which does page graph structure.</td>
     </tr>
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_DISKANN_CACHE_SIZE</code><Since v="v3.1.0" /></td>
@@ -1183,7 +1183,7 @@ surreal start --allow-all true
       <td scope="row" data-label="Command">`start`</td>
       <td scope="row" data-label="Default">5s</td>
       <td scope="row" data-label="Allowed values">A duration</td>
-      <td scope="row" data-label="Notes">The interval at which to compact queued index updates. Writes to a full-text, count, or HNSW index enqueue pending updates that a background task folds into the index; this controls how often that task runs. One node in a cluster performs the work for the whole cluster. Lengthening the interval allows the pending backlog to grow, which increases the work each subsequent query must do to read through it.</td>
+      <td scope="row" data-label="Notes">The interval at which to compact queued index updates. Writes to a full-text, count, or vector index enqueue pending updates that a background task folds into the index; this controls how often that task runs. One node in a cluster performs the work for the whole cluster. Lengthening the interval allows the pending backlog to grow, which increases the work each subsequent query must do to read through it.</td>
     </tr>
     <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_KEY</code></td>

--- a/src/content/reference/query-language/statements/define/indexes.mdx
+++ b/src/content/reference/query-language/statements/define/indexes.mdx
@@ -424,7 +424,9 @@ Used to determine the maximum level ll for a new element during its insertion in
 
 <Since v="v3.0.0" />
 
-HNSW vector search uses a bounded memory cache by default, reducing memory spikes and improving stability under load. The cache is a single budget **shared across every HNSW index** in the process, not a per-index allowance. It defaults to 256 MiB and can be modified via the `SURREAL_HNSW_CACHE_SIZE` [environment variable](/docs/reference/cli/surrealdb-cli/environment-variables). The value is an integer number of bytes — for example, `268435456` for the 256 MiB default.
+HNSW vector search caches element vectors in a bounded memory cache, reducing memory spikes and improving stability under load. The cache is a single budget **shared across every HNSW index** in the process, not a per-index allowance. It defaults to 256 MiB and can be modified via the `SURREAL_HNSW_CACHE_SIZE` [environment variable](/docs/reference/cli/surrealdb-cli/environment-variables). The value is an integer number of bytes — for example, `268435456` for the 256 MiB default.
+
+This budget covers the cached **vectors** only. As noted above, the HNSW graph itself is held in memory: it is loaded on first use and is not bounded by this setting, so it must be sized for separately. If the full graph will not fit in RAM, DISKANN below is the index designed for that case.
 
 ### DISKANN (disk-based approximate nearest neighbours)
 


### PR DESCRIPTION
Follow-up to [#1915](https://github.com/surrealdb/docs.surrealdb.com/pull/1915), which merged before these corrections were pushed. **Both errors below are currently live on `main`, and I introduced both in that PR.**

## 1. The HNSW cache row is backwards (the important one)

Currently on `main`:

> The maximum total size, in bytes, of the HNSW index cache, shared across all HNSW indexes in the process. **HNSW graph data lives in the key-value store and is paged through this bounded cache.**

That second sentence describes **DISKANN**, not HNSW. I copied it from the DISKANN row.

What the source actually does:

- `HnswCache` holds `Vector` / `DocSet` / `DocId` entries — there is no graph or edge family.
- The adjacency graph is an in-memory `HashMap<ElementId, _>` per layer (`UndirectedGraph`), loaded on first use and retained for the datastore's lifetime.

So `SURREAL_HNSW_CACHE_SIZE` bounds cached **vectors**, and there is no setting that caps total HNSW memory. As written the row tells anyone sizing a pod the opposite, which is the worst direction for this particular error.

It also contradicted two things already in the docs:

- `define/indexes.mdx`: "Keep in mind the **in-memory nature of HNSW** when considering system resource allocation."
- The DISKANN section, which exists precisely for sets "where keeping the full graph in RAM (**as with HNSW**) is impractical".

Since the HNSW row had been reworded to match the DISKANN row verbatim, the distinction the vector-index docs are built around was erased. Both the env-var row and the DEFINE INDEX paragraph now state what the budget covers and that the graph sits outside it.

## 2. The write-stall note points at the wrong limit

Currently on `main`, in the SurrealDS knob table:

> Memtable and block-cache memory are bounded together by a write-buffer manager that **stalls writes on reaching the limit** rather than failing them.

Stalling is enabled (`allow_stall = true`), but the manager's threshold is the **combined** ceiling — memtables *plus* `block_cache_size` — while its accounting tracks only memtable arena memory. Memtable memory is separately capped at `4 x (WRITE_BUFFER_SIZE x MAX_WRITE_BUFFER_NUMBER) + 8 MiB` by the per-column-family `MAX_WRITE_BUFFER_NUMBER`, which sits below that threshold by the entire cache size (3–31 GiB at the derived defaults).

The manager's stall path is therefore not the one an operator reaches. Real stalls come from the per-CF memtable limit and the L0 compaction trigger. The conclusion ("latency, not errors") still holds; the mechanism and therefore the knob to tune did not.

## 3. Smaller, same PR

- The block-cache entry said full-text **and vector** index reads are served through it. True for full-text, loose for vector — HNSW traversal runs off the resident graph, so the store serves load and misses.
- Widened the section heading and lead-in, which promised "networking and consensus" knobs while now carrying two storage-memory ones.

## Provenance

Found by a review pass over my own merged changes, verified against the source at `v3.0.0`, `v3.1.0`, `v3.2.4` and `main` (the HNSW cache/graph split is the same at every one, so this is not a version-drift issue — the row was simply wrong).

Not built locally: the worktree has no `node_modules`. Content-only edits inside existing cells and one paragraph, no new components.