### PR TITLE
Mount the header once, above the page groups

### DIFF
--- a/src/assets/styles/override.scss
+++ b/src/assets/styles/override.scss
@@ -150,8 +150,7 @@
 }
 
 // Structural rules: the header's underline and the page aside's rail.
-[class*="_layout_"] > header,
-[class*="_fullWidthLayout_"] > header {
+[class*="_layout_"] > header {
 	border-bottom-color: var(--surreal-border-default) !important;
 }
 

--- a/src/components/Layout/frame.tsx
+++ b/src/components/Layout/frame.tsx
@@ -1,0 +1,76 @@
+import { Box, Drawer } from "@mantine/core";
+import { useDisclosure } from "@mantine/hooks";
+import { type CSSProperties, useEffect } from "react";
+import { usePageContext } from "vike-react/usePageContext";
+import globulesImg from "~/assets/img/globules.webp";
+import { Footer } from "~/components/Footer";
+import { Header, MobileNav } from "./header";
+import { navLinksForPath } from "./nav";
+import { getProductFromPath } from "./products";
+import classes from "./style.module.scss";
+
+/**
+ * The page frame: backdrop, header, mobile navigation and footer.
+ *
+ * This sits in the root layout rather than in each page group's, and that
+ * placement is the point. Every group has its own `+Layout.tsx` in its own
+ * lazily loaded chunk, so moving between two groups - switching product, most
+ * visibly - unmounts one layout and mounts another. Rebuilding the header as
+ * part of that swap made the wordmark blink on every product switch, waiting on
+ * a chunk that had nothing to do with it. Mounted once above the groups, the
+ * header is untouched by the transition and the switch is just a repaint.
+ *
+ * Nothing here depends on a group: the header's links follow from the path, and
+ * the footer is the same everywhere.
+ */
+export function PageFrame({ children }: { children: React.ReactNode }) {
+    const [menuOpened, { toggle: toggleMenu, close: closeMenu }] = useDisclosure();
+    const { urlPathname } = usePageContext();
+
+    const product = getProductFromPath(urlPathname);
+    const navLinks = navLinksForPath(urlPathname);
+
+    // Mantine portals its drawers and menus to `document.body`, outside this
+    // element, so the accent tokens have to be reachable from the root too.
+    useEffect(() => {
+        document.documentElement.dataset.product = product;
+    }, [product]);
+
+    // The drawer used to be discarded along with the layout on every
+    // navigation, which closed it as a side effect. It now outlives the page,
+    // so following one of its own links has to close it.
+    // biome-ignore lint/correctness/useExhaustiveDependencies: re-run on route change
+    useEffect(() => {
+        closeMenu();
+    }, [urlPathname]);
+
+    return (
+        <Box
+            className={classes.layout}
+            data-product={product}
+            style={
+                {
+                    "--bg-image": `url(${globulesImg})`,
+                    "--bg-opacity": 0.15,
+                } as CSSProperties
+            }
+        >
+            <Header
+                navLinks={navLinks}
+                opened={menuOpened}
+                onToggle={toggleMenu}
+            />
+            <Drawer
+                opened={menuOpened}
+                onClose={closeMenu}
+                size="325px"
+                hiddenFrom="lg"
+                withCloseButton={false}
+            >
+                <MobileNav navLinks={navLinks} />
+            </Drawer>
+            {children}
+            <Footer />
+        </Box>
+    );
+}

--- a/src/components/Layout/full-width.tsx
+++ b/src/components/Layout/full-width.tsx
@@ -1,58 +1,22 @@
-import { Container, Drawer, Stack } from "@mantine/core";
-import { useDisclosure } from "@mantine/hooks";
-import type { CSSProperties } from "react";
-import { usePageContext } from "vike-react/usePageContext";
-import globulesImg from "~/assets/img/globules.webp";
-import { Footer } from "~/components/Footer";
-import { Header, MobileNav } from "./header";
-import type { NavEntry } from "./nav";
-import { getProductFromPath } from "./products";
-import classes from "./style.module.scss";
+import { Container } from "@mantine/core";
 
 export interface FullWidthLayoutProps {
     children: React.ReactNode;
-    /** Top navigation entries shown in the header. Defined per layout. */
-    navLinks: NavEntry[];
 }
 
-export function FullWidthLayout({ children, navLinks }: FullWidthLayoutProps) {
-    const [menuOpened, { toggle: toggleMenu, close: closeMenu }] = useDisclosure();
-    const { urlPathname } = usePageContext();
-
+/**
+ * A page with no documentation tree beside it - the labs index and the error
+ * page. Header, backdrop and footer come from the frame around it, so all that
+ * is left here is the reading column.
+ */
+export function FullWidthLayout({ children }: FullWidthLayoutProps) {
     return (
-        <Stack
-            className={classes.fullWidthLayout}
-            data-product={getProductFromPath(urlPathname)}
-            gap={0}
-            style={
-                {
-                    "--bg-image": `url(${globulesImg})`,
-                    "--bg-opacity": 0.15,
-                } as CSSProperties
-            }
+        <Container
+            component="main"
+            size="lg"
+            flex={1}
         >
-            <Header
-                navLinks={navLinks}
-                opened={menuOpened}
-                onToggle={toggleMenu}
-            />
-            <Drawer
-                opened={menuOpened}
-                onClose={closeMenu}
-                size="325px"
-                hiddenFrom="lg"
-                withCloseButton={false}
-            >
-                <MobileNav navLinks={navLinks} />
-            </Drawer>
-            <Container
-                component="main"
-                size="lg"
-                flex={1}
-            >
-                {children}
-            </Container>
-            <Footer />
-        </Stack>
+            {children}
+        </Container>
     );
 }

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -12,26 +12,19 @@ import {
 } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
 import { Icon, iconSidebar } from "@surrealdb/ui";
-import { type CSSProperties, useEffect, useRef } from "react";
+import { useEffect, useRef } from "react";
 import { usePageContext } from "vike-react/usePageContext";
-import globulesImg from "~/assets/img/globules.webp";
 import { PageContentActions } from "~/components/ContentActions";
 import { PageAside } from "~/components/PageAside";
 import type { PageData } from "~/utils/data";
 import { CopyPageMenu } from "../CopyPageMenu";
-import { Footer } from "../Footer";
-import { Header, MobileNav } from "./header";
-import type { NavEntry } from "./nav";
 import { PageNavigation } from "./page-navigation";
-import { getProductFromPath } from "./products";
 import { Sidebar } from "./sidebar";
 import classes from "./style.module.scss";
 
 export interface DefaultLayoutProps {
     data: PageData;
     children: React.ReactNode;
-    /** Top navigation entries shown in the header. Defined per layout. */
-    navLinks: NavEntry[];
     lastUpdated?: string;
     showToc?: boolean;
     versionSelector?: React.ReactNode;
@@ -40,11 +33,9 @@ export interface DefaultLayoutProps {
 export function DefaultLayout({
     children,
     data,
-    navLinks,
     showToc = true,
     versionSelector,
 }: DefaultLayoutProps) {
-    const [menuOpened, { toggle: toggleMenu, close: closeMenu }] = useDisclosure();
     const [sidebarOpened, { toggle: toggleSidebar, close: closeSidebar }] = useDisclosure();
     const contentRef = useRef<HTMLDivElement>(null);
     const { urlPathname } = usePageContext();
@@ -52,39 +43,11 @@ export function DefaultLayout({
     // biome-ignore lint/correctness/useExhaustiveDependencies: re-run on route change
     useEffect(() => {
         window.scrollTo({ top: 0, behavior: "smooth" });
-    }, [urlPathname]);
-
-    // Mantine portals its drawers and menus to `document.body`, outside this
-    // element, so the accent tokens have to be reachable from the root too.
-    useEffect(() => {
-        document.documentElement.dataset.product = getProductFromPath(urlPathname);
+        closeSidebar();
     }, [urlPathname]);
 
     return (
-        <Box
-            className={classes.layout}
-            data-product={getProductFromPath(urlPathname)}
-            style={
-                {
-                    "--bg-image": `url(${globulesImg})`,
-                    "--bg-opacity": 0.15,
-                } as CSSProperties
-            }
-        >
-            <Header
-                navLinks={navLinks}
-                opened={menuOpened}
-                onToggle={toggleMenu}
-            />
-            <Drawer
-                opened={menuOpened}
-                onClose={closeMenu}
-                size="325px"
-                hiddenFrom="lg"
-                withCloseButton={false}
-            >
-                <MobileNav navLinks={navLinks} />
-            </Drawer>
+        <>
             <Drawer
                 opened={sidebarOpened}
                 onClose={closeSidebar}
@@ -203,7 +166,6 @@ export function DefaultLayout({
                     </Group>
                 </Stack>
             </Box>
-            <Footer />
-        </Box>
+        </>
     );
 }

--- a/src/components/Layout/nav.ts
+++ b/src/components/Layout/nav.ts
@@ -33,6 +33,7 @@ import {
     iconTransfer,
     iconVideo,
 } from "@surrealdb/ui";
+import { getProductFromPath } from "~/utils/product";
 
 export interface NavItem {
     label: string;
@@ -376,3 +377,16 @@ export const AGENT_MEMORY_NAV_LINKS: NavEntry[] = [
     { label: "Cookbooks", href: "/docs/agent-memory/cookbooks" },
     { label: "Reference", href: "/docs/agent-memory/reference" },
 ];
+
+/**
+ * Top navigation for a path.
+ *
+ * The header is rendered once for the whole site, above the page groups, so it
+ * has to work out its own links rather than take them from a group's layout.
+ * Product is the only thing that varies, and the path already determines that.
+ */
+export function navLinksForPath(pathname: string): NavEntry[] {
+    return getProductFromPath(pathname) === "agent-memory"
+        ? AGENT_MEMORY_NAV_LINKS
+        : SURREALDB_NAV_LINKS;
+}

--- a/src/components/Layout/style.module.scss
+++ b/src/components/Layout/style.module.scss
@@ -37,8 +37,7 @@
 	}
 }
 
-.layout,
-.fullWidthLayout {
+.layout {
 	position: relative;
 	min-height: 100vh;
 	background-color: rgba(from var(--mantine-color-obsidian-8) r g b / 0.25);
@@ -122,8 +121,7 @@
 	}
 }
 
-.layout,
-.fullWidthLayout {
+.layout {
 	// Neither shell has an inner scroll pane: the page itself scrolls. The
 	// backdrop is pinned to the viewport instead of stretching across the full
 	// document height, and the header pins with it.

--- a/src/pages/+Layout.tsx
+++ b/src/pages/+Layout.tsx
@@ -4,6 +4,7 @@ import { MantineProvider, v8CssVariablesResolver } from "@mantine/core";
 import { MANTINE_THEME } from "@surrealdb/ui";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { type ReactNode, useState } from "react";
+import { PageFrame } from "~/components/Layout/frame";
 
 export default function Layout({ children }: { children: ReactNode }) {
     const [queryClient] = useState(
@@ -24,7 +25,7 @@ export default function Layout({ children }: { children: ReactNode }) {
                 defaultColorScheme="dark"
                 cssVariablesResolver={v8CssVariablesResolver}
             >
-                {children}
+                <PageFrame>{children}</PageFrame>
             </MantineProvider>
         </QueryClientProvider>
     );

--- a/src/pages/_error/+Layout.tsx
+++ b/src/pages/_error/+Layout.tsx
@@ -1,6 +1,5 @@
 import { FullWidthLayout } from "~/components/Layout/full-width";
-import { SURREALDB_NAV_LINKS } from "~/components/Layout/nav";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-    return <FullWidthLayout navLinks={SURREALDB_NAV_LINKS}>{children}</FullWidthLayout>;
+    return <FullWidthLayout>{children}</FullWidthLayout>;
 }

--- a/src/pages/agent-memory/cookbooks/+Layout.tsx
+++ b/src/pages/agent-memory/cookbooks/+Layout.tsx
@@ -1,17 +1,9 @@
 import { useData } from "vike-react/useData";
 import { DefaultLayout } from "~/components/Layout";
-import { AGENT_MEMORY_NAV_LINKS } from "~/components/Layout/nav";
 import type { PageData } from "~/utils/data";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
     const data = useData<PageData>();
 
-    return (
-        <DefaultLayout
-            data={data}
-            navLinks={AGENT_MEMORY_NAV_LINKS}
-        >
-            {children}
-        </DefaultLayout>
-    );
+    return <DefaultLayout data={data}>{children}</DefaultLayout>;
 }

--- a/src/pages/agent-memory/index/+Layout.tsx
+++ b/src/pages/agent-memory/index/+Layout.tsx
@@ -1,17 +1,9 @@
 import { useData } from "vike-react/useData";
 import { DefaultLayout } from "~/components/Layout";
-import { AGENT_MEMORY_NAV_LINKS } from "~/components/Layout/nav";
 import type { PageData } from "~/utils/data";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
     const data = useData<PageData>();
 
-    return (
-        <DefaultLayout
-            data={data}
-            navLinks={AGENT_MEMORY_NAV_LINKS}
-        >
-            {children}
-        </DefaultLayout>
-    );
+    return <DefaultLayout data={data}>{children}</DefaultLayout>;
 }

--- a/src/pages/agent-memory/integrations/+Layout.tsx
+++ b/src/pages/agent-memory/integrations/+Layout.tsx
@@ -1,17 +1,9 @@
 import { useData } from "vike-react/useData";
 import { DefaultLayout } from "~/components/Layout";
-import { AGENT_MEMORY_NAV_LINKS } from "~/components/Layout/nav";
 import type { PageData } from "~/utils/data";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
     const data = useData<PageData>();
 
-    return (
-        <DefaultLayout
-            data={data}
-            navLinks={AGENT_MEMORY_NAV_LINKS}
-        >
-            {children}
-        </DefaultLayout>
-    );
+    return <DefaultLayout data={data}>{children}</DefaultLayout>;
 }

--- a/src/pages/agent-memory/reference/+Layout.tsx
+++ b/src/pages/agent-memory/reference/+Layout.tsx
@@ -1,17 +1,9 @@
 import { useData } from "vike-react/useData";
 import { DefaultLayout } from "~/components/Layout";
-import { AGENT_MEMORY_NAV_LINKS } from "~/components/Layout/nav";
 import type { PageData } from "~/utils/data";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
     const data = useData<PageData>();
 
-    return (
-        <DefaultLayout
-            data={data}
-            navLinks={AGENT_MEMORY_NAV_LINKS}
-        >
-            {children}
-        </DefaultLayout>
-    );
+    return <DefaultLayout data={data}>{children}</DefaultLayout>;
 }

--- a/src/pages/build/ai-agents/+Layout.tsx
+++ b/src/pages/build/ai-agents/+Layout.tsx
@@ -1,17 +1,9 @@
 import { useData } from "vike-react/useData";
 import { DefaultLayout } from "~/components/Layout";
-import { SURREALDB_NAV_LINKS } from "~/components/Layout/nav";
 import type { PageData } from "~/utils/data";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
     const data = useData<PageData>();
 
-    return (
-        <DefaultLayout
-            data={data}
-            navLinks={SURREALDB_NAV_LINKS}
-        >
-            {children}
-        </DefaultLayout>
-    );
+    return <DefaultLayout data={data}>{children}</DefaultLayout>;
 }

--- a/src/pages/build/embedding/+Layout.tsx
+++ b/src/pages/build/embedding/+Layout.tsx
@@ -1,17 +1,9 @@
 import { useData } from "vike-react/useData";
 import { DefaultLayout } from "~/components/Layout";
-import { SURREALDB_NAV_LINKS } from "~/components/Layout/nav";
 import type { PageData } from "~/utils/data";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
     const data = useData<PageData>();
 
-    return (
-        <DefaultLayout
-            data={data}
-            navLinks={SURREALDB_NAV_LINKS}
-        >
-            {children}
-        </DefaultLayout>
-    );
+    return <DefaultLayout data={data}>{children}</DefaultLayout>;
 }

--- a/src/pages/build/integrations/+Layout.tsx
+++ b/src/pages/build/integrations/+Layout.tsx
@@ -1,17 +1,9 @@
 import { useData } from "vike-react/useData";
 import { DefaultLayout } from "~/components/Layout";
-import { SURREALDB_NAV_LINKS } from "~/components/Layout/nav";
 import type { PageData } from "~/utils/data";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
     const data = useData<PageData>();
 
-    return (
-        <DefaultLayout
-            data={data}
-            navLinks={SURREALDB_NAV_LINKS}
-        >
-            {children}
-        </DefaultLayout>
-    );
+    return <DefaultLayout data={data}>{children}</DefaultLayout>;
 }

--- a/src/pages/build/migrating/+Layout.tsx
+++ b/src/pages/build/migrating/+Layout.tsx
@@ -1,17 +1,9 @@
 import { useData } from "vike-react/useData";
 import { DefaultLayout } from "~/components/Layout";
-import { SURREALDB_NAV_LINKS } from "~/components/Layout/nav";
 import type { PageData } from "~/utils/data";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
     const data = useData<PageData>();
 
-    return (
-        <DefaultLayout
-            data={data}
-            navLinks={SURREALDB_NAV_LINKS}
-        >
-            {children}
-        </DefaultLayout>
-    );
+    return <DefaultLayout data={data}>{children}</DefaultLayout>;
 }

--- a/src/pages/explore/ml-models/+Layout.tsx
+++ b/src/pages/explore/ml-models/+Layout.tsx
@@ -1,17 +1,9 @@
 import { useData } from "vike-react/useData";
 import { DefaultLayout } from "~/components/Layout";
-import { SURREALDB_NAV_LINKS } from "~/components/Layout/nav";
 import type { PageData } from "~/utils/data";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
     const data = useData<PageData>();
 
-    return (
-        <DefaultLayout
-            data={data}
-            navLinks={SURREALDB_NAV_LINKS}
-        >
-            {children}
-        </DefaultLayout>
-    );
+    return <DefaultLayout data={data}>{children}</DefaultLayout>;
 }

--- a/src/pages/explore/studio/+Layout.tsx
+++ b/src/pages/explore/studio/+Layout.tsx
@@ -1,17 +1,9 @@
 import { useData } from "vike-react/useData";
 import { DefaultLayout } from "~/components/Layout";
-import { SURREALDB_NAV_LINKS } from "~/components/Layout/nav";
 import type { PageData } from "~/utils/data";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
     const data = useData<PageData>();
 
-    return (
-        <DefaultLayout
-            data={data}
-            navLinks={SURREALDB_NAV_LINKS}
-        >
-            {children}
-        </DefaultLayout>
-    );
+    return <DefaultLayout data={data}>{children}</DefaultLayout>;
 }

