### PR TITLE
Docs audit quick wins: legacy redirects, first queries, SDK compat copy, time estimates, llms-full.txt

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -2,7 +2,7 @@
 
 SurrealDB is a [multi-model database](https://surrealdb.com/features) that stores relational, document, graph, time-series, vector, full-text and key-value data in one place, queried through [SurrealQL](https://surrealdb.com/docs/reference/query-language). It runs embedded in an application, as a single node, or as a distributed cluster, and is also available as [SurrealDB Agent Memory](https://surrealdb.com/docs/agent-memory), a memory and knowledge layer for AI agents.
 
-> Markdown for agents: every documentation page is also available as markdown. Append ".md" to any page path to fetch it directly, for example "https://surrealdb.com/docs/reference/query-language/statements/select.md". The same document is served on the page's own URL to a request sending an "Accept: text/markdown" header, with "Content-Type: text/markdown" and an "x-markdown-tokens" estimate. HTML stays the default for browsers. Links inside a markdown page already point at the ".md" variants, so following them keeps an agent in markdown.
+> Markdown for agents: every documentation page is also available as markdown. Append ".md" to any page path to fetch it directly, for example "https://surrealdb.com/docs/reference/query-language/statements/select.md". The same document is served on the page's own URL to a request sending an "Accept: text/markdown" header, with "Content-Type: text/markdown" and an "x-markdown-tokens" estimate. HTML stays the default for browsers. Links inside a markdown page already point at the ".md" variants, so following them keeps an agent in markdown. The complete documentation is also available as a single markdown document at "https://surrealdb.com/docs/llms-full.txt".
 
 Working notes:
 

--- a/redirects.ts
+++ b/redirects.ts
@@ -99,6 +99,134 @@ function legacyMigratingRedirects(): Redirect[] {
     return out;
 }
 
+/**
+ * Legacy `/docs/surrealdb/*` tree from the pre-restructure IA. The www repo
+ * redirects some of this tree (`installation`, `security`, `cli`, and the bare
+ * `/docs/surrealdb`), but `introduction/*`, the nested `surrealql/*` pages, and
+ * the old top-level `/docs/cli` prefix were left behind and 404 (verified
+ * August 2026). Exact page rules precede the folder catch-alls that would
+ * otherwise swallow them.
+ */
+function legacySurrealdbTreeRedirects(): Redirect[] {
+    // "prefix" collapses a removed tree onto one page; "prefix-path" carries
+    // the path through to a tree whose slugs still match one-for-one.
+    const moves: [string, string, "exact" | "prefix" | "prefix-path"][] = [
+        // The old "Start" page covered running the server; its successor is the
+        // Running section index.
+        ["surrealdb/introduction/start", "running/overview", "exact"],
+        ["surrealdb/introduction/concepts", "concepts", "exact"],
+        ["surrealdb/introduction/architecture", "architecture", "exact"],
+        ["surrealdb/introduction", "what-is-surrealdb", "prefix"],
+        // SurrealQL nested under the product prefix → the query language
+        // reference, whose slugs mirror the old tree.
+        ["surrealdb/surrealql", "reference/query-language", "prefix-path"],
+        // Remaining unmapped pages fold into the product introduction rather
+        // than 404. The www rules for `installation`, `security`, and `cli`
+        // run first in production, so this only catches what they miss.
+        ["surrealdb", "what-is-surrealdb", "prefix"],
+    ];
+
+    const out: Redirect[] = [];
+
+    for (const [from, to, kind] of moves) {
+        // Both source spellings: the www rewrite strips `/docs` in production,
+        // while dev and preview see the prefixed path.
+        for (const source of [`/${from}`, `/docs/${from}`]) {
+            out.push({ source, destination: `/docs/${to}`, statusCode: 301 });
+
+            if (kind !== "exact") {
+                out.push({
+                    source: `${source}/:path*`,
+                    destination: kind === "prefix-path" ? `/docs/${to}/:path*` : `/docs/${to}`,
+                    statusCode: 301,
+                });
+            }
+        }
+    }
+
+    // The very old top-level CLI prefix. `overview` sits beside the commands
+    // folder, so it is named before the command catch-all.
+    out.push(
+        { source: "/cli", destination: "/docs/reference/cli", statusCode: 301 },
+        { source: "/docs/cli", destination: "/docs/reference/cli", statusCode: 301 },
+        {
+            source: "/cli/overview",
+            destination: "/docs/reference/cli/surrealdb-cli/overview",
+            statusCode: 301,
+        },
+        {
+            source: "/docs/cli/overview",
+            destination: "/docs/reference/cli/surrealdb-cli/overview",
+            statusCode: 301,
+        },
+        {
+            source: "/cli/:path*",
+            destination: "/docs/reference/cli/surrealdb-cli/commands/:path*",
+            statusCode: 301,
+        },
+        {
+            source: "/docs/cli/:path*",
+            destination: "/docs/reference/cli/surrealdb-cli/commands/:path*",
+            statusCode: 301,
+        },
+    );
+
+    return out;
+}
+
+/**
+ * Old `/docs/integration(s)/sdks/*` pages → the per-language docs. Without
+ * these, the general `integrations → build/integrations` prefix rule sends
+ * SDK paths to `/docs/build/integrations/sdks/*`, which does not exist - a
+ * redirect chain that ends in a 404 (verified August 2026). Spread before
+ * `legacyPrefixRedirects("integrations", …)` so these rules win.
+ */
+function legacyIntegrationSdkRedirects(): Redirect[] {
+    const sdks: [string, string][] = [
+        ["nodejs", "javascript"],
+        ["deno", "javascript"],
+        ["dotnet", "dotnet"],
+        ["golang", "golang"],
+        ["java", "java"],
+        ["javascript", "javascript"],
+        ["kotlin", "kotlin"],
+        ["php", "php"],
+        ["python", "python"],
+        ["rust", "rust"],
+    ];
+
+    const out: Redirect[] = [];
+
+    for (const [from, to] of sdks) {
+        for (const source of [`/integrations/sdks/${from}`, `/docs/integrations/sdks/${from}`]) {
+            out.push(
+                { source, destination: `/docs/languages/${to}`, statusCode: 301 },
+                // Deeper legacy paths collapse onto the language hub; mapping
+                // them through would name pages that no longer exist.
+                {
+                    source: `${source}/:path*`,
+                    destination: `/docs/languages/${to}`,
+                    statusCode: 301,
+                },
+            );
+        }
+    }
+
+    // The section index and any SDK slug not named above.
+    out.push(
+        { source: "/integrations/sdks", destination: "/docs/languages", statusCode: 301 },
+        { source: "/docs/integrations/sdks", destination: "/docs/languages", statusCode: 301 },
+        { source: "/integrations/sdks/:path*", destination: "/docs/languages", statusCode: 301 },
+        {
+            source: "/docs/integrations/sdks/:path*",
+            destination: "/docs/languages",
+            statusCode: 301,
+        },
+    );
+
+    return out;
+}
+
 /** Database functions overview merged into the section index. */
 function databaseFunctionsOverviewRedirects(): Redirect[] {
     const from = "/reference/query-language/functions/database-functions/overview";
@@ -597,10 +725,12 @@ export const docsRedirects: Redirect[] = [
     { source: "/surrealist", destination: "/explore/studio", statusCode: 301 },
     { source: "/surrealist/:path*", destination: "/explore/studio", statusCode: 301 },
     ...legacyPrefixRedirects("surrealml", "explore/ml-models"),
+    ...legacyIntegrationSdkRedirects(),
     ...legacyPrefixRedirects("integrations", "build/integrations"),
     ...legacyPrefixRedirects("tutorials", "explore/tutorials"),
     ...sdkRedirects(),
     ...legacyMigratingRedirects(),
+    ...legacySurrealdbTreeRedirects(),
     ...deploymentObservabilityToManageRedirects(),
     ...runningFromSelfHostedRedirects(),
     ...databaseFunctionsOverviewRedirects(),

--- a/src/content/index/running/docker.mdx
+++ b/src/content/index/running/docker.mdx
@@ -114,3 +114,53 @@ SUBCOMMANDS:
 ```
 
 For details on the different commands available, visit the [CLI tool documentation](/docs/reference/cli/surrealdb-cli/overview).
+
+## Run your first query
+
+With the server container running and port `8000` published, connect to it with the [`surreal sql`](/docs/reference/cli/surrealdb-cli/commands/sql) command from the same image. This starts a SurrealQL REPL against the server, using the credentials from the authentication step above.
+
+```bash
+docker run --rm --pull always -it surrealdb/surrealdb:latest sql --endpoint http://host.docker.internal:8000 --username root --password secret --namespace main --database main --pretty
+```
+
+> [!NOTE]
+> `host.docker.internal` resolves to the host on Docker Desktop for macOS and Windows. On Linux, add `--add-host=host.docker.internal:host-gateway` to the command, or use `--network host` and connect to `http://localhost:8000`. If you have the `surreal` binary installed on the host, you can connect with `surreal sql --endpoint http://localhost:8000` and the same flags instead.
+
+Create a record. There is no need to define the table first, because SurrealDB creates it on the first write.
+
+```surql
+CREATE person:tobie SET name = "Tobie", city = "London";
+```
+
+```surql title="Output"
+[
+	{
+		city: 'London',
+		id: person:tobie,
+		name: 'Tobie'
+	}
+]
+```
+
+Select it back to confirm the round trip.
+
+```surql
+SELECT name, city FROM person;
+```
+
+```surql title="Output"
+[
+	{
+		city: 'London',
+		name: 'Tobie'
+	}
+]
+```
+
+When you finish, exit the REPL with `Ctrl+C`. If you started the server with a mounted volume and the on-disk storage engine, the record persists across container restarts.
+
+## Next steps
+
+- Query from your application with an [SDK](/docs/languages/javascript) - each language guide starts with a connect-and-query walkthrough.
+- Try SurrealQL without a server in the [Studio Sandbox](/docs/running/sandbox).
+- Learn the query language, starting with the [`SELECT` statement](/docs/reference/query-language/statements/select).

--- a/src/content/index/running/file-backed.mdx
+++ b/src/content/index/running/file-backed.mdx
@@ -108,3 +108,49 @@ SurrealKV tends to work well for write-heavy workloads, prefix-based access patt
 </TabItem>
 
 </Tabs>
+## Run your first query
+
+With the server running, open a second terminal and connect to it with the [`surreal sql`](/docs/reference/cli/surrealdb-cli/commands/sql) command. This starts a SurrealQL REPL against the server, using the credentials from the step above.
+
+```bash
+surreal sql --endpoint http://localhost:8000 --username root --password secret --namespace main --database main --pretty
+```
+
+Create a record. There is no need to define the table first, because SurrealDB creates it on the first write.
+
+```surql
+CREATE person:tobie SET name = "Tobie", city = "London";
+```
+
+```surql title="Output"
+[
+	{
+		city: 'London',
+		id: person:tobie,
+		name: 'Tobie'
+	}
+]
+```
+
+Select it back to confirm the round trip.
+
+```surql
+SELECT name, city FROM person;
+```
+
+```surql title="Output"
+[
+	{
+		city: 'London',
+		name: 'Tobie'
+	}
+]
+```
+
+When you finish, exit the REPL with `Ctrl+C`. The record persists on disk, so it is still there the next time you start the server against the same path.
+
+## Next steps
+
+- Query from your application with an [SDK](/docs/languages/javascript) - each language guide starts with a connect-and-query walkthrough.
+- Try SurrealQL without a server in the [Studio Sandbox](/docs/running/sandbox).
+- Learn the query language, starting with the [`SELECT` statement](/docs/reference/query-language/statements/select).

--- a/src/content/index/running/in-memory.mdx
+++ b/src/content/index/running/in-memory.mdx
@@ -145,3 +145,50 @@ For details on the different commands available, visit the [CLI tool documentati
 </TabItem>
 
 </Tabs>
+
+## Run your first query
+
+With the server running, open a second terminal and connect to it with the [`surreal sql`](/docs/reference/cli/surrealdb-cli/commands/sql) command. This starts a SurrealQL REPL against the server, using the credentials from the step above.
+
+```bash
+surreal sql --endpoint http://localhost:8000 --username root --password secret --namespace main --database main --pretty
+```
+
+Create a record. There is no need to define the table first, because SurrealDB creates it on the first write.
+
+```surql
+CREATE person:tobie SET name = "Tobie", city = "London";
+```
+
+```surql title="Output"
+[
+	{
+		city: 'London',
+		id: person:tobie,
+		name: 'Tobie'
+	}
+]
+```
+
+Select it back to confirm the round trip.
+
+```surql
+SELECT name, city FROM person;
+```
+
+```surql title="Output"
+[
+	{
+		city: 'London',
+		name: 'Tobie'
+	}
+]
+```
+
+When you finish, exit the REPL with `Ctrl+C`. Data in an in-memory server is lost on shutdown unless you enable the persistence options above.
+
+## Next steps
+
+- Query from your application with an [SDK](/docs/languages/javascript) - each language guide starts with a connect-and-query walkthrough.
+- Try SurrealQL without a server in the [Studio Sandbox](/docs/running/sandbox).
+- Learn the query language, starting with the [`SELECT` statement](/docs/reference/query-language/statements/select).

--- a/src/content/index/running/overview.mdx
+++ b/src/content/index/running/overview.mdx
@@ -10,11 +10,11 @@ You can start with SurrealDB in more than one way. This section orders them from
 
 ## Try it without installing
 
-1. **[SurrealDB Studio Sandbox](/docs/running/sandbox)** - Open SurrealDB Studio in the browser and use the built-in Sandbox. Nothing to install; data is not persistent, which is perfect for quick experiments and learning SurrealQL.
+1. **[SurrealDB Studio Sandbox](/docs/running/sandbox)** (under a minute) - Open SurrealDB Studio in the browser and use the built-in Sandbox. Nothing to install; data is not persistent, which is perfect for quick experiments and learning SurrealQL.
 
-2. **[SurrealDB Cloud](/docs/running/cloud)** - Create a free [SurrealDB Cloud](/docs/manage/instances) instance (you will need an email to sign in). You keep persistence and a managed database without running a server on your own machine.
+2. **[SurrealDB Cloud](/docs/running/cloud)** (about 5 minutes) - Create a free [SurrealDB Cloud](/docs/manage/instances) instance (you will need an email to sign in). You keep persistence and a managed database without running a server on your own machine.
 
-3. **[Installation](/docs/running/installation)** - Install the `surreal` binary and run SurrealDB locally or on your own infrastructure. This is the path when you want full control, offline work, or production self-hosting.
+3. **[Installation](/docs/running/installation)** (about 10 minutes) - Install the `surreal` binary and run SurrealDB locally or on your own infrastructure. This is the path when you want full control, offline work, or production self-hosting.
 
 ## How you run the database on your own infrastructure
 

--- a/src/content/reference/dotnet/index.mdx
+++ b/src/content/reference/dotnet/index.mdx
@@ -14,7 +14,7 @@ The SurrealDB SDK for C# and .NET enables you to interact with SurrealDB from se
 
 > [!NOTE]
 > The latest version of the SDK is <Version sdk=".net" />.
-> The SDK works with SurrealDB versions `v2.0.0` to <Version />, ensuring compatibility with the latest version.
+> The SDK works with SurrealDB versions `v2.0.0` and later, including the current release, <Version />.
 
 ## Getting started
 

--- a/src/content/reference/golang/index.mdx
+++ b/src/content/reference/golang/index.mdx
@@ -13,7 +13,7 @@ The SurrealDB SDK for Go enables you to interact with SurrealDB from server-side
 
 > [!NOTE]
 > The latest version of the SDK is <Version sdk="golang" />.
-> The SDK works with SurrealDB versions `v2.0.0` to <Version />, ensuring compatibility with the latest version.
+> The SDK works with SurrealDB versions `v2.0.0` and later, including the current release, <Version />.
 
 ## Getting started
 

--- a/src/content/reference/java/index.mdx
+++ b/src/content/reference/java/index.mdx
@@ -10,7 +10,7 @@ The SurrealDB SDK for Java lets you connect to [SurrealDB](/docs) from any Java 
 
 > [!NOTE]
 > The latest version of the SDK is <Version sdk="java" />.
-> The SDK works with SurrealDB versions `v2.0.0` to <Version />, ensuring compatibility with the latest version.
+> The SDK works with SurrealDB versions `v2.0.0` and later, including the current release, <Version />.
 
 ## Getting started
 

--- a/src/content/reference/javascript/index.mdx
+++ b/src/content/reference/javascript/index.mdx
@@ -10,7 +10,7 @@ The SurrealDB SDK for JavaScript and TypeScript lets you easily connect to Surre
 
 > [!NOTE]
 > The latest version of the SDK is <Version sdk="javascript" />.
-> The SDK works with SurrealDB versions `v2.0.0` to <Version />, ensuring compatibility with the latest version.
+> The SDK works with SurrealDB versions `v2.0.0` and later, including the current release, <Version />.
 
 ## Getting started
 <Boxes>

--- a/src/content/reference/python/index.mdx
+++ b/src/content/reference/python/index.mdx
@@ -13,7 +13,7 @@ The SurrealDB SDK for Python lets you connect to SurrealDB from any Python appli
 
 > [!NOTE]
 > The latest version of the SDK is <Version sdk="python" />.
-> The SDK works with SurrealDB versions `v2.0.0` to <Version />, ensuring compatibility with the latest version.
+> The SDK works with SurrealDB versions `v2.0.0` and later, including the current release, <Version />.
 
 ## Getting started
 

--- a/src/content/reference/rust/index.mdx
+++ b/src/content/reference/rust/index.mdx
@@ -13,7 +13,7 @@ The SurrealDB SDK for Rust enables you to interact with SurrealDB from client-si
 
 > [!NOTE]
 > The latest version of the SDK is <Version sdk="rust" />.
-> The SDK works with SurrealDB versions `v2.0.0` to <Version />, ensuring compatibility with the latest version.
+> The SDK works with SurrealDB versions `v2.0.0` and later, including the current release, <Version />.
 
 ## Getting started
 

--- a/src/pages/+server.ts
+++ b/src/pages/+server.ts
@@ -8,11 +8,47 @@ import {
     MARKDOWN_CACHE_CONTROL,
     MARKDOWN_CONTENT_TYPE,
 } from "~/utils/agent-markdown";
-import { composeRawMarkdown, resolveCollectionEntry } from "~/utils/collections";
+import {
+    composeFullCorpusMarkdown,
+    composeRawMarkdown,
+    resolveCollectionEntry,
+} from "~/utils/collections";
 
 const BASE = "/docs";
 
 const app = new Hono();
+
+/**
+ * The full documentation corpus as one markdown document, following the
+ * llms-full.txt convention. The hand-maintained index at `/docs/llms.txt`
+ * links pages individually; this endpoint serves every page in one response
+ * for agents that prefer a single fetch over walking the index.
+ *
+ * Composed once per server instance: the content is fixed at build time, and
+ * SDK versions come from the same file-backed cache the page render uses. A
+ * failed compose is not memoised, so the next request retries.
+ */
+let fullCorpus: Promise<string> | undefined;
+
+app.get(`${BASE}/llms-full.txt`, async (c) => {
+    if (!fullCorpus) {
+        fullCorpus = fetchAllSdkVersions().then(composeFullCorpusMarkdown);
+        fullCorpus.catch(() => {
+            fullCorpus = undefined;
+        });
+    }
+
+    const markdown = await fullCorpus;
+
+    return c.body(markdown, 200, {
+        "Content-Type": MARKDOWN_CONTENT_TYPE,
+        "Cache-Control": MARKDOWN_CACHE_CONTROL,
+        "X-Markdown-Tokens": String(estimateTokens(markdown)),
+        // One giant concatenation of pages that are all indexed at their own
+        // URLs; keep it out of search results as a duplicate.
+        "X-Robots-Tag": "noindex",
+    });
+});
 
 /**
  * Serves a page's markdown representation, two ways:

--- a/src/utils/collections.ts
+++ b/src/utils/collections.ts
@@ -1,4 +1,5 @@
-import { getCollectionEntry } from "vike-content-collection";
+import type { CollectionMap } from "vike-content-collection";
+import { getCollection, getCollectionEntry } from "vike-content-collection";
 import type { SdkVersionMap } from "~/lib/versions";
 import { stripLanguageTestComments, stripLeadingH1 } from "./markdown";
 import { flattenMdxComponents } from "./mdx-to-markdown";
@@ -129,4 +130,40 @@ export function composeRawMarkdown(entry: CollectionEntry, sdkVersions?: SdkVers
     const document = [heading, metadata.description, body].filter(Boolean).join("\n\n");
 
     return `${suffixDocsLinks(document)}\n`;
+}
+
+const DOCS_ORIGIN = "https://surrealdb.com";
+
+/**
+ * Build the full documentation corpus served at `/docs/llms-full.txt`: every
+ * page of every collection as one markdown document, in the llms-full.txt
+ * convention. Each page opens with a `Source:` line naming its canonical URL,
+ * so an agent can cite or re-fetch the page it is quoting.
+ *
+ * Pages are composed with the same `composeRawMarkdown` pipeline as the
+ * per-page `.md` endpoint, so `<Version>` markers, stripped test annotations,
+ * and `.md`-suffixed internal links all match what a single-page fetch returns.
+ * `__category` entries are folder metadata, not pages, and are skipped.
+ */
+export function composeFullCorpusMarkdown(sdkVersions?: SdkVersionMap): string {
+    const sections: string[] = [
+        "# SurrealDB documentation - full corpus",
+        `> The complete SurrealDB documentation as a single markdown document. Each page starts with a "Source:" line naming its canonical URL. The page index is at ${DOCS_ORIGIN}/docs/llms.txt, and every page is also available individually by appending \`.md\` to its URL.`,
+    ];
+
+    for (const { prefix, id } of COLLECTION_ROUTES) {
+        const entries = [...getCollection(id as keyof CollectionMap)]
+            .filter((entry) => !entry.slug.endsWith("__category"))
+            .sort((a, b) => a.slug.localeCompare(b.slug));
+
+        for (const entry of entries) {
+            const path = [prefix, entry.slug].filter(Boolean).join("/");
+            const url = path ? `${DOCS_ORIGIN}/docs/${path}` : `${DOCS_ORIGIN}/docs`;
+            const page = composeRawMarkdown(entry, sdkVersions).trimEnd();
+
+            sections.push(`---\n\nSource: ${url}\n\n${page}`);
+        }
+    }
+
+    return `${sections.join("\n\n")}\n`;
 }


### PR DESCRIPTION
## Summary

Five quick wins from the August 2026 competitive documentation audit, one commit each:

1. **Redirect legacy URLs that 404** - The IA restructure left historically canonical URLs dead (all verified as live 404s against production on 2026-08-24):
   - `/docs/surrealdb/introduction/start` → `/docs/running/overview` (plus `concepts`, `architecture`, and an `introduction` catch-all)
   - `/docs/surrealdb/surrealql/*` → `/docs/reference/query-language/*` (path carried through, slugs match one-for-one)
   - `/docs/cli` and `/docs/cli/*` → the CLI reference
   - `/docs/integrations/sdks/*` → `/docs/languages/*` (`nodejs`/`deno` aliased to `javascript`); previously chained through the general integrations rule into a 404 at `/docs/build/integrations/sdks/*`
   - A `/surrealdb/*` catch-all folds anything else into `/docs/what-is-surrealdb`; the www repo's own rules (`installation`, `security`, `cli`) run first in production, so this only catches what they miss
2. **First query on every Running page** - `in-memory`, `file-backed`, and `docker` started the server and stopped. Each now ends with a "Run your first query" section: `surreal sql` connect, `CREATE` and `SELECT` with expected output, a persistence note, and next steps to the SDK guides, Studio Sandbox, and SurrealQL reference.
3. **SDK compatibility copy** - Six SDK reference index pages said "works with `v2.0.0` to `<Version />`", rendering the latest release as a tested ceiling that contradicted "since v3.2.5" markers elsewhere. Now states the floor: "`v2.0.0` and later, including the current release".
4. **Time estimates** on the three getting-started paths in `running/overview` (under a minute / ~5 minutes / ~10 minutes).
5. **`/docs/llms-full.txt`** - Serves the full docs corpus as one markdown document through the same pipeline as the per-page `.md` endpoint (each page led by a `Source:` line naming its canonical URL), memoised per server instance, with `x-markdown-tokens` and `noindex` headers, advertised from `llms.txt`.

## Test plan

- [x] `bun run qa` and `bun run qc` pass
- [x] 20 legacy-URL cases through `resolveRedirect` and against the dev server, including both `/docs`-prefixed and stripped spellings; existing rules (e.g. `surrealdb/migrating/*`) still win where they should
- [x] Dev server: `/docs/llms-full.txt` returns 200, 998 pages, ~6.9 MB, `text/markdown` with token-estimate and noindex headers
- [x] Dev server: first-query sections render on all three Running pages with titled Output blocks and appear in the on-page ToC
- [x] Reworded compatibility sentence and time estimates verified through the `.md` endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)