### PR TITLE
Fix 500 error on SurrealDB Studio docs

### DIFF
--- a/src/content/explore/studio/__category.json
+++ b/src/content/explore/studio/__category.json
@@ -1,9 +1,5 @@
 {
     "position": 1,
     "title": "SurrealDB Studio",
-    "icon": "grid",
-    "search": {
-        "label": "SurrealDB Studio",
-        "kind": "tool"
-    }
+    "icon": "grid"
 }


### PR DESCRIPTION
## Problem

`https://surrealdb.com/docs/explore/studio` returns a **500** in production:

```
$ curl -o /dev/null -w "%{http_code}" https://surrealdb.com/docs/explore/studio
500
```

## Cause

`src/content/explore/studio/__category.json` declared a `search` object:

```json
"search": {
    "label": "SurrealDB Studio",
    "kind": "tool"
}
```

`pageSchema` in `src/utils/schema.ts` is a `strictObject`, so the unknown key
fails validation and `vike-content-collection` drops the **whole** collection:

```
[vike-content-collection] Failed to process collection "explore/studio":
  Schema validation failed:
  src/content/explore/studio/__category.json: Unrecognized key: "search"
```

With no entries in the collection, `+onBeforePrerenderStart.ts` produced no
URLs, so `/explore/studio` was never prerendered. Requests fell through to the
SSR function, where the missing entry surfaced as a 500 in production (in dev
the same failure shows as a 302 back to the parent path).

## Fix

Removes the `search` block. Nothing in the codebase reads a `search` key on
category metadata, and no other `__category.json` declares one — it was dead
config that happened to break the collection.

## Verification

Before, against the dev server:

```
/docs/explore/studio     -> 302
/docs/explore/ml-models  -> 200
/docs/explore/tutorials  -> 200
```

After:

```
/docs/explore/studio     -> 200
/docs/explore/ml-models  -> 200
/docs/explore/tutorials  -> 200
```

The page renders with its sidebar entry, breadcrumb, title, body and button,
and the dev server reports no collection-processing errors. `bun run qa` and
`bun run qc` are clean (the one remaining warning is a pre-existing file-size
warning unrelated to this change).

## Follow-up worth considering

A single unrecognised frontmatter key silently discards an entire collection and
turns into a production 500 — the build still succeeds and deploys. Failing the
build on collection schema errors would catch this class of bug before release.