### PR TITLE
Add rule to AGENTS.md on ordering for similar examples, reorder a few examples to match

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,10 +53,10 @@ All user-facing text uses **British English** spelling (`-ise`, `-our`, `-re`, `
 Use the standard hyphen (`-`) everywhere. Em dashes (`—`) and en dashes (`–`) do
 not appear in this repo, in prose, headings, tables, code comments or these guides.
 
-| Use | Instead of |
-| --- | ---------- |
-| `a spaced hyphen - like this` | `an em dash — like this` |
-| `2-3 minutes`, `pages 10-12` | `2–3 minutes`, `pages 10–12` |
+| Use                           | Instead of                   |
+| ----------------------------- | ---------------------------- |
+| `a spaced hyphen - like this` | `an em dash — like this`     |
+| `2-3 minutes`, `pages 10-12`  | `2–3 minutes`, `pages 10–12` |
 
 A parenthetical takes a hyphen with a space on each side, so the words either
 side stay separate. A numeric range takes a tight hyphen with no spaces.
@@ -79,11 +79,11 @@ line), multi-line JSX attributes, tables and frontmatter.
 Use **sentence case** for multi-word headings (`##`, `###`, `####`). Do not use
 Title Case on every main word.
 
-| Pattern | Rule | Examples |
-| ------- | ---- | -------- |
-| Single word | Capitalise the word | `## Syntax`, `#### Parameters`, `#### Returns` |
-| Multiple words | Capitalise the **first word only**; lowercase the rest | `## Type parameters`, `### Complete examples`, `### Default response` |
-| Numbered lists | Same as multiple words - capitalise the first word after the number | `### 3. Don't reuse transactions`, `## 1. Install the SDK` |
+| Pattern        | Rule                                                                | Examples                                                              |
+| -------------- | ------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| Single word    | Capitalise the word                                                 | `## Syntax`, `#### Parameters`, `#### Returns`                        |
+| Multiple words | Capitalise the **first word only**; lowercase the rest              | `## Type parameters`, `### Complete examples`, `### Default response` |
+| Numbered lists | Same as multiple words - capitalise the first word after the number | `### 3. Don't reuse transactions`, `## 1. Install the SDK`            |
 
 **Keep capitalised** where they are names, not prose:
 
@@ -129,6 +129,23 @@ include inline test assertions and response blocks. SDK pages show imports,
 configuration, and the trade-off when an option changes behaviour. Tutorials
 include verification steps so readers can confirm the setup worked.
 
+**Example ordering.** SurrealQL often has several equivalents of the
+same operation, and readers - agents included, since the docs are served raw
+through the `.md` endpoints and `llms.txt` - take the first example shown as
+the recommendation. Where a page presents two equivalent forms, lead with the
+one whose meaning is fully visible in the snippet itself, breaking ties by
+token count and then by similarity to mainstream languages. In practice:
+literal unions (`TYPE 'draft' | 'published'`) before `ASSERT $value IN [...]`,
+method syntax (`$value.len()`) before qualified paths in incidental examples,
+`.map()`/`.filter()` chains before `FOR` loops for pure transformations,
+inline closures before closures bound to a parameter first, and object forms
+(`CONTENT {...}`, `INSERT INTO ... [{...}]`) before `SET` clauses. The other
+form stays, with a one-line note on when to prefer it. Carve-outs: a page
+documenting a construct keeps that construct first, migration pages stay
+chronological, version-gated syntax keeps its `<Since>` marker, and statement
+choice (`CREATE`/`INSERT`/`UPSERT`) is never swapped - those differ on
+existing records.
+
 **Callouts.** Use `> [!NOTE]`, `> [!WARNING]`, and `> [!IMPORTANT]` for
 exceptions, security caveats, and breaking or easy-to-miss details.
 
@@ -160,13 +177,13 @@ obligation:
 Not fine, because each one only works if the reader is in a state we have
 decided for them:
 
-| Avoid | What it presumes | Use |
-| ----- | ---------------- | --- |
-| No message broker, no polling, no glue code | Nothing states the subject, so the reader becomes it | The database is your event bus and your source of truth at once |
-| One engine, not a pile of stores | They suspected we were a pile of stores | One engine, one transaction |
-| Nothing here is a mention tally. The count is… | They guessed "mention tally" | The count is… |
-| Forget about infrastructure operations | Ops is their burden today - and instructs them | SurrealDB Cloud runs the infrastructure for you |
-| Stop stitching databases together | They stitch databases together - and instructs them | One database for every model your app needs |
+| Avoid                                          | What it presumes                                     | Use                                                             |
+| ---------------------------------------------- | ---------------------------------------------------- | --------------------------------------------------------------- |
+| No message broker, no polling, no glue code    | Nothing states the subject, so the reader becomes it | The database is your event bus and your source of truth at once |
+| One engine, not a pile of stores               | They suspected we were a pile of stores              | One engine, one transaction                                     |
+| Nothing here is a mention tally. The count is… | They guessed "mention tally"                         | The count is…                                                   |
+| Forget about infrastructure operations         | Ops is their burden today - and instructs them       | SurrealDB Cloud runs the infrastructure for you                 |
+| Stop stitching databases together              | They stitch databases together - and instructs them  | One database for every model your app needs                     |
 
 Two forms to watch for:
 
@@ -270,11 +287,11 @@ There is no `urlForCollection`. The URL prefix is the optional third argument to
 `resolveDataFromCollection` in the page group's `+data.ts`, defaulting to the
 collection id:
 
-| Collection         | `+data.ts` call                           | URL                             |
-| ------------------ | ----------------------------------------- | ------------------------------- |
-| `manage/instances` | `(context, "manage/instances")`           | `/docs/manage/instances/<slug>` |
-| `index`            | `(context, "index", "")`                  | `/docs/<slug>`                  |
-| `agent-memory/index` | `(context, "agent-memory/index", "agent-memory")` | `/docs/agent-memory/<slug>` |
+| Collection           | `+data.ts` call                                   | URL                             |
+| -------------------- | ------------------------------------------------- | ------------------------------- |
+| `manage/instances`   | `(context, "manage/instances")`                   | `/docs/manage/instances/<slug>` |
+| `index`              | `(context, "index", "")`                          | `/docs/<slug>`                  |
+| `agent-memory/index` | `(context, "agent-memory/index", "agent-memory")` | `/docs/agent-memory/<slug>`     |
 
 ### Adding content
 

--- a/src/content/learn/data-models/geospatial/geometry-types.mdx
+++ b/src/content/learn/data-models/geospatial/geometry-types.mdx
@@ -13,14 +13,14 @@ SurrealDB’s `geometry` type follows the [GeoJSON](https://en.wikipedia.org/wik
 Points are defined with **longitude before latitude**, as required by the GeoJSON spec. Many map services display latitude first, so be sure to confirm the order when ingesting external data.
 
 ```surql
--- Tuple shorthand for a point (lon, lat)
-CREATE city:london SET centre = (-0.118092, 51.509865);
-
 -- Full GeoJSON object form
 CREATE city:london SET centre = {
     type: "Point",
     coordinates: [-0.118092, 51.509865],
 };
+
+-- Tuple shorthand for a point (lon, lat)
+CREATE city:london SET centre = (-0.118092, 51.509865);
 ```
 
 See the [Geometries](/docs/reference/query-language/language-primitives/data-types/geometries) reference for `LineString`, `Polygon`, `MultiPoint`, `MultiLineString`, `MultiPolygon`, and `Collection`, including examples for each type.

--- a/src/content/reference/query-language/language-primitives/idioms.mdx
+++ b/src/content/reference/query-language/language-primitives/idioms.mdx
@@ -487,7 +487,7 @@ SELECT *, name.uppercase() FROM person;
 
 In the example above, `uppercase()` is a method called on `person.name` to convert it to uppercase. Although this method is called as `.uppercase()`, it is actually the [`string::uppercase()`](/docs/reference/query-language/functions/database-functions/string#stringuppercase) function that is called.
 
-SurrealDB will automatically recognize that the idiom part `.uppercase()` refers to the `string::uppercase()` function and call this function when the query is executed. What this means is that the following two queries are equivilent:
+SurrealDB will automatically recognize that the idiom part `.uppercase()` refers to the `string::uppercase()` function and call this function when the query is executed. What this means is that the following two queries are equivalent:
 
 ```surql title="Using method chaining"
 SELECT *, name.uppercase() FROM person;
@@ -781,7 +781,6 @@ value = "[{ id: planet:earth, name: 'Earth', orbits: [star:sun] }]"
 value = "[{ id: planet:earth, name: 'Earth', orbits: [star:sun] }]"
 */
 
-, [{ id: planet:earth, name: 'Earth', orbits: [star:sun] }]]
 CREATE star:sun SET name = "The Sun";
 CREATE planet:earth SET name = "Earth";
 RELATE planet:earth->orbits->star:sun;

--- a/src/content/reference/query-language/statements/create.mdx
+++ b/src/content/reference/query-language/statements/create.mdx
@@ -94,7 +94,27 @@ CREATE type::record("person", "one");
 
 ## Adding record data
 
-When creating a record, you can specify the record data using the `SET` clause, or the `CONTENT` clause. The `SET` clause is used to specify record data one field at a time, while the `CONTENT` clause is used to specify record data using a SurrealQL object. The `CONTENT` clause is useful when the record data is already in the form of a SurrealQL or JSON object.
+When creating a record, you can specify the record data using the `CONTENT` clause, or the `SET` clause. The `CONTENT` clause is used to specify record data using a SurrealQL object, while the `SET` clause is used to specify record data one field at a time. The `CONTENT` clause is useful when the record data is already in the form of a SurrealQL or JSON object, while the `SET` clause reads well when each field is computed on its own line.
+
+Specifying record data using the `CONTENT` keyword:
+
+```surql
+/**[test]
+
+[[test.results]]
+value = "[{ company: 'SurrealDB', id: person:100, name: 'Tobie', skills: ['Rust', 'Go', 'JavaScript'] }]"
+
+*/
+
+-- Create a new record with a numeric id
+CREATE person:100 CONTENT {
+	name: 'Tobie',
+	company: 'SurrealDB',
+	skills: ['Rust', 'Go', 'JavaScript'],
+};
+```
+
+Specifying the same record data one field at a time using the `SET` clause:
 
 ```surql
 /**[test]
@@ -122,24 +142,6 @@ The above will create a new record with the ID `person:tobie` and the specified 
 		"skills": ["Rust", "Go", "JavaScript"]
 	}
 ]
-```
-
-Specifing record data using the `CONTENT` keyword:
-
-```surql
-/**[test]
-
-[[test.results]]
-value = "[{ company: 'SurrealDB', id: person:100, name: 'Tobie', skills: ['Rust', 'Go', 'JavaScript'] }]"
-
-*/
-
--- Create a new record with a numeric id
-CREATE person:100 CONTENT {
-	name: 'Tobie',
-	company: 'SurrealDB',
-	skills: ['Rust', 'Go', 'JavaScript'],
-};
 ```
 
 ## Options and clauses

--- a/src/content/reference/query-language/statements/relate.mdx
+++ b/src/content/reference/query-language/statements/relate.mdx
@@ -332,26 +332,20 @@ RELATE [cat:mr_meow, cat:mrs_meow]->parent_of->[cat:kitten, cat:kitten2];
 
 Graph edges are standalone tables that can hold other fields besides the default `in`, `out`, and `id`. These can be added during a `RELATE` statement or during an `UPDATE` in the same manner as any other SurrealDB table.
 
-Let's look at the two ways you can add record data in the `RELATE` statement. Both of these queries will produce the same result.
+Let's look at the two ways you can add record data in the `RELATE` statement. Both of these queries will produce the same result. Use `CONTENT` to pass the record data as a single object, and `SET` to assign or compute each field on its own line.
 
 ```surql
 /**[test]
 
 [[test.results]]
-value = "[{ id: wrote:oapxwx4gdbpfsz1yxhih, in: person:l19zjikkw1p1h9o6ixrg, metadata: { location: 'Tallinn', time_written: d'2025-10-08T04:28:09.169160Z' }, out: article:8nkk6uj4yprt49z7y3zm }]"
-skip-record-id-key = true
-
-[[test.results]]
 value = "[{ id: wrote:fvrxtrn5cj2fnz2gliyw, in: person:l19zjikkw1p1h9o6ixrg, metadata: { location: 'Tallinn', time_written: d'2025-10-08T04:28:09.171256Z' }, out: article:8nkk6uj4yprt49z7y3zm }]"
 skip-record-id-key = true
 
+[[test.results]]
+value = "[{ id: wrote:oapxwx4gdbpfsz1yxhih, in: person:l19zjikkw1p1h9o6ixrg, metadata: { location: 'Tallinn', time_written: d'2025-10-08T04:28:09.169160Z' }, out: article:8nkk6uj4yprt49z7y3zm }]"
+skip-record-id-key = true
+
 */
-
-RELATE person:l19zjikkw1p1h9o6ixrg->wrote->article:8nkk6uj4yprt49z7y3zm
-    SET 
-		metadata.time_written = time::now(),
-		metadata.location = "Tallinn";
-
 
 RELATE person:l19zjikkw1p1h9o6ixrg->wrote->article:8nkk6uj4yprt49z7y3zm
 	CONTENT {
@@ -360,6 +354,12 @@ RELATE person:l19zjikkw1p1h9o6ixrg->wrote->article:8nkk6uj4yprt49z7y3zm
 			location: "Tallinn"
 		}
 	};
+
+
+RELATE person:l19zjikkw1p1h9o6ixrg->wrote->article:8nkk6uj4yprt49z7y3zm
+    SET 
+		metadata.time_written = time::now(),
+		metadata.location = "Tallinn";
 ```
 
 ```surql title="Response"


### PR DESCRIPTION
SurrealQL can often do the same thing in more than one way and where a user might prefer one over the other without one being objectively superior.

```
DEFINE FIELD role ON user TYPE string ASSERT $value IN ['user', 'admin', 'root'];
DEFINE FIELD role ON user TYPE 'user' | 'admin' | 'root';
```

Where this is the case, the documentation should default to those that are more self-explanatory or produce fewer tokens so that visiting agents can more efficiently put queries together. (And improves the experience for regular visitors as well since self-explanatory is by nature...self-explaining).