### PR TITLE
Add errors to protocols plus SDK handling

### DIFF
--- a/.agents/skills/documentation/SKILL.md
+++ b/.agents/skills/documentation/SKILL.md
@@ -133,6 +133,7 @@ Structure carries meaning. Do not leave everything in prose blocks.
 - **Code fences:** runnable commands and snippets; show expected output when it helps the reader verify.
 - **Callouts:** `NOTE` for tips, `WARNING` / `IMPORTANT` for safety, data loss, or secrets.
 - **Placeholders:** `<your-token>`, `YOUR_PROJECT_ID` - never real credentials.
+- **Example passwords:** make them look like passwords (`secret`, `hunter123`), never reuse the username. The SurrealDB default is `secret` with the username `root`.
 - **Links:** push depth outward; keep the current page focused.
 - **Hub pages:** title + one-line description per destination beats long essays.
 

--- a/src/components/Layout/nav.ts
+++ b/src/components/Layout/nav.ts
@@ -284,9 +284,10 @@ export const SURREALDB_NAV_LINKS: NavEntry[] = [
                         icon: iconSandbox,
                     },
                     {
-                        label: "REST API",
+                        label: "APIs & protocols",
                         href: "/docs/reference/rest-api",
-                        description: "Call the HTTP API for queries and admin.",
+                        description:
+                            "REST, HTTP, RPC, CBOR and Postgres wire protocols, and the error format they share.",
                         icon: iconAPI,
                     },
                     {

--- a/src/content/reference/golang/concepts/error-handling.mdx
+++ b/src/content/reference/golang/concepts/error-handling.mdx
@@ -8,6 +8,8 @@ description: The Go SDK provides structured error types for distinguishing betwe
 
 The Go SDK uses Go's standard `error` interface and the `errors.As` / `errors.Is` functions for error handling. Errors fall into three main categories: structured [server errors](/docs/reference/golang/api/errors#servererror) from SurrealDB, per-statement [query errors](/docs/reference/golang/api/errors#queryerror), and transport-level failures.
 
+The error kinds, wire codes and structured shape behind these are documented once in [Errors](/docs/reference/rest-api/errors), which applies to every SDK and protocol.
+
 This page covers how to identify and handle each error type, and which errors are safe to retry.
 
 ## API references

--- a/src/content/reference/java/concepts/error-handling.mdx
+++ b/src/content/reference/java/concepts/error-handling.mdx
@@ -8,6 +8,8 @@ description: The Java SDK provides a structured exception hierarchy for handling
 
 The Java SDK provides a structured exception hierarchy for handling errors from the database and SDK. All exceptions extend [`SurrealException`](/docs/reference/java/api/errors#surreal-exception), which is an unchecked exception. Server-returned errors are represented as [`ServerException`](/docs/reference/java/api/errors#server-exception) subclasses with typed error details.
 
+The error kinds, wire codes and structured shape behind these are documented once in [Errors](/docs/reference/rest-api/errors), which applies to every SDK and protocol.
+
 ## API references
 
 <table>

--- a/src/content/reference/javascript/concepts/error-handling.mdx
+++ b/src/content/reference/javascript/concepts/error-handling.mdx
@@ -8,6 +8,8 @@ description: The JavaScript SDK provides specific error classes for handling dif
 
 The JavaScript SDK defines specific error classes for different failure scenarios. All SDK errors extend the base `SurrealError` class, making it easy to distinguish SDK errors from other JavaScript errors and to handle specific failure types with `instanceof` checks.
 
+The error kinds, wire codes and structured shape behind these are documented once in [Errors](/docs/reference/rest-api/errors), which applies to every SDK and protocol.
+
 ## API references
 
 <table>
@@ -42,6 +44,65 @@ The JavaScript SDK defines specific error classes for different failure scenario
 </table>
 
 A complete list of error classes is available in the [Errors API reference](/docs/reference/javascript/api/errors).
+
+## Where an error surfaces
+
+A query travels through two layers, and it is worth knowing which one a failure comes from.
+
+The first is the request itself: a connection that is unavailable, a rejected sign-in, a query that will not parse. The second is the individual statements inside the query, which can fail while the request as a whole succeeds.
+
+Awaiting a query collapses both into a rejection. It rejects on the first statement that fails, so a query whose earlier statements succeeded resolves to nothing at all: those results are lost along with the error.
+
+Where the per-statement outcome matters, `.responses()` returns every statement instead of rejecting. Each entry carries a `success` flag, and a failing one carries an `error` with its `kind`.
+
+```ts
+import { Surreal, createRemoteEngines, ThrownError } from 'surrealdb';
+
+const db = new Surreal({ engines: { ...createRemoteEngines() } });
+await db.connect('http://localhost:8000');
+await db.signin({ username: 'root', password: 'secret' });
+await db.use({ namespace: 'test', database: 'test' });
+
+// Awaiting the query rejects on the first statement that fails, so the
+// result of the statement that succeeded is not returned.
+try {
+    await db.query("RETURN 1; THROW 'second'");
+} catch (e) {
+    if (e instanceof ThrownError) {
+        console.log(`${e.kind}: ${e.message}`);
+    }
+}
+
+// .responses() reports every statement instead of rejecting.
+const responses = await db.query("RETURN 1; THROW 'second'").responses();
+for (const [index, statement] of responses.entries()) {
+    console.log(index, statement.success, statement.success ? statement.result : statement.error.kind);
+}
+```
+
+```ts title="Output"
+Thrown: An error occurred: second
+0 true 1
+1 false Thrown
+```
+
+## Error kinds
+
+Every server error carries a `kind`, and the SDK throws a dedicated class for each of the kinds below. The meaning of each kind is described in [Errors](/docs/reference/rest-api/errors#error-kinds). Match on the kind or the class rather than on the message text, which is free to change between releases.
+
+| Kind | Error class |
+| --- | --- |
+| `Validation` | `ValidationError` |
+| `Configuration` | `ConfigurationError` |
+| `Query` | `QueryError` |
+| `Serialization` | `SerializationError` |
+| `NotAllowed` | `NotAllowedError` |
+| `NotFound` | `NotFoundError` |
+| `AlreadyExists` | `AlreadyExistsError` |
+| `Thrown` | `ThrownError` |
+| `Internal` | `InternalError` |
+
+Any kind without a dedicated class, including one added by a newer server, arrives as the base `ServerError` with its `kind` intact. Catching `ServerError` therefore stays correct as the server grows new kinds.
 
 ## Catching SDK errors
 

--- a/src/content/reference/kotlin/concepts/error-handling.mdx
+++ b/src/content/reference/kotlin/concepts/error-handling.mdx
@@ -8,6 +8,8 @@ description: Handle exceptions and feature-support errors raised by the SurrealD
 
 Networked operations on the SDK throw a [`SurrealException`](/docs/reference/kotlin/api/errors) on failure, or you can use the [`Result` variants](/docs/reference/kotlin/concepts/executing-queries#result-variants) to handle failures functionally without exceptions.
 
+The error kinds, wire codes and structured shape behind these are documented once in [Errors](/docs/reference/rest-api/errors), which applies to every SDK and protocol.
+
 ## Exception hierarchy
 
 All SDK exceptions extend the sealed base [`SurrealException`](/docs/reference/kotlin/api/errors).

--- a/src/content/reference/mojo/concepts/error-handling.mdx
+++ b/src/content/reference/mojo/concepts/error-handling.mdx
@@ -8,6 +8,8 @@ description: How the Mojo SDK reports errors, both on responses and as raised Mo
 
 The Mojo SDK reports failures in two places: on the `RpcResponse` for errors the server returns, and as raised Mojo `Error` values for transport and protocol failures.
 
+The error kinds, wire codes and structured shape behind these are documented once in [Errors](/docs/reference/rest-api/errors), which applies to every SDK and protocol.
+
 ## Response errors
 
 A query that the server rejects comes back as an `RpcResponse` with `is_error()` true. Read the code and message with `error_code()` and `error_message()`.

--- a/src/content/reference/php/v2/concepts/error-handling.mdx
+++ b/src/content/reference/php/v2/concepts/error-handling.mdx
@@ -8,6 +8,8 @@ description: Handle failures in version 2 of the PHP SDK with the typed exceptio
 
 Version 2 of the PHP SDK throws typed exceptions for different failures. They all extend `SurrealException`, which in turn extends PHP's `RuntimeException`. This lets you catch SDK errors broadly or target a specific failure with an `instanceof` check or a `catch` type.
 
+The error kinds, wire codes and structured shape behind these are documented once in [Errors](/docs/reference/rest-api/errors), which applies to every SDK and protocol.
+
 ## Common exceptions
 
 All exceptions live in the `SurrealDB\SDK\Exceptions` namespace.

--- a/src/content/reference/python/concepts/error-handling.mdx
+++ b/src/content/reference/python/concepts/error-handling.mdx
@@ -8,6 +8,8 @@ description: The Python SDK provides a structured error hierarchy for handling s
 
 All errors raised by the Python SDK extend [`SurrealError`](/docs/reference/python/api/errors/#surrealerror), so you can catch every SDK error with a single `except` clause. Server-originated errors use the [`ServerError`](/docs/reference/python/api/errors/#servererror) subtree with structured kinds, details, and cause chains. SDK-side errors cover connection, parsing, and feature support failures.
 
+The error kinds, wire codes and structured shape behind these are documented once in [Errors](/docs/reference/rest-api/errors), which applies to every SDK and protocol.
+
 See the [Errors reference](/docs/reference/python/api/errors/) for the complete error hierarchy and all available properties.
 
 ## API references
@@ -47,6 +49,60 @@ See the [Errors reference](/docs/reference/python/api/errors/) for the complete 
 	</tbody>
 </table>
 
+## Where an error surfaces
+
+A query travels through two layers, and it is worth knowing which one a failure comes from.
+
+The first is the request itself: a connection that is unavailable, a rejected sign-in, a query that will not parse. The second is the individual statements inside the query, which can fail while the request as a whole succeeds.
+
+`.execute()` collapses both into an exception. It raises on the first statement that fails, so a query whose earlier statements succeeded returns nothing at all: those results are lost along with the error.
+
+Where the per-statement outcome matters, [`query_raw()`](/docs/reference/python/api/core/surreal#query-raw) returns every statement instead of raising. Each entry carries a `status` of `OK` or `ERR`, and a failing one also carries the `kind`.
+
+```python
+from surrealdb import Surreal, ThrownError
+
+with Surreal("ws://localhost:8000") as db:
+    db.signin({"username": "root", "password": "secret"})
+    db.use("test", "test")
+
+    # .execute() raises on the first statement that fails, so the result of
+    # the statement that succeeded is not returned.
+    try:
+        db.query("RETURN 1; THROW 'second'").execute()
+    except ThrownError as e:
+        print(f"{e.kind}: {e}")
+
+    # query_raw() reports every statement instead of raising.
+    response = db.query_raw("RETURN 1; THROW 'second'")
+    for index, statement in enumerate(response["result"]):
+        print(index, statement["status"], statement["result"])
+```
+
+```python title="Output"
+Thrown: An error occurred: second
+0 OK 1
+1 ERR An error occurred: second
+```
+
+## Error kinds
+
+Every server error carries a `.kind`, and the SDK raises a dedicated class for each of the kinds below. The meaning of each kind is described in [Errors](/docs/reference/rest-api/errors#error-kinds). Match on the kind or the class rather than on the message text, which is free to change between releases.
+
+| Kind | Exception class |
+| --- | --- |
+| `Validation` | `ValidationError` |
+| `Configuration` | `ConfigurationError` |
+| `Query` | `QueryError` |
+| `Serialization` | `SerializationError` |
+| `NotAllowed` | `NotAllowedError` |
+| `NotFound` | `NotFoundError` |
+| `AlreadyExists` | `AlreadyExistsError` |
+| `Thrown` | `ThrownError` |
+| `Internal` | `InternalError` |
+
+Any kind without a dedicated class, including one added by a newer server, arrives as the base `ServerError` with its `.kind` intact. Catching `ServerError` therefore stays correct as the server grows new kinds, and the `ErrorKind` enum can be used with `.has_kind()` to test for one without importing its class.
+
 ## Catching all SDK errors
 
 The simplest way to handle errors is to catch `SurrealError`, which is the base class for every exception the SDK raises.
@@ -56,7 +112,7 @@ from surrealdb import Surreal, SurrealError
 
 with Surreal("ws://localhost:8000") as db:
     db.use("my_ns", "my_db")
-    db.signin({"username": "root", "password": "root"})
+    db.signin({"username": "root", "password": "secret"})
 
     try:
         result = db.query("SELECT * FROM users").execute()
@@ -172,7 +228,7 @@ from surrealdb import Surreal, UnsupportedFeatureError
 
 with Surreal("http://localhost:8000") as db:
     db.use("my_ns", "my_db")
-    db.signin({"username": "root", "password": "root"})
+    db.signin({"username": "root", "password": "secret"})
 
     try:
         session = db.new_session()

--- a/src/content/reference/rest-api/errors.mdx
+++ b/src/content/reference/rest-api/errors.mdx
@@ -1,0 +1,181 @@
+---
+position: 6
+title: Errors
+description: Every error SurrealDB returns carries a kind, a wire code, optional structured details and an optional cause, in the same shape across every protocol and SDK.
+---
+
+# Errors
+
+Every error SurrealDB returns has the same shape, whichever protocol carries it. The SDKs map that shape onto their own idioms, so the vocabulary on this page is the one behind every SDK's error type.
+
+The preferred way to handle an error is to branch on `kind` first and `code` second, both of which are a stable contract. The `message` is written for a person reading it and is free to change between releases, so treat it as text to display rather than something to match on.
+
+## Where an error appears
+
+A request has two layers that can fail independently, and they report failure differently.
+
+The **call** can fail as a whole: incorrect syntax, an unknown method, a rejected sign-in. In this case the response will carry an `error` object in place of a result.
+
+```json title="Call-level error"
+{
+    "error": {
+        "cause": null,
+        "code": -32603,
+        "details": { "kind": "InvalidParams" },
+        "kind": "Validation",
+        "message": "Expected (what, data)"
+    }
+}
+```
+
+Once the call succeeds, individual statements inside will be either successes or failures. Each statement reports its own `status`, and a failing one carries its `kind` with the message in `result`. Statements that ran before it keep their results.
+
+Take these three statements for example which can be sent as one call. The field definition and the first `CREATE` statement are accepted, and only the third breaks the assertion:
+
+```surql
+DEFINE FIELD name ON user TYPE string ASSERT $value.len() <= 20;
+CREATE user:short SET name = "Billy";
+CREATE user:long SET name = "Mr. Muchtoolongname the Fourth";
+```
+
+The call itself succeeded, so there is no `error` object. The failure is reported against the one statement that caused it, and `user:short` is still created:
+
+```json title="Statement-level error"
+{
+    "result": [
+        { "result": null, "status": "OK", "time": "7.899708ms", "type": null },
+        {
+            "result": [{ "id": "user:short", "name": "Billy" }],
+            "status": "OK",
+            "time": "10.369375ms",
+            "type": null
+        },
+        {
+            "kind": "Internal",
+            "result": "Found 'Mr. Muchtoolongname the Fourth' for field `name`, with record `user:long`, but field must conform to: $value.len() <= 20",
+            "status": "ERR",
+            "time": "1.351458ms",
+            "type": null
+        }
+    ]
+}
+```
+
+A failed statement does not stop the ones after it, and does not roll back the ones before it. Statements are independent unless a [transaction](/docs/reference/query-language/statements/begin) makes them otherwise.
+
+### Inside a transaction
+
+Wrapping the same two `CREATE` statements in `BEGIN` and `COMMIT` ties their fates together:
+
+```surql
+DEFINE FIELD name ON user TYPE string ASSERT $value.len() <= 20;
+
+BEGIN;
+CREATE user:short SET name = "Billy";
+CREATE user:long SET name = "Mr. Muchtoolongname the Fourth";
+COMMIT;
+```
+
+The call still succeeds, so there is still no `error` object. What changes is that the statement which would have worked on its own now reports `NotExecuted`, and the `COMMIT` refuses:
+
+```json title="Statement errors inside a transaction"
+{
+    "result": [
+        { "result": null, "status": "OK", "time": "8.304667ms", "type": null },
+        { "result": null, "status": "OK", "time": "0ns", "type": null },
+        {
+            "details": { "kind": "NotExecuted" },
+            "kind": "Query",
+            "result": "The query was not executed due to a failed transaction",
+            "status": "ERR",
+            "time": "10.880333ms",
+            "type": null
+        },
+        {
+            "kind": "Internal",
+            "result": "Found 'Mr. Muchtoolongname the Fourth' for field `name`, with record `user:long`, but field must conform to: $value.len() <= 20",
+            "status": "ERR",
+            "time": "923.041µs",
+            "type": null
+        },
+        {
+            "details": { "kind": "NotExecuted" },
+            "kind": "Query",
+            "result": "Cannot COMMIT: the transaction was aborted due to a prior error",
+            "status": "ERR",
+            "time": "0ns",
+            "type": null
+        }
+    ]
+}
+```
+
+Neither record exists afterwards, `user:short` included. The `DEFINE FIELD` is untouched, because it ran before `BEGIN`: only the statements inside the transaction are rolled back.
+
+This split is why each SDK offers two ways to read a query result: one that surfaces the first failure, and one that reports every statement. The names differ per language, and each SDK's error page covers its own.
+
+## The error object
+
+| Field | Description |
+| --- | --- |
+| `kind` | The error category. The primary thing to branch on. |
+| `code` | Numeric wire code, kept for backwards compatibility. |
+| `message` | A human-readable description liable to change. Be sure not to match on it unless you are able to update the match when upgrading versions. |
+| `details` | Structured detail for kinds that carry one, itself carrying a nested `kind`. |
+| `cause` | The underlying error, where one was attached. Nested errors use this same shape. |
+
+## Error kinds
+
+| Kind | Meaning |
+| --- | --- |
+| `Validation` | Parse error, invalid request, or invalid parameters |
+| `Configuration` | A feature or configuration is not supported |
+| `Query` | A query timed out, was cancelled, or was not executed |
+| `Serialization` | A value could not be serialised or deserialised |
+| `NotAllowed` | A permission or authorisation check failed |
+| `NotFound` | A resource does not exist |
+| `AlreadyExists` | A resource already exists |
+| `Connection` | A client-side connection failure |
+| `Thrown` | A `THROW` statement ran in SurrealQL |
+| `Internal` | An internal or unexpected failure |
+| `Context` | A wrapper carrying context around another error |
+
+`Internal` doubles as the catch-all for a kind the reader does not recognise, so code that handles the kinds it cares about and treats the rest as internal keeps working against a newer server.
+
+## Wire codes
+
+| Code | Name |
+| --- | --- |
+| `-32700` | Parse error |
+| `-32600` | Invalid request |
+| `-32601` | Method not found |
+| `-32602` | Method not allowed |
+| `-32603` | Invalid parameters |
+| `-32604` | Live query not supported |
+| `-32605` | Bad live query configuration |
+| `-32606` | Bad GraphQL configuration |
+| `-32000` | Internal error |
+| `-32001` | Client-side error |
+| `-32002` | Invalid authentication |
+| `-32003` | Query not executed |
+| `-32004` | Query timed out |
+| `-32005` | Query cancelled |
+| `-32006` | Thrown |
+| `-32007` | Serialization error |
+| `-32008` | Deserialization error |
+| `-32009` | Query transaction conflict |
+
+Two of these differ from the JSON-RPC conventions they resemble: `-32602` is method-not-allowed rather than invalid parameters, and invalid parameters is `-32603`. A code also does not always follow from the kind, since an error can be a `Validation` while carrying the generic `-32000`. Reading `kind` avoids both surprises.
+
+## In the SDKs
+
+Each SDK exposes these kinds through its own error type, and documents the two-layer behaviour in its own idiom.
+
+- [Rust](/docs/reference/rust/concepts/error-handling)
+- [JavaScript](/docs/reference/javascript/concepts/error-handling)
+- [Python](/docs/reference/python/concepts/error-handling)
+- [Go](/docs/reference/golang/concepts/error-handling)
+- [Java](/docs/reference/java/concepts/error-handling)
+- [Kotlin](/docs/reference/kotlin/concepts/error-handling)
+- [PHP](/docs/reference/php/v2/concepts/error-handling)
+- [Mojo](/docs/reference/mojo/concepts/error-handling)

--- a/src/content/reference/rest-api/rpc-protocol.mdx
+++ b/src/content/reference/rest-api/rpc-protocol.mdx
@@ -619,11 +619,16 @@ If you do not specify the `table` parameter (i.e., set it to `null` or `none`), 
 {
     "id": 3,
     "error": {
-        "code": -32602,
-        "message": "Invalid parameters"
+        "cause": null,
+        "code": -32603,
+        "details": { "kind": "InvalidParams" },
+        "kind": "Validation",
+        "message": "Expected (what, data)"
     }
 }
 ```
+
+See [Errors](/docs/reference/rest-api/errors) for the full error shape, the list of kinds, and the wire codes.
 
 ### Best practices
 

--- a/src/content/reference/rust/concepts/error-handling.mdx
+++ b/src/content/reference/rust/concepts/error-handling.mdx
@@ -1,0 +1,123 @@
+---
+position: 12
+title: Error handling
+description: Every fallible method in the Rust SDK returns a surrealdb::Error, which carries a kind you can match on along with structured details and a cause chain.
+---
+
+# Error handling
+
+Every fallible method in the Rust SDK returns `surrealdb::Result<T>`, an alias for `Result<T, surrealdb::Error>`. That error type is the same one the server sends over the wire, so a failure raised inside the database and a failure raised by the SDK arrive in the same shape.
+
+The error kinds, wire codes and structured shape behind these are documented once in [Errors](/docs/reference/rest-api/errors), which applies to every SDK and protocol.
+
+Be sure to match on the error's kind rather than on its message. The kind and the wire code are a stable contract, while message text is free to change between releases.
+
+## Two places an error can appear
+
+A query travels through two layers, and each reports failure differently.
+
+The `Result` covers the request as a whole: a malformed query, a connection that is unavailable, a rejected sign-in. The response covers the individual statements inside the query, which can fail while the request itself succeeds.
+
+That second layer is easy to miss. A query whose statements fail still returns `Ok`, because the request reached the server and came back. The statement errors appear only when the response is inspected with [`.check()`](/docs/reference/rust/methods/query) or `.take_errors()`.
+
+```rust
+use surrealdb::engine::any::connect;
+
+#[tokio::main]
+async fn main() -> surrealdb::Result<()> {
+    let db = connect("memory").await?;
+    db.use_ns("test").use_db("test").await?;
+
+    // Three statements in one call. Only the third breaks the assertion.
+    let mut response = db
+        .query(
+            "DEFINE FIELD name ON user TYPE string ASSERT $value.len() <= 20;
+             CREATE user:short SET name = 'Billy';
+             CREATE user:long SET name = 'Mr. Muchtoolongname the Fourth';",
+        )
+        .await?;
+
+    // The call succeeded, so `?` above did not fire. take_errors() reports which
+    // statements failed and leaves the successful ones in place.
+    for (index, e) in response.take_errors() {
+        println!("statement {index}: {} - {}", e.kind_str(), e.message());
+    }
+
+    // The record created by the statement that worked is still there.
+    let created: Vec<String> = db.query("SELECT VALUE name FROM user").await?.take(0)?;
+    println!("records still created: {created:?}");
+
+    // A malformed query fails the call itself, so this one does return Err.
+    if let Err(e) = db.query("SELECT * FROM").await {
+        println!("call error: {} (is_validation = {})", e.kind_str(), e.is_validation());
+    }
+
+    // Some kinds carry structured details.
+    if let Err(e) = connect("ws://127.0.0.1:9/").await {
+        println!("{}: {:?}", e.kind_str(), e.connection_details());
+    }
+    Ok(())
+}
+```
+
+```text title="Output"
+statement 2: Internal - Found 'Mr. Muchtoolongname the Fourth' for field `name`, with record `user:long`, but field must conform to: $value.len() <= 20
+records still created: ["Billy"]
+call error: Validation (is_validation = true)
+Connection: Some(ConnectionFailed)
+```
+
+`take_errors()` gives the index of each failing statement, which is what makes it possible to tell which one of a multi-statement query went wrong. The same call wrapped in a transaction behaves differently: see [Errors](/docs/reference/rest-api/errors#inside-a-transaction).
+
+## Error kinds
+
+`.kind_str()` returns the kind as a string, and each kind has a matching predicate for use in a `match` guard. The meaning of each kind is described in [Errors](/docs/reference/rest-api/errors#error-kinds).
+
+| Kind | Predicate |
+| --- | --- |
+| `Validation` | `.is_validation()` |
+| `Configuration` | `.is_configuration()` |
+| `Query` | `.is_query()` |
+| `Serialization` | `.is_serialization()` |
+| `NotAllowed` | `.is_not_allowed()` |
+| `NotFound` | `.is_not_found()` |
+| `AlreadyExists` | `.is_already_exists()` |
+| `Connection` | `.is_connection()` |
+| `Thrown` | `.is_thrown()` |
+| `Internal` | `.is_internal()` |
+| `Context` | `.is_context()` |
+
+Because `Internal` absorbs unrecognised kinds, a `match` that handles the kinds it cares about and treats the rest as internal stays correct against a newer server.
+
+```rust
+match db.query("SELECT * FROM person").await {
+    Ok(response) => { /* inspect statements with .check() */ }
+    Err(e) if e.is_validation() => eprintln!("bad query: {}", e.message()),
+    Err(e) if e.is_not_allowed() => eprintln!("not permitted: {}", e.message()),
+    Err(e) if e.is_connection() => eprintln!("connection lost: {}", e.message()),
+    Err(e) => eprintln!("{}: {}", e.kind_str(), e.message()),
+}
+```
+
+## Structured details
+
+Eight of the kinds carry a typed detail enum, reached through an accessor named after the kind: `.validation_details()`, `.configuration_details()`, `.query_details()`, `.serialization_details()`, `.not_allowed_details()`, `.not_found_details()`, `.already_exists_details()`, and `.connection_details()`. Each returns `Option`, since a kind does not always carry a detail.
+
+The detail types live under `surrealdb::types`, so the `ConnectionFailed` printed by the example above is a `surrealdb::types::ConnectionError`. `Thrown`, `Internal` and `Context` have no detail type.
+
+## Following the cause chain
+
+`.cause()` returns the underlying error where one was attached, so a failure that passed through several layers can be unwound to its origin.
+
+```rust
+let mut current = Some(&error);
+while let Some(e) = current {
+    eprintln!("{}: {}", e.kind_str(), e.message());
+    current = e.cause();
+}
+```
+
+## Learn more
+
+- [`.query()`](/docs/reference/rust/methods/query) - `.check()` and `.take_errors()` on a response
+- [Working with types](/docs/reference/rust/concepts/working-with-types) - the `surrealdb::types` crate that defines `Error`

--- a/src/content/reference/rust/concepts/index.mdx
+++ b/src/content/reference/rust/concepts/index.mdx
@@ -18,3 +18,4 @@ This section covers the core concepts of the SurrealDB SDK for Rust: connecting 
 - [Working with types](/docs/reference/rust/concepts/working-with-types)
 - [SurrealValue attributes](/docs/reference/rust/concepts/surrealvalue-attributes)
 - [Multi-tenancy](/docs/reference/rust/concepts/multi-tenancy)
+- [Error handling](/docs/reference/rust/concepts/error-handling)

--- a/src/content/reference/rust/index.mdx
+++ b/src/content/reference/rust/index.mdx
@@ -26,6 +26,7 @@ The SurrealDB SDK for Rust enables you to interact with SurrealDB from client-si
 <Boxes>
 	<IconBox title="Concepts" description="Guides for connecting, authenticating, querying, and working with data." href="/docs/reference/rust/concepts" />
 	<IconBox title="API Reference" description="Complete reference for the SDK's methods, types, and errors." href="/docs/reference/rust/methods" />
+	<IconBox title="Error handling" description="Match on error kinds, inspect structured details, and follow the cause chain." href="/docs/reference/rust/concepts/error-handling" />
 </Boxes>
 
 ## Frameworks


### PR DESCRIPTION
Fixes/improves a few things:

- Right now when you mouseover Reference there is a REST API option which is actually a link to all the protocols, not just REST. Changes that
- Since SurrealDB now has a standardised error structure over the wire, adds an errors page in the same section.
- Adds error handling info for some major SDKs along with links back to this error overview page.
- Gives some extra handling info to three major languages: Rust (because the error type and database itself is Rust), Python, and Javascript.

Related issue: https://github.com/surrealdb/docs.surrealdb.com/issues/1940