### PR TITLE
Document the SELECT ... FOR UPDATE clause

### DIFF
--- a/src/content/reference/query-language/statements/select.mdx
+++ b/src/content/reference/query-language/statements/select.mdx
@@ -30,6 +30,7 @@ SELECT
     [ START [ AT ] @start 0 ]
     [ FETCH @fields ... ]
     [ TIMEOUT @duration ]
+    [ FOR UPDATE ]
     [ TEMPFILES ]
     [ EXPLAIN [ FULL ] ]
 ;
@@ -39,7 +40,7 @@ SELECT
   <TabItem label="Railroad Diagram">
 
 
-<RailroadDiagram ast='{"type":"Diagram","padding":[10,20,10,20],"children":[{"type":"Sequence","children":[{"type":"Terminal","text":"SELECT"},{"type":"Choice","index":1,"children":[{"type":"Sequence","children":[{"type":"Terminal","text":"VALUE"},{"type":"NonTerminal","text":"@field"}]},{"type":"NonTerminal","text":"@fields"}]},{"type":"Optional","child":{"type":"Sequence","children":[{"type":"Terminal","text":"AS"},{"type":"NonTerminal","text":"@alias"}]}},{"type":"Optional","child":{"type":"Sequence","children":[{"type":"Terminal","text":"OMIT"},{"type":"NonTerminal","text":"@fields ..."}]}},{"type":"Terminal","text":"FROM"},{"type":"Optional","child":{"type":"Terminal","text":"ONLY"}},{"type":"NonTerminal","text":"@targets"},{"type":"Optional","child":{"type":"Sequence","children":[{"type":"Terminal","text":"WITH"},{"type":"Choice","index":1,"children":[{"type":"Terminal","text":"NOINDEX"},{"type":"Sequence","children":[{"type":"Terminal","text":"INDEX"},{"type":"NonTerminal","text":"@indexes ..."}]}]}]}},{"type":"Optional","child":{"type":"Sequence","children":[{"type":"Terminal","text":"WHERE"},{"type":"NonTerminal","text":"@conditions"}]}},{"type":"Optional","child":{"type":"Choice","index":1,"children":[{"type":"Sequence","children":[{"type":"Terminal","text":"SPLIT"},{"type":"Optional","child":{"type":"Terminal","text":"ON"}},{"type":"NonTerminal","text":"@field, ..."}]},{"type":"Sequence","children":[{"type":"Terminal","text":"GROUP"},{"type":"Choice","index":1,"children":[{"type":"Terminal","text":"ALL"},{"type":"Sequence","children":[{"type":"Optional","child":{"type":"Terminal","text":"BY"}},{"type":"NonTerminal","text":"@field, ..."}]}]}]}]}},{"type":"Optional","child":{"type":"Sequence","children":[{"type":"Terminal","text":"ORDER"},{"type":"Optional","child":{"type":"Terminal","text":"BY"}},{"type":"Choice","index":1,"children":[{"type":"Sequence","children":[{"type":"NonTerminal","text":"@field"},{"type":"Optional","child":{"type":"Terminal","text":"COLLATE"}},{"type":"Optional","child":{"type":"Terminal","text":"NUMERIC"}},{"type":"Optional","child":{"type":"Choice","index":1,"children":[{"type":"Terminal","text":"ASC"},{"type":"Terminal","text":"DESC"}]}}]},{"type":"Terminal","text":"RAND()"}]}]}},{"type":"Optional","child":{"type":"Sequence","children":[{"type":"Terminal","text":"LIMIT"},{"type":"Optional","child":{"type":"Terminal","text":"BY"}},{"type":"NonTerminal","text":"@limit"}]}},{"type":"Optional","child":{"type":"Sequence","children":[{"type":"Terminal","text":"START"},{"type":"Optional","child":{"type":"Terminal","text":"AT"}},{"type":"NonTerminal","text":"@start"}]}},{"type":"Optional","child":{"type":"Sequence","children":[{"type":"Terminal","text":"FETCH"},{"type":"NonTerminal","text":"@fields ..."}]}},{"type":"Optional","child":{"type":"Sequence","children":[{"type":"Terminal","text":"TIMEOUT"},{"type":"NonTerminal","text":"@duration"}]}},{"type":"Optional","child":{"type":"Terminal","text":"TEMPFILES"}},{"type":"Optional","child":{"type":"Sequence","children":[{"type":"Terminal","text":"EXPLAIN"},{"type":"Optional","child":{"type":"Terminal","text":"FULL"}}]}},{"type":"Terminal","text":";"}]}]}' />
+<RailroadDiagram ast='{"type":"Diagram","padding":[10,20,10,20],"children":[{"type":"Sequence","children":[{"type":"Terminal","text":"SELECT"},{"type":"Choice","index":1,"children":[{"type":"Sequence","children":[{"type":"Terminal","text":"VALUE"},{"type":"NonTerminal","text":"@field"}]},{"type":"NonTerminal","text":"@fields"}]},{"type":"Optional","child":{"type":"Sequence","children":[{"type":"Terminal","text":"AS"},{"type":"NonTerminal","text":"@alias"}]}},{"type":"Optional","child":{"type":"Sequence","children":[{"type":"Terminal","text":"OMIT"},{"type":"NonTerminal","text":"@fields ..."}]}},{"type":"Terminal","text":"FROM"},{"type":"Optional","child":{"type":"Terminal","text":"ONLY"}},{"type":"NonTerminal","text":"@targets"},{"type":"Optional","child":{"type":"Sequence","children":[{"type":"Terminal","text":"WITH"},{"type":"Choice","index":1,"children":[{"type":"Terminal","text":"NOINDEX"},{"type":"Sequence","children":[{"type":"Terminal","text":"INDEX"},{"type":"NonTerminal","text":"@indexes ..."}]}]}]}},{"type":"Optional","child":{"type":"Sequence","children":[{"type":"Terminal","text":"WHERE"},{"type":"NonTerminal","text":"@conditions"}]}},{"type":"Optional","child":{"type":"Choice","index":1,"children":[{"type":"Sequence","children":[{"type":"Terminal","text":"SPLIT"},{"type":"Optional","child":{"type":"Terminal","text":"ON"}},{"type":"NonTerminal","text":"@field, ..."}]},{"type":"Sequence","children":[{"type":"Terminal","text":"GROUP"},{"type":"Choice","index":1,"children":[{"type":"Terminal","text":"ALL"},{"type":"Sequence","children":[{"type":"Optional","child":{"type":"Terminal","text":"BY"}},{"type":"NonTerminal","text":"@field, ..."}]}]}]}]}},{"type":"Optional","child":{"type":"Sequence","children":[{"type":"Terminal","text":"ORDER"},{"type":"Optional","child":{"type":"Terminal","text":"BY"}},{"type":"Choice","index":1,"children":[{"type":"Sequence","children":[{"type":"NonTerminal","text":"@field"},{"type":"Optional","child":{"type":"Terminal","text":"COLLATE"}},{"type":"Optional","child":{"type":"Terminal","text":"NUMERIC"}},{"type":"Optional","child":{"type":"Choice","index":1,"children":[{"type":"Terminal","text":"ASC"},{"type":"Terminal","text":"DESC"}]}}]},{"type":"Terminal","text":"RAND()"}]}]}},{"type":"Optional","child":{"type":"Sequence","children":[{"type":"Terminal","text":"LIMIT"},{"type":"Optional","child":{"type":"Terminal","text":"BY"}},{"type":"NonTerminal","text":"@limit"}]}},{"type":"Optional","child":{"type":"Sequence","children":[{"type":"Terminal","text":"START"},{"type":"Optional","child":{"type":"Terminal","text":"AT"}},{"type":"NonTerminal","text":"@start"}]}},{"type":"Optional","child":{"type":"Sequence","children":[{"type":"Terminal","text":"FETCH"},{"type":"NonTerminal","text":"@fields ..."}]}},{"type":"Optional","child":{"type":"Sequence","children":[{"type":"Terminal","text":"TIMEOUT"},{"type":"NonTerminal","text":"@duration"}]}},{"type":"Optional","child":{"type":"Sequence","children":[{"type":"Terminal","text":"FOR"},{"type":"Terminal","text":"UPDATE"}]}},{"type":"Optional","child":{"type":"Terminal","text":"TEMPFILES"}},{"type":"Optional","child":{"type":"Sequence","children":[{"type":"Terminal","text":"EXPLAIN"},{"type":"Optional","child":{"type":"Terminal","text":"FULL"}}]}},{"type":"Terminal","text":";"}]}]}' />
 
   </TabItem>
 </Tabs>