--- a/src/pages/explore/tutorials/+Layout.tsx
+++ b/src/pages/explore/tutorials/+Layout.tsx
@@ -1,17 +1,9 @@
 import { useData } from "vike-react/useData";
 import { DefaultLayout } from "~/components/Layout";
-import { SURREALDB_NAV_LINKS } from "~/components/Layout/nav";
 import type { PageData } from "~/utils/data";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
     const data = useData<PageData>();
 
-    return (
-        <DefaultLayout
-            data={data}
-            navLinks={SURREALDB_NAV_LINKS}
-        >
-            {children}
-        </DefaultLayout>
-    );
+    return <DefaultLayout data={data}>{children}</DefaultLayout>;
 }

--- a/src/pages/index/+Layout.tsx
+++ b/src/pages/index/+Layout.tsx
@@ -1,17 +1,9 @@
 import { useData } from "vike-react/useData";
 import { DefaultLayout } from "~/components/Layout";
-import { SURREALDB_NAV_LINKS } from "~/components/Layout/nav";
 import type { PageData } from "~/utils/data";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
     const data = useData<PageData>();
 
-    return (
-        <DefaultLayout
-            data={data}
-            navLinks={SURREALDB_NAV_LINKS}
-        >
-            {children}
-        </DefaultLayout>
-    );
+    return <DefaultLayout data={data}>{children}</DefaultLayout>;
 }

