### PR TITLE
CLI reference: document the configurable readiness heartbeat window

### DIFF
--- a/src/content/reference/cli/surrealdb-cli/commands/start.mdx
+++ b/src/content/reference/cli/surrealdb-cli/commands/start.mdx
@@ -527,6 +527,11 @@ Database:
           [env: SURREAL_NODE_MEMBERSHIP_CLEANUP_INTERVAL=]
           [default: 300s]
 
+      --readiness-heartbeat-max-age <READINESS_HEARTBEAT_MAX_AGE>
+          How stale this node's cluster heartbeat may get before /ready reports it unhealthy (defaults to three refresh intervals)
+
+          [env: SURREAL_READINESS_HEARTBEAT_MAX_AGE=]
+
       --changefeed-gc-interval <CHANGEFEED_GC_INTERVAL>
           The interval at which to perform changefeed garbage collection
 

--- a/src/content/reference/cli/surrealdb-cli/environment-variables.mdx
+++ b/src/content/reference/cli/surrealdb-cli/environment-variables.mdx
@@ -1429,6 +1429,14 @@ surreal start --allow-all true
       <td scope="row" data-label="Notes">The maximum duration that a set of statements can run for.</td>
     </tr>
     <tr>
+      <td scope="row" data-label="Env var"><code>SURREAL_READINESS_HEARTBEAT_MAX_AGE</code><Since v="v3.3.0" /></td>
+      <td scope="row" data-label="Command arg"><code>readiness-heartbeat-max-age</code></td>
+      <td scope="row" data-label="Command">`start`</td>
+      <td scope="row" data-label="Default">Three times <code>node-membership-refresh-interval</code> (9s)</td>
+      <td scope="row" data-label="Allowed values">A duration</td>
+      <td scope="row" data-label="Notes">How stale this node's cluster heartbeat may get before <code>/ready</code> reports the node unhealthy. When unset, it is derived as three times <code>node-membership-refresh-interval</code>. Startup warns if the configured value reaches 30s — the interval after which peers archive an unresponsive node and collect its live queries — because a node reported ready after the cluster has written it off keeps taking traffic. The value is not clamped.</td>
+    </tr>
+    <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_RECLAIM_INTERVAL</code><Since v="v3.2.0" /></td>
       <td scope="row" data-label="Command arg"><code>reclaim-interval</code></td>
       <td scope="row" data-label="Command">`start`</td>


### PR DESCRIPTION
`--readiness-heartbeat-max-age` / `SURREAL_READINESS_HEARTBEAT_MAX_AGE` ships in `v3.3.0-beta.2` but was missing from both CLI reference pages. Companion to the release notes in surrealdb/www.surrealdb.com#1718.

## What the flag does

The `/ready` probe treats a node as unhealthy once its cluster heartbeat goes stale. That staleness window was previously always derived as three times `node-membership-refresh-interval` (9s by default), which welds the probe to the very write path it measures. That is fine for a storage engine whose node-row write is local and sub-millisecond, but under a distributed engine the same write is a consensus transaction whose latency moves with cluster health — so a slow-but-healthy write path made every replica flip `NotReady` at once, presenting partial degradation as total unavailability.

The new flag sets the window directly. The default is unchanged — unset, it is still three refresh intervals — so behaviour is identical unless you set it.

## Placement

**`commands/start.mdx`** reproduces `surreal start --help`, which lists flags in declaration order, so the block goes between `--node-membership-cleanup-interval` and `--changefeed-gc-interval`. There is deliberately no `[default:]` line: the flag is an `Option<Duration>` with no clap default, and the derived fallback is described in the help text instead.

**`environment-variables.mdx`** is alphabetical within its table, so the row goes between `SURREAL_QUERY_TIMEOUT` and `SURREAL_RECLAIM_INTERVAL`. Tagged `<Since v="v3.3.0" />`, matching the existing convention of naming the release line rather than a beta suffix.

## The 30s warning

The env-var row records that startup warns when the configured window reaches 30s — the interval after which peers archive an unresponsive node and collect its live queries, so a window reaching it can report a node ready after the cluster has already written it off, which is worse than either outcome alone.

I checked this against the engine rather than taking it from the changelog: the condition is `max_heartbeat_age >= NODE_ARCHIVE_THRESHOLD`, where the threshold is a hardcoded 30s constant — not derived from `node-membership-check-interval`. The value is deliberately not clamped, so the note says so rather than implying a ceiling.

## Checks

- The `start.mdx` addition sits inside the fenced help block, so `<READINESS_HEARTBEAT_MAX_AGE>` is not parsed as JSX.
- `<Since />` needs no import in `environment-variables.mdx` — it is already used throughout the file.
- Documentation only; 13 lines added, nothing removed or edited.