### PR TITLE
Update Rust SDK docs

### DIFF
--- a/src/content/reference/rust/concepts/rust-after-3.0.mdx
+++ b/src/content/reference/rust/concepts/rust-after-3.0.mdx
@@ -354,6 +354,98 @@ async fn main() {
 }
 ```
 
+## Value construction macros
+
+Alongside `kind!`, the crate exports four macros for building values by hand: `object!`, `array!`, `set!` and `vars!`. Each is available from `surrealdb::types` as well as from `surrealdb_types` directly.
+
+| Macro | Builds | Notes |
+| ----- | ------ | ----- |
+| `object!` | `Object` | Keys can be bare identifiers or quoted string literals |
+| `array!` | `Array` | Uses square brackets, like `vec!` |
+| `set!` | `Set` | Deduplicates its items; takes `Value`s, not raw Rust values |
+| `vars!` | `Variables` | Same syntax as `object!`, used for `.bind()` after `.query()` |
+
+Values passed to `object!`, `array!` and `vars!` only need to implement `SurrealValue`, so ordinary Rust types can be used directly.
+
+```rust
+use surrealdb::types::{Value, array, object, set};
+
+fn main() {
+    let obj = object! {
+        name: "Aeon",
+        age: 30,
+        "home-town": "Bregna",
+    };
+
+    let arr = array![1, "two", true];
+
+    let tags = set! {
+        Value::from_t("rust"),
+        Value::from_t("surrealdb"),
+        Value::from_t("rust"),
+    };
+
+    println!("{obj:?}");
+    println!("{arr:?}");
+    println!("{tags:?}");
+}
+```
+
+Output:
+
+```
+Object({"age": Number(Int(30)), "home-town": String("Bregna"), "name": String("Aeon")})
+Array([Number(Int(1)), String("two"), Bool(true)])
+Set({String("rust"), String("surrealdb")})
+```
+
+Note the two differences between `array!` and `set!`. `set!` drops the duplicate `"rust"`, and it does not convert its items for you: each one must already be a `Value`. Passing `set! { 1, 2, 3 }` will not compile, while `array![1, 2, 3]` will.
+
+### The `vars!` macro
+
+`vars!` builds a `Variables` map, which is what the [`.bind()`](/docs/reference/rust/methods/query#binding-parameters) method on a query takes. It is the most direct way to pass more than one parameter into a query.
+
+```rust
+use surrealdb::engine::any::connect;
+use surrealdb::types::{RecordId, SurrealValue, vars};
+
+#[derive(Debug, SurrealValue)]
+struct Person {
+    id: RecordId,
+    name: String,
+    age: i64,
+}
+
+#[tokio::main]
+async fn main() -> surrealdb::Result<()> {
+    let db = connect("mem://").await?;
+    db.use_ns("main").use_db("main").await?;
+
+    let sql = "
+        CREATE type::table($table) SET name = $name, age = $age;
+        SELECT * FROM type::table($table) WHERE age >= $min_age;
+    ";
+
+    let mut result = db
+        .query(sql)
+        .bind(vars! {
+            table: "person",
+            name: "Aeon",
+            age: 30,
+            min_age: 18,
+        })
+        .await?;
+
+    let created: Option<Person> = result.take(0)?;
+    dbg!(created);
+    let adults: Vec<Person> = result.take(1)?;
+    dbg!(adults);
+    Ok(())
+}
+```
+
+`Variables` is an ordinary struct as well as a macro target. `Variables::new()` followed by `.insert()` builds the same value at runtime, which is the better choice when the set of parameters is not known when the code is written.
+
 ## Convenience methods for the `Value` type
 
 Importing the `SurrealValue` trait gives access to a lot of convenience methods.

--- a/src/content/reference/rust/methods/connect.mdx
+++ b/src/content/reference/rust/methods/connect.mdx
@@ -60,6 +60,56 @@ async fn main() -> surrealdb::Result<()> {
 }
 ```
 
