### PR TITLE
docs: update HNSW default TYPE from F64 to F32

### DIFF
--- a/src/content/learn/data-models/vector-search/vector-indexes.mdx
+++ b/src/content/learn/data-models/vector-search/vector-indexes.mdx
@@ -47,7 +47,7 @@ Both are [proximity graph](/docs/reference/query-language/statements/define/inde
 | ------------- | --------- | ----------------------- | ------------- |
 | DIMENSION     |           |                         | Size of the vector
 | DIST          | EUCLIDEAN | EUCLIDEAN, COSINE, MANHATTAN | Distance function
-| TYPE          | F64       | F64, F32, I64, I32, I16 | Vector type
+| TYPE          | F32       | F64, F32, I64, I32, I16 | Vector type
 | EFC           | 150       |                         | EF construction
 | M             | 12        |                         | Max connections per element
 | M0            | 24        |                         | Max connections in the lowest layer
@@ -59,7 +59,7 @@ Examples:
 -- User statement:
 DEFINE INDEX hnsw_idx ON pts FIELDS point HNSW DIMENSION 4;
 -- Defaults to:
-DEFINE INDEX hnsw_idx ON pts FIELDS point HNSW DIMENSION 4 DIST EUCLIDEAN TYPE F64 EFC 150 M 12 M0 24 LM 0.40242960438184466f;
+DEFINE INDEX hnsw_idx ON pts FIELDS point HNSW DIMENSION 4 DIST EUCLIDEAN TYPE F32 EFC 150 M 12 M0 24 LM 0.40242960438184466f;
 -- Users are strongly suggested not to set an LM value, as
 -- it is computed based on other parameters. Only users
 -- completely versed in the field should manually set it

--- a/src/content/reference/query-language/statements/define/indexes.mdx
+++ b/src/content/reference/query-language/statements/define/indexes.mdx
@@ -376,7 +376,7 @@ When defining a vector index with [HNSW](#hnsw-hierarchical-navigable-small-worl
 
 
 > [!NOTE]
-> In SurrealDB the default type for vectors is `F64`.
+> In SurrealDB the default type for vectors is `F32`.
 
 <Since v="v3.1.0" />
 


### PR DESCRIPTION
## 📌 What This PR Does

This PR brings the SurrealDB documentation in line with **actual engine behavior** in `v3.2.0+`. 

Previously, the docs claimed that HNSW vector indexes defaulted to `F64` – but **the engine materializes them as `F32`** when `TYPE` is omitted. This mismatch has been confusing users, leading to unexpected memory usage and export outputs.

**No more guesswork. No more confusion.** This PR fixes that.

---

## 🔍 What Was Wrong

| What the docs said | What the engine actually does |
|-------------------|-------------------------------|
| HNSW `TYPE` defaults to `F64` | HNSW `TYPE` defaults to `F32` |
| Expanded example used `TYPE F64` | Export shows `TYPE F32` |
| "Default type for vectors is F64" | Engine materializes `F32` |

---

## ✅ What's Changed

| File | Change |
|------|--------|
| `vector-indexes.mdx` | HNSW parameter table: `TYPE` default `F64` → `F32` |
| `vector-indexes.mdx` | Expanded-defaults example: `TYPE F64` → `TYPE F32` |
| `define/indexes.mdx` | Default type description: `F64` → `F32` |

---

## 🧠 Why This Matters

- **Memory efficiency** – `F32` uses half the memory of `F64`, making it the practical choice for production workloads.
- **Accuracy** – Users deserve documentation that reflects what the engine *actually* does.
- **Consistency** – DISKANN already defaults to `F32`. Now HNSW docs match too.

---

## 📎 Related Issue

Closes **#1871** – *"HNSW default vector TYPE: documentation states F64 in three places, but v3.2.0 materialises TYPE F32 when TYPE is omitted"*

---

## 🙏 Thank You!

Big thanks to the SurrealDB team and community for maintaining such an amazing project. This is a small but meaningful step toward better docs and happier developers. ❤️

---

**Ready to review!** 🚀