### PR TITLE
Move Sample queries into Learn > Querying

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -14,7 +14,6 @@ Working notes:
 
 - [Getting started](https://surrealdb.com/docs): The official documentation for SurrealDB, a multi-model database for modern applications.
 - [Agent setup](https://surrealdb.com/docs/agents): Connect your agents to SurrealDB with Agent Skills and MCP.
-- [Sample queries](https://surrealdb.com/docs/sample-queries): Learn how to get started with SurrealDB
 - [What is SurrealDB](https://surrealdb.com/docs/what-is-surrealdb): SurrealDB is a multi-model database written in Rust. This page covers what it stores, how it runs, and what SurrealDB Agent Memory adds for AI agents.
 - [Claude Code](https://surrealdb.com/docs/agents/claude-code): Set up Claude Code for SurrealDB with the hosted MCP server and the official Agent Skills.
 - [Codex](https://surrealdb.com/docs/agents/codex): Set up the OpenAI Codex CLI for SurrealDB with the hosted MCP server and the official Agent Skills.
@@ -146,6 +145,7 @@ Working notes:
 - [Live queries](https://surrealdb.com/docs/learn/querying/real-time/live-queries): Subscribing to inserts, updates, and deletes with LIVE SELECT so clients stay in sync over a persistent connection.
 - [Real-time best practices](https://surrealdb.com/docs/learn/querying/real-time/real-time-best-practices): This guide outlines some best practices for using SurrealDB in an event-driven and real-time manner.
 - [Executing queries](https://surrealdb.com/docs/learn/querying/surrealql/executing-queries): In this section, you will explore methods to query data in SurrealDB using SurrealQL, GraphQL or any of the available SDKs. This allows you to retrieve, filter, and manipulate data efficiently and in the best way for your use case.
+- [Sample queries](https://surrealdb.com/docs/learn/querying/surrealql/sample-queries): Runnable SurrealQL examples for CREATE, SELECT, UPDATE and DELETE, each editable in an embedded SurrealDB Studio.
 - [Statements and values](https://surrealdb.com/docs/learn/querying/surrealql/statements-and-values): SurrealQL statements grouped as resource definitions, control flow with transactions, and CRUD-style query operations.
 - [What is SurrealQL?](https://surrealdb.com/docs/learn/querying/surrealql/what-is-surrealql): SurrealQL is SurrealDB’s SQL-like language for queries, schemas, graph relationships and optimised execution.
 - [Writing SurrealQL](https://surrealdb.com/docs/learn/querying/surrealql/writing-surrealql): Ways of executing SurrealQL queries such as SurrealDB Studio, CLI, HTTP, SDKs, and GraphQL.

--- a/redirects.ts
+++ b/redirects.ts
@@ -707,18 +707,23 @@ function agentMemoryRedirects(): Redirect[] {
 
 /**
  * Overview section consolidation (August 2026). The Getting started overview
- * held four pages where two would do, so `architecture` absorbed `concepts` and
- * moved under Data models, and `transactions-and-isolation` merged into the
- * querying guide that already covered `BEGIN` and `COMMIT`.
+ * held five pages where one would do, so `architecture` absorbed `concepts` and
+ * moved under Data models, `transactions-and-isolation` merged into the querying
+ * guide that already covered `BEGIN` and `COMMIT`, and `sample-queries` moved
+ * into the SurrealQL section. `what-is-surrealdb` is all that remains beside the
+ * section index.
  *
- * All three sources sat directly under `/docs`, so each is an exact rule - there
- * is no subtree below them to carry through.
+ * Every source sat directly under `/docs`, so each is an exact rule - there is
+ * no subtree below them to carry through.
  */
 function overviewConsolidationRedirects(): Redirect[] {
     const moves: [string, string][] = [
         ["/architecture", "/docs/learn/data-models/architecture"],
         ["/concepts", "/docs/learn/data-models/architecture"],
         ["/transactions-and-isolation", "/docs/learn/querying/concepts-and-guides/transactions"],
+        // Runnable SurrealQL examples belong beside the pages that teach the
+        // language, next to the GraphQL and GQL pages of the same name.
+        ["/sample-queries", "/docs/learn/querying/surrealql/sample-queries"],
     ];
 
     return moves.flatMap(([source, destination]): Redirect[] => [

--- a/src/content/index/what-is-surrealdb.mdx
+++ b/src/content/index/what-is-surrealdb.mdx
@@ -13,7 +13,7 @@ The platform has two products, and both run on the same engine:
 - **SurrealDB** is the database. You design the schema, and you choose how strictly to define it.
 - **[SurrealDB Agent Memory](/docs/agent-memory)** is a memory and knowledge layer for AI agents, built on top of that database.
 
-This page covers the main capabilities of both. If you would rather start writing queries, go to [Sample queries](/docs/sample-queries). If you want to run the database first, go to [Running SurrealDB](/docs/running/overview).
+This page covers the main capabilities of both. If you would rather start writing queries, go to [Sample queries](/docs/learn/querying/surrealql/sample-queries). If you want to run the database first, go to [Running SurrealDB](/docs/running/overview).
 
 ## One engine for every data model
 
@@ -135,7 +135,7 @@ More detail is on the [case studies page](/casestudies), and the complete capabi
 	<IconBox
 		title="Sample queries"
 		description="Run your first SurrealQL queries against a live instance."
-		href="/docs/sample-queries"
+		href="/docs/learn/querying/surrealql/sample-queries"
 		icon="@ui/pictoQL"
 	/>
 	<IconBox

--- a/src/content/learn/querying/surrealql/executing-queries/__category.json
+++ b/src/content/learn/querying/surrealql/executing-queries/__category.json
@@ -1,4 +1,4 @@
 {
-    "position": 4,
+    "position": 5,
     "title": "Executing queries"
 }

--- a/src/content/learn/querying/surrealql/sample-queries.mdx
+++ b/src/content/learn/querying/surrealql/sample-queries.mdx
@@ -8,8 +8,7 @@ description: "Runnable SurrealQL examples for CREATE, SELECT, UPDATE and DELETE,
 
 This page walks through the four statements that do most of the work in [SurrealQL](/docs/reference/query-language): `CREATE`, `SELECT`, `UPDATE` and `DELETE`. Every example runs against a live database in an embedded [SurrealDB Studio](/docs/explore/studio), so you can edit a query and run it again to see what changes.
 
-SurrealQL takes its shape from SQL, and adds record links, subqueries and nested field access. The examples below introduce each of those in turn.
-
+SurrealQL's basic shape is largely equivalent to SQL, but includes additional syntax to allow conveniences such as record links, subqueries and nested field access. The examples below introduce each of those in turn.
 
 ### Creating data with CREATE
 

--- a/src/content/learn/querying/surrealql/sample-queries.mdx
+++ b/src/content/learn/querying/surrealql/sample-queries.mdx
@@ -1,18 +1,14 @@
 ---
-position: 2
+position: 4
 title: Sample queries
-description: "Learn how to get started with SurrealDB"
+description: "Runnable SurrealQL examples for CREATE, SELECT, UPDATE and DELETE, each editable in an embedded SurrealDB Studio."
 ---
 
-Welcome to SurrealDB! In this guide, you will learn about the various ways you can start using SurrealDB with interactive examples. Before we dive in, let's cover some basics.
+# Sample queries
 
-## Running queries in SurrealDB
+This page walks through the four statements that do most of the work in [SurrealQL](/docs/reference/query-language): `CREATE`, `SELECT`, `UPDATE` and `DELETE`. Every example runs against a live database in an embedded [SurrealDB Studio](/docs/explore/studio), so you can edit a query and run it again to see what changes.
 
-Much like any other database, you can communicate with SurrealDB by executing queries.
-
-Queries are written using [SurrealQL](/docs/reference/query-language), SurrealDB's powerful and flexible query language. While SurrealQL takes inspiration from traditional SQL, it is designed to be more expressive and flexible, allowing you to query your data in a variety of ways.
-
-Let's take a look at some of the basic queries you can run in SurrealDB.
+SurrealQL takes its shape from SQL, and adds record links, subqueries and nested field access. The examples below introduce each of those in turn.
 
 
 ### Creating data with CREATE
@@ -48,7 +44,7 @@ When creating records, you can also explicitly set the record ID. This can be us
 			signup_at = time::now();
 	`} />
 
-One of the many powerful features of SurrealDB is the ability to write subqueries, which in the following example is used to populate the `category` field of the `article` record with the ID of the `Technology` category.
+SurrealDB also supports subqueries, used in the following example to populate the `category` field of the `article` record with the ID of the `Technology` category.
 
 <br />
 
@@ -74,7 +70,7 @@ One of the many powerful features of SurrealDB is the ability to write subquerie
 
 ### Querying data with SELECT
 
-After inserting records into your database, you can now use the [SELECT statement](/docs/reference/query-language/statements/select) to retrieve data. While this statement will be familiar to anyone who has used traditional SQL before, SurrealDB's SELECT statement includes additional powerful features inspired by NoSQL databases.
+After inserting records into your database, you can now use the [SELECT statement](/docs/reference/query-language/statements/select) to retrieve data. While this statement will be familiar to anyone who has used traditional SQL before, SurrealDB's SELECT statement adds features drawn from NoSQL databases.
 
 For example, in addition to selecting records from a single table, you can also select records from multiple tables, or select specific records by their Record ID.
 
@@ -109,7 +105,7 @@ For example, in addition to selecting records from a single table, you can also 
 	`}
 />
 
-The [SELECT statement](/docs/reference/query-language/statements/select) offers a variety of different features, such as the ability to filter on fields, fetch and resolve record id contents, and the ability to access data directly from Record IDs without the need of JOINs or complex queries.
+The [SELECT statement](/docs/reference/query-language/statements/select) can filter on fields, resolve the contents of a record link, and reach data through a Record ID directly, with no JOIN to write.
 
 The following query combines a number of such features:
 - **Filtering**: Use the `WHERE` clause to only include records where the author's age is less than 30.
@@ -237,5 +233,10 @@ The following example demonstrates the use of the `RETURN` clause, which instruc
 		DELETE article WHERE author.name.first = 'David' RETURN BEFORE;
 	" />
 
-Congratulations, you're now on your way to database and API simplicity! For the next steps, we will explore the different ways to integrate SurrealDB into your applications.
+## Where next
+
+- [Writing SurrealQL](/docs/learn/querying/surrealql/writing-surrealql) for the syntax rules behind these examples.
+- [Statements and values](/docs/learn/querying/surrealql/statements-and-values) for choosing between `CREATE`, `INSERT`, `UPDATE`, `UPSERT` and `RELATE`.
+- [Executing queries](/docs/learn/querying/surrealql/executing-queries) for running the same statements from the CLI, an SDK or over HTTP.
+- [Transactions](/docs/learn/querying/concepts-and-guides/transactions) for grouping statements that must succeed or fail together.
 

--- a/src/content/learn/querying/surrealql/sample-queries.mdx
+++ b/src/content/learn/querying/surrealql/sample-queries.mdx
@@ -104,7 +104,7 @@ For example, in addition to selecting records from a single table, you can also 
 	`}
 />
 
-The [SELECT statement](/docs/reference/query-language/statements/select) can filter on fields, resolve the contents of a record link, and reach data through a Record ID directly, with no JOIN to write.
+The [SELECT statement](/docs/reference/query-language/statements/select) can filter on fields, resolve the contents of a record link, and reach data through a Record ID directly, with no JOIN planning or indexes needed.
 
 The following query combines a number of such features:
 - **Filtering**: Use the `WHERE` clause to only include records where the author's age is less than 30.


### PR DESCRIPTION
Follows #1960, which reduced the Getting started overview. `Sample queries` was the last page there that belonged elsewhere.

## The move

The page teaches `CREATE`, `SELECT`, `UPDATE` and `DELETE` through eight embedded SurrealDB Studio examples. That is SurrealQL material rather than orientation:

| | Before | After |
| --- | --- | --- |
| URL | `/docs/sample-queries` | `/docs/learn/querying/surrealql/sample-queries` |
| Section | Get started → Overview | Learn → Querying → SurrealQL |

The SurrealQL section now reads: What is SurrealQL? → Writing SurrealQL → Statements and values → **Sample queries** → Executing queries. `Sample queries` takes `position: 4` and `Executing queries` moves to 5.

Placing it under `surrealql/` also completes a set: each query language in the section now has its own `sample-queries` page, alongside the existing [GraphQL](https://surrealdb.com/docs/learn/querying/graphql/sample-queries) and [GQL](https://surrealdb.com/docs/learn/querying/gql/sample-queries) ones.

The Get started overview is now just **Getting started → What is SurrealDB**.

## Prose the move required

Two paragraphs were written for the page's old position and no longer hold:

- **The opener** was `Welcome to SurrealDB! In this guide... Before we dive in, let's cover some basics.` It greeted a reader arriving at the docs. It now says what the page covers and that the examples are editable and runnable. (It also carried two things `AGENTS.md` rules out: `dive in` and `powerful`.)
- **The closer** was `Congratulations, you're now on your way to database and API simplicity! For the next steps, we will explore the different ways to integrate SurrealDB into your applications.` That "next" page was the following item in the Getting started flow. It is now a `Where next` list pointing into the rest of the section.

Two further sentences lost `powerful` while I was in the surrounding paragraphs. **Every query, every `SurrealistMini` block and every explanation between them is unchanged** - the diff is 27 lines on a 240-line page.

Also added an `# Sample queries` h1, matching `graphql/sample-queries.mdx` and the other pages in the section, so the `.md` variant titles itself.

## Verification

- `bun run qa`, `bun run qc` and `tsc --noEmit` clean.
- New URL returns 200; `/docs/sample-queries` and `/sample-queries` both 301 to it. The three redirects from #1960 still resolve.
- The `legacyPrefixRedirects("surrealql", …)` rules do not touch the new path (their sources are `/surrealql` and `/docs/surrealql`), and the GraphQL and GQL siblings already prove that; both still return 200, as does `executing-queries`.
- All 8 Studio embeds render, and the four `##` heading anchors survive.
- Every internal link on the moved page and on What is SurrealDB checked against the dev server, with a negative control to confirm the check catches a miss.
- `public/llms.txt` regenerated with `bun run generate:llms`.