### PR TITLE
Add JS insert recordid example, fix old references bit

### DIFF
--- a/src/content/reference/javascript/api/queries/insert-promise.mdx
+++ b/src/content/reference/javascript/api/queries/insert-promise.mdx
@@ -292,6 +292,29 @@ const users = await db.insert(new Table('users'), [
 ]);
 ```
 
+### Insert a record link
+
+A field typed as a record link needs a [`RecordId`](/docs/reference/javascript/api/values/record-id) instance, built from the table name and the id as separate arguments. A string that looks like a record ID stays a string, so the insert fails with `Expected record<company> but found 'company:acme'`.
+
+```ts
+import { RecordId, Table } from 'surrealdb';
+
+// Schema: DEFINE FIELD company ON job TYPE record<company>;
+await db.insert(new Table('job'), {
+    description: 'Hello World',
+    company: new RecordId('company', 'acme')
+});
+```
+
+Where the id arrives as a single string, convert it inside the query with [`type::record()`](/docs/reference/query-language/functions/database-functions/type#typerecord) instead:
+
+```ts
+await db.query(
+    'INSERT INTO job { description: $description, company: type::record($company) }',
+    { description: 'Hello World', company: 'company:acme' }
+);
+```
+
 ### Ignore duplicates
 
 ```ts

--- a/src/content/reference/query-language/statements/define/field.mdx
+++ b/src/content/reference/query-language/statements/define/field.mdx
@@ -1251,6 +1251,6 @@ CREATE user SET name = 'Ada';
 
 <Since v="v2.2.0" />
 
-A field that is a record link (type `record`, `option<record>`, `array<record<person>>`, and so on) can be defined as a `REFERENCE`. If this clause is used, any linked to record will be able to define a field of its own of type `references` which will be aware of the incoming links.
+A field that is a record link (type `record`, `option<record>`, `array<record<person>>`, and so on) can be defined as a `REFERENCE`. If this clause is used, any linked to record will be able to define a computed field of its own using the `<~` syntax, which will be aware of the incoming links.
 
 For more information, see [the page in the datamodel section on references](/docs/reference/query-language/language-primitives/record-references).


### PR DESCRIPTION
Two changes after https://github.com/surrealdb/docs.surrealdb.com/issues/1594:

- Adds insert example to make it clear how to insert a record ID
- Fixes an old section discovered coincidentally written when `TYPE references` was a thing (only briefly during a beta)