### PR TITLE
Name section landing pages after their section

### DIFF
--- a/src/content/agent-memory/cookbooks/index.mdx
+++ b/src/content/agent-memory/cookbooks/index.mdx
@@ -1,6 +1,6 @@
 ---
 position: 1
-title: Overview
+title: Cookbooks
 description: "Opinionated recipes and migration guides."
 ---
 

--- a/src/content/agent-memory/index/index.mdx
+++ b/src/content/agent-memory/index/index.mdx
@@ -1,6 +1,6 @@
 ---
 position: 0
-title: Overview
+title: Agent Memory
 description: "Principles, architecture, quickstarts, and mental model for SurrealDB Agent Memory - memory and knowledge for AI agents on SurrealDB."
 ---
 

--- a/src/content/agent-memory/integrations/index.mdx
+++ b/src/content/agent-memory/integrations/index.mdx
@@ -1,6 +1,6 @@
 ---
 position: 0
-title: Overview
+title: Agent Memory integrations
 description: "Connecting SurrealDB Agent Memory to your stack - SDKs, MCP server, AI SDKs, agent frameworks, voice tools, and automation."
 ---
 

--- a/src/content/agent-memory/reference/index.mdx
+++ b/src/content/agent-memory/reference/index.mdx
@@ -1,6 +1,6 @@
 ---
 position: 0
-title: Overview
+title: Agent Memory reference
 description: "Complete API and configuration reference for SurrealDB Agent Memory."
 ---
 

--- a/src/content/build/integrations/authentication/better-auth/overview.mdx
+++ b/src/content/build/integrations/authentication/better-auth/overview.mdx
@@ -1,6 +1,6 @@
 ---
 position: 0
-title: Overview
+title: Better Auth
 description: Use SurrealDB as the database behind Better Auth with the @surrealdb/better-auth adapter, including schema generation, transactions, and support for all Better Auth plugins.
 ---
 

--- a/src/content/explore/tutorials/demos/overview.mdx
+++ b/src/content/explore/tutorials/demos/overview.mdx
@@ -1,6 +1,6 @@
 ---
 position: 0
-title: Overview
+title: Demos
 description: "Sample applications and datasets you can clone, import, or run locally to explore SurrealDB without a long-form walkthrough."
 ---
 

--- a/src/content/explore/tutorials/tutorials/overview.mdx
+++ b/src/content/explore/tutorials/tutorials/overview.mdx
@@ -1,6 +1,6 @@
 ---
 position: 0
-title: Overview
+title: Tutorials
 description: "Step-by-step tutorials and walkthroughs for specific tasks with SurrealDB: integrations, real-time apps, AI patterns, and more."
 ---
 

--- a/src/content/index/running/overview.mdx
+++ b/src/content/index/running/overview.mdx
@@ -1,6 +1,6 @@
 ---
 position: 1
-title: Overview
+title: Running SurrealDB
 description: "Ways to run SurrealDB - from a browser sandbox to a managed cloud instance to installing on your own hardware."
 ---
 

--- a/src/content/learn/querying/gql/overview.mdx
+++ b/src/content/learn/querying/gql/overview.mdx
@@ -1,6 +1,6 @@
 ---
 position: 1
-title: Overview
+title: GQL
 description: "Query SurrealDB graph data with ISO GQL - a Cypher-like graph pattern language over HTTP and RPC."
 ---
 

--- a/src/content/reference/cli/surrealctl/commands/index.mdx
+++ b/src/content/reference/cli/surrealctl/commands/index.mdx
@@ -1,6 +1,6 @@
 ---
 position: 1
-title: Overview
+title: surrealctl commands
 description: A map of every surrealctl command group and leaf command, with links to the page documenting each one.
 ---
 

--- a/src/content/reference/cli/surrealctl/overview.mdx
+++ b/src/content/reference/cli/surrealctl/overview.mdx
@@ -1,6 +1,6 @@
 ---
 position: 1
-title: Overview
+title: surrealctl reference
 description: What surrealctl is, where the control plane ends and the SurrealDB CLI begins, the command grammar, and how this reference is organised.
 ---
 