--- a/src/pages/labs/+Layout.tsx
+++ b/src/pages/labs/+Layout.tsx
@@ -1,6 +1,5 @@
 import { FullWidthLayout } from "~/components/Layout/full-width";
-import { SURREALDB_NAV_LINKS } from "~/components/Layout/nav";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-    return <FullWidthLayout navLinks={SURREALDB_NAV_LINKS}>{children}</FullWidthLayout>;
+    return <FullWidthLayout>{children}</FullWidthLayout>;
 }

--- a/src/pages/learn/data-models/+Layout.tsx
+++ b/src/pages/learn/data-models/+Layout.tsx
@@ -1,17 +1,9 @@
 import { useData } from "vike-react/useData";
 import { DefaultLayout } from "~/components/Layout";
-import { SURREALDB_NAV_LINKS } from "~/components/Layout/nav";
 import type { PageData } from "~/utils/data";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
     const data = useData<PageData>();
 
-    return (
-        <DefaultLayout
-            data={data}
-            navLinks={SURREALDB_NAV_LINKS}
-        >
-            {children}
-        </DefaultLayout>
-    );
+    return <DefaultLayout data={data}>{children}</DefaultLayout>;
 }

--- a/src/pages/learn/extensions/+Layout.tsx
+++ b/src/pages/learn/extensions/+Layout.tsx
@@ -1,17 +1,9 @@
 import { useData } from "vike-react/useData";
 import { DefaultLayout } from "~/components/Layout";
