### PR TITLE
Update examples and advice on IF ELSE syntax

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,6 +150,26 @@ chronological, version-gated syntax keeps its `<Since>` marker, and statement
 choice (`CREATE`/`INSERT`/`UPSERT`) is never swapped - those differ on
 existing records.
 
+**`IF` blocks.** Always write a conditional as `IF @condition { … }`, with any
+`ELSE IF` and `ELSE` taking blocks of their own. The older
+`IF @condition THEN @expression ELSE @expression END` form still parses, but it
+is kept for compatibility rather than recommended, and no example should teach
+it. Its branch holds a single expression rather than a block, so a branch cannot
+take a `LET`, a `THROW`, a `BREAK`, a `CONTINUE`, or two statements separated by
+`;`. Adding a second statement reports
+`Parse error: Unexpected token 'CREATE', expected if to end`, which points at
+the wrong token and names a construct the reader never wrote. The form also
+persists: a `DEFINE FUNCTION`, `DEFINE FIELD` or `DEFINE EVENT` keeps a body in
+the schema, and the stored form is never normalised, so `INFO FOR DB` and
+`surreal export` both emit `THEN … END` again and `surreal import` has to parse
+it back. That round trip is what keeps the parse path in the server, so treat
+the syntax as permanent and simply never teach it.
+
+The word `THEN` is unrelated and correct in `DEFINE EVENT … THEN`,
+`DEFINE API … THEN` and `REFERENCE ON DELETE THEN`, where it is the only syntax.
+Leave those, and leave historical `THEN … END` in release notes and migration
+pages, which stay chronological.
+
 **`RETURN` in examples.** Bare expressions are valid statements that yield the
 same value, so a snippet that is a single expression drops the leading
 `RETURN`: the bare form is the fragment a reader can paste into a `SELECT`

--- a/src/content/reference/javascript/api/queries/run-promise.mdx
+++ b/src/content/reference/javascript/api/queries/run-promise.mdx
@@ -283,11 +283,11 @@ await db.run('fn::cleanup_old_records');
 ```ts
 await db.query(`
     DEFINE FUNCTION fn::factorial($n: number) -> number {
-        IF $n <= 1 THEN
+        IF $n <= 1 {
             RETURN 1
-        ELSE
+        } ELSE {
             RETURN $n * fn::factorial($n - 1)
-        END
+        }
     };
 `).collect();
 

--- a/src/content/reference/query-language/statements/if-else.mdx
+++ b/src/content/reference/query-language/statements/if-else.mdx
@@ -33,19 +33,22 @@ IF @condition { @expression; .. }
   </TabItem>
 </Tabs>
 
+> [!NOTE]
+> An older `IF @condition THEN @expression ELSE @expression END` form predates the block syntax introduced in 1.0.0 and is still accepted, so that definitions written against earlier versions keep parsing. A definition stored that way is also returned by `INFO FOR DB` in the same form. Use the block syntax in new queries: a `THEN` branch holds a single expression, which leaves no room for a `LET`, a `THROW`, a `BREAK`, a `CONTINUE`, or two statements separated by a semicolon.
+
 ## Example usage
 
 ### Basic usage
 
 The following queries show example usage of this statement.
 
-The smallest possible `IF THEN` statement simply does something when a condition is true, and nothing otherwise.
+The smallest possible `IF` statement simply does something when a condition is true, and nothing otherwise.
 
 ```surql
 IF 9 = 9 { 'Nine is indeed nine' };
 ```
 
-As the last line of a scope is its return value, the `RETURN` keyword can also be placed before the entire `IF THEN` statement. This is particularly convenient in long `IF ELSE` chains to avoid using the `RETURN` keyword at the end of every check for a condition.
+As the last line of a scope is its return value, the `RETURN` keyword can also be placed before the entire `IF ELSE` statement. This is particularly convenient in long `IF ELSE` chains to avoid using the `RETURN` keyword at the end of every check for a condition.
 
 ```surql
 /**[test]


### PR DESCRIPTION
The old IF ... ELSE ... THEN syntax seems to be showing up a lot more in SurrealQL examples shared by users and is probably because LLMs are opting for it first. This PR changes some examples and AGENTS.md to try to counteract that.