+### Connecting over gRPC
+
+<Since v="v3.3.0" />
+
+Alongside WebSocket and HTTP, the SDK can talk to a server over gRPC. The server exposes it on the same address and port as the other two, so no extra server configuration is needed.
+
+gRPC is the only remote protocol that delivers query results incrementally, which is what makes [`.stream_items()`](/docs/reference/rust/methods/query#stream-items) worthwhile on a remote connection. On WebSocket and HTTP the results are buffered and replayed instead.
+
+The engine is behind the `protocol-grpc` feature, which is not enabled by default:
+
+```toml title="Cargo.toml"
+surrealdb = { version = "3", features = ["protocol-grpc"] }
+```
+
+Use `Grpc` for a plain connection and `Grpcs` for a TLS one, in the same way as `Ws` and `Wss`.
+
+```rust
+use surrealdb::Surreal;
+use surrealdb::engine::remote::grpc::Grpc;
+use surrealdb::opt::auth::Root;
+use surrealdb::types::Value;
+
+#[tokio::main]
+async fn main() -> surrealdb::Result<()> {
+    let db = Surreal::new::<Grpc>("127.0.0.1:8000").await?;
+
+    db.signin(Root {
+        username: "root".to_string(),
+        password: "secret".to_string(),
+    })
+    .await?;
+
+    db.use_ns("main").use_db("main").await?;
+
+    let mut res = db.query("RETURN 1 + 1").await?;
+    println!("{:?}", res.take::<Value>(0)?);
+    Ok(())
+}
+```
+
+The `any` engine accepts `grpc://` and `grpcs://` URLs, so a connection can be chosen at runtime in the same way as `ws://` or `http://`.
+
+```rust
+let db = surrealdb::engine::any::connect("grpc://127.0.0.1:8000").await?;
+```
+
+> [!NOTE]
+> A `grpc://` URL passed to `any::connect()` in a build without the `protocol-grpc` feature fails at connection time rather than at compile time, with `Cannot connect to the gRPC remote engine as it is not enabled in this build of SurrealDB`. The engine is also unavailable on `wasm32` targets, as its underlying transport does not build for them.
+
 ### See also
 
 * [.connect() method on Docs.rs](https://docs.rs/surrealdb/latest/surrealdb/engine/any/fn.connect.html)
+* [Streaming query results with `.stream_items()`](/docs/reference/rust/methods/query#stream-items)

--- a/src/content/reference/rust/methods/new.mdx
+++ b/src/content/reference/rust/methods/new.mdx
@@ -76,6 +76,107 @@ async fn main() -> Result<(), Error> {
 }
 ```
 
+##### Config options
+
+`Config` is a builder with methods that can be chained. `Config::new()` and `Config::default()` are equivalent starting points.
+
+<table>
+    <thead>
+        <tr>
+            <th scope="col">Method</th>
+            <th scope="col">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td scope="row" data-label="Method"><code>.user(root)</code></td>
+            <td scope="row" data-label="Description">Sets the root user the local engines start with. Takes an <code>opt::auth::Root</code>.</td>
+        </tr>
+        <tr>
+            <td scope="row" data-label="Method"><code>.capabilities(caps)</code></td>
+            <td scope="row" data-label="Description">Sets which functions, network targets, scripting and live queries are permitted. See <a href="/docs/learn/security/authorization/capabilities">Capabilities</a>.</td>
+        </tr>
+        <tr>
+            <td scope="row" data-label="Method"><code>.query_timeout(duration)</code></td>
+            <td scope="row" data-label="Description">Maximum time a single query may run for.</td>
+        </tr>
+        <tr>
+            <td scope="row" data-label="Method"><code>.transaction_timeout(duration)</code></td>
+            <td scope="row" data-label="Description">Maximum time a transaction may stay open for.</td>
+        </tr>
+        <tr>
+            <td scope="row" data-label="Method"><code>.ast_payload()</code></td>
+            <td scope="row" data-label="Description">Sends queries as a parsed AST rather than as text. <code>.set_ast_payload(bool)</code> sets the same option from a variable.</td>
+        </tr>
+        <tr>
+            <td scope="row" data-label="Method"><code>.websocket(config)</code></td>
+            <td scope="row" data-label="Description">Sets the WebSocket buffer sizes. Returns a <code>Result</code>, as the maximum write buffer must be larger than the write buffer.</td>
+        </tr>
+        <tr>
+            <td scope="row" data-label="Method"><code>.rustls(config)</code>, <code>.native_tls(config)</code></td>
+            <td scope="row" data-label="Description">Configures TLS. Each requires the matching feature flag. Neither is covered by the SDK's stability guarantee, as the underlying crate is not yet stable.</td>
+        </tr>
+        <tr>
+            <td scope="row" data-label="Method"><code>.temporary_directory(path)</code></td>
+            <td scope="row" data-label="Description">Where the local engines spill temporary data. Requires a storage backend feature flag.</td>
+        </tr>
+        <tr>
+            <td scope="row" data-label="Method"><code>.changefeed_gc_interval(duration)</code></td>
+            <td scope="row" data-label="Description">How often expired change feed entries are collected.</td>
+        </tr>
+        <tr>
+            <td scope="row" data-label="Method"><code>.node_membership_refresh_interval(duration)</code>, <code>.node_membership_check_interval(duration)</code>, <code>.node_membership_cleanup_interval(duration)</code></td>
+            <td scope="row" data-label="Description">Intervals for the node maintenance tasks the local engines run. A zero duration is treated as unset.</td>
+        </tr>
+    </tbody>
+</table>
+
+An example of the `Config` builder used to set a number of attributes in a single chain:
+
+```rust
+use std::time::Duration;
+
+use surrealdb::engine::any::connect;
+use surrealdb::opt::Config;
+use surrealdb::opt::auth::Root;
+use surrealdb::opt::capabilities::Capabilities;
+
+#[tokio::main]
+async fn main() -> surrealdb::Result<()> {
+    let config = Config::new()
+        .user(Root {
+            username: "root".to_string(),
+            password: "secret".to_string(),
+        })
+        .query_timeout(Duration::from_secs(5))
+        .transaction_timeout(Duration::from_secs(10))
+        .capabilities(
+            Capabilities::all()
+                .with_function_denied("http::*")
+                .unwrap(),
+        );
+
+    let db = connect(("mem://", config)).await?;
+    db.signin(Root {
+        username: "root".to_string(),
+        password: "secret".to_string(),
+    })
+    .await?;
+    db.use_ns("main").use_db("main").await?;
+
+    println!("{:?}", db.query("RETURN http::get('https://example.com')").await?);
+    Ok(())
+}
+```
+
+The denied function shows up as an error on the statement rather than on the call as a whole:
+
+```
+Err(Error { code: -32602, message: "Function 'http::get' is not allowed to be executed", details: NotAllowed(Some(Function { name: "http::get" })), cause: None })
+```
+
+Note that the `Capabilities` methods that take a function or network target parse their argument, so they return a `Result`. The pairs come in two shapes: `allow_function` / `deny_function` take `&mut self`, while `with_function_allowed` / `with_function_denied` consume and return the value, which is what makes them chainable.
+
 #### Using a backend with versioning
 
 To make a new connection that includes SurrealKV versioning, add the "kv-surrealkv" feature flag to the `surrealdb` dependency in `Cargo.toml`, add the path to the folder containing the database inside `new()`, and call the `.versioned()` method. Versioning is also available with the memory backend.

--- a/src/content/reference/rust/methods/query.mdx
+++ b/src/content/reference/rust/methods/query.mdx
@@ -201,6 +201,95 @@ Errors: {2: InternalError("Tried to set `$x`, but couldn't coerce value: Expecte
 Successes: IndexedResults { results: {0: (DbResultStats { execution_time: Some(301.375µs), query_type: Some(Other) }, Ok(None)), 3: (DbResultStats { execution_time: Some(2.278083ms), query_type: Some(Other) }, Ok(Array(Array([Object(Object({"id": RecordId(RecordId { table: Table("person"), key: String("yq7gxgm3ffkr4kibumeb") })}))]))))}, live_queries: {} }
 ```
 
+### Binding parameters (`.bind()`) {#binding-parameters}
+
+The [`.bind()`](https://docs.rs/surrealdb/latest/surrealdb/method/struct.Query.html#method.bind) method sets the parameters that a query refers to with SurrealQL's `$` syntax. It accepts anything that implements `IntoVariables`, which covers any type implementing `SurrealValue` that converts into an object, plus key-value pairs.
+
+<table>
+    <thead>
+        <tr>
+            <th scope="col">Form</th>
+            <th scope="col">Example</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td scope="row" data-label="Form">A single key-value pair</td>
+            <td scope="row" data-label="Example"><code>.bind(("table", "person"))</code></td>
+        </tr>
+        <tr>
+            <td scope="row" data-label="Form">The <code>vars!</code> macro</td>
+            <td scope="row" data-label="Example"><code>.bind(vars! { table: "person", min_age: 18 })</code></td>
+        </tr>
+        <tr>
+            <td scope="row" data-label="Form">The <code>object!</code> macro</td>
+            <td scope="row" data-label="Example"><code>.bind(object! { table: "person" })</code></td>
+        </tr>
+        <tr>
+            <td scope="row" data-label="Form">A struct deriving <code>SurrealValue</code></td>
+            <td scope="row" data-label="Example"><code>.bind(Filters { min_age: 18 })</code></td>
+        </tr>
+        <tr>
+            <td scope="row" data-label="Form">A map, such as <code>HashMap&lt;String, Value&gt;</code></td>
+            <td scope="row" data-label="Example"><code>.bind(map)</code></td>
+        </tr>
+    </tbody>
+</table>
+
+The [`vars!`](/docs/reference/rust/concepts/rust-after-30#the-vars-macro) macro is the most direct way to set several parameters at once, as each pair is written in place rather than chained one call at a time.
+
+```rust
+use surrealdb::engine::any::connect;
+use surrealdb::types::{RecordId, SurrealValue, vars};
+
+#[derive(Debug, SurrealValue)]
+struct Person {
+    id: RecordId,
+    name: String,
+    age: i64,
+}
+
+#[tokio::main]
+async fn main() -> surrealdb::Result<()> {
+    let db = connect("memory").await?;
+    db.use_ns("ns").use_db("db").await?;
+
+    let statements = "
+        CREATE type::table($table) SET name = $name, age = $age;
+        SELECT * FROM type::table($table) WHERE age >= $min_age;
+    ";
+
+    let mut result = db
+        .query(statements)
+        .bind(vars! {
+            table: "person",
+            name: "Aeon",
+            age: 30,
+            min_age: 18,
+        })
+        .await?;
+
+    let created: Option<Person> = result.take(0)?;
+    dbg!(created);
+    let adults: Vec<Person> = result.take(1)?;
+    dbg!(adults);
+    Ok(())
+}
+```
+
+Calls to `.bind()` accumulate rather than replace, so parameters can be gathered from more than one place before the query is awaited. A later call wins if it repeats a name.
+
+```rust
+let mut result = db
+    .query("RETURN [$a, $b]")
+    .bind(vars! { a: 1 })
+    .bind(vars! { b: 2 })
+    .await?;
+```
+
+> [!NOTE]
+> A binding error is not raised at the point of the `.bind()` call. It is held until the query is awaited, and surfaces there as the result of the whole query.
+
 ### Per-statement stats (`.with_stats()`)
 
 The [`.with_stats()`](https://docs.rs/surrealdb/latest/surrealdb/method/struct.Query.html#method.with_stats) method can be used on the query builder before awaiting the future. The awaited value is [`WithStats<IndexedResults>`](https://docs.rs/surrealdb/latest/surrealdb/method/query/struct.WithStats.html), which wraps the usual [`IndexedResults`](https://docs.rs/surrealdb/latest/surrealdb/method/query/struct.IndexedResults.html) so each `.take(...)` can return both [`Stats`](https://docs.rs/surrealdb/latest/surrealdb/method/struct.Stats.html) (including execution time) and the deserialized statement result.
@@ -277,6 +366,64 @@ To test the live stream, either log in using SurrealDB Studio or the CLI using t
 Notification { query_id: Uuid(3bad02bb-fd1e-402b-9a43-5b3eae88f279), action: Create, data: Object(Object({"id": RecordId(RecordId { table: Table("person"), key: String("zhby5ibqh8b2hfyyao30") })})) }
 Notification { query_id: Uuid(829d7ec7-d67c-47ef-bd7c-8b3e10b8d149), action: Create, data: Object(Object({"id": RecordId(RecordId { table: Table("cat"), key: String("cgu921pkfco7uk7ajeym") })})) }
 ```
+
+### Stream results as they arrive (`.stream_items()`) {#stream-items}
+
+<Since v="v3.3.0" />
+
+Awaiting a query gives an `IndexedResults`, which holds the entire result set in memory and yields nothing until the last row has been read. The [`.stream_items()`](https://docs.rs/surrealdb/latest/surrealdb/method/struct.Query.html#method.stream_items) method returns an [`ItemStream`](https://docs.rs/surrealdb/latest/surrealdb/method/query/struct.ItemStream.html) instead, so a large `SELECT` can be processed while the server is still producing it. The stream implements [`futures::Stream`](https://docs.rs/futures/latest/futures/stream/trait.Stream.html) and yields [`StreamItem`](https://docs.rs/surrealdb/latest/surrealdb/method/query/enum.StreamItem.html) values, of which there are two:
+
+* `StreamItem::Row` carries one row along with the index of the statement that produced it.
+* `StreamItem::StatementEnd` marks a statement as finished, and carries its stats and its `Result`.
+
+```rust
+use futures::StreamExt;
+use surrealdb::engine::any::connect;
+use surrealdb::method::StreamItem;
+
+#[tokio::main]
+async fn main() -> surrealdb::Result<()> {
+    let db = connect("memory").await?;
+    db.use_ns("ns").use_db("db").await?;
+
+    db.query("CREATE person:ada SET name = 'Ada'; CREATE person:grace SET name = 'Grace';")
+        .await?
+        .check()?;
+
+    let mut rows = db.query("SELECT name FROM person").stream_items()?;
+
+    while let Some(item) = rows.next().await {
+        match item? {
+            StreamItem::Row { statement, value } => {
+                println!("statement {statement} produced {value:?}");
+            }
+            StreamItem::StatementEnd { statement, stats, result } => {
+                result?;
+                println!("statement {statement} finished in {:?}", stats.execution_time);
+            }
+        }
+    }
+    Ok(())
+}
+```
+
+Output:
+
+```
+statement 0 produced Object(Object({"name": String("Ada")}))
+statement 0 produced Object(Object({"name": String("Grace")}))
+statement 0 finished in Some(1.8045ms)
+```
+
+> [!IMPORTANT]
+> Rows are provisional until their statement ends. A statement can still fail on a later row, and a `BEGIN … COMMIT` block can still roll back, so a `StatementEnd` carrying an error retracts every row that preceded it. Code that acts on rows as they arrive has to be able to undo that.
+
+Two further points worth knowing:
+
+* Only some engines stream incrementally. The embedded engines (`mem://`, `rocksdb://`, `surrealkv://` and file paths) and the gRPC remote engine (`grpc://`) deliver rows as the server produces them. The WebSocket and HTTP engines have no incremental path, so they run the query to completion and then replay the items. Every engine yields the same items in the same order; on those two they simply do not arrive any earlier than awaiting the query would.
+* Dropping the stream stops the query, as the execution behind it holds an open transaction that has to be finalised rather than abandoned.
+
+`LIVE SELECT` is not served by this method. A live query's ID arrives as an ordinary row and nothing subscribes to it. Use the awaited form described in [Stream `LIVE SELECT` output](#live-select-stream) for live queries, and `.stream_items()` for reading rows.
 
 ### Security when using the .query() method
 

--- a/src/content/reference/rust/methods/update.mdx
+++ b/src/content/reference/rust/methods/update.mdx
@@ -371,6 +371,59 @@ async fn main() -> surrealdb::Result<()> {
 }
 ```
 
+#### Multiple operations with `PatchOps`
+
+Chaining `.patch()` once per operation works, but each call adds a level of nesting to the builder. [`PatchOps`](https://docs.rs/surrealdb/latest/surrealdb/opt/struct.PatchOps.html) collects the operations into a single value instead, and carries the same four methods so that they can be chained on one another.
+
+```rust
+use surrealdb::engine::any::connect;
+use surrealdb::opt::PatchOps;
+use surrealdb::types::{Datetime, SurrealValue};
+
+#[derive(Debug, SurrealValue, Default)]
+struct Person {
+    name: String,
+    company: Option<String>,
+    settings: Option<Settings>,
+    created_at: Option<Datetime>,
+    tags: Option<Vec<String>>,
+}
+
+#[derive(Debug, SurrealValue)]
+struct Settings {
+    active: bool,
+}
+
+#[tokio::main]
+async fn main() -> surrealdb::Result<()> {
+    let db = connect("memory").await?;
+    db.use_ns("main").use_db("main").await?;
+
+    db.query(
+        "CREATE person:tobie SET name = 'Tobie', company = 'SurrealDB', settings = { active: true }",
+    )
+    .await?
+    .check()?;
+
+    let person: Option<Person> = db
+        .update(("person", "tobie"))
+        .patch(
+            PatchOps::new()
+                .replace("/settings/active", false)
+                .add("/tags", ["developer", "engineer"])
+                .remove("/company"),
+        )
+        .await?;
+    dbg!(person);
+    Ok(())
+}
+```
+
+`PatchOps` is built up in order and applied in order, so an operation can depend on one before it. A single `PatchOp` still works wherever `PatchOps` is expected, as `.patch()` takes anything that converts into `PatchOps`, including a `Vec<PatchOp>`.
+
+> [!NOTE]
+> Removing a field the target struct declares as non-optional will make the response fail to deserialise. Take the result as a `Value`, or declare the field as an `Option`, when a patch removes it.
+
 ### Translated query
 This function will run the following query in the database:
 

--- a/src/content/reference/rust/methods/upsert.mdx
+++ b/src/content/reference/rust/methods/upsert.mdx
@@ -335,6 +335,59 @@ async fn main() -> surrealdb::Result<()> {
 }
 ```
 
+#### Multiple operations with `PatchOps`
+
+Chaining `.patch()` once per operation works, but each call adds a level of nesting to the builder. [`PatchOps`](https://docs.rs/surrealdb/latest/surrealdb/opt/struct.PatchOps.html) collects the operations into a single value instead, and carries the same four methods so that they can be chained on one another.
+
+```rust
+use surrealdb::engine::any::connect;
+use surrealdb::opt::PatchOps;
+use surrealdb::types::{Datetime, SurrealValue};
+
+#[derive(Debug, SurrealValue, Default)]
+struct Person {
+    name: String,
+    company: Option<String>,
+    settings: Option<Settings>,
+    created_at: Option<Datetime>,
+    tags: Option<Vec<String>>,
+}
+
+#[derive(Debug, SurrealValue)]
+struct Settings {
+    active: bool,
+}
+
+#[tokio::main]
+async fn main() -> surrealdb::Result<()> {
+    let db = connect("memory").await?;
+    db.use_ns("main").use_db("main").await?;
+
+    db.query(
+        "CREATE person:tobie SET name = 'Tobie', company = 'SurrealDB', settings = { active: true }",
+    )
+    .await?
+    .check()?;
+
+    let person: Option<Person> = db
+        .upsert(("person", "tobie"))
+        .patch(
+            PatchOps::new()
+                .replace("/settings/active", false)
+                .add("/tags", ["developer", "engineer"])
+                .remove("/company"),
+        )
+        .await?;
+    dbg!(person);
+    Ok(())
+}
+```
+
+`PatchOps` is built up in order and applied in order, so an operation can depend on one before it. A single `PatchOp` still works wherever `PatchOps` is expected, as `.patch()` takes anything that converts into `PatchOps`, including a `Vec<PatchOp>`.
+
+> [!NOTE]
+> Removing a field the target struct declares as non-optional will make the response fail to deserialise. Take the result as a `Value`, or declare the field as an `Option`, when a patch removes it.
+
 ### Translated query
 This function will run the following query in the database:
 


### PR DESCRIPTION
Adds the following:

* Convenient macros like vars! that were missing
* Some builder structs, their methods and examples
* Post-3.3 functionality like connecting via gRPC and streaming (`.stream_items()`)