-import { SURREALDB_NAV_LINKS } from "~/components/Layout/nav";
 import type { PageData } from "~/utils/data";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
     const data = useData<PageData>();
 
-    return (
-        <DefaultLayout
-            data={data}
-            navLinks={SURREALDB_NAV_LINKS}
-        >
-            {children}
-        </DefaultLayout>
-    );
+    return <DefaultLayout data={data}>{children}</DefaultLayout>;
 }

--- a/src/pages/learn/querying/+Layout.tsx
+++ b/src/pages/learn/querying/+Layout.tsx
@@ -1,17 +1,9 @@
 import { useData } from "vike-react/useData";
 import { DefaultLayout } from "~/components/Layout";
-import { SURREALDB_NAV_LINKS } from "~/components/Layout/nav";
 import type { PageData } from "~/utils/data";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
     const data = useData<PageData>();
 
-    return (
-        <DefaultLayout
-            data={data}
-            navLinks={SURREALDB_NAV_LINKS}
-        >
-            {children}
-        </DefaultLayout>
-    );
+    return <DefaultLayout data={data}>{children}</DefaultLayout>;
 }

--- a/src/pages/learn/schema-management/+Layout.tsx
+++ b/src/pages/learn/schema-management/+Layout.tsx
@@ -1,17 +1,9 @@
 import { useData } from "vike-react/useData";
 import { DefaultLayout } from "~/components/Layout";
