### PR TITLE
Auth discovery: hand off openid-configuration and oauth-authorization-server

### DIFF
--- a/redirects.ts
+++ b/redirects.ts
@@ -342,8 +342,48 @@ function aiAgentsRedirects(): Redirect[] {
     return out;
 }
 
+/**
+ * OAuth/OIDC discovery hand-offs.
+ *
+ * Probing this origin for these documents did not 404 - it returned
+ * `200 text/html`. The request fell through to the parent-path fallback, which
+ * walks up to the nearest valid page and lands on `/docs`, so a client asking
+ * for JSON metadata got a rendered docs page with a success status. That is
+ * worse than a 404: a strict client fails to parse it, and a lenient one may
+ * treat HTML as a valid response.
+ *
+ * These hand off to the host that owns each document. `auth.surrealdb.com` is
+ * the issuer (`https://auth.surrealdb.com/`) and already publishes both.
+ * Serving copies here would declare a docs site to be an OIDC issuer, which it
+ * is not; a redirect points at the real one without ever claiming to be it.
+ *
+ * Both path forms are covered because this project is reached two ways:
+ * directly, and through the `/docs` prefix that surrealdb.com rewrites onto it.
+ *
+ * 307 rather than 301: auth infrastructure moves more often than docs URLs, and
+ * a permanent redirect gets cached hard by clients.
+ *
+ * `oauth-protected-resource` is deliberately absent. Per RFC 9728 it belongs on
+ * the resource host, and api.surrealdb.com serves it per-resource (for example
+ * `/.well-known/oauth-protected-resource/api/mcp`). There is no single document
+ * for this origin to point at, and redirecting to a guess would be worse than
+ * the 404 a client gets today.
+ */
+function authDiscoveryRedirects(): Redirect[] {
+    const documents = ["openid-configuration", "oauth-authorization-server"] as const;
+
+    return ["", "/docs"].flatMap((prefix) =>
+        documents.map((doc) => ({
+            source: `${prefix}/.well-known/${doc}`,
+            destination: `https://auth.surrealdb.com/.well-known/${doc}`,
+            statusCode: 307,
+        })),
+    );
+}
+
 /** Shared with vercel.ts (production) and the Vite dev server (local). */
 export const docsRedirects: Redirect[] = [
+    ...authDiscoveryRedirects(),
     { source: "/start", destination: "/what-is-surrealdb", statusCode: 302 },
     ...legacyPrefixRedirects("surrealql", "reference/query-language"),
     ...legacyPrefixRedirects("cloud", "manage/cloud"),


### PR DESCRIPTION
Companion to surrealdb/www.surrealdb.com#1712 and surrealdb/api.surrealdb.com#123, from the `api.surrealdb.com` chore list in [this thread](https://surrealdb.slack.com/archives/C0AK5TNG3ME/p1787046158883099).

## The problem is not a missing 404 - it is a false 200

I expected these paths to 404 here. They do not:

```
GET https://docs.surrealdb.com/.well-known/openid-configuration
  301 -> surrealdb.com/docs/.well-known/openid-configuration
  302 -> /docs/.well-known
  302 -> /docs/
  308 -> /docs
  200    text/html          <-- a rendered docs page
```

The request falls through to the parent-path fallback, which walks up to the nearest valid page and lands on `/docs`. All three of `openid-configuration`, `oauth-authorization-server`, and `oauth-protected-resource` behave this way.

So a client asking for JSON metadata receives an HTML docs page **with a success status**. That is worse than a 404 - a strict client fails to parse, and a lenient one may treat HTML as a valid response rather than falling back.

## What this adds

Four entries at the front of `docsRedirects`:

| Source | 307 to |
| --- | --- |
| `/.well-known/openid-configuration` | `auth.surrealdb.com/.well-known/openid-configuration` |
| `/.well-known/oauth-authorization-server` | `auth.surrealdb.com/.well-known/oauth-authorization-server` |
| `/docs/.well-known/openid-configuration` | (same) |
| `/docs/.well-known/oauth-authorization-server` | (same) |

A redirect rather than serving copies: an `openid-configuration` served from here would declare a docs site to be an OIDC **issuer**, which it is not. The issuer is `https://auth.surrealdb.com/` and it already publishes both documents, so redirecting points at the real one without this origin claiming to be it.

Notes:

- **Both path forms** because this project is reached two ways - directly, and through the `/docs` prefix that surrealdb.com rewrites onto it. Vercel runs `redirects` before `rewrites`, so these short-circuit the fallback.
- **Placed first** in `docsRedirects` so they resolve ahead of the legacy prefix rules. Since that array is shared with the Vite dev server, the behaviour is the same locally.
- **307, not 301** - auth infrastructure moves more often than docs URLs, and a permanent redirect gets cached hard.
- **`oauth-protected-resource` is deliberately absent.** Per RFC 9728 it belongs on the resource host, and api.surrealdb.com serves it per-resource (e.g. `/.well-known/oauth-protected-resource/api/mcp`). There is no single document for this origin to point at, so a redirect would be a guess. It still returns the false 200 described above - see below.

## Worth a separate look: the parent-path fallback swallows `.well-known`

This PR fixes the two paths it can point somewhere real, but the underlying behaviour is broader: **any** unknown `/.well-known/*` path on this origin resolves to `200 text/html` rather than 404. RFC 8615 well-known URIs are exactly the kind of path where a fallback to a content page is wrong.

`www.surrealdb.com` guards against this explicitly in its middleware:

```js
// `public/.well-known/*` (RFC 8615) must not hit parent-walk
if (p.startsWith("/.well-known")) return;
```

This repo has no equivalent, and I could not locate the fallback in the source to add one - `middleware.ts` does not exist on `main`, yet the deployed behaviour clearly performs the walk. Someone with more context on where that now lives should probably exclude `/.well-known` from it wholesale, which would also fix `oauth-protected-resource` without needing a redirect.

## Validation

- `bunx biome check redirects.ts` - clean
- `bun run qts` - **72 errors, identical to a stashed baseline** on `main` (pre-existing `src/pages/spectron/*` collection-type errors). This PR adds none.
- `bun run qc` fails on this machine for an unrelated reason: a stale nested `biome.json` under `.claude/worktrees/python-query-return-shape/` breaks the root config. Not touched by this PR.
- Verified the generated entries by importing `docsRedirects` directly: 4 entries, correct destinations, no duplicate sources, ordered first.

The redirects themselves want confirming on a preview deploy, since Vercel routing is not exercised locally.
