### PR TITLE
Markdown for agents: flatten MDX components, negotiate Accept, complete the headers

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -4,6 +4,8 @@ Unified by a powerful SQL like query language [SurrealQL](https://surrealdb.com/
 
 Also providing additional query methods like [GraphQL](https://surrealdb.com/docs/learn/querying/graphql/overview), [HTTP](https://surrealdb.com/docs/reference/rest-api/http-protocol) and [RPC](https://surrealdb.com/docs/reference/rest-api/rpc-protocol), you can also query SurrealDB in your native environments using [SDKs](https://surrealdb.com/docs/languages/overview), we support [JavaScript](https://surrealdb.com/docs/languages/javascript), [Python](https://surrealdb.com/docs/languages/python), [Go](https://surrealdb.com/docs/languages/golang), [Rust](https://surrealdb.com/docs/languages/rust), [Java](https://surrealdb.com/docs/languages/java) and [.NET](https://surrealdb.com/docs/languages/dotnet).
 
+> Markdown for agents: every documentation page is also available as markdown. Append ".md" to any page path to fetch it directly, for example "https://surrealdb.com/docs/reference/query-language/statements/select.md". The same document is served on the page's own URL to a request sending an "Accept: text/markdown" header, with "Content-Type: text/markdown" and an "x-markdown-tokens" estimate. HTML stays the default for browsers. Links inside a markdown page already point at the ".md" variants, so following them keeps an agent in markdown.
+
 Things to remember when working with SurrealDB:
 
 - SurrealDB combines different data models in a single database, allowing you to store and manage data in [relational, document, graph, time-series, vector & search and key-value models in one place](https://surrealdb.com/features)

--- a/src/pages/+Head.tsx
+++ b/src/pages/+Head.tsx
@@ -20,6 +20,12 @@ export function Head() {
     const { urlPathname } = pageContext;
     const canonicalUrl = buildCanonicalUrl(urlPathname);
 
+    // The docs root has no path segment to suffix, so its markdown lives at
+    // `/docs/index.md` - matching how the apex site addresses its homepage.
+    const markdownUrl = `${canonicalUrl.replace(/\/$/, "")}${
+        urlPathname === "/" ? "/index.md" : ".md"
+    }`;
+
     const navigation = (pageContext.data as PageData)?.navigation ?? [];
     const breadcrumbJsonLd = buildBreadcrumbJsonLd(navigation);
 
@@ -37,6 +43,15 @@ export function Head() {
             <link
                 rel="canonical"
                 href={canonicalUrl}
+            />
+            {/* How an agent holding the HTML discovers the markdown rendering of
+                this page. The same document is also served on this URL to a
+                request sending `Accept: text/markdown` - see src/pages/+server.ts. */}
+            <link
+                rel="alternate"
+                type="text/markdown"
+                href={markdownUrl}
+                title="Markdown version of this page"
             />
             <meta
                 property="og:url"

--- a/src/pages/+server.ts
+++ b/src/pages/+server.ts
@@ -1,31 +1,70 @@
 import vike, { type App } from "@vikejs/hono";
 import { Hono } from "hono";
 import type { Server } from "vike/types";
+import { fetchAllSdkVersions } from "~/lib/versions";
+import {
+    acceptsMarkdown,
+    estimateTokens,
+    MARKDOWN_CACHE_CONTROL,
+    MARKDOWN_CONTENT_TYPE,
+} from "~/utils/agent-markdown";
 import { composeRawMarkdown, resolveCollectionEntry } from "~/utils/collections";
 
 const BASE = "/docs";
 
 const app = new Hono();
 
-// Serve a page's raw markdown when its URL is suffixed with `.md`
-// (e.g. `/docs/reference/query-language/statements/select.md`). Registered
-// before Vike so it wins over Vike's catch-all route.
+/**
+ * Serves a page's markdown representation, two ways:
+ *
+ *   - a `.md`-suffixed URL, e.g.
+ *     `/docs/reference/query-language/statements/select.md`, and
+ *   - content negotiation, when a request for the page's own URL sends
+ *     `Accept: text/markdown`.
+ *
+ * The apex site answers negotiation in edge middleware, but that middleware
+ * skips `/docs` entirely, so both entry points have to be served here.
+ * Registered before Vike so it wins over Vike's catch-all route.
+ *
+ * The two differ only in cache and indexing metadata. A `.md` URL is a distinct
+ * URL, so it is marked `noindex` to keep it out of search results as a duplicate
+ * of the page it mirrors - which matters now that every page links its own `.md`
+ * URL from the "View as Markdown" menu. A negotiated response is the *same* URL
+ * as the HTML, so it carries `Vary: Accept` instead and stays indexable.
+ */
 app.get("*", async (c, next) => {
     const { pathname } = new URL(c.req.url);
+    const suffixed = pathname.endsWith(".md");
+    const negotiated = !suffixed && acceptsMarkdown(c.req.header("accept"));
 
-    if (!pathname.endsWith(".md")) {
+    if (!suffixed && !negotiated) {
         return next();
     }
 
-    const path = pathname.slice(0, -".md".length).replace(new RegExp(`^${BASE}`), "");
-    const entry = resolveCollectionEntry(path);
+    const path = (suffixed ? pathname.slice(0, -".md".length) : pathname).replace(
+        new RegExp(`^${BASE}`),
+        "",
+    );
+    // The docs root cannot carry the suffix on its own path, so `/docs/index.md`
+    // addresses it - the same convention the apex site uses for its homepage.
+    const entry = resolveCollectionEntry(path.replace(/^\/?index$/, ""));
 
     if (!entry) {
-        return c.text("Not Found", 404);
+        // A `.md` URL names a page that does not exist; a negotiated request
+        // may be for an asset or a non-content route, so let Vike answer it.
+        return negotiated ? next() : c.text("Not Found", 404);
     }
 
-    return c.body(composeRawMarkdown(entry), 200, {
-        "Content-Type": "text/markdown; charset=utf-8",
+    // Resolved from the same file-backed cache the page render uses, so
+    // `<Version>` markers report what the HTML reports.
+    const sdkVersions = await fetchAllSdkVersions();
+    const markdown = composeRawMarkdown(entry, sdkVersions);
+
+    return c.body(markdown, 200, {
+        "Content-Type": MARKDOWN_CONTENT_TYPE,
+        "Cache-Control": MARKDOWN_CACHE_CONTROL,
+        "X-Markdown-Tokens": String(estimateTokens(markdown)),
+        ...(suffixed ? { "X-Robots-Tag": "noindex" } : { Vary: "Accept" }),
     });
 });
 

--- a/src/utils/agent-markdown.ts
+++ b/src/utils/agent-markdown.ts
@@ -1,0 +1,80 @@
+/**
+ * Shared pieces of the "markdown for agents" contract, kept identical to the
+ * marketing site's implementation (`src/lib/html-to-markdown.ts` in
+ * www.surrealdb.com) so that both halves of surrealdb.com answer agents the
+ * same way. The apex site's edge middleware deliberately skips `/docs`, so the
+ * docs app has to honour the contract itself.
+ */
+
+export const MARKDOWN_CONTENT_TYPE = "text/markdown; charset=utf-8";
+
+/**
+ * Markdown is derived from content the same deploy already serves as HTML, so
+ * it gets the cache profile its HTML twin gets. Set explicitly here rather than
+ * inherited from the apex project's fallback header, which only applies because
+ * this app currently sends none.
+ */
+export const MARKDOWN_CACHE_CONTROL = "public, max-age=300, stale-while-revalidate=60";
+
+/**
+ * Returns true when an `Accept` header explicitly asks for `text/markdown`
+ * and does not prefer HTML over it. Browsers never list `text/markdown`, so
+ * regular traffic is unaffected; agents send `Accept: text/markdown` (alone
+ * or alongside other types) to opt in. A client listing both types picks the
+ * winner via RFC 9110 quality values, e.g. `text/markdown;q=0.5,text/html`
+ * still receives HTML. HTML's effective quality also honours wildcard ranges
+ * (`text/*`, `star/star`) per RFC 9110 specificity, so
+ * `text/markdown;q=0.5,text/*;q=0.9` receives HTML too - but a wildcard
+ * alone never opts a client into markdown.
+ */
+export function acceptsMarkdown(acceptHeader: string | null | undefined): boolean {
+    if (!acceptHeader) return false;
+    // Cheap pre-filter before parsing: the header must mention the type.
+    if (!acceptHeader.toLowerCase().includes("text/markdown")) return false;
+
+    let markdown: number | null = null;
+    let html: number | null = null;
+    let textWildcard: number | null = null;
+    let anyWildcard: number | null = null;
+
+    for (const part of acceptHeader.split(",")) {
+        const [range, ...params] = part.split(";");
+        const media = range?.trim().toLowerCase();
+        if (!media) continue;
+
+        let q = 1;
+        for (const param of params) {
+            const eq = param.indexOf("=");
+            if (eq === -1) continue;
+            if (param.slice(0, eq).trim().toLowerCase() !== "q") continue;
+            const value = Number.parseFloat(param.slice(eq + 1).trim());
+            if (Number.isFinite(value)) q = Math.min(Math.max(value, 0), 1);
+        }
+
+        if (media === "text/markdown") {
+            markdown = Math.max(markdown ?? 0, q);
+        } else if (media === "text/html" || media === "application/xhtml+xml") {
+            html = Math.max(html ?? 0, q);
+        } else if (media === "text/*") {
+            textWildcard = Math.max(textWildcard ?? 0, q);
+        } else if (media === "*/*") {
+            anyWildcard = Math.max(anyWildcard ?? 0, q);
+        }
+    }
+
+    // Markdown must be listed explicitly to opt in; a wildcard never counts
+    // (explicit ranges are more specific, so they set markdown's quality).
+    if (markdown === null || markdown <= 0) return false;
+    // HTML's quality comes from its most specific matching range.
+    const htmlQuality = html ?? textWildcard ?? anyWildcard;
+    return htmlQuality === null || markdown >= htmlQuality;
+}
+
+/**
+ * Rough token estimate (~4 characters per token for English prose), matching
+ * the "estimated tokens" semantics of Cloudflare's `x-markdown-tokens`.
+ */
+export function estimateTokens(text: string): number {
+    if (text.length === 0) return 0;
+    return Math.max(1, Math.ceil(text.length / 4));
+}

--- a/src/utils/collections.ts
+++ b/src/utils/collections.ts
@@ -1,5 +1,7 @@
 import { getCollectionEntry } from "vike-content-collection";
-import { stripLeadingH1 } from "./markdown";
+import type { SdkVersionMap } from "~/lib/versions";
+import { stripLanguageTestComments, stripLeadingH1 } from "./markdown";
+import { flattenMdxComponents } from "./mdx-to-markdown";
 
 /**
  * Maps a URL prefix to the content collection that serves it.
@@ -105,13 +107,24 @@ export function suffixDocsLinks(markdown: string): string {
  *
  * Prepends the frontmatter title as a top-level heading and the description
  * beneath it, followed by the page body (with its own leading H1 removed to
- * avoid a duplicate heading). Internal docs links are rewritten to `.md` so
- * link-following stays in markdown mode.
+ * avoid a duplicate heading). MDX components are flattened to plain markdown,
+ * and internal docs links are rewritten to `.md` so link-following stays in
+ * markdown mode.
+ *
+ * The `[test]` annotations that the docs test harness embeds in code samples are
+ * stripped, mirroring `resolveMarkdown` - without this the markdown carries
+ * internal expectations the rendered page never shows.
+ *
+ * `sdkVersions` resolves `<Version>` markers to the version numbers the
+ * rendered page shows; without it they fall back to "latest".
  */
-export function composeRawMarkdown(entry: CollectionEntry): string {
+export function composeRawMarkdown(entry: CollectionEntry, sdkVersions?: SdkVersionMap): string {
     const metadata = entry.metadata as { title?: string; description?: string };
     const heading = metadata.title ? `# ${metadata.title}` : undefined;
-    const body = stripLeadingH1(entry.content);
+    const body = flattenMdxComponents(
+        stripLanguageTestComments(stripLeadingH1(entry.content)),
+        sdkVersions,
+    );
 
     const document = [heading, metadata.description, body].filter(Boolean).join("\n\n");
 

--- a/src/utils/markdown.tsx
+++ b/src/utils/markdown.tsx
@@ -30,7 +30,7 @@ function stripLanguageTestComment(code: string): string {
     return match[2] ?? code;
 }
 
-function stripLanguageTestComments(markdown: string): string {
+export function stripLanguageTestComments(markdown: string): string {
     return markdown.replace(FENCED_CODE_BLOCK, (_match, fence, body, closing) => {
         return `${fence}${stripLanguageTestComment(body)}${closing}`;
     });

--- a/src/utils/mdx-to-markdown.ts
+++ b/src/utils/mdx-to-markdown.ts
@@ -1,0 +1,296 @@
+import type { SdkVersionMap } from "~/lib/versions";
+
+/**
+ * Flattens the MDX components used across docs content into plain markdown.
+ *
+ * A page's `.md` representation is composed from its MDX source, so every
+ * component the browser renders is otherwise emitted as raw JSX. An agent
+ * reading `select.md` would meet nested `<Tabs>`/`<TabItem>` wrappers, inline
+ * `<Since v="v3.2.5" />` markers, and a `<RailroadDiagram ast='{...}' />` whose
+ * single attribute is a couple of kilobytes of serialised diagram. None of that
+ * carries meaning without the component that renders it.
+ *
+ * Each component is therefore rewritten to the closest plain-markdown
+ * equivalent (or dropped, when it is purely visual). Anything not listed here
+ * is left untouched: an unrecognised tag surviving into the output is a much
+ * better failure than mangled prose.
+ *
+ * Code is masked before any rewriting happens - see `maskCode`.
+ */
+
+/**
+ * Attribute-text pattern shared by every component matcher.
+ *
+ * The character class admits newlines, because content is formatted across
+ * several lines (`<IconBox>` in particular), and the quoted-string branches let
+ * a `>` inside an attribute value pass without ending the tag early. Attribute
+ * expressions such as `icon={{ light: LightRust }}` match the plain branch:
+ * they contain no `>`. A tag whose attributes *do* contain a bare `>` simply
+ * fails to match and is left as-is.
+ */
+const ATTRS = `(?:[^>"']|"[^"]*"|'[^']*')*`;
+
+/** Matches a component tag, self-closing or opening, capturing its attributes. */
+function tag(name: string): RegExp {
+    return new RegExp(`<${name}(${ATTRS})/?>`, "g");
+}
+
+/** Matches a wrapper component's opening and closing tags alike. */
+function wrapper(name: string): RegExp {
+    return new RegExp(`</?${name}(?:${ATTRS})?/?>`, "g");
+}
+
+/**
+ * Unwraps a braced attribute expression down to the string it carries, so that
+ * `query={`CREATE ...`}` yields the query and not a stray pair of backticks.
+ */
+function unwrapExpression(value: string): string {
+    const match = /^([`'"])([\s\S]*)\1$/.exec(value.trim());
+    return match ? match[2] : value.trim();
+}
+
+/**
+ * Removes the indentation an attribute value inherited from the surrounding
+ * JSX, so a multi-line query lands flush against the fence that wraps it.
+ */
+function dedent(text: string): string {
+    const lines = text.replace(/^\n+/, "").replace(/\s+$/, "").split("\n");
+    const indents = lines
+        .filter((line) => line.trim())
+        .map((line) => (/^[ \t]*/.exec(line)?.[0] ?? "").length);
+    const common = indents.length > 0 ? Math.min(...indents) : 0;
+
+    return lines.map((line) => line.slice(common)).join("\n");
+}
+
+/**
+ * Parses the quoted and braced attributes of a tag. Keys are lower-cased so
+ * that both spellings of `<Tabs synckey>` / `<Tabs syncKey>` resolve alike.
+ *
+ * The braced branch tracks brace pairs two levels deep, which covers the
+ * expression attributes content actually uses: `icon={{ light, dark }}` and
+ * `query={`...`}` holding SurrealQL object literals. A more deeply nested
+ * expression stops matching, leaving the tag in place rather than truncating it.
+ */
+const ATTR_PATTERN =
+    /([A-Za-z][\w-]*)\s*=\s*(?:"([^"]*)"|'([^']*)'|\{((?:[^{}]|\{(?:[^{}]|\{[^{}]*\})*\})*)\})/g;
+
+function parseAttrs(raw: string): Record<string, string> {
+    const attrs: Record<string, string> = {};
+
+    for (const match of raw.matchAll(ATTR_PATTERN)) {
+        const value = match[2] ?? match[3] ?? (match[4] ? unwrapExpression(match[4]) : "");
+        attrs[match[1].toLowerCase()] = value;
+    }
+
+    return attrs;
+}
+
+/** Placeholder delimiter - a NUL byte cannot occur in docs content. */
+const MASK = "\u0000";
+
+/**
+ * Replaces fenced code blocks and inline code spans with placeholders, so the
+ * component rewrites can never reach example code. Docs samples are full of
+ * angle brackets that look like JSX - `Vec<String>`, `<T>`, `->` traversals,
+ * `<|2,COSINE|>` operators - and a single one of those rewritten inside a code
+ * block is a broken example.
+ */
+function maskCode(markdown: string): { text: string; blocks: string[] } {
+    const blocks: string[] = [];
+    const out: string[] = [];
+    let fence: string | null = null;
+    let buffer: string[] = [];
+
+    const store = (value: string) => {
+        blocks.push(value);
+        return `${MASK}${blocks.length - 1}${MASK}`;
+    };
+
+    for (const line of markdown.split("\n")) {
+        const marker = /^\s*(`{3,}|~{3,})/.exec(line)?.[1];
+
+        if (fence === null) {
+            // A fence opens: buffer it whole, including the closing marker.
+            if (marker) {
+                fence = marker;
+                buffer = [line];
+                continue;
+            }
+            // Inline spans are safe to mask line by line.
+            out.push(line.replace(/`+[^`\n]*`+/g, (span) => store(span)));
+            continue;
+        }
+
+        buffer.push(line);
+
+        // A fence closes on a marker of the same character, at least as long.
+        if (marker && marker[0] === fence[0] && marker.length >= fence.length) {
+            out.push(store(buffer.join("\n")));
+            fence = null;
+            buffer = [];
+        }
+    }
+
+    // An unterminated fence: keep the remainder masked rather than exposing it.
+    if (buffer.length > 0) {
+        out.push(store(buffer.join("\n")));
+    }
+
+    return { text: out.join("\n"), blocks };
+}
+
+function restoreCode(text: string, blocks: string[]): string {
+    return text.replace(
+        new RegExp(`${MASK}(\\d+)${MASK}`, "g"),
+        (match, index) => blocks[Number(index)] ?? match,
+    );
+}
+
+/**
+ * Rewrites `<TabItem>` panels into labelled sections and drops the `<Tabs>`
+ * wrapper. Labels become bold text rather than headings: a tab sits at an
+ * arbitrary depth inside a page, and injecting headings would corrupt the
+ * outline that agents use to chunk a document.
+ *
+ * Panels are matched innermost-first (the body pattern excludes further
+ * `TabItem` tags), so nested tab sets flatten from the inside out. A panel left
+ * empty by an earlier rewrite - typically one that held only a railroad diagram
+ * - is dropped along with its label.
+ */
+function flattenTabs(markdown: string): string {
+    const panel = new RegExp(`<TabItem(${ATTRS})>((?:(?!</?TabItem)[\\s\\S])*)</TabItem>`, "g");
+    let out = markdown;
+
+    // Each pass unwraps one level of nesting; docs content never goes deeper
+    // than two, and the loop exits as soon as a pass changes nothing.
+    for (let depth = 0; depth < 5; depth++) {
+        const next = out.replace(panel, (_match, raw: string, body: string) => {
+            const attrs = parseAttrs(raw);
+            const label = attrs.label ?? attrs.value;
+            const content = body.trim();
+
+            if (!content) return "";
+
+            return label ? `\n\n**${label}**\n\n${content}\n` : `\n\n${content}\n`;
+        });
+
+        if (next === out) break;
+        out = next;
+    }
+
+    return out.replace(wrapper("Tabs"), "");
+}
+
+/** Renders an `<IconBox>` link card as a list item. */
+function iconBox(attrs: Record<string, string>): string {
+    const label = attrs.title ?? attrs.subtitle;
+
+    // Icon-only boxes are decorative and carry no text to keep.
+    if (!label) return "";
+
+    const link = attrs.href ? `[${label}](${attrs.href})` : `**${label}**`;
+    const status = attrs.status ? `(${attrs.status})` : "";
+    const detail = attrs.title && attrs.subtitle ? attrs.subtitle : undefined;
+    const description = [detail, attrs.description].filter(Boolean).join(" - ");
+
+    return `\n- ${[link, status].filter(Boolean).join(" ")}${description ? ` - ${description}` : ""}`;
+}
+
+/**
+ * Renders a `<SurrealistMini>` playground embed as the query it runs plus a
+ * link to the playground. The query is the content: in the `url` form it is a
+ * `?query=` parameter, which is otherwise served to agents as an unreadable
+ * percent-encoded blob.
+ */
+function surrealistMini(attrs: Record<string, string>): string {
+    let query: string | undefined = attrs.query;
+
+    if (!query && attrs.url) {
+        try {
+            query = new URL(attrs.url).searchParams.get("query") ?? undefined;
+        } catch {
+            // A malformed URL just means no query to extract.
+        }
+    }
+
+    const parts: string[] = [];
+
+    if (query?.trim()) {
+        parts.push(`\`\`\`surql\n${dedent(query)}\n\`\`\``);
+    }
+
+    if (attrs.url) {
+        parts.push(`[Run this example in SurrealDB Studio](${attrs.url})`);
+    }
+
+    return parts.length > 0 ? `\n\n${parts.join("\n\n")}\n` : "";
+}
+
+/** Resolves `<Version>` against the same SDK version map the pages render. */
+function version(attrs: Record<string, string>, versions: SdkVersionMap): string {
+    const resolved = versions[attrs.sdk ?? "surrealdb"];
+
+    return resolved && resolved !== "unknown" ? `\`${attrs.prefix ?? ""}${resolved}\`` : "latest";
+}
+
+const EDITION_LABELS: Record<string, string> = {
+    community: "Community",
+    enterprise: "Enterprise",
+};
+
+export function flattenMdxComponents(markdown: string, sdkVersions: SdkVersionMap = {}): string {
+    const { text, blocks } = maskCode(markdown);
+    let out = text;
+
+    // Purely visual, and its `ast` attribute is kilobytes of noise. Removed
+    // before the tab pass so a diagram-only panel collapses to nothing.
+    out = out.replace(tag("RailroadDiagram"), "");
+
+    // Inline badges and markers.
+    out = out.replace(tag("Since"), (_match, raw: string) => {
+        const value = parseAttrs(raw).v;
+        return value ? `_(since ${value})_` : "";
+    });
+    out = out.replace(tag("Edition"), (_match, raw: string) => {
+        const value = parseAttrs(raw).value;
+        return value ? `_(${EDITION_LABELS[value] ?? value})_` : "";
+    });
+    out = out.replace(tag("Label"), (_match, raw: string) => {
+        const value = parseAttrs(raw).label;
+        return value ? `_(${value})_` : "";
+    });
+    out = out.replace(tag("Version"), (_match, raw: string) =>
+        version(parseAttrs(raw), sdkVersions),
+    );
+
+    // Structural wrappers.
+    out = flattenTabs(out);
+    out = out.replace(wrapper("Boxes"), "");
+
+    // Components that emit links or code, applied last so the markdown they
+    // introduce is not itself a candidate for rewriting.
+    out = out.replace(tag("IconBox"), (_match, raw: string) => iconBox(parseAttrs(raw)));
+    out = out.replace(tag("SurrealistMini"), (_match, raw: string) =>
+        surrealistMini(parseAttrs(raw)),
+    );
+    out = out.replace(tag("Button"), (_match, raw: string) => {
+        const attrs = parseAttrs(raw);
+        return attrs.href ? `[${attrs.label ?? attrs.href}](${attrs.href})` : "";
+    });
+    out = out.replace(tag("Image"), (_match, raw: string) => {
+        const attrs = parseAttrs(raw);
+        return attrs.src ? `![${attrs.alt ?? ""}](${attrs.src})` : "";
+    });
+    out = out.replace(tag("YouTube"), (_match, raw: string) => {
+        const attrs = parseAttrs(raw);
+        return attrs.code
+            ? `[Watch on YouTube](https://www.youtube.com/watch?v=${attrs.code})`
+            : "";
+    });
+
+    // Collapse the blank-line runs the rewrites leave behind.
+    out = out.replace(/[ \t]+$/gm, "").replace(/\n{3,}/g, "\n\n");
+
+    return restoreCode(out, blocks).trim();
+}


### PR DESCRIPTION
Follows up [#1880](https://github.com/surrealdb/docs.surrealdb.com/pull/1880), which added `.md` URLs, and closes the remaining gaps against the contract the apex site implements.

## 1. MDX components no longer leak into the markdown

A page's `.md` representation is composed from its MDX source, so every component the browser renders reached agents as raw JSX. `select.md` was 39 KB containing:

```
<Tabs synckey="select-statement">
  <TabItem label="SurrealQL Syntax">
<RailroadDiagram ast='{"type":"Diagram","padding":[10,20,10,20],...}' />
<Since v="v3.2.5" />
```

That one `RailroadDiagram` line is ~2.5 KB of serialised AST carrying no information without the component that draws it, and `<Tabs>`/`<TabItem>` hide the structure that tells a reader which variant they are looking at.

`src/utils/mdx-to-markdown.ts` now flattens each component to its closest plain-markdown equivalent:

| Component | Becomes |
|---|---|
| `<TabItem label="X">` | `**X**` followed by the panel body |
| `<Tabs>`, `<Boxes>` | unwrapped |
| `<Since v="v3.2.5" />` | `_(since v3.2.5)_` |
| `<Edition value="enterprise" />` | `_(Enterprise)_` |
| `<Label label="required" />` | `_(required)_` |
| `<Version sdk="..." />` | the resolved version, e.g. `` `v3.2.4` `` |
| `<IconBox title href status description />` | a list item |
| `<SurrealistMini url\|query />` | the query as a `surql` block, plus a playground link |
| `<Button>`, `<Image>`, `<YouTube>` | markdown link / image |
| `<RailroadDiagram />` | dropped |

Two details worth review:

- **Code is masked before any rewriting.** Fenced blocks and inline spans are swapped for placeholders and restored at the end, so the angle brackets that fill docs examples - `Vec<String>`, `<T>`, `->` traversals, `<|2,COSINE|>` - can never be rewritten. This was the main risk in the change.
- **Tab labels become bold text, not headings.** A tab sits at an arbitrary depth inside a page, so injecting headings would corrupt the outline agents use to chunk a document. A panel left empty by an earlier rewrite (typically one that held only a railroad diagram) is dropped along with its label.

Also fixed here: the `.md` path was serving the `[test]` annotations that the docs test harness embeds in code samples. `resolveMarkdown` strips those for the rendered page; `composeRawMarkdown` now does the same.

`select.md` goes from 39,370 to 31,890 bytes, all of it noise.

## 2. `Accept: text/markdown` is honoured

Requesting a page URL with `Accept: text/markdown` returned HTML. The apex site answers negotiation in edge middleware, but that middleware skips `/docs` entirely, so the docs app has to serve it. `acceptsMarkdown` is ported from `www.surrealdb.com`'s `src/lib/html-to-markdown.ts` unchanged, so RFC 9110 quality values behave identically across both halves of the site: `text/markdown;q=0.5,text/html` still gets HTML, and a bare wildcard never opts a client into markdown.

## 3. Response headers completed

| Header | Before | After |
|---|---|---|
| `X-Robots-Tag: noindex` | absent | set on `.md` URLs |
| `Cache-Control` | inherited from the apex project's fallback | set explicitly by the route |
| `x-markdown-tokens` | absent | set |

The `noindex` is the one that matters: every page now links its own `.md` URL from the "View as Markdown" menu, so without it Google can index ~780 markdown duplicates of pages it already has. A negotiated response is the *same* URL as the HTML, so it carries `Vary: Accept` instead and stays indexable.

## 4 and 5. Discovery

Every page advertises its markdown variant with `<link rel="alternate" type="text/markdown">`, and `llms.txt` documents both entry points so an agent does not have to guess that `.md` works.

The docs root has no path segment to suffix, so it is addressed at `/docs/index.md`, matching how the apex site addresses its homepage. `/docs/.md` still resolves.

## Verification

Against a dev server:

- `.md` URL returns `text/markdown` with all four headers
- `Accept: text/markdown` on a page URL returns markdown with `Vary: Accept`
- a browser `Accept` still returns HTML
- `text/markdown;q=0.5,text/html` returns HTML
- an unknown `.md` path still 404s
- `Accept: text/markdown` against a static asset falls through untouched

The flattener was run over all 1,066 content files: no fence corruption, and the only surviving capitalised tags are 6 occurrences of `<T>`, `<Table`, `<YOUR_...>` and `<String>` that are code-sample text and correctly left alone. Biome and `tsc --noEmit` are clean.

## Known limitation

Two files - `reference/dotnet/installation.mdx` and `reference/query-language/statements/remove.mdx` - contain genuine MDX-level `export const` blocks that still appear in their markdown. Stripping multi-line brace-matched exports for two files looked more fragile than it is worth; happy to add it if reviewers disagree.