### PR TITLE
docs: warn Community Edition silently ignores audit env vars

### DIFF
--- a/src/content/manage/observability/audit-logging.mdx
+++ b/src/content/manage/observability/audit-logging.mdx
@@ -9,6 +9,10 @@ description: "The Enterprise audit log pipeline: events captured, record shape, 
 <Edition value="enterprise" />
 <Since v="v3.1.0" />
 
+> [!WARNING]
+> On Community Edition builds, the `SURREAL_AUDIT_SINK` and `SURREAL_AUDIT_FILE_PATH` environment variables are **silently ignored**: the server starts normally, no startup warning is emitted, and no audit file is created. Audit sinks are only compiled into Enterprise binaries—do not rely on these settings for compliance when running Community Edition.
+
+
 The audit log pipeline records authoritative, identity-bound events that operators and auditors need to reconstruct who did what, when, and with what outcome. It is part of SurrealDB Enterprise and is **off by default** — set `SURREAL_AUDIT_SINK=file` and `SURREAL_AUDIT_FILE_PATH` to enable it.
 
 Records flow through two parallel paths:

--- a/src/content/manage/observability/audit-logging.mdx
+++ b/src/content/manage/observability/audit-logging.mdx
@@ -9,11 +9,10 @@ description: "The Enterprise audit log pipeline: events captured, record shape, 
 <Edition value="enterprise" />
 <Since v="v3.1.0" />
 
-> [!WARNING]
-> On Community Edition builds, the `SURREAL_AUDIT_SINK` and `SURREAL_AUDIT_FILE_PATH` environment variables are **silently ignored**: the server starts normally, no startup warning is emitted, and no audit file is created. Audit sinks are only compiled into Enterprise binaries—do not rely on these settings for compliance when running Community Edition.
-
-
 The audit log pipeline records authoritative, identity-bound events that operators and auditors need to reconstruct who did what, when, and with what outcome. It is part of SurrealDB Enterprise and is **off by default** — set `SURREAL_AUDIT_SINK=file` and `SURREAL_AUDIT_FILE_PATH` to enable it.
+
+> [!WARNING]
+> The `SURREAL_AUDIT_*` variables are registered only by the Enterprise binary. As Community builds never reads them, the server starts normally, nothing is written to the configured path, and no audit file is created. The loud startup failures described below apply to Enterprise builds only, so do not rely on these settings for compliance on a Community build.
 
 Records flow through two parallel paths:
 


### PR DESCRIPTION
On Community Edition builds, the `SURREAL_AUDIT_SINK` and `SURREAL_AUDIT_FILE_PATH` environment variables are **silently ignored** – the server starts normally, no warning is emitted, and no audit file is created.

This PR adds a warning box at the top of the audit-logging page to clearly inform operators that audit logging is only available in Enterprise Edition.

## Related Issue

Closes #1873