--- a/src/content/reference/cli/surrealdb-cli/commands/index.mdx
+++ b/src/content/reference/cli/surrealdb-cli/commands/index.mdx
@@ -1,6 +1,6 @@
 ---
 position: 1
-title: Overview
+title: SurrealDB CLI commands
 description: How the SurrealDB CLI is organised into subcommands, with links to each command’s flags and examples.
 ---
 

--- a/src/content/reference/php/frameworks/laravel/index.mdx
+++ b/src/content/reference/php/frameworks/laravel/index.mdx
@@ -1,6 +1,6 @@
 ---
 position: 1
-title: Overview
+title: Laravel
 description: The Laravel integration wires the SurrealDB PHP SDK and the Surqlize ORM into Laravel's config, service container, facades, and Artisan commands.
 ---
 

--- a/src/content/reference/php/index.mdx
+++ b/src/content/reference/php/index.mdx
@@ -1,6 +1,6 @@
 ---
 position: 1
-title: Overview
+title: PHP SDK
 description: The SurrealDB SDK for PHP lets you query a remote SurrealDB instance from any PHP application, with a stable v1 release and a v2 rewrite in alpha.
 ---
 

--- a/src/content/reference/php/libraries/surqlize/index.mdx
+++ b/src/content/reference/php/libraries/surqlize/index.mdx
@@ -1,6 +1,6 @@
 ---
 position: 1
-title: Overview
+title: Surqlize
 description: Surqlize is an object-relational mapper for SurrealDB in PHP, built on version 2 of the SDK, with attribute-driven models, a typed query builder, graph relations, and schema tooling.
 ---
 

--- a/src/content/reference/php/v1/index.mdx
+++ b/src/content/reference/php/v1/index.mdx
@@ -1,6 +1,6 @@
 ---
 position: 1
-title: Overview
+title: PHP SDK v1
 description: Version 1 is the current stable release of the SurrealDB PHP SDK, with direct RPC-style methods for querying a remote database.
 ---
 

--- a/src/content/reference/php/v2/index.mdx
+++ b/src/content/reference/php/v2/index.mdx
@@ -1,6 +1,6 @@
 ---
 position: 1
-title: Overview
+title: PHP SDK v2
 description: Version 2 of the SurrealDB SDK for PHP is a rewrite with a fluent query builder, typed credentials, and a PSR-based transport layer.
 ---
 

--- a/src/content/reference/query-language/statements/alter/overview.mdx
+++ b/src/content/reference/query-language/statements/alter/overview.mdx
@@ -1,6 +1,6 @@
 ---
 position: 1
-title: Overview
+title: ALTER
 description: "The ALTER statement can be used to change authentication access and behaviour, global parameters, table configurations, table events, schema definitions, and indexes."
 ---
 

--- a/src/content/reference/query-language/statements/define/overview.mdx
+++ b/src/content/reference/query-language/statements/define/overview.mdx
@@ -1,6 +1,6 @@
 ---
 position: 1
-title: Overview
+title: DEFINE
 description: "DEFINE declares SurrealDB schema: namespaces, tables, fields, indexes, functions, events and access in SurrealQL."
 ---
 


### PR DESCRIPTION
Nineteen pages were titled "Overview".

In a sidebar that reads fine, because the surrounding tree says which overview it is. But the title is also the breadcrumb, the search result, and the heading of the markdown an agent retrieves, and in all three the context is gone. `# Overview` is not a useful thing for a retrieval index to hold nineteen copies of.

Each of these pages already sat in a folder whose `__category.json` carried the real name, so that is the name they now take.

Two needed something other than the folder name to stay distinct:

- `reference/cli/surrealctl` - `manage/surrealctl` already owns the plain executable name, so this is "surrealctl reference".
- Agent Memory's `reference` and `integrations` trees run alongside the database's, so both are prefixed.

After: zero pages titled "Overview", and duplicate titles drop from 357 pages to 338. The remainder are the twelve parallel SDK trees, where "Installation" or "Transactions" repeating per SDK is correct - the `<title>` tag already qualifies those with their section and product.

🤖 Generated with [Claude Code](https://claude.com/claude-code)