### PR TITLE
Reference the v3 tag of the setup-surreal action

### DIFF
--- a/src/content/explore/tutorials/tutorials/github-actions.mdx
+++ b/src/content/explore/tutorials/tutorials/github-actions.mdx
@@ -24,7 +24,7 @@ jobs:
     - name: Git checkout
       uses: actions/checkout@v4
     - name: Start SurrealDB
-      uses: surrealdb/setup-surreal@v2
+      uses: surrealdb/setup-surreal@v3
       with:
         surrealdb_version: latest
         surrealdb_port: 8000
@@ -259,7 +259,7 @@ jobs:
       uses: actions/checkout@v4
     - name: Start SurrealDB
       id: surrealdb
-      uses: surrealdb/setup-surreal@v2
+      uses: surrealdb/setup-surreal@v3
       with:
         surrealdb_version: latest
         surrealdb_port: 8000


### PR DESCRIPTION
The tutorial points at `surrealdb/setup-surreal@v2`. The action's major version tracks the major version of SurrealDB whose support it introduces, so SurrealDB v3 support is released as `v3.0.0`.

The `v2` tag stays where it is, on `v2.1.0`, so workflows that already reference it keep working against SurrealDB v3. New workflows should use `v3`.

Follows on from #1954. Depends on the v3.0.0 release of the action.