### PR TITLE
Paint the mobile menu drawers white in light mode

### DIFF
--- a/src/components/Layout/frame.tsx
+++ b/src/components/Layout/frame.tsx
@@ -66,6 +66,7 @@ export function PageFrame({ children }: { children: React.ReactNode }) {
                 size="325px"
                 hiddenFrom="lg"
                 withCloseButton={false}
+                classNames={{ content: classes.drawerContent }}
             >
                 <MobileNav navLinks={navLinks} />
             </Drawer>

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -54,6 +54,7 @@ export function DefaultLayout({
                 size="325px"
                 hiddenFrom="lg"
                 withCloseButton={false}
+                classNames={{ content: classes.drawerContent }}
             >
                 <Sidebar
                     navigation={data.navigation}

--- a/src/components/Layout/style.module.scss
+++ b/src/components/Layout/style.module.scss
@@ -150,6 +150,24 @@
 	}
 }
 
+// Both mobile drawers (the page-frame menu and the sidebar tree) portal to
+// `document.body`, so the layout's own light-mode surfaces never reach them
+// and they fall back to the theme's grey body colour. Painted white here to
+// match the reading column, with the same treatment the kit's NavLink label
+// gets in light mode extended to its description - the kit ships no light
+// override for it, leaving near-white text on a white sheet.
+.drawer-content {
+	@include light {
+		background-color: var(--mantine-color-white);
+	}
+
+	:global(.mantine-NavLink-description) {
+		@include light {
+			color: var(--mantine-color-slate-6);
+		}
+	}
+}
+
 .breadcrumb-scroll {
 	overflow-x: auto;
 	scrollbar-width: none;


### PR DESCRIPTION
## What

Makes both mobile drawers (the burger menu and the sidebar-tree drawer) render on a white sheet in light mode, and restores contrast on the menu subheading text, which was invisible on live.

## Why

Both drawers portal to `document.body`, so the layout's light-mode surfaces never reach them and they fell back to the theme's grey body colour. Separately, `@surrealdb/ui`'s NavLink variant paints the `description` text in `slate-2` (near-white, meant for dark surfaces) and ships a light-mode override for the label but not the description, so on the light drawer the subheadings were white-on-white.

## How

- A new `drawer-content` class in `style.module.scss`: white background under the light scheme, and the description colour mirrored to `slate-6` (the same colour the label takes in light mode). Every new rule sits under the light-scheme selector, so dark mode is untouched.
- The class is passed to both drawers via `classNames={{ content: … }}` in `frame.tsx` and `index.tsx`.

## Verification

Opened the drawer in the dev server and read computed styles: light mode gives drawer background `rgb(255,255,255)` and description text `rgb(53,60,74)`; dark mode still gives background `rgb(24,23,33)` with light `rgb(214,220,230)` descriptions. `bun run qa` and `bun run qc` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)