### PR TITLE
Document the full setup-surreal argument surface

### DIFF
--- a/src/content/explore/tutorials/tutorials/github-actions.mdx
+++ b/src/content/explore/tutorials/tutorials/github-actions.mdx
@@ -62,7 +62,21 @@ The official SurrealDB GitHub Action accepts several arguments to configure the 
                 latest
             </td>
             <td scope="row" data-label="Value">
-                latest, v2.x.x
+                latest, nightly, beta, alpha, v1.x.x, v2.x.x, v3.x.x
+            </td>
+        </tr>
+        <tr>
+            <td scope="row" data-label="Argument">
+                surrealdb_datastore
+            </td>
+            <td scope="row" data-label="Description">
+                Datastore to start SurrealDB with
+            </td>
+            <td scope="row" data-label="Default">
+                memory
+            </td>
+            <td scope="row" data-label="Value">
+                Any valid datastore path, for example rocksdb:data
             </td>
         </tr>
         <tr>
@@ -87,7 +101,7 @@ The official SurrealDB GitHub Action accepts several arguments to configure the 
                 Username to use for SurrealDB
             </td>
             <td scope="row" data-label="Default">
-                
+                root
             </td>
             <td scope="row" data-label="Value">
                 Customisable by the user
@@ -98,10 +112,10 @@ The official SurrealDB GitHub Action accepts several arguments to configure the 
                 surrealdb_password
             </td>
             <td scope="row" data-label="Description">
-                Password to use for SurrealDB         
+                Password to use for SurrealDB
             </td>
             <td scope="row" data-label="Default">
-                
+                root
             </td>
             <td scope="row" data-label="Value">
                 Customisable by the user
@@ -112,10 +126,10 @@ The official SurrealDB GitHub Action accepts several arguments to configure the 
                 surrealdb_auth
             </td>
             <td scope="row" data-label="Description">
-                Enable authentication        
+                Enable authentication
             </td>
             <td scope="row" data-label="Default">
-                
+                false
             </td>
             <td scope="row" data-label="Value">
                 true, false
@@ -126,10 +140,10 @@ The official SurrealDB GitHub Action accepts several arguments to configure the 
                 surrealdb_strict
             </td>
             <td scope="row" data-label="Description">
-                Enable strict mode       
+                Enable strict mode
             </td>
             <td scope="row" data-label="Default">
-                
+                false
             </td>
             <td scope="row" data-label="Value">
                 true, false
@@ -140,13 +154,27 @@ The official SurrealDB GitHub Action accepts several arguments to configure the 
                 surrealdb_log
             </td>
             <td scope="row" data-label="Description">
-                Enable logs       
+                Enable logs
+            </td>
+            <td scope="row" data-label="Default">
+                trace
+            </td>
+            <td scope="row" data-label="Value">
+                none, full, error, warn, info, debug, trace
+            </td>
+        </tr>
+        <tr>
+            <td scope="row" data-label="Argument">
+                surrealdb_import_file
+            </td>
+            <td scope="row" data-label="Description">
+                SurrealQL file to import on startup
             </td>
             <td scope="row" data-label="Default">
                 
             </td>
             <td scope="row" data-label="Value">
-                none, full, warn, info, debug, trace
+                Path to a .surql file, requires SurrealDB v3.0.0 or later
             </td>
         </tr>
         <tr>
@@ -154,13 +182,60 @@ The official SurrealDB GitHub Action accepts several arguments to configure the 
                 surrealdb_additional_args
             </td>
             <td scope="row" data-label="Description">
-                Additional arguments for SurrealDB       
+                Additional arguments for SurrealDB
             </td>
             <td scope="row" data-label="Default">
                 
             </td>
             <td scope="row" data-label="Value">
-                <a href="/docs/reference/cli/surrealdb-cli/commands/start" target="_blank" rel="noopener noreferrer" title="Any valid SurrealDB CLI arguments">Any valid SurrealDB CLI arguments</a>            
+                <a href="/docs/reference/cli/surrealdb-cli/commands/start" target="_blank" rel="noopener noreferrer" title="Any valid SurrealDB CLI arguments">Any valid SurrealDB CLI arguments</a>
+            </td>
+        </tr>
+        <tr>
+            <td scope="row" data-label="Argument">
+                surrealdb_retry_count
+            </td>
+            <td scope="row" data-label="Description">
+                Seconds to wait for SurrealDB to become ready
+            </td>
+            <td scope="row" data-label="Default">
+                30
+            </td>
+            <td scope="row" data-label="Value">
+                Any valid integer
+            </td>
+        </tr>
+    </tbody>
+</table>
+
+The file passed to `surrealdb_import_file` selects its own namespace and database, so it should begin with a `USE NS ... DB ...;` statement.
+
+### Workflow outputs
+
+The action exposes the details of the instance it started, so that later steps do not have to reconstruct them:
+
+<table>
+    <thead>
+        <tr>
+            <th scope="col">Output</th>
+            <th scope="col">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td scope="row" data-label="Output">
+                endpoint
+            </td>
+            <td scope="row" data-label="Description">
+                The HTTP endpoint the SurrealDB instance is listening on
+            </td>
+        </tr>
+        <tr>
+            <td scope="row" data-label="Output">
+                version
+            </td>
+            <td scope="row" data-label="Description">
+                The exact version of SurrealDB that was installed
             </td>
         </tr>
     </tbody>
@@ -183,6 +258,7 @@ jobs:
     - name: Git checkout
       uses: actions/checkout@v4
     - name: Start SurrealDB
+      id: surrealdb
       uses: surrealdb/setup-surreal@v2
       with:
         surrealdb_version: latest
@@ -194,11 +270,15 @@ jobs:
         surrealdb_log: info
         surrealdb_additional_args: --allow-all
         surrealdb_retry_count: 30
+    - name: Run the tests
+      run: ./run-tests.sh
+      env:
+        SURREALDB_ENDPOINT: ${{ steps.surrealdb.outputs.endpoint }}
 ```
 
 ### Tips for customisation
 
-1. **Version Control**: Use specific versions to avoid unexpected changes. Example: surrealdb_version: v2.0.0.
+1. **Version Control**: Use specific versions to avoid unexpected changes. Example: surrealdb_version: v3.2.4.
 2. **Security**: Always use strong passwords for surrealdb_password and avoid using default credentials in production.
 3. **Logs**: Set an appropriate log level based on your needs. For debugging, use debug or trace.
 4. **Additional Arguments**: Utilise surrealdb_additional_args to pass any additional CLI arguments required by your setup.


### PR DESCRIPTION
The GitHub Actions tutorial's arguments table has drifted from what the action accepts. It omits `surrealdb_retry_count` even though the example directly beneath it uses that argument, and it leaves the Default column blank for the username, password, authentication, strict mode and logging arguments, all of which do have defaults.

This brings the table back in line with the action, and documents the arguments and outputs added in surrealdb/setup-surreal#11:

- `surrealdb_datastore`, for starting against something other than the in-memory datastore.
- `surrealdb_import_file`, for seeding a database on startup.
- The `endpoint` and `version` outputs, with the example configuration now showing how the endpoint is passed on to a later step.
- `v3.x.x` and the `nightly`, `beta` and `alpha` version values, alongside the existing ones.
- `error` in the list of log levels, which was missing.

The version pinning tip pointed at `v2.0.0` and now points at a current release.

Depends on surrealdb/setup-surreal#11, since `surrealdb_datastore`, `surrealdb_import_file` and the two outputs only exist once that ships. Everything else on this page is correct today.