@@ -804,6 +805,35 @@ SELECT * FROM person
   WHERE ->knows->person->(knows
   WHERE influencer = true) TIMEOUT 5s;
 ```
+
+## The `FOR UPDATE` clause
+
+<Since v="v3.3.0" />
+
+Inside a transaction, a plain `SELECT` reads a consistent snapshot, but the transaction can still commit successfully even if the records it read were modified by another transaction in the meantime. When later writes depend on a value that was only read, this allows the transaction to commit decisions based on stale data.
+
+The `FOR UPDATE` clause registers each selected record for commit-time conflict detection: the enclosing transaction will only commit if none of those records were modified by another transaction after the snapshot was taken. If a concurrent modification is detected, `COMMIT` fails with a transaction conflict error, and the transaction can be retried.
+
+```surql
+BEGIN;
+
+-- Read the account purely as a decision input; it is not written below
+LET $account = SELECT * FROM ONLY account:one FOR UPDATE;
+
+IF $account.status = "active" {
+    CREATE order SET account = account:one, item = "widget";
+};
+
+-- Fails with a retryable conflict error if another transaction
+-- modified account:one after this transaction's snapshot
+COMMIT;
+```
+
+`FOR UPDATE` is only needed for records that are read as decision inputs but never written within the transaction. A record that the transaction also writes is already protected, because the write itself is checked for conflicts at commit time.
+
+The `FOR UPDATE` clause requires record ids as targets, and each selected record is protected individually. It does not lock tables, ranges, or query predicates, so it does not prevent new matching records from being created by concurrent transactions.
+
+The clause cannot be combined with the `VERSION`, `GROUP`, or `SPLIT` clauses, and it cannot be used with targets other than record ids. It also cannot be used in a read-only context, such as within an expression that is evaluated as part of a read-only statement, because the conflict registration can only be validated when the transaction commits.
 
 ## The `TEMPFILES` clause
 


### PR DESCRIPTION
## What

Documents the new `SELECT ... FOR UPDATE` clause on the SELECT statement reference page: statement syntax, railroad diagram, and a dedicated clause section with a `<Since v="v3.3.0" />` badge.

The clause registers each selected record for commit-time conflict detection, so the enclosing transaction only commits if none of those records were concurrently modified. The section explains when it is needed (records read as decision inputs but never written), the retry contract on conflict, and its limits (record-id targets only, per-record protection with no predicate locking, and the clause combinations it rejects).

## Merge timing

The feature is implemented in surrealdb PR #998, which is awaiting engine-dependency releases before it merges. This docs PR should merge alongside the v3.3.0 feature availability.