-import { SURREALDB_NAV_LINKS } from "~/components/Layout/nav";
 import type { PageData } from "~/utils/data";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
     const data = useData<PageData>();
 
-    return (
-        <DefaultLayout
-            data={data}
-            navLinks={SURREALDB_NAV_LINKS}
-        >
-            {children}
-        </DefaultLayout>
-    );
+    return <DefaultLayout data={data}>{children}</DefaultLayout>;
 }

--- a/src/pages/learn/security/+Layout.tsx
+++ b/src/pages/learn/security/+Layout.tsx
@@ -1,17 +1,9 @@
 import { useData } from "vike-react/useData";
 import { DefaultLayout } from "~/components/Layout";
-import { SURREALDB_NAV_LINKS } from "~/components/Layout/nav";
 import type { PageData } from "~/utils/data";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
     const data = useData<PageData>();
 
-    return (
-        <DefaultLayout
-            data={data}
-            navLinks={SURREALDB_NAV_LINKS}
-        >
-            {children}
-        </DefaultLayout>
-    );
+    return <DefaultLayout data={data}>{children}</DefaultLayout>;
 }

--- a/src/pages/manage/enterprise/+Layout.tsx
+++ b/src/pages/manage/enterprise/+Layout.tsx
@@ -1,17 +1,9 @@
 import { useData } from "vike-react/useData";
 import { DefaultLayout } from "~/components/Layout";
-import { SURREALDB_NAV_LINKS } from "~/components/Layout/nav";
 import type { PageData } from "~/utils/data";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
     const data = useData<PageData>();
 
-    return (
-        <DefaultLayout
-            data={data}
-            navLinks={SURREALDB_NAV_LINKS}
-        >
-            {children}
-        </DefaultLayout>
-    );
+    return <DefaultLayout data={data}>{children}</DefaultLayout>;
 }

