### PR TITLE
Explain why search::score can be 0 in small datasets

### DIFF
--- a/src/content/learn/data-models/full-text-search/scoring-and-ranking.mdx
+++ b/src/content/learn/data-models/full-text-search/scoring-and-ranking.mdx
@@ -131,6 +131,64 @@ WHERE
 ]
 ```
 
+## Why a score can be 0
+
+BM25 weights every term by its inverse document frequency, a measure of how rare that term is across the indexed documents. SurrealDB computes it as `ln((N - n + 0.5) / (n + 0.5))`, where `N` is the number of indexed documents and `n` is how many of them contain the term, and then clamps the result at zero so that very common terms never carry a negative weight.
+
+That clamp is reached as soon as `n` is at least half of `N`. A term held by half or more of the indexed documents weighs exactly `0`, and because that weight multiplies the rest of the formula, `search::score()` returns `0` for it.
+
+Small datasets reach the threshold easily. Three documents, two of which contain the term being searched for, are already enough:
+
+```surql
+DEFINE ANALYZER simple TOKENIZERS class FILTERS lowercase;
+DEFINE INDEX doc_text ON document FIELDS text FULLTEXT ANALYZER simple BM25;
+
+CREATE document:1 SET text = "a database for graphs";
+CREATE document:2 SET text = "a database for documents";
+CREATE document:3 SET text = "an engine for vectors";
+
+SELECT id, search::score(0) AS score FROM document WHERE text @0@ 'database';
+```
+
+```surql title="Output"
+[
+	{
+		id: document:1,
+		score: 0f
+	},
+	{
+		id: document:2,
+		score: 0f
+	}
+]
+```
+
+Four more documents that never mention the term leave `n` at 2 while `N` rises to 7, putting the term under the threshold and giving it a positive weight. The index, the query and the two matching records are all unchanged:
+
+```surql
+CREATE document:4 SET text = "an engine for time series";
+CREATE document:5 SET text = "an engine for documents";
+CREATE document:6 SET text = "a store for vectors";
+CREATE document:7 SET text = "a store for graphs";
+
+SELECT id, search::score(0) AS score FROM document WHERE text @0@ 'database';
+```
+
+```surql title="Output"
+[
+	{
+		id: document:1,
+		score: 0.7997389435768127f
+	},
+	{
+		id: document:2,
+		score: 0.7997389435768127f
+	}
+]
+```
+
+Matching is unaffected either way, so the same rows come back and only their ranking weight is zero. A score of `0` across a handful of records is the clamp behaving as designed, which makes a small dataset a poor place to measure relevance. It is preferable to benchmark on a larger corpus (the size of the real one if possible), and read `ORDER BY score DESC` over a toy dataset as unordered.
+
 The `AND` and `OR` clauses can be used inside the `@@` as well. This allows a single string to be compared against instead of needing to specify individual parts of the string.
 
 ```surql

--- a/src/content/learn/data-models/vector-search/hybrid-search.mdx
+++ b/src/content/learn/data-models/vector-search/hybrid-search.mdx
@@ -89,3 +89,6 @@ LET $ft = SELECT id, search::score(1) as score FROM test
 -- Fuse with Reciprocal Rank Fusion (k defaults to 60 if omitted)
 search::rrf([$vs, $ft], 2, 60);
 ```
+
+> [!NOTE]
+> On a small dataset the lexical half of a hybrid query can contribute membership without contributing order. BM25 clamps the weight of any term appearing in half or more of the indexed documents to zero, so `search::score` returns `0` for every match and the `ORDER BY score DESC` above has nothing to sort on. Reciprocal rank fusion then folds in an arbitrary ordering of the matched rows. See [why a score can be 0](/docs/learn/data-models/full-text-search/scoring-and-ranking#why-a-score-can-be-0).

--- a/src/content/reference/query-language/functions/database-functions/search.mdx
+++ b/src/content/reference/query-language/functions/database-functions/search.mdx
@@ -433,6 +433,9 @@ SELECT id, title, search::score(1) AS score FROM book
 ]
 ```
 
+> [!NOTE]
+> This function returns `0` for a term that appears in half or more of the indexed documents, because BM25 clamps the inverse document frequency of such a term to zero. Small datasets meet that condition easily, so every score can come back as `0` while matching itself still works. See [why a score can be 0](/docs/learn/data-models/full-text-search/scoring-and-ranking#why-a-score-can-be-0).
+
 ## See also
 
 - [Representations and codecs](/docs/learn/querying/concepts-and-guides/representations-and-codecs) - `search::analyze` as an offline preview of analyzer tokenization

--- a/src/content/reference/query-language/statements/define/indexes.mdx
+++ b/src/content/reference/query-language/statements/define/indexes.mdx
@@ -351,7 +351,7 @@ DEFINE INDEX userNameIndex ON TABLE user COLUMNS name FULLTEXT ANALYZER example_
 
 - `SEARCH` or `FULLTEXT`: By using the `SEARCH` keyword, you enable full-text search on the specified column.
 - `ANALYZER ascii`: Uses a custom [analyzer](/docs/reference/query-language/statements/define/analyzer) called `example_ascii` which uses the class tokenizier and `ascii` filter to analysing the text input.
-- `BM25`: Ranking algorithm used for relevance scoring.
+- `BM25`: Ranking algorithm used for relevance scoring. BM25 weighs a term by how rare it is, and clamps that weight to zero for any term appearing in half or more of the indexed documents, which makes [`search::score`](/docs/reference/query-language/functions/database-functions/search#searchscore) return `0` for it. See [why a score can be 0](/docs/learn/data-models/full-text-search/scoring-and-ranking#why-a-score-can-be-0).
 - `HIGHLIGHTS`: Allows keyword highlighting in search results output when using the [`search::highlight`](/docs/reference/query-language/functions/database-functions/search#searchhighlight) function
 - `FIELDS`: a full-text search index can only be used on one field at a time. To use full-text search on more than one field, use a separate `DEFINE INDEX` statement for each one.
 


### PR DESCRIPTION
Issue https://github.com/surrealdb/surrealdb/issues/7290 shows how search::score shows up as 0, which is in fact intentional. This PR explains the details and how adding a few more documents is enough to get past the clamp at 0.