--- a/src/pages/manage/instances/+Layout.tsx
+++ b/src/pages/manage/instances/+Layout.tsx
@@ -1,17 +1,9 @@
 import { useData } from "vike-react/useData";
 import { DefaultLayout } from "~/components/Layout";
-import { SURREALDB_NAV_LINKS } from "~/components/Layout/nav";
 import type { PageData } from "~/utils/data";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
     const data = useData<PageData>();
 
-    return (
-        <DefaultLayout
-            data={data}
-            navLinks={SURREALDB_NAV_LINKS}
-        >
-            {children}
-        </DefaultLayout>
-    );
+    return <DefaultLayout data={data}>{children}</DefaultLayout>;
 }

--- a/src/pages/manage/observability/+Layout.tsx
+++ b/src/pages/manage/observability/+Layout.tsx
@@ -1,17 +1,9 @@
 import { useData } from "vike-react/useData";
 import { DefaultLayout } from "~/components/Layout";
-import { SURREALDB_NAV_LINKS } from "~/components/Layout/nav";
 import type { PageData } from "~/utils/data";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
     const data = useData<PageData>();
 
-    return (
-        <DefaultLayout
-            data={data}
-            navLinks={SURREALDB_NAV_LINKS}
-        >
-            {children}
-        </DefaultLayout>
-    );
+    return <DefaultLayout data={data}>{children}</DefaultLayout>;
 }

--- a/src/pages/manage/organisations/+Layout.tsx
+++ b/src/pages/manage/organisations/+Layout.tsx
@@ -1,17 +1,9 @@
 import { useData } from "vike-react/useData";
 import { DefaultLayout } from "~/components/Layout";
-import { SURREALDB_NAV_LINKS } from "~/components/Layout/nav";
 import type { PageData } from "~/utils/data";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
     const data = useData<PageData>();
 
-    return (
-        <DefaultLayout
-            data={data}
-            navLinks={SURREALDB_NAV_LINKS}
-        >
-            {children}
-        </DefaultLayout>
-    );
+    return <DefaultLayout data={data}>{children}</DefaultLayout>;
 }

--- a/src/pages/manage/schema-migration/+Layout.tsx
+++ b/src/pages/manage/schema-migration/+Layout.tsx
@@ -1,17 +1,9 @@
 import { useData } from "vike-react/useData";
 import { DefaultLayout } from "~/components/Layout";
-import { SURREALDB_NAV_LINKS } from "~/components/Layout/nav";
 import type { PageData } from "~/utils/data";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
     const data = useData<PageData>();
 
-    return (
-        <DefaultLayout
-            data={data}
-            navLinks={SURREALDB_NAV_LINKS}
-        >
-            {children}
-        </DefaultLayout>
-    );
+    return <DefaultLayout data={data}>{children}</DefaultLayout>;
 }

--- a/src/pages/manage/self-hosted/+Layout.tsx
+++ b/src/pages/manage/self-hosted/+Layout.tsx
@@ -1,17 +1,9 @@
 import { useData } from "vike-react/useData";
 import { DefaultLayout } from "~/components/Layout";
-import { SURREALDB_NAV_LINKS } from "~/components/Layout/nav";
 import type { PageData } from "~/utils/data";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
     const data = useData<PageData>();
 
-    return (
-        <DefaultLayout
-            data={data}
-            navLinks={SURREALDB_NAV_LINKS}
-        >
-            {children}
-        </DefaultLayout>
-    );
+    return <DefaultLayout data={data}>{children}</DefaultLayout>;
 }

--- a/src/pages/manage/surrealctl/+Layout.tsx
+++ b/src/pages/manage/surrealctl/+Layout.tsx
@@ -1,17 +1,9 @@
 import { useData } from "vike-react/useData";
 import { DefaultLayout } from "~/components/Layout";
-import { SURREALDB_NAV_LINKS } from "~/components/Layout/nav";
 import type { PageData } from "~/utils/data";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
     const data = useData<PageData>();
 
-    return (
-        <DefaultLayout
-            data={data}
-            navLinks={SURREALDB_NAV_LINKS}
-        >
-            {children}
-        </DefaultLayout>
-    );
+    return <DefaultLayout data={data}>{children}</DefaultLayout>;
 }

--- a/src/pages/reference/cli/+Layout.tsx
+++ b/src/pages/reference/cli/+Layout.tsx
@@ -1,17 +1,9 @@
 import { useData } from "vike-react/useData";
 import { DefaultLayout } from "~/components/Layout";
-import { SURREALDB_NAV_LINKS } from "~/components/Layout/nav";
 import type { PageData } from "~/utils/data";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
     const data = useData<PageData>();
 
-    return (
-        <DefaultLayout
-            data={data}
-            navLinks={SURREALDB_NAV_LINKS}
-        >
-            {children}
-        </DefaultLayout>
-    );
+    return <DefaultLayout data={data}>{children}</DefaultLayout>;
 }

--- a/src/pages/reference/dotnet/+Layout.tsx
+++ b/src/pages/reference/dotnet/+Layout.tsx
@@ -1,17 +1,9 @@
 import { useData } from "vike-react/useData";
 import { DefaultLayout } from "~/components/Layout";
-import { SURREALDB_NAV_LINKS } from "~/components/Layout/nav";
 import type { PageData } from "~/utils/data";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
     const data = useData<PageData>();
 
-    return (
-        <DefaultLayout
-            data={data}
-            navLinks={SURREALDB_NAV_LINKS}
-        >
-            {children}
-        </DefaultLayout>
-    );
+    return <DefaultLayout data={data}>{children}</DefaultLayout>;
 }

--- a/src/pages/reference/golang/+Layout.tsx
+++ b/src/pages/reference/golang/+Layout.tsx
@@ -1,17 +1,9 @@
 import { useData } from "vike-react/useData";
 import { DefaultLayout } from "~/components/Layout";
-import { SURREALDB_NAV_LINKS } from "~/components/Layout/nav";
 import type { PageData } from "~/utils/data";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
     const data = useData<PageData>();
 
-    return (
-        <DefaultLayout
-            data={data}
-            navLinks={SURREALDB_NAV_LINKS}
-        >
-            {children}
-        </DefaultLayout>
-    );
+    return <DefaultLayout data={data}>{children}</DefaultLayout>;
 }

--- a/src/pages/reference/java/+Layout.tsx
+++ b/src/pages/reference/java/+Layout.tsx
@@ -1,17 +1,9 @@
 import { useData } from "vike-react/useData";
 import { DefaultLayout } from "~/components/Layout";
-import { SURREALDB_NAV_LINKS } from "~/components/Layout/nav";
 import type { PageData } from "~/utils/data";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
     const data = useData<PageData>();
 
-    return (
-        <DefaultLayout
-            data={data}
-            navLinks={SURREALDB_NAV_LINKS}
-        >
-            {children}
-        </DefaultLayout>
-    );
+    return <DefaultLayout data={data}>{children}</DefaultLayout>;
 }

--- a/src/pages/reference/javascript/+Layout.tsx
+++ b/src/pages/reference/javascript/+Layout.tsx
@@ -1,17 +1,9 @@
 import { useData } from "vike-react/useData";
 import { DefaultLayout } from "~/components/Layout";
-import { SURREALDB_NAV_LINKS } from "~/components/Layout/nav";
 import type { PageData } from "~/utils/data";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
     const data = useData<PageData>();
 
-    return (
-        <DefaultLayout
-            data={data}
-            navLinks={SURREALDB_NAV_LINKS}
-        >
-            {children}
-        </DefaultLayout>
-    );
+    return <DefaultLayout data={data}>{children}</DefaultLayout>;
 }

--- a/src/pages/reference/kotlin/+Layout.tsx
+++ b/src/pages/reference/kotlin/+Layout.tsx
@@ -1,17 +1,9 @@
 import { useData } from "vike-react/useData";
 import { DefaultLayout } from "~/components/Layout";
-import { SURREALDB_NAV_LINKS } from "~/components/Layout/nav";
 import type { PageData } from "~/utils/data";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
     const data = useData<PageData>();
 
-    return (
-        <DefaultLayout
-            data={data}
-            navLinks={SURREALDB_NAV_LINKS}
-        >
-            {children}
-        </DefaultLayout>
-    );
+    return <DefaultLayout data={data}>{children}</DefaultLayout>;
 }

--- a/src/pages/reference/mojo/+Layout.tsx
+++ b/src/pages/reference/mojo/+Layout.tsx
@@ -1,17 +1,9 @@
 import { useData } from "vike-react/useData";
 import { DefaultLayout } from "~/components/Layout";
-import { SURREALDB_NAV_LINKS } from "~/components/Layout/nav";
 import type { PageData } from "~/utils/data";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
     const data = useData<PageData>();
 
-    return (
-        <DefaultLayout
-            data={data}
-            navLinks={SURREALDB_NAV_LINKS}
-        >
-            {children}
-        </DefaultLayout>
-    );
+    return <DefaultLayout data={data}>{children}</DefaultLayout>;
 }

--- a/src/pages/reference/php/+Layout.tsx
+++ b/src/pages/reference/php/+Layout.tsx
@@ -1,17 +1,9 @@
 import { useData } from "vike-react/useData";
 import { DefaultLayout } from "~/components/Layout";
-import { SURREALDB_NAV_LINKS } from "~/components/Layout/nav";
 import type { PageData } from "~/utils/data";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
     const data = useData<PageData>();
 
-    return (
-        <DefaultLayout
-            data={data}
-            navLinks={SURREALDB_NAV_LINKS}
-        >
-            {children}
-        </DefaultLayout>
-    );
+    return <DefaultLayout data={data}>{children}</DefaultLayout>;
 }

--- a/src/pages/reference/python/+Layout.tsx
+++ b/src/pages/reference/python/+Layout.tsx
@@ -1,17 +1,9 @@
 import { useData } from "vike-react/useData";
 import { DefaultLayout } from "~/components/Layout";
-import { SURREALDB_NAV_LINKS } from "~/components/Layout/nav";
 import type { PageData } from "~/utils/data";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
     const data = useData<PageData>();
 
-    return (
-        <DefaultLayout
-            data={data}
-            navLinks={SURREALDB_NAV_LINKS}
-        >
-            {children}
-        </DefaultLayout>
-    );
+    return <DefaultLayout data={data}>{children}</DefaultLayout>;
 }

--- a/src/pages/reference/query-language/+Layout.tsx
+++ b/src/pages/reference/query-language/+Layout.tsx
@@ -1,17 +1,9 @@
 import { useData } from "vike-react/useData";
 import { DefaultLayout } from "~/components/Layout";
-import { SURREALDB_NAV_LINKS } from "~/components/Layout/nav";
 import type { PageData } from "~/utils/data";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
     const data = useData<PageData>();
 
-    return (
-        <DefaultLayout
-            data={data}
-            navLinks={SURREALDB_NAV_LINKS}
-        >
-            {children}
-        </DefaultLayout>
-    );
+    return <DefaultLayout data={data}>{children}</DefaultLayout>;
 }

--- a/src/pages/reference/rest-api/+Layout.tsx
+++ b/src/pages/reference/rest-api/+Layout.tsx
@@ -1,17 +1,9 @@
 import { useData } from "vike-react/useData";
 import { DefaultLayout } from "~/components/Layout";
-import { SURREALDB_NAV_LINKS } from "~/components/Layout/nav";
 import type { PageData } from "~/utils/data";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
     const data = useData<PageData>();
 
-    return (
-        <DefaultLayout
-            data={data}
-            navLinks={SURREALDB_NAV_LINKS}
-        >
-            {children}
-        </DefaultLayout>
-    );
+    return <DefaultLayout data={data}>{children}</DefaultLayout>;
 }

--- a/src/pages/reference/rust/+Layout.tsx
+++ b/src/pages/reference/rust/+Layout.tsx
@@ -1,17 +1,9 @@
 import { useData } from "vike-react/useData";
 import { DefaultLayout } from "~/components/Layout";
-import { SURREALDB_NAV_LINKS } from "~/components/Layout/nav";
 import type { PageData } from "~/utils/data";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
     const data = useData<PageData>();
 
-    return (
-        <DefaultLayout
-            data={data}
-            navLinks={SURREALDB_NAV_LINKS}
-        >
-            {children}
-        </DefaultLayout>
-    );
+    return <DefaultLayout data={data}>{children}</DefaultLayout>;
 }

--- a/src/pages/reference/swift/+Layout.tsx
+++ b/src/pages/reference/swift/+Layout.tsx
@@ -1,17 +1,9 @@
 import { useData } from "vike-react/useData";
 import { DefaultLayout } from "~/components/Layout";
-import { SURREALDB_NAV_LINKS } from "~/components/Layout/nav";
 import type { PageData } from "~/utils/data";
 
 export default function Layout({ children }: { children: React.ReactNode }) {
     const data = useData<PageData>();
 
-    return (
-        <DefaultLayout
-            data={data}
-            navLinks={SURREALDB_NAV_LINKS}
-        >
-            {children}
-        </DefaultLayout>
-    );
+    return <DefaultLayout data={data}>{children}</DefaultLayout>;
 }


### PR DESCRIPTION
Switching between Database and Agent Memory made the logo, the divider and the "Docs" wordmark blink - none of which differ between the two products.

## Cause

Every page group has its own `+Layout.tsx`, in its own lazily loaded chunk, and each one rendered its own `Header`. Moving between two groups unmounts one layout and mounts another, so the header was torn down and rebuilt as part of the transition - waiting on a chunk that had nothing to do with it.

Measured on the live site, tagging the header node and then switching product:

| | before | after |
|---|---|---|
| client-side routed | `true` | `true` |
| header is the same DOM node | **`false`** | **`true`** |
| logo SVG is the same node | **`false`** | **`true`** |

So this was not a loading problem - the routing was already working. The header was simply being rebuilt for no reason.

## Change

The page frame - backdrop, header, mobile navigation, footer - moves into the root layout, which is mounted once for the whole site. Nothing in it depended on a group: the header's links follow from the path (`navLinksForPath`), and the footer is the same everywhere. Each group's layout keeps only the part that is genuinely its own, and the `navLinks` prop threaded through all thirty-nine of them is gone.

Two knock-on changes:

- `FullWidthLayout` is now only a reading column, so the `.fullWidthLayout` rules fold into `.layout`. They described the same page frame.
- The two drawers used to be closed by being discarded on navigation. Now that they outlive the page, they close themselves.

## Verified

Same DOM nodes survive a switch in both directions; header stays sticky at 66px; header, shell and footer remain direct children of `.layout`, which is what the frame's CSS keys on. SSR output is structurally identical to production - one header, one footer, one main, three navs, one aside - on a docs page, on `/docs/agent-memory`, and on `/docs/labs`. `qa`, `qc`, `tsc` and the production build are all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)