### PR TITLE
Standardise how examples show their output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,6 +190,132 @@ flow), and on the page documenting `RETURN` itself. Prose that only narrates
 the keyword ("shows this function used in a `RETURN` statement") is trimmed
 along with it.
 
+**Showing output.** An example's result goes in its own fence directly below the
+code, titled `Output`:
+
+```surql
+math::sum([ 26.164, 13.746189, 23, 16.4, 41.42 ]);
+```
+
+```surql title="Output"
+120.730189f
+```
+
+The renderer joins an adjacent pair into one block with a divider, so the pair
+costs about two lines more than a trailing comment while staying unambiguous.
+Nothing to write for that: `wrapOutputPairs` inserts the `<CodeWithOutput>`
+wrapper while parsing, and the raw `.md` endpoints keep both fences so an agent
+can tell which half is runnable.
+
+`Output` is the plain label, and `Response` is kept only on the HTTP and RPC
+pages, where it is the counterpart of a `Request` block. Anything with the word
+`output` in it pairs and renders in full, so reach for a qualifier whenever the
+value shown is one of several a reader might see - `Sample output` and
+`Possible output` for a generated record id, a datetime or a live API,
+`Expected output` for a value a test asserts, `Error output` for a failure, or a
+condition spelled out as in `title="Output when $transfer_amount set to 150"`.
+`Response` and `Result` only pair at the start of a title, because a code block
+titled for what it does with a response (`Handle Individual Responses`,
+`Map results onto a dataclass`) would otherwise be joined to the example above
+it as though it were its output.
+
+The language names the format of the bytes, so `surql` for SurrealQL value
+notation, `json` for HTTP JSON, `text` or `bash` for terminal output.
+
+Where several statements in one block each have a result, the result stays a
+comment, marked `//-` so it is not read as commentary:
+
+```surql
+array::all([ 1, 2, 3, NONE, 'SurrealDB', 5 ]);
+//- false
+
+["all", "clear"].all();
+//- true
+```
+
+`//-` refers to the statement directly above it, always, and a `--` label
+describes the statement directly below it. That is what makes either signal
+decodable on its own: position and marker say the same thing, so a reader or an
+agent that goes by one of them lands in the same place. A result above its
+statement, or a label below it, breaks that.
+
+Everything after `//-` is the value, verbatim, and nothing else - no `Returns`,
+no trailing note, no parenthetical. The marker already says the line is a
+result, so `Returns` is always redundant, and a note riding along behind the
+value leaves the value unextractable: a reader cannot take the rest of the line,
+and no delimiter helps, because a value can itself end in `)`. Put the remark on
+a `--` label above the statement, where it has room:
+
+```surql
+-- Not inside an array, unlike a SELECT
+CREATE ONLY cat:one;
+//- { id: cat:one }
+```
+
+Because `//-` asserts that the statement returned this, a value a rerun would
+not reproduce needs the label above to say so - the inline counterpart of the
+`Possible output` and `Sample output` fence titles:
+
+```surql
+-- Possible output, since the timeout may or may not be exceeded
+sequence::nextval('mySeq3');
+//- 'The query was not executed because it exceeded the timeout'
+```
+
+Reserve that for when the varying thing *is* the value: a random datetime, a
+live query id, a timeout that may or may not fire. A generated record id sitting
+inside a returned record is incidental - the reader sees the same shape with a
+different suffix - and caveating those would put a note on most examples in the
+docs while telling the reader nothing they cannot see.
+
+SurrealQL takes `--`, `//` and `#` as line comments, all equivalent to the
+parser, and the docs spend two of them: **`--` for prose, `//-` for a result.**
+Reserve `//-` for a value the server returned or an error it raised; prose about
+the statement, a numbered step, or commented-out alternative code stays on `--`.
+A bare `//` therefore means something was missed, which makes the convention
+auditable with a single grep.
+
+Three reasons the two roles take different tokens rather than `--` and `-->`:
+
+- `--` is a **prefix** of `-->`, so any matcher has to test the longer form
+  first, and getting that ordering wrong fails in the worse direction - a prose
+  detector keyed on `^--` swallows results and reads them as commentary. `--`
+  and `//-` differ at the first character, so no ordering is involved.
+- A `>` is **entity-encoded in the rendered page**. A marker containing one
+  appears as `--&gt;` in the HTML a reader sees, so grepping the rendered page
+  for it silently finds nothing - the same trap this guide documents for
+  `" />`. `//-` escapes to nothing, so one string matches in the source, in the
+  raw `.md` and in the rendered HTML alike, and a check written once holds on
+  all three surfaces.
+- `-->` is already SurrealDB's own parse-error location pointer (` --> [3:12]`),
+  which appears inside error output on about ten pages. A marker that collides
+  with something the server prints is ambiguous exactly where output is being
+  quoted.
+
+Three places keep `//` and must not be swept onto `--`: the exact strings
+`// highlight-next-line`, `// highlight-start` and `// highlight-end`, which the
+viewer's highlighter matches literally; comments inside an embedded JavaScript
+`function() { … }` body, where `--` is a syntax error; and the
+[Comments](src/content/reference/query-language/language-primitives/comments.mdx)
+page, whose subject is the three forms themselves. Where a comment states an outcome without
+showing a value ("2: Statement will fail because the value for email was not
+valid"), it is narration and stays on `--`.
+
+A single result at the end of a block is a fence, not a comment, and the
+dividing line is attribution. With one statement there is nothing a fence can
+attribute wrongly, so it costs no clarity and gains two things: its copy button
+yields the query alone, where an inline `//-` would ride along as a comment
+holding a value that drifts, and `title="Output"` needs no legend in the raw
+`.md` a per-page fetch returns, where `//-` relies on the agent inferring it.
+With several statements each returning something, no fence can say which value
+came from which statement without restating them, so the marker is the only form
+that keeps the pairing - and it keeps the block paste-and-run, with its expected
+values alongside for an agent to diff against.
+
+On a block that sets up its data first, the fence labels the **last** statement,
+the same convention `RETURN` follows: three `CREATE`s and then the `SELECT`
+whose result is shown is one fence pair, not four.
+
 **Callouts.** Use `> [!NOTE]`, `> [!WARNING]`, and `> [!IMPORTANT]` for
 exceptions, security caveats, and breaking or easy-to-miss details.
 
@@ -407,6 +533,9 @@ every component in that file.
 | `<YouTube code="…" />`           | Embedded video. The `code` is the YouTube id.                 |
 | `<SurrealistMini query="…" />`   | Runnable query embed of a live editor.                        |
 
+`<CodeWithOutput>` is absent from that table on purpose: `wrapOutputPairs` inserts
+it around an output pair while parsing, and no page writes it by hand.
+
 > [!IMPORTANT]
 > Braced attribute values are parsed as **JSON**, not JavaScript. Object keys and
 > strings need double quotes; an invalid value is dropped with a console warning.
@@ -523,9 +652,13 @@ Markdown pipeline (`resolveMarkdown` in `src/utils/markdown.tsx`) returns
 
 1. `stripLeadingH1` - the rendered heading comes from frontmatter `title`.
 2. Strip leading language-test block comments out of fenced code.
-3. `inlineSynopsisCommands` - move `<Synopsis>` bodies into the `command` attribute.
-4. `injectIconScope` - quote `icon={{ … }}` keys and resolve icon identifiers to URLs.
-5. `parseMarkdownTree` and `extractHeadings` (both from `@surrealdb/ui`) for the page aside.
+3. `wrapOutputPairs` - wrap a code fence and the `title="Output"` fence below it in
+   `<CodeWithOutput>` so the pair renders as one block. Render-only:
+   `composeRawMarkdown` shares steps 1 and 2 but not this one, so the `.md`
+   endpoints keep the two fences separate.
+4. `inlineSynopsisCommands` - move `<Synopsis>` bodies into the `command` attribute.
+5. `injectIconScope` - quote `icon={{ … }}` keys and resolve icon identifiers to URLs.
+6. `parseMarkdownTree` and `extractHeadings` (both from `@surrealdb/ui`) for the page aside.
 
 Sidebar: `buildNavigation` in `src/utils/navigation.ts` builds sections from
 `getCollectionTree(id)`. The root folder becomes the first section, each top-level

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -9,6 +9,7 @@ Working notes:
 - SurrealQL is the native query language. [GraphQL](https://surrealdb.com/docs/learn/querying/graphql/overview), [HTTP](https://surrealdb.com/docs/reference/rest-api/http-protocol), [RPC](https://surrealdb.com/docs/reference/rest-api/rpc-protocol) and [CBOR](https://surrealdb.com/docs/reference/rest-api/cbor-protocol) are also available.
 - Live queries push changes to subscribers rather than requiring polling.
 - The same database serves documents, graphs, vectors and time series inside one ACID transaction, so joins across models do not need a second store.
+- In code examples, a fenced block whose title contains "output" holds the result of the block above it rather than runnable code, and a qualifier such as "Sample output" or "Possible output" means the value shown is one of several possible ones. Inside a block, a "//-" comment marks a value the statement above it returned, while "--" is an ordinary comment.
 
 ## Get started
 

--- a/src/components/CodeWithOutput/index.tsx
+++ b/src/components/CodeWithOutput/index.tsx
@@ -1,0 +1,21 @@
+import { Box } from "@mantine/core";
+import type { ReactNode } from "react";
+import classes from "./style.module.scss";
+
+interface CodeWithOutputProps {
+    /** The code fence followed by its output fence, in that order. */
+    children?: ReactNode;
+}
+
+/**
+ * A code fence and the output fence beneath it, joined into a single block.
+ *
+ * `wrapOutputPairs` inserts this around an adjacent pair while parsing, so no page
+ * writes it by hand: content keeps two fences, which is the form the `.md` endpoints
+ * serve and the form that tells an agent which half is runnable. The wrapper supplies
+ * only the surrounding chrome, leaving both panes to the viewer's own code renderer,
+ * so highlighting matches every other fence and each pane copies on its own.
+ */
+export function CodeWithOutput({ children }: CodeWithOutputProps) {
+    return <Box className={classes.pair}>{children}</Box>;
+}

--- a/src/components/CodeWithOutput/style.module.scss
+++ b/src/components/CodeWithOutput/style.module.scss
@@ -1,0 +1,26 @@
+.pair {
+	margin-block: var(--mantine-spacing-md);
+
+	/* Both panes come from the viewer's fence renderer, which gives each its own
+	 * block spacing and rounded, bordered shell. The selectors below reach into that
+	 * markup structurally, because its class names are hashed inside the kit's CSS
+	 * modules and cannot be named here. Joining the two panes belongs in
+	 * @surrealdb/ui alongside the renderer; until it moves there, keep these rules
+	 * tied to structure and to the `data-language` attribute the renderer sets. */
+	> * + * {
+		margin-top: 0;
+	}
+
+	/* Code pane: keep the top corners, drop the bottom ones and the shared seam. */
+	> *:first-child pre[data-language] {
+		border-bottom-left-radius: 0;
+		border-bottom-right-radius: 0;
+		border-bottom: 0;
+	}
+
+	/* The output fence's caption becomes the divider between the two panes. */
+	> *:last-child > *:first-child {
+		border-top-left-radius: 0;
+		border-top-right-radius: 0;
+	}
+}

--- a/src/content/build/migrating/from-old-surrealdb-versions/2x-to-3x.mdx
+++ b/src/content/build/migrating/from-old-surrealdb-versions/2x-to-3x.mdx
@@ -499,7 +499,7 @@ Replace with `let $val = ...` to keep the previous behavior.
 **Before (2.x)**:
 ```surql
 SELECT age, emails FROM user SPLIT emails GROUP BY age;
-// SPLIT had no effect.
+-- SPLIT had no effect.
 ```
 
 **After (3.x) - Option 1 (split then group)**:
@@ -620,7 +620,7 @@ CREATE record SET closure = |$a| $a + 1
 
 **After (3.x)**:
 ```surql
-# This will now throw an error
+-- This will now throw an error
 CREATE record SET closure = |$a| $a + 1
 ```
 
@@ -680,15 +680,15 @@ CREATE record SET closure = |$a| $a + 1
 **Before (2.x)**:
 ```surql
 [{ a: ["a","b"]}, {a: [1,2]}].a[0]
-// returns ["a","b"]
-// Evaluated as: ([...].a)[0]
+-- returns ["a","b"]
+-- Evaluated as: ([...].a)[0]
 ```
 
 **After (3.x)**:
 ```surql
 [{ a: ["a","b"]}, {a: [1,2]}].a[0]
-// returns ["a",1]
-// Evaluated on each element: [(...).a[0], (...).a[0]]
+-- returns ["a",1]
+-- Evaluated on each element: [(...).a[0], (...).a[0]]
 ```
 
 **Migration**: Swap idiom parts if old behaviour needed.
@@ -791,7 +791,7 @@ r"a:b[r\"c:d\"]"  // must escape "
 ```surql
 -- 3.x returns errors instead of empty arrays
 SELECT * FROM doesnt_exist;
---> Error: "The table 'doesnt_exist' does not exist"
+//- Error: "The table 'doesnt_exist' does not exist"
 ```
 
 **SCHEMAFULL Tables**:
@@ -802,7 +802,7 @@ DEFINE FIELD name ON user TYPE string;
 -- 2.x: extra fields silently filtered
 -- 3.x: extra fields cause error
 CREATE user CONTENT { name: "Billy", other: "value" };
---> Error: "Found field 'other', but no such field exists"
+//- Error: "Found field 'other', but no such field exists"
 
 -- Use destructuring to select only defined fields
 CREATE user CONTENT { name: "Billy", other: "value" }.{ name };
@@ -829,7 +829,7 @@ SELECT * FROM t; // returns `[{ id: [1] }, { id: [1f] }]`
 ```surql
 CREATE t:[1];
 CREATE t:[1f];
-// returns an error, record with key `t:[1]` alread exisits.
+-- returns an error, record with key `t:[1]` alread exisits.
 SELECT * FROM t; // returns `[{ id: [1] }]`
 ```
 

--- a/src/content/build/migrating/from-old-surrealdb-versions/2x-to-3x.mdx
+++ b/src/content/build/migrating/from-old-surrealdb-versions/2x-to-3x.mdx
@@ -791,7 +791,7 @@ r"a:b[r\"c:d\"]"  // must escape "
 ```surql
 -- 3.x returns errors instead of empty arrays
 SELECT * FROM doesnt_exist;
--- Error: "The table 'doesnt_exist' does not exist"
+--> Error: "The table 'doesnt_exist' does not exist"
 ```
 
 **SCHEMAFULL Tables**:
@@ -802,7 +802,7 @@ DEFINE FIELD name ON user TYPE string;
 -- 2.x: extra fields silently filtered
 -- 3.x: extra fields cause error
 CREATE user CONTENT { name: "Billy", other: "value" };
--- Error: "Found field 'other', but no such field exists"
+--> Error: "Found field 'other', but no such field exists"
 
 -- Use destructuring to select only defined fields
 CREATE user CONTENT { name: "Billy", other: "value" }.{ name };

--- a/src/content/build/migrating/from-other-databases/from-neo4j.mdx
+++ b/src/content/build/migrating/from-other-databases/from-neo4j.mdx
@@ -128,8 +128,8 @@ CREATE (John:Person {name:‘John’}), (Jane:Person {name: ‘Jane’})
 ```
 
 ```surql
-// SurrealQL
-// Table implicitly created if it doesn't exist
+-- SurrealQL
+-- Table implicitly created if it doesn't exist
 INSERT INTO person [ {id: “John”, name: “John”}, {id: “Jane”, name: “Jane”} ]
 ```
 
@@ -141,7 +141,7 @@ MATCH (p:Person {name:‘Jane’}), (pr:Product {name:‘iPhone’}) CREATE (p)-
 ```
 
 ```surql
-// SurrealQL
+-- SurrealQL
 RELATE person:Jane->order->product:iPhone
 ```
 
@@ -153,7 +153,7 @@ CREATE INDEX personNameIndex FOR (p:Person) ON (p.name)
 ```
 
 ```surql
-// SurrealQL
+-- SurrealQL
 DEFINE INDEX idx_name ON TABLE person COLUMNS name
 ```
 
@@ -169,7 +169,7 @@ MATCH (p:Person) RETURN p
 ```
 
 ```surql
-// SurrealQL
+-- SurrealQL
 SELECT * FROM person
 ```
 
@@ -181,7 +181,7 @@ MATCH (p:Person) RETURN p.name
 ```
 
 ```surql
-// SurrealQL
+-- SurrealQL
 SELECT name FROM person
 ```
 
@@ -193,7 +193,7 @@ MATCH (p:Person) WHERE p.name = “Jane” RETURN p.name
 ```
 
 ```surql
-// SurrealQL
+-- SurrealQL
 SELECT name FROM person WHERE name = “Jane”
 ```
 
@@ -205,7 +205,7 @@ EXPLAIN MATCH (p:Person) WHERE p.name = "Jane" RETURN p.name
 ```
 
 ```surql
-// SurrealQL
+-- SurrealQL
 SELECT name FROM person WHERE name = "Jane" EXPLAIN
 ```
 
@@ -217,7 +217,7 @@ MATCH (p:Person) RETURN count(*) as person_count
 ```
 
 ```surql
-// SurrealQL
+-- SurrealQL
 SELECT count() AS person_count FROM person GROUP ALL
 ```
 
@@ -229,7 +229,7 @@ MATCH (p:Person) RETURN distinct p.name
 ```
 
 ```surql
-// SurrealQL
+-- SurrealQL
 SELECT array::distinct(name) FROM person GROUP ALL
 ```
 
@@ -241,7 +241,7 @@ MATCH (p:Person) RETURN p LIMIT 10
 ```
 
 ```surql
-// SurrealQL
+-- SurrealQL
 SELECT * FROM person LIMIT 10
 ```
 
@@ -253,7 +253,7 @@ MATCH (p:Person)-[:ORDER]->(pr:Product) RETURN p.name, pr.name
 ```
 
 ```surql
-// SurrealQL
+-- SurrealQL
 SELECT name, ->order->product.name FROM person
 ```
 
@@ -269,7 +269,7 @@ MATCH (p:Person)  WHERE p.name = "Jane"  SET p.last_name = 'Doe'  RETURN p
 ```
 
 ```surql
-// SurrealQL
+-- SurrealQL
 UPDATE person SET last_name = "Doe" WHERE name = "Jane"
 ```
 
@@ -281,7 +281,7 @@ MATCH (p:Person)   WHERE p.name = "Jane"   REMOVE p.last_name RETURN p
 ```
 
 ```surql
-// SurrealQL
+-- SurrealQL
 UPDATE person UNSET last_name WHERE name = "Jane"
 ```
 
@@ -297,7 +297,7 @@ MATCH (p:Person)  WHERE p.name = "Jane"  DELETE p
 ```
 
 ```surql
-// SurrealQL
+-- SurrealQL
 DELETE person WHERE name = "Jane"
 ```
 
@@ -309,7 +309,7 @@ MATCH (p:Person)  DELETE p
 ```
 
 ```surql
-// SurrealQL
+-- SurrealQL
 DELETE person
 ```
 
@@ -321,7 +321,7 @@ MATCH (p:Person)  DELETE p
 ```
 
 ```surql
-// SurrealQL
+-- SurrealQL
 REMOVE TABLE person
 ```
 

--- a/src/content/build/migrating/from-other-databases/from-postgresql.mdx
+++ b/src/content/build/migrating/from-other-databases/from-postgresql.mdx
@@ -60,7 +60,7 @@ INSERT INTO product
 ```
 
 ```surql
-// SurrealQL
+-- SurrealQL
 CREATE product CONTENT {
     name: 'Shirt',
     id: 'shirt',
@@ -94,9 +94,9 @@ DEFINE FIELD name ON TABLE product TYPE string;
 DEFINE FIELD description ON TABLE product TYPE string;
 DEFINE FIELD price ON TABLE product 
     TYPE number 
-    // Only show two digits after decimal point
+    -- Only show two digits after decimal point
     VALUE math::fixed($value, 2) 
-    // Price must be within this range
+    -- Price must be within this range
     ASSERT $value IN 0..=99999999;
 DEFINE FIELD category ON TABLE product TYPE string;
 DEFINE FIELD images ON TABLE product TYPE array<string>;
@@ -138,7 +138,7 @@ SELECT * FROM product WHERE id=1;
 ```
 
 ```surql
-// SurrealQL
+-- SurrealQL
 SELECT * FROM product:shirt;
 ```
 
@@ -150,7 +150,7 @@ SELECT * FROM product WHERE id IN (1, 2, 3);
 ```
 
 ```surql
-// SurrealQL
+-- SurrealQL
 SELECT * FROM [product:1, product:2, product:3];
 ```
 
@@ -162,7 +162,7 @@ SELECT COUNT(*) FROM product;
 ```
 
 ```surql
-// SurrealQL
+-- SurrealQL
 SELECT count() FROM product GROUP ALL;
 ```
 
@@ -210,7 +210,7 @@ ORDER BY p.id;
 In SurrealQL, tables can be joined to each other via edges, such as the `bought` edge in this example.
 
 ```surql
-// Relate a 'customer' to a 'product' via 'bought'
+-- Relate a 'customer' to a 'product' via 'bought'
 RELATE customer:tobie->bought->product:iphone CONTENT {
     option: { Size: 'M', Color: 'Max' },
     quantity: 1,
@@ -247,7 +247,7 @@ WHERE p.id IN (
 ```
 
 ```surql
-// SurrealQL
+-- SurrealQL
 customer:tobie->bought->product<-bought<-customer.*;
 ```
 

--- a/src/content/learn/data-models/full-text-search/other-ways-to-work-with-text.mdx
+++ b/src/content/learn/data-models/full-text-search/other-ways-to-work-with-text.mdx
@@ -70,16 +70,20 @@ The functions [`array::sort_natural()`, `array::sort_lexical()`, and `array::sor
 The most basic way to see if one string is contained inside another is to use the `IN` operator, or the [`string::contains()` function](/docs/reference/query-language/functions/database-functions/string#stringcontains).
 
 ```surql
--- false
 "Umple" IN "Rumplestiltskin";
+--> false
 string::contains("Rumplestiltskin", "Umple");
+--> false
 -- Same function using method syntax
 "Rumplestiltskin".contains("Umple");
+--> false
 
--- true
 "umple" IN "Rumplestiltskin";
+--> true
 string::contains("Rumplestiltskin", "umple");
+--> true
 "Rumplestiltskin".contains("umple");
+--> true
 ```
 
 SurrealDB has a number of [operators](/docs/reference/query-language/language-primitives/operators) to determine if all or some of the values of one array are contained in another, such as `CONTAINSALL` and `CONTAINSANY`, or `ALLINSIDE` and `ANYINSIDE`. The queries with `CONTAINS` and `INSIDE` perform the same operation, just in the opposite order.
@@ -132,27 +136,27 @@ While the word "Unite" is clearly closer to the word "United" than it is to "Uni
 However, the `string::similarity::jaro()` function returns an output that approaches 1 if two strings are equal, making it a more apt solution when the first and second string may be entirely different. Using the same input strings as above shows that "Unite" is clearly the most similar of the strings that are not outright equal to "United".
 
 ```surql
--- 0.8095238095238096f
 string::similarity::jaro("United Kingdom", "United");
--- 0.7857142857142857f
+--> 0.8095238095238096f
 string::similarity::jaro("United Kingdom", "Unite");
--- 1
+--> 0.7857142857142857f
 string::similarity::jaro("United", "United");
--- 0.9444444444444445f
+--> 1
 string::similarity::jaro("United", "Unite");
+--> 0.9444444444444445f
 ```
 
 Another example of the large difference between algorithms is the Hamming distance algorithm, which only compares strings of equal length.
 
 ```surql
--- Error: strings have different length
 string::distance::hamming("United Kingdom", "United");
--- Returns 0
+--> Error: strings have different length
 string::distance::hamming("United", "United");
--- Returns 1
+--> 0
 string::distance::hamming("United", "Unitéd");
--- Returns 6
+--> 1
 string::distance::hamming("United", "uNITED");
+--> 6
 ```
 
 ## Regex matching
@@ -160,10 +164,10 @@ string::distance::hamming("United", "uNITED");
 The `string::matches()` function can be used to perform regex matching on a string.
 
 ```surql
--- true
 string::matches("Cat", "[HC]at");
--- Also true
+--> true
 string::matches("Hat", "[HC]at");
+--> true
 ```
 
 ## Other string functions

--- a/src/content/learn/data-models/full-text-search/other-ways-to-work-with-text.mdx
+++ b/src/content/learn/data-models/full-text-search/other-ways-to-work-with-text.mdx
@@ -71,19 +71,19 @@ The most basic way to see if one string is contained inside another is to use th
 
 ```surql
 "Umple" IN "Rumplestiltskin";
---> false
+//- false
 string::contains("Rumplestiltskin", "Umple");
---> false
+//- false
 -- Same function using method syntax
 "Rumplestiltskin".contains("Umple");
---> false
+//- false
 
 "umple" IN "Rumplestiltskin";
---> true
+//- true
 string::contains("Rumplestiltskin", "umple");
---> true
+//- true
 "Rumplestiltskin".contains("umple");
---> true
+//- true
 ```
 
 SurrealDB has a number of [operators](/docs/reference/query-language/language-primitives/operators) to determine if all or some of the values of one array are contained in another, such as `CONTAINSALL` and `CONTAINSANY`, or `ALLINSIDE` and `ANYINSIDE`. The queries with `CONTAINS` and `INSIDE` perform the same operation, just in the opposite order.
@@ -137,26 +137,26 @@ However, the `string::similarity::jaro()` function returns an output that approa
 
 ```surql
 string::similarity::jaro("United Kingdom", "United");
---> 0.8095238095238096f
+//- 0.8095238095238096f
 string::similarity::jaro("United Kingdom", "Unite");
---> 0.7857142857142857f
+//- 0.7857142857142857f
 string::similarity::jaro("United", "United");
---> 1
+//- 1
 string::similarity::jaro("United", "Unite");
---> 0.9444444444444445f
+//- 0.9444444444444445f
 ```
 
 Another example of the large difference between algorithms is the Hamming distance algorithm, which only compares strings of equal length.
 
 ```surql
 string::distance::hamming("United Kingdom", "United");
---> Error: strings have different length
+//- Error: strings have different length
 string::distance::hamming("United", "United");
---> 0
+//- 0
 string::distance::hamming("United", "Unitéd");
---> 1
+//- 1
 string::distance::hamming("United", "uNITED");
---> 6
+//- 6
 ```
 
 ## Regex matching
@@ -165,9 +165,9 @@ The `string::matches()` function can be used to perform regex matching on a stri
 
 ```surql
 string::matches("Cat", "[HC]at");
---> true
+//- true
 string::matches("Hat", "[HC]at");
---> true
+//- true
 ```
 
 ## Other string functions

--- a/src/content/learn/data-models/full-text-search/search-indexes.mdx
+++ b/src/content/learn/data-models/full-text-search/search-indexes.mdx
@@ -41,7 +41,7 @@ DEFINE INDEX body_index
 
 ```surql title="Output"
 'Parse error: Expected one column, found 2
- --> [5:55]
+ //- [5:55]
   |
 5 | ...LDS body, title FULLTEXT ANALYZER my_analyzer;
   |              ^^^^^

--- a/src/content/learn/data-models/graph/creating-relations.mdx
+++ b/src/content/learn/data-models/graph/creating-relations.mdx
@@ -261,12 +261,12 @@ Graph edge rows can exist **before** the two endpoint records are created:
 ```surql
 -- Works fine
 RELATE person:one->likes->person:two;
--- Returns []
 person:one->likes->person;
+--> []
 -- Finally create the 'person' records
 CREATE person:one, person:two;
--- Now it returns [ person:two ]
 person:one->likes->person;
+--> [person:two]
 ```
 
 To forbid that, add [`ENFORCED`](/docs/reference/query-language/statements/define/table) on the relation table:

--- a/src/content/learn/data-models/graph/creating-relations.mdx
+++ b/src/content/learn/data-models/graph/creating-relations.mdx
@@ -262,11 +262,11 @@ Graph edge rows can exist **before** the two endpoint records are created:
 -- Works fine
 RELATE person:one->likes->person:two;
 person:one->likes->person;
---> []
+//- []
 -- Finally create the 'person' records
 CREATE person:one, person:two;
 person:one->likes->person;
---> [person:two]
+//- [person:two]
 ```
 
 To forbid that, add [`ENFORCED`](/docs/reference/query-language/statements/define/table) on the relation table:

--- a/src/content/learn/data-models/graph/graph-traversal.mdx
+++ b/src/content/learn/data-models/graph/graph-traversal.mdx
@@ -146,14 +146,14 @@ When two lookups follow each other, or a filter follows a lookup, results can **
 
 ```surql
 CREATE 
-	// One president
+	-- One president
 	person:president, 
-	// Two managers
+	-- Two managers
 	person:manager1, person:manager2,
-	// Four employees
+	-- Four employees
 	person:employee1, person:employee2, person:employee3, person:employee4;
 
-// Employees work two to a manager, managers work two to a president
+-- Employees work two to a manager, managers work two to a president
 RELATE [person:manager1, person:manager2]->works_for->person:president;
 RELATE [person:employee1, person:employee2]->works_for->person:manager1;
 RELATE [person:employee3, person:employee4]->works_for->person:manager2;
@@ -171,15 +171,15 @@ You can approximate the same with nested `SELECT` / `map`, but nesting grows qui
 
 ```surql
 [person:employee1, person:employee2, person:employee3, person:employee4]
-	// Each $p is a single record: an array<record>
+	-- Each $p is a single record: an array<record>
     .map(|$p| SELECT VALUE out FROM works_for WHERE in = $p.id)
-	// Each $p is an array, so now you have to map each item inside that
+	-- Each $p is an array, so now you have to map each item inside that
     .map(|$p| $p.map(|$p| SELECT VALUE out FROM works_for
       WHERE in = $p.id))
-    // Now an array<array<array<record>>>
+    -- Now an array<array<array<record>>>
     .map(|$p| $p.map(|$p| $p.map(|$p| SELECT VALUE in FROM works_for
       WHERE out = $p.id)))
-    // Now an array<array<array<array<record>>>>
+    -- Now an array<array<array<array<record>>>>
     .map(|$p| $p.map(|$p| $p.map(|$p| $p.map(|$p| SELECT VALUE in
       FROM works_for WHERE out = $p.id))));
 ```

--- a/src/content/learn/data-models/vector-search/overview.mdx
+++ b/src/content/learn/data-models/vector-search/overview.mdx
@@ -39,7 +39,7 @@ Inside a database they will be stored in this sort of manner.
 			0.0007022718782536685,
 			0.004178352188318968,
 			0.009888353757560253,
-            // and so on for 128, 256, 768, or even more numbers
+            -- and so on for 128, 256, 768, or even more numbers
 		],
 		text: "To be, or not to be: that is the question."
 	},

--- a/src/content/learn/extensions/plugins/quick-tutorial.mdx
+++ b/src/content/learn/extensions/plugins/quick-tutorial.mdx
@@ -221,20 +221,20 @@ And now the magic begins! Let's give the `parse_number()` function a try, now av
 
 ```surql
 mod::test::parse_number("10");
--- 10
+--> 10
 mod::test::parse_number("Hi I'm number");
--- 'Thrown error: WASM function returned error: invalid digit found in string'
+--> 'Thrown error: WASM function returned error: invalid digit found in string'
 ```
 
 Next, we can use `random_user()` to create some random users.
 
 ```surql
 CREATE user CONTENT mod::test::random_user();
--- [{ age: 18, first_name: 'Thomas', id: user:hr8ohmn36zrpv3zthhnf, last_name: 'Meier', middle_name: 'Ninon' }]
+--> [{ age: 18, first_name: 'Thomas', id: user:hr8ohmn36zrpv3zthhnf, last_name: 'Meier', middle_name: 'Ninon' }]
 CREATE user CONTENT mod::test::random_user();
--- [{ age: 13, first_name: 'Verda', id: user:zg0ucdjizdp71fzq9syc, last_name: 'Schuster', middle_name: 'Clarisse' }]
+--> [{ age: 13, first_name: 'Verda', id: user:zg0ucdjizdp71fzq9syc, last_name: 'Schuster', middle_name: 'Clarisse' }]
 CREATE user CONTENT mod::test::random_user();
--- [{ age: 45, first_name: 'Zelda', id: user:rulp2bf82twrh94ifhsh, last_name: 'Berger', middle_name: 'Noah' }]
+--> [{ age: 45, first_name: 'Zelda', id: user:rulp2bf82twrh94ifhsh, last_name: 'Berger', middle_name: 'Noah' }]
 ```
 
 That leaves us with one function left to try out, the `can_drive()` function.

--- a/src/content/learn/extensions/plugins/quick-tutorial.mdx
+++ b/src/content/learn/extensions/plugins/quick-tutorial.mdx
@@ -221,20 +221,20 @@ And now the magic begins! Let's give the `parse_number()` function a try, now av
 
 ```surql
 mod::test::parse_number("10");
---> 10
+//- 10
 mod::test::parse_number("Hi I'm number");
---> 'Thrown error: WASM function returned error: invalid digit found in string'
+//- 'Thrown error: WASM function returned error: invalid digit found in string'
 ```
 
 Next, we can use `random_user()` to create some random users.
 
 ```surql
 CREATE user CONTENT mod::test::random_user();
---> [{ age: 18, first_name: 'Thomas', id: user:hr8ohmn36zrpv3zthhnf, last_name: 'Meier', middle_name: 'Ninon' }]
+//- [{ age: 18, first_name: 'Thomas', id: user:hr8ohmn36zrpv3zthhnf, last_name: 'Meier', middle_name: 'Ninon' }]
 CREATE user CONTENT mod::test::random_user();
---> [{ age: 13, first_name: 'Verda', id: user:zg0ucdjizdp71fzq9syc, last_name: 'Schuster', middle_name: 'Clarisse' }]
+//- [{ age: 13, first_name: 'Verda', id: user:zg0ucdjizdp71fzq9syc, last_name: 'Schuster', middle_name: 'Clarisse' }]
 CREATE user CONTENT mod::test::random_user();
---> [{ age: 45, first_name: 'Zelda', id: user:rulp2bf82twrh94ifhsh, last_name: 'Berger', middle_name: 'Noah' }]
+//- [{ age: 45, first_name: 'Zelda', id: user:rulp2bf82twrh94ifhsh, last_name: 'Berger', middle_name: 'Noah' }]
 ```
 
 That leaves us with one function left to try out, the `can_drive()` function.

--- a/src/content/learn/querying/concepts-and-guides/parameterised-queries.mdx
+++ b/src/content/learn/querying/concepts-and-guides/parameterised-queries.mdx
@@ -17,7 +17,7 @@ CREATE person SET name = "Tobie " + $suffix;
 CREATE person SET name = string::join(" ", "Jaime", $suffix);
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
     {
         "id": "person:3vs17lb9eso9m7gd8mml",
@@ -44,7 +44,7 @@ $founders.{
 };
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
 	{
 		company: 'SurrealDB',

--- a/src/content/learn/querying/concepts-and-guides/representations-and-codecs.mdx
+++ b/src/content/learn/querying/concepts-and-guides/representations-and-codecs.mdx
@@ -37,7 +37,10 @@ LET $payload = { event: 'signup', user: 'tobie' };
 
 -- Value → JSON text → value again
 encoding::json::decode(encoding::json::encode($payload));
--- { event: 'signup', user: 'tobie' }
+```
+
+```surql title="Output"
+{ event: 'signup', user: 'tobie' }
 ```
 
 Related one-way or format-specific helpers elsewhere include `string::html::encode`, `geo::hash::encode`, and [`crypto::*`](/docs/reference/query-language/functions/database-functions/crypto) hashes.
@@ -52,7 +55,10 @@ The "format" here is not JSON or CBOR; it is whatever pipeline you defined on th
 DEFINE ANALYZER demo_blank TOKENIZERS blank;
 
 search::analyze("demo_blank", "SurrealDB graph queries");
--- ['SurrealDB', 'graph', 'queries']
+```
+
+```surql title="Output"
+['SurrealDB', 'graph', 'queries']
 ```
 
 Compare the tokens above with what you get after adding `FILTERS lowercase, snowball(english)` - the same input string produces a different token list, which is why `search::analyze` is handy when tuning an analyzer before you create a [`FULLTEXT`](/docs/reference/query-language/statements/define/indexes) index.
@@ -66,7 +72,10 @@ Compare the tokens above with what you get after adding `FILTERS lowercase, snow
 	domain: parse::url::domain("https://surrealdb.com/docs"),
 	user: parse::email::user("tobie@surrealdb.com"),
 };
--- { domain: 'surrealdb.com', user: 'tobie' }
+```
+
+```surql title="Output"
+{ domain: 'surrealdb.com', user: 'tobie' }
 ```
 
 ## In-value transforms (`value::*`)
@@ -79,7 +88,10 @@ LET $after = { title: 'Weekly update', status: 'published' };
 LET $patch = value::diff($before, $after);
 
 value::patch($before, $patch);
--- { title: 'Weekly update', status: 'published' }
+```
+
+```surql title="Output"
+{ title: 'Weekly update', status: 'published' }
 ```
 
 `value::diff` produced the patch; `value::patch` applied it. The same pair works when you receive patch operations from a client or a live diff stream.
@@ -100,7 +112,10 @@ Use `eval::*` when the query string is only known at runtime. Prefer [`DEFINE FU
 -- Query text from a table, config row, or user input (requires allow-eval-query)
 LET $template = "$greeting + ', ' + $name";
 eval::surql($template, { greeting: 'Hello', name: 'world' });
--- 'Hello, world'
+```
+
+```surql title="Output"
+'Hello, world'
 ```
 
 For [ISO GQL](/docs/learn/querying/gql/overview) strings, use `eval::gql` instead - same bindings object, plus [`--allow-eval-query`](/docs/learn/security/authorization/capabilities#eval-queries). See [Eval functions](/docs/reference/query-language/functions/database-functions/eval) for setup and examples.

--- a/src/content/learn/querying/concepts-and-guides/working-with-types.mdx
+++ b/src/content/learn/querying/concepts-and-guides/working-with-types.mdx
@@ -19,7 +19,7 @@ Working with arrays is one of the most important skills when working with Surrea
 SELECT * FROM 9;
 -- Use the `ONLY` clause to return a single item
 SELECT * FROM ONLY 9;
--- Error: array has more than one item
+-- `ONLY` errors when the array holds more than one item
 SELECT * FROM ONLY [1,9];
 ```
 

--- a/src/content/learn/querying/real-time/changefeeds.mdx
+++ b/src/content/learn/querying/real-time/changefeeds.mdx
@@ -39,7 +39,7 @@ SHOW CHANGES FOR TABLE reading SINCE 1 LIMIT 10;
 
 If the datetime is after the changefeed was created and lines up with your retention window, you get a list of entries, each with `changes` and a `versionstamp` (where you are in the log). How each mutation is encoded depends on your [`DEFINE TABLE ... CHANGEFEED`](/docs/reference/query-language/statements/define/table#example-usage) options; when differences are stored (`INCLUDE ORIGINAL`), an update to an existing row carries a **reverse diff** from the current state to the state immediately before that write. The [`SHOW`](/docs/reference/query-language/statements/show) reference covers this in full. The following shape is representative:
 
-```surql title="Response"
+```surql title="Output"
 [
 	{
 		changes: [

--- a/src/content/learn/querying/real-time/live-queries.mdx
+++ b/src/content/learn/querying/real-time/live-queries.mdx
@@ -18,8 +18,10 @@ By default, creates and updates deliver the full record; deletes return nothing 
 
 ```surql
 LIVE SELECT * FROM person;
+```
 
--- u'b1f1d115-ad0f-460d-8cbf-dbc7ce48851c'
+```surql title="Output"
+u'b1f1d115-ad0f-460d-8cbf-dbc7ce48851c'
 ```
 
 Message layout on the wire is described in the [live query / WebSocket protocol](/docs/reference/rest-api/rpc-protocol#live) section.
@@ -30,8 +32,10 @@ If you prefer patches instead of whole documents on update, use `DIFF`. Updates 
 
 ```surql
 LIVE SELECT DIFF FROM person;
+```
 
--- 'b87cbb0d-ca15-4f0a-8f86-caa680672aa5'
+```surql title="Output"
+'b87cbb0d-ca15-4f0a-8f86-caa680672aa5'
 ```
 
 ## Filtering with WHERE

--- a/src/content/learn/querying/real-time/real-time-best-practices.mdx
+++ b/src/content/learn/querying/real-time/real-time-best-practices.mdx
@@ -207,11 +207,11 @@ A ULID and UUID can be created from a datetime, and both ULIDs and UUIDs can be 
 ```surql
 LET $uuid = rand::uuid(d'1997-08-29');
 time::from_uuid($uuid);
--- d'1997-08-29T00:00:00Z'
+--> d'1997-08-29T00:00:00Z'
 
 LET $ulid = rand::ulid(d'1997-08-29');
 time::from_ulid($ulid);
--- d'1997-08-29T00:00:00Z'
+--> d'1997-08-29T00:00:00Z'
 ```
 
 However, because datetimes have nanosecond precision but ULIDs and UUIDs have millisecond precision, a roundtrip from datetime to ULID/UUID and back will not be exactly the same as the original datetime.

--- a/src/content/learn/querying/real-time/real-time-best-practices.mdx
+++ b/src/content/learn/querying/real-time/real-time-best-practices.mdx
@@ -146,12 +146,12 @@ To make the output nice, we'll use a little bit of SurrealQL magic. First we'll 
 
 ```surql
 {
-    // 100,000 weather records
+    -- 100,000 weather records
     FOR $_ IN 0..100000 {
     CREATE weather:["London", time::now() - rand::duration(0ns, 1y)] SET temperature = 9.0;
     };
 
-    // 100,000 weather2 records
+    -- 100,000 weather2 records
     FOR $_ IN 0..100000 {
         CREATE weather2 SET 
         location = "London",
@@ -207,11 +207,11 @@ A ULID and UUID can be created from a datetime, and both ULIDs and UUIDs can be 
 ```surql
 LET $uuid = rand::uuid(d'1997-08-29');
 time::from_uuid($uuid);
---> d'1997-08-29T00:00:00Z'
+//- d'1997-08-29T00:00:00Z'
 
 LET $ulid = rand::ulid(d'1997-08-29');
 time::from_ulid($ulid);
---> d'1997-08-29T00:00:00Z'
+//- d'1997-08-29T00:00:00Z'
 ```
 
 However, because datetimes have nanosecond precision but ULIDs and UUIDs have millisecond precision, a roundtrip from datetime to ULID/UUID and back will not be exactly the same as the original datetime.

--- a/src/content/learn/querying/surrealql/statements-and-values.mdx
+++ b/src/content/learn/querying/surrealql/statements-and-values.mdx
@@ -186,8 +186,8 @@ FOR $person IN SELECT * FROM person {
     LET $filtered = $person.*.entries().filter(|$entry| !!$entry[1]);
     CREATE new_table CONTENT object::from_entries($filtered);
     
-    // Or all in one line:
-    // CREATE new_table CONTENT object::from_entries($person.*.entries().filter(|$n| !!$n[1]))
+    -- Or all in one line:
+    -- CREATE new_table CONTENT object::from_entries($person.*.entries().filter(|$n| !!$n[1]))
 };
 
 SELECT * FROM new_table;

--- a/src/content/learn/schema-management/computed-data/closures.mdx
+++ b/src/content/learn/schema-management/computed-data/closures.mdx
@@ -60,7 +60,7 @@ The `chain` function which performs an operation on a value before passing it on
     .chain(|$num| <number>$num * 1000);
 ```
 
-```surql title="Response"
+```surql title="Output"
 2000
 ```
 
@@ -83,7 +83,7 @@ The following example shows a chain of array functions used to remove useless da
     .chain(|$v| <string>$v);
 ```
 
-```surql title="Response"
+```surql title="Output"
 'true'
 ```
 
@@ -132,7 +132,10 @@ fn::test_create("direct_call");
 -- 3. Call the function inside .map() - fails
 LET $names = ["Alice", "Bob", "Charlie"];
 $names.map(|$n| fn::test_create($n));
--- Error: "Couldn't write to a read only transaction"
+```
+
+```surql title="Output"
+Error: "Couldn't write to a read only transaction"
 ```
 
 In many cases, a closure can be substituted by another operation such as a `FOR` loop or a regular `SELECT` statement.
@@ -173,7 +176,7 @@ LET $names = ["Alice", "Bob", "Charlie"];
 $names.map(|$n| fn::test_create($n));
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
 	{ created: true, name: 'Alice' },
 	{ created: true, name: 'Bob' },

--- a/src/content/learn/schema-management/events-and-triggers/defining-events.mdx
+++ b/src/content/learn/schema-management/events-and-triggers/defining-events.mdx
@@ -36,9 +36,9 @@ DEFINE EVENT OVERWRITE test
   ON TABLE user WHEN $before.email != $after.email THEN (
     CREATE log SET 
         user       = $value.id,
-        // Turn events like "CREATE" into string "email created"
+        -- Turn events like "CREATE" into string "email created"
         action     = 'email' + ' ' + $event.lowercase() + 'd',
-        // `email` field may be NONE, log as '' if so
+        -- `email` field may be NONE, log as '' if so
         old_email  = $before.email ?? '',
         new_email  = $after.email  ?? '',
         at         = time::now()

--- a/src/content/learn/schema-management/files/buckets.mdx
+++ b/src/content/learn/schema-management/files/buckets.mdx
@@ -98,7 +98,7 @@ DEFINE BUCKET my_bucket BACKEND "memory";
 INFO FOR DB;
 ```
 
-```surql title="Response"
+```surql title="Output"
 {
   accesses: {},
   analyzers: {},

--- a/src/content/learn/schema-management/files/working-with-files.mdx
+++ b/src/content/learn/schema-management/files/working-with-files.mdx
@@ -71,7 +71,7 @@ fn::save_file("temp_cart_user_24567", {
 });
 
 fn::get_file("temp_cart_user_24567");
---> { items: ['shirt1', 'deck_of_cards'], last_updated: d'2025-11-20T01:03:24.141080Z' }
+//- { items: ['shirt1', 'deck_of_cards'], last_updated: d'2025-11-20T01:03:24.141080Z' }
 
 -- User adds item, save over file with newer information
 fn::save_file("temp_cart_user_24567", {
@@ -80,7 +80,7 @@ fn::save_file("temp_cart_user_24567", {
 });
 
 fn::get_file("temp_cart_user_24567");
---> { items: ['shirt1', 'deck_of_cards'], last_updated: d'2025-11-20T01:06:02.752429Z' }
+//- { items: ['shirt1', 'deck_of_cards'], last_updated: d'2025-11-20T01:06:02.752429Z' }
 
 -- Session is over, delete temp file
 fn::delete_file("temp_cart_user_24567");

--- a/src/content/learn/schema-management/files/working-with-files.mdx
+++ b/src/content/learn/schema-management/files/working-with-files.mdx
@@ -71,7 +71,7 @@ fn::save_file("temp_cart_user_24567", {
 });
 
 fn::get_file("temp_cart_user_24567");
--- Returns { items: ['shirt1', 'deck_of_cards'], last_updated: d'2025-11-20T01:03:24.141080Z' }
+--> { items: ['shirt1', 'deck_of_cards'], last_updated: d'2025-11-20T01:03:24.141080Z' }
 
 -- User adds item, save over file with newer information
 fn::save_file("temp_cart_user_24567", {
@@ -80,7 +80,7 @@ fn::save_file("temp_cart_user_24567", {
 });
 
 fn::get_file("temp_cart_user_24567");
--- Returns { items: ['shirt1', 'deck_of_cards'], last_updated: d'2025-11-20T01:06:02.752429Z' }
+--> { items: ['shirt1', 'deck_of_cards'], last_updated: d'2025-11-20T01:06:02.752429Z' }
 
 -- Session is over, delete temp file
 fn::delete_file("temp_cart_user_24567");

--- a/src/content/learn/schema-management/indexes/index-types-and-strategies.mdx
+++ b/src/content/learn/schema-management/indexes/index-types-and-strategies.mdx
@@ -67,7 +67,7 @@ CREATE user:1 SET email = 'test@surrealdb.com';
 CREATE user:2 SET email = 'test@surrealdb.com';
 ```
 
-```surql title="Response"
+```surql title="Output"
 "Database index `userEmailIndex` already contains 'test@surrealdb.com',
 with record `user:1`"
 ```

--- a/src/content/learn/schema-management/schema-design/schema-best-practices.mdx
+++ b/src/content/learn/schema-management/schema-design/schema-best-practices.mdx
@@ -86,7 +86,10 @@ CREATE user SET name = "Billy", metadata = {
     age: 5,
     wrong_field: "WRONG DATA"
 };
--- "Found field 'metadata.wrong_field', but no such field exists for table 'user'"
+```
+
+```surql title="Output"
+"Found field 'metadata.wrong_field', but no such field exists for table 'user'"
 ```
 
 If you have data that includes a non-defined field in such a table, you can use the destructuring operator to access the current structure and only pass on the necessary fields for the operation.
@@ -263,7 +266,7 @@ fn::return_response({ type: "internal_error", message: "You can't do that"});
 fn::return_response(a:wrong_argument);
 ```
 
-```surql title="Response"
+```surql title="Output"
 -------- Query --------
 500
 
@@ -291,10 +294,10 @@ DEFINE FIELD parents ON person ASSERT <-parent_of<-person
 -- Is first_generation, doesn't need to indicate parents
 CREATE person:one SET first_generation = true;
 
--- Error: 
--- 'Found NONE for field `parents`, with record `person:two`,
--- but field must conform to: <-parent_of<-person OR first_generation'
 CREATE person:two;
+--> Error:
+--> 'Found NONE for field `parents`, with record `person:two`,
+--> but field must conform to: <-parent_of<-person OR first_generation'
 
 -- Give person:two a parent
 RELATE person:one->parent_of->person:two;

--- a/src/content/learn/schema-management/schema-design/schema-best-practices.mdx
+++ b/src/content/learn/schema-management/schema-design/schema-best-practices.mdx
@@ -232,7 +232,7 @@ DEFINE FUNCTION fn::do_something_with_month($input: string) {
     IF !($input IN $MONTHS) {
         THROW "Some error about wrong input";
     } ELSE {
-        // do something with months here
+        -- do something with months here
     }
 };
 ```
@@ -295,9 +295,9 @@ DEFINE FIELD parents ON person ASSERT <-parent_of<-person
 CREATE person:one SET first_generation = true;
 
 CREATE person:two;
---> Error:
---> 'Found NONE for field `parents`, with record `person:two`,
---> but field must conform to: <-parent_of<-person OR first_generation'
+//- Error:
+//- 'Found NONE for field `parents`, with record `person:two`,
+//- but field must conform to: <-parent_of<-person OR first_generation'
 
 -- Give person:two a parent
 RELATE person:one->parent_of->person:two;

--- a/src/content/learn/schema-management/tables-and-fields/fields-and-validation.mdx
+++ b/src/content/learn/schema-management/tables-and-fields/fields-and-validation.mdx
@@ -125,7 +125,7 @@ Without `FLEXIBLE`, the `metadata` field is a schemafull object and only declare
 
 With `FLEXIBLE`, the field accepts any extra keys on `metadata` while still requiring `name` and a valid `metadata.user_id`.
 
-```surql title="Response"
+```surql title="Output"
 {
 	id: user:lsdk473e279oik1k484b,
 	metadata: {
@@ -293,7 +293,7 @@ DEFINE FIELD some_info ON TABLE some_table TYPE string;
 INFO FOR TABLE some_table;
 ```
 
-```surql title="Response"
+```surql title="Output"
 {
 	events: {},
 	fields: {
@@ -358,7 +358,7 @@ CREATE order:good SET coffee = { special_order: "Venti Quadruple Ristretto Half-
 CREATE order:bad SET coffee = "small";
 ```
 
-```surql title="Response"
+```surql title="Output"
 -------- Query --------
 
 [

--- a/src/content/learn/schema-management/tables-and-fields/fields-and-validation.mdx
+++ b/src/content/learn/schema-management/tables-and-fields/fields-and-validation.mdx
@@ -340,7 +340,7 @@ DEFINE FIELD last_name
 DEFINE FIELD full_name 
   ON TABLE person             VALUE first_name + ' ' + last_name;
 
-// Creates a `person` with `full_name` of "bob BOBSON", not "bob bobson"
+-- Creates a `person` with `full_name` of "bob BOBSON", not "bob bobson"
 CREATE person SET first_name = "Bob", last_name = "BOBSON";
 ```
 

--- a/src/content/learn/schema-management/tables-and-fields/record-ids-and-addressing.mdx
+++ b/src/content/learn/schema-management/tables-and-fields/record-ids-and-addressing.mdx
@@ -42,16 +42,16 @@ CREATE company;
 Record IDs can be generated with a number of built-in ID generation functions, which are cryptographically secure and suitable for dispersion across a distributed datastore. These include a 20 digit alphanumeric ID (the default), sequentially incrementing and temporally sortable ULID Record identifiers, and UUID version 7 Record identifiers.
 
 ```surql
-// Generate a random record ID 20 characters in length
-// Charset: `abcdefghijklmnopqrstuvwxyz0123456789`
+-- Generate a random record ID 20 characters in length
+-- Charset: `abcdefghijklmnopqrstuvwxyz0123456789`
 CREATE temperature:rand() SET time = time::now(), celsius = 37.5;
-// Identical to the above CREATE statement, because
-// :rand() is the default random ID format
+-- Identical to the above CREATE statement, because
+-- :rand() is the default random ID format
 CREATE temperature SET time = time::now(), celsius = 37.5;
 
-// Generate a ULID-based record ID
+-- Generate a ULID-based record ID
 CREATE temperature:ulid() SET time = time::now(), celsius = 37.5;
-// Generate a UUIDv7-based record ID
+-- Generate a UUIDv7-based record ID
 CREATE temperature:uuid() SET time = time::now(), celsius = 37.5;
 ```
 

--- a/src/content/learn/schema-management/tables-and-fields/tables.mdx
+++ b/src/content/learn/schema-management/tables-and-fields/tables.mdx
@@ -136,7 +136,7 @@ DEFINE TABLE some_other_table;
 INFO FOR DB;
 ```
 
-```surql title="Response"
+```surql title="Output"
 {
 	analyzers: {},
 	functions: {},

--- a/src/content/learn/security/authorization/capabilities.mdx
+++ b/src/content/learn/security/authorization/capabilities.mdx
@@ -274,11 +274,11 @@ Guest access is used when you want to expose certain parts of a database to non-
 Even when this capability is allowed, a guest user can only execute functions or data operations like SELECT, CREATE, etc, and only if the `PERMISSIONS` clause for the resource being used in the query allows it.
 
 ```surql
-// Prepare tables with custom PERMISSIONS
+-- Prepare tables with custom PERMISSIONS
 test/test> DEFINE TABLE protected PERMISSIONS NONE;
 test/test> DEFINE TABLE public PERMISSIONS FULL;
 
-// When guest access is allowed
+-- When guest access is allowed
 $ surreal start --allow-guests
 
 test/test> CREATE public;
@@ -293,7 +293,7 @@ test/test> CREATE protected;
 test/test> SELECT * FROM protected;
 []
 
-// When guest access is denied
+-- When guest access is denied
 $ surreal start --deny-guests
 
 test/test> CREATE public;

--- a/src/content/reference/cli/formatter/overview.mdx
+++ b/src/content/reference/cli/formatter/overview.mdx
@@ -92,4 +92,6 @@ For the options of the version you have installed, run `surqlfmt --help`.
 - **In CI** - add a `surqlfmt --check` step to catch inconsistencies early.
 - **During development** - pipe ad-hoc queries through the formatter for readability.
 
+The `surreal` binary also has a built-in [`format`](/docs/reference/cli/surrealdb-cli/commands/format) command, which formats one file at a time and takes no style options. `surqlfmt` is the tool for sweeping a tree of `.surql` files or gating a CI job on formatting.
+
 For the other command-line tools, see the [CLI tools overview](/docs/reference/cli).

--- a/src/content/reference/query-language/clauses/from.mdx
+++ b/src/content/reference/query-language/clauses/from.mdx
@@ -69,14 +69,15 @@ The following examples show when the `ONLY` keyword can be used on its own and w
 -- Create ten random user records along with `user:one`
 CREATE |user:10|, user:one;
 
--- Returns [user:one] inside an array
 SELECT * FROM user:one;
+--> Returns [user:one] inside an array
 
--- Returns { id: user:one }
+
 SELECT * FROM ONLY user:one;
+--> Returns { id: user:one }
 
--- Error: more than one user record returned
 SELECT * FROM ONLY user;
+--> Error: more than one user record returned
 
 -- Success: LIMIT 1 guarantees a single value
 SELECT * FROM ONLY user LIMIT 1;
@@ -84,8 +85,8 @@ SELECT * FROM ONLY user LIMIT 1;
 -- Success: single value returned
 SELECT * FROM ONLY 9;
 
--- Error: more than one value returned
 SELECT * FROM ONLY 8, 9;
+--> Error: more than one value returned
 
 -- Success: LIMIT 1 guarantees a single value
 SELECT * FROM ONLY 8, 9 LIMIT 1;

--- a/src/content/reference/query-language/clauses/from.mdx
+++ b/src/content/reference/query-language/clauses/from.mdx
@@ -70,14 +70,14 @@ The following examples show when the `ONLY` keyword can be used on its own and w
 CREATE |user:10|, user:one;
 
 SELECT * FROM user:one;
---> Returns [user:one] inside an array
+//- Returns [user:one] inside an array
 
 
 SELECT * FROM ONLY user:one;
---> Returns { id: user:one }
+//- Returns { id: user:one }
 
 SELECT * FROM ONLY user;
---> Error: more than one user record returned
+//- Error: more than one user record returned
 
 -- Success: LIMIT 1 guarantees a single value
 SELECT * FROM ONLY user LIMIT 1;
@@ -86,7 +86,7 @@ SELECT * FROM ONLY user LIMIT 1;
 SELECT * FROM ONLY 9;
 
 SELECT * FROM ONLY 8, 9;
---> Error: more than one value returned
+//- Error: more than one value returned
 
 -- Success: LIMIT 1 guarantees a single value
 SELECT * FROM ONLY 8, 9 LIMIT 1;

--- a/src/content/reference/query-language/clauses/group.mdx
+++ b/src/content/reference/query-language/clauses/group.mdx
@@ -46,7 +46,7 @@ math::sum([
         money: 20
     }
 ].money);
---> 30
+//- 30
 ```
 
 Attempting to use the same function inside a `SELECT` query will not work as `math::sum()` expects an array of numbers but only receives a single integer each time it is called.

--- a/src/content/reference/query-language/clauses/group.mdx
+++ b/src/content/reference/query-language/clauses/group.mdx
@@ -36,7 +36,6 @@ A [number of functions](/docs/reference/query-language/functions/database-functi
 For example, the [`math::sum()`](/docs/reference/query-language/functions/database-functions/math#mathsum) function can be used on an array of numbers to calculate their final sum.
 
 ```surql
--- Returns 30
 math::sum([
     {
         name: "Billy",
@@ -47,6 +46,7 @@ math::sum([
         money: 20
     }
 ].money);
+--> 30
 ```
 
 Attempting to use the same function inside a `SELECT` query will not work as `math::sum()` expects an array of numbers but only receives a single integer each time it is called.

--- a/src/content/reference/query-language/clauses/limit.mdx
+++ b/src/content/reference/query-language/clauses/limit.mdx
@@ -36,7 +36,7 @@ value = "[5, 6, 7, 8, 9]"
 SELECT * FROM [1,2,3,4,5,6,7,8,9,10] LIMIT 5 START 4;
 ```
 
-```surql title="Result"
+```surql title="Output"
 [
 	5,
 	6,

--- a/src/content/reference/query-language/functions/database-functions/api.mdx
+++ b/src/content/reference/query-language/functions/database-functions/api.mdx
@@ -301,7 +301,7 @@ api::invoke("/limited", {
 });
 ```
 
-```surql title="Response"
+```surql title="Output"
 {
 	body: 'Invalid request body: The body exceeded the max payload size of 10b',
 	headers: {  },
@@ -338,7 +338,7 @@ api::invoke("/serialize_json").{
 };
 ```
 
-```surql title="Response"
+```surql title="Output"
 { 
     body: '{"message":"Hello"}', 
     headers: { "access-control-allow-origin": '*',
@@ -437,7 +437,7 @@ DEFINE API "/always_ok"
 api::invoke("/always_ok");
 ```
 
-```surql title="Response"
+```surql title="Output"
 { 
     body: {some: 'data'}, 
     context: {}, 
@@ -463,7 +463,7 @@ DEFINE API "/status/invalid-low"
 api::invoke("/status/invalid-low");
 ```
 
-```surql title="Response"
+```surql title="Output"
 'Invalid HTTP status code: 99. Must be between 100 and 599'
 ```
 

--- a/src/content/reference/query-language/functions/database-functions/array.mdx
+++ b/src/content/reference/query-language/functions/database-functions/array.mdx
@@ -314,10 +314,10 @@ value = "true"
 */
 
 array::all([ 1, 2, 3, NONE, 'SurrealDB', 5 ]);
---> false
+//- false
 
 ["all", "clear"].all();
---> true
+//- true
 ```
 
 The `array::all` function can also be followed with a value or a [closure](/docs/reference/query-language/language-primitives/data-types/closures) to check if all elements conform to a condition.
@@ -337,7 +337,7 @@ value = "false"
 */
 
 ["same", "same", "same"].all("same");
---> true
+//- true
 
 [
   "What's",
@@ -347,10 +347,10 @@ value = "false"
   "its",
   "pocketses??"
 ].all(|$s| $s.len() > 1);
---> true
+//- true
 
 [1, 2, "SurrealDB"].all(|$var| $var.is_string());
---> false
+//- false
 ```
 
 The `array::all` function can also be called using its alias `array::every`.
@@ -389,10 +389,10 @@ value = "false"
 */
 
 array::any([ 1, 2, 3, NONE, 'SurrealDB', 5 ]);
---> true
+//- true
 
 ["", 0, NONE, NULL, [], {}].any();
---> false
+//- false
 ```
 
 The `array::any` function can also be followed with a value or a [closure](/docs/reference/query-language/language-primitives/data-types/closures) to check if any elements conform to a condition.
@@ -412,7 +412,7 @@ value = "true"
 */
 
 ["same", "same?", "Dude, same!"].any("same");
---> true
+//- true
 
 [
   "What's",
@@ -422,10 +422,10 @@ value = "true"
   "its",
   "pocketses??"
 ].any(|$s| $s.len() > 15);
---> false
+//- false
 
 [1, 2, "SurrealDB"].any(|$var| $var.is_string());
---> true
+//- true
 ```
 
 The `array::any` function can also be called using the aliases `array::some` and `array::includes`.
@@ -442,10 +442,10 @@ value = "false"
 */
 
 [1, 2, 3].some(|$num| $num > 2);
---> true
+//- true
 
 [1999, 2001, 2002].includes(2000);
---> false
+//- false
 ```
 
 <br />
@@ -781,10 +781,10 @@ value = "[1, 2, 3, 4, 3, 4, 5, 6]"
 */
 
 array::concat([1, 2, 3, 4], [3, 4, 5, 6]);
---> [1, 2, 3, 4, 3, 4, 5, 6]
+//- [1, 2, 3, 4, 3, 4, 5, 6]
 
 [1,2].concat([3,4], [4,3])
---> [1, 2, 3, 4, 4, 3]
+//- [1, 2, 3, 4, 4, 3]
 ```
 
 As of SurrealDB 3.0.0, the behaviour of this function can also be achieved using the `+` operator.
@@ -986,10 +986,10 @@ value = "[true, true, true]"
 */
 
 array::filter([ 1, 2, 1, 3, 3, 4 ], 1);
---> [ 1, 1 ]
+//- [ 1, 1 ]
 
 [true, false, false, false, true, true].filter(true);
---> [ true, true, true ]
+//- [ true, true, true ]
 ```
 
 The `array::filter` function can also take a [closure](/docs/reference/query-language/language-primitives/data-types/closures) for more customised filtering.
@@ -1105,10 +1105,10 @@ value = "[0, 1, 3, 4]"
 */
 
 array::filter_index(['a', 'b', 'c', 'b', 'a'], 'b');
---> [ 1, 3 ]
+//- [ 1, 3 ]
 
 [0, 0, 1, 0, 0, 5, 1].filter_index(0);
---> [ 0, 1, 3, 4 ]
+//- [ 0, 1, 3, 4 ]
 ```
 
 The `array::filter_index` function can also take a [closure](/docs/reference/query-language/language-primitives/data-types/closures) for more customised filtering.
@@ -1160,10 +1160,10 @@ value = "NONE"
 */
 
 array::find(['a', 'b', 'c', 'b', 'a'], 'b');
---> 'b'
+//- 'b'
 
 [1, 2, 3].find(4);
---> NONE
+//- NONE
 ```
 
 The `array::find` function is most useful when a [closure](/docs/reference/query-language/language-primitives/data-types/closures) is passed in which allows for customised searching.
@@ -1230,10 +1230,10 @@ value = "NONE"
 */
 
 array::find_index(['a', 'b', 'c', 'b', 'a'], 'b');
---> 1
+//- 1
 
 [1, 2, 3].find_index(4);
---> NONE
+//- NONE
 ```
 
 The `array::find_index` function can also take a [closure](/docs/reference/query-language/language-primitives/data-types/closures) for more customised searching.
@@ -1354,7 +1354,7 @@ value = "53"
 */
 
 [10,12,10,15].fold(100, |$a, $b| $a - $b);
---> 53
+//- 53
 ```
 
 The function will then perform the following operation for each step of the way.
@@ -1577,10 +1577,10 @@ value = "[1, 2, 3, 4, 5]"
 */
 
 array::insert([1, 2, 3, 4], 'and me', 0);
---> ['and me', 1, 2, 3, 4]
+//- ['and me', 1, 2, 3, 4]
 
 array::insert([1, 2, 3, 4], 'and me', -1);
---> [1, 2, 3, 'and me', 4]
+//- [1, 2, 3, 'and me', 4]
 ```
 
 A negative index can be provided to specify a position relative to the end of the array.

--- a/src/content/reference/query-language/functions/database-functions/array.mdx
+++ b/src/content/reference/query-language/functions/database-functions/array.mdx
@@ -272,16 +272,20 @@ value = "['one', 'two', 'three']"
 
 
 array::add(["one", "two"], "three");
+```
 
--- ['one', 'two', 'three']
+```surql title="Output"
+['one', 'two', 'three']
 ```
 
 If the item to add is an array, it will add each item of the array instead of the array itself as a separate value.
 
 ```surql
 [1,2,3].add([2,3,4]);
+```
 
--- [1, 2, 3, 4]
+```surql title="Output"
+[1, 2, 3, 4]
 ```
 
 <br />
@@ -310,10 +314,10 @@ value = "true"
 */
 
 array::all([ 1, 2, 3, NONE, 'SurrealDB', 5 ]);
--- false
+--> false
 
 ["all", "clear"].all();
--- true
+--> true
 ```
 
 The `array::all` function can also be followed with a value or a [closure](/docs/reference/query-language/language-primitives/data-types/closures) to check if all elements conform to a condition.
@@ -333,7 +337,7 @@ value = "false"
 */
 
 ["same", "same", "same"].all("same");
--- true
+--> true
 
 [
   "What's",
@@ -343,17 +347,20 @@ value = "false"
   "its",
   "pocketses??"
 ].all(|$s| $s.len() > 1);
--- true
+--> true
 
 [1, 2, "SurrealDB"].all(|$var| $var.is_string());
--- false
+--> false
 ```
 
 The `array::all` function can also be called using its alias `array::every`.
 
 ```surql
 [1, 2, 3].every(|$num| $num > 0);
--- true
+```
+
+```surql title="Output"
+true
 ```
 
 <br />
@@ -382,10 +389,10 @@ value = "false"
 */
 
 array::any([ 1, 2, 3, NONE, 'SurrealDB', 5 ]);
--- true
+--> true
 
 ["", 0, NONE, NULL, [], {}].any();
--- false
+--> false
 ```
 
 The `array::any` function can also be followed with a value or a [closure](/docs/reference/query-language/language-primitives/data-types/closures) to check if any elements conform to a condition.
@@ -405,7 +412,7 @@ value = "true"
 */
 
 ["same", "same?", "Dude, same!"].any("same");
--- true
+--> true
 
 [
   "What's",
@@ -415,10 +422,10 @@ value = "true"
   "its",
   "pocketses??"
 ].any(|$s| $s.len() > 15);
--- false
+--> false
 
 [1, 2, "SurrealDB"].any(|$var| $var.is_string());
--- true
+--> true
 ```
 
 The `array::any` function can also be called using the aliases `array::some` and `array::includes`.
@@ -435,10 +442,10 @@ value = "false"
 */
 
 [1, 2, 3].some(|$num| $num > 2);
--- true
+--> true
 
 [1999, 2001, 2002].includes(2000);
--- false
+--> false
 ```
 
 <br />
@@ -462,8 +469,10 @@ value = "'r'"
 */
 
 array::at(['s', 'u', 'r', 'r', 'e', 'a', 'l'], 2);
+```
 
--- 'r'
+```surql title="Output"
+'r'
 ```
 
 You can also pass a negative index. This will perform the lookup in reverse:
@@ -477,8 +486,10 @@ value = "'e'"
 */
 
 array::at(['s', 'u', 'r', 'r', 'e', 'a', 'l'], -3);
+```
 
--- 'e'
+```surql title="Output"
+'e'
 ```
 
 <br />
@@ -502,8 +513,10 @@ value = "[1, 2, 3, 4, 5]"
 */
 
 array::append([1, 2, 3, 4], 5);
+```
 
--- [1, 2, 3, 4, 5]
+```surql title="Output"
+[1, 2, 3, 4, 5]
 ```
 
 <br />
@@ -544,8 +557,10 @@ array::boolean_and(["true",
   "true",
   0,
   "true"]);
+```
 
--- [true, true, false, true]
+```surql title="Output"
+[true, true, false, true]
 ```
 
 For those that take two arrays, missing elements (if one array is shorter than the other) are considered `null` and thus false.
@@ -562,8 +577,10 @@ value = "false"
 */
 
 array::boolean_and([true, true], [false]);
+```
 
--- [ false, false ]
+```surql title="Output"
+[ false, false ]
 ```
 
 <br />
@@ -604,8 +621,10 @@ array::boolean_or([false,
   false,
   true,
   true]);
+```
 
--- [false, true, true, true]
+```surql title="Output"
+[false, true, true, true]
 ```
 
 <br />
@@ -645,8 +664,10 @@ array::boolean_xor([false,
   false,
   true,
   true]);
+```
 
--- [false, true, true, false]
+```surql title="Output"
+[false, true, true, false]
 ```
 
 <br />
@@ -679,8 +700,10 @@ value = "false"
 
 */
 array::boolean_not([ false, true, 0, 1 ]);
+```
 
--- [true, false, true, false]
+```surql title="Output"
+[true, false, true, false]
 ```
 
 <br />
@@ -704,8 +727,10 @@ value = "[[[1, 2], [1, 3], [2, 2], [2, 3]]]"
 */
 
 array::combine([1, 2], [2, 3]);
+```
 
--- [ [1, 2], [1, 3], [2, 2], [2, 3] ]
+```surql title="Output"
+[ [1, 2], [1, 3], [2, 2], [2, 3] ]
 ```
 
 <br />
@@ -729,8 +754,10 @@ value = "[1, 2]"
 */
 
 array::complement([1, 2, 3, 4], [3, 4, 5, 6]);
+```
 
--- [1, 2]
+```surql title="Output"
+[1, 2]
 ```
 
 <br />
@@ -754,10 +781,10 @@ value = "[1, 2, 3, 4, 3, 4, 5, 6]"
 */
 
 array::concat([1, 2, 3, 4], [3, 4, 5, 6]);
--- [1, 2, 3, 4, 3, 4, 5, 6]
+--> [1, 2, 3, 4, 3, 4, 5, 6]
 
 [1,2].concat([3,4], [4,3])
--- [1, 2, 3, 4, 4, 3]
+--> [1, 2, 3, 4, 4, 3]
 ```
 
 As of SurrealDB 3.0.0, the behaviour of this function can also be achieved using the `+` operator.
@@ -771,8 +798,10 @@ value = "[1, 2, 3, 4, 3, 4, 5, 6]"
 */
 
 [1, 2, 3, 4] + [3, 4, 5, 6];
+```
 
--- [ 1, 2, 3, 4, 3, 4, 5, 6 ]
+```surql title="Output"
+[ 1, 2, 3, 4, 3, 4, 5, 6 ]
 ```
 
 <br />
@@ -806,7 +835,7 @@ RETURN array::clump($array, 2);
 RETURN array::clump($array, 3);
 ```
 
-```surql title="Response"
+```surql title="Output"
 -- [ [ 1, 2], [3, 4] ]
 -- [ [1, 2, 3], [4] ]
 ```
@@ -832,8 +861,10 @@ value = "[1, 2, 5, 6]"
 */
 
 array::difference([1, 2, 3, 4], [3, 4, 5, 6]);
+```
 
--- [ 1, 2, 5, 6 ]
+```surql title="Output"
+[ 1, 2, 5, 6 ]
 ```
 
 <br />
@@ -857,8 +888,10 @@ value = "[1, 2, 3, 4]"
 */
 
 array::distinct([ 1, 2, 1, 3, 3, 4 ]);
+```
 
--- [ 1, 2, 3, 4 ]
+```surql title="Output"
+[ 1, 2, 3, 4 ]
 ```
 
 <br />
@@ -888,8 +921,10 @@ value = "[10, 10, 10, 10, 10]"
 */
 
 array::fill([ 1, 2, 3, 4, 5 ], 10);
+```
 
--- [ 10, 10, 10, 10, 10 ]
+```surql title="Output"
+[ 10, 10, 10, 10, 10 ]
 ```
 
 The following example shows how you can use this function with a starting position, and an ending position, which in this example will replace one item from the array:
@@ -903,8 +938,10 @@ value = "[1, 10, 3, 4, 5]"
 */
 
 array::fill([ 1, NONE, 3, 4, 5 ], 10, 1, 2);
+```
 
--- [ 1, 10, 3, 4, 5 ]
+```surql title="Output"
+[ 1, 10, 3, 4, 5 ]
 ```
 
 The following example shows how you can use this function with starting and ending negative positions, which in this example will replace one item from the array:
@@ -918,8 +955,10 @@ value = "[1, 2, 10, 4, 5]"
 */
 
 array::fill([ 1, 2, NONE, 4, 5 ], 10, -3, -2);
+```
 
--- [ 1, 2, 10, 4, 5 ]
+```surql title="Output"
+[ 1, 2, 10, 4, 5 ]
 ```
 
 <br />
@@ -947,10 +986,10 @@ value = "[true, true, true]"
 */
 
 array::filter([ 1, 2, 1, 3, 3, 4 ], 1);
--- [ 1, 1 ]
+--> [ 1, 1 ]
 
 [true, false, false, false, true, true].filter(true);
--- [ true, true, true ]
+--> [ true, true, true ]
 ```
 
 The `array::filter` function can also take a [closure](/docs/reference/query-language/language-primitives/data-types/closures) for more customised filtering.
@@ -973,7 +1012,7 @@ value = "[{ importance: 10, message: 'I need some help with this query...' }, { 
 ].filter(|$v| $v.importance > 5);
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
 	{
 		importance: 10,
@@ -998,8 +1037,10 @@ value = "[1, 2, 3]"
 */
 
 [1,2,3,NONE,0,"",{},[]].filter(|$v| $v);
+```
 
--- [1, 2, 3]
+```surql title="Output"
+[1, 2, 3]
 ```
 
 A more real-life example of this pattern in which only the `person` records that have been seen by another are returned:
@@ -1028,7 +1069,7 @@ FROM person)
     .filter(|$person| $person.is_seen_by);
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
 	{
 		id: person:two,
@@ -1064,10 +1105,10 @@ value = "[0, 1, 3, 4]"
 */
 
 array::filter_index(['a', 'b', 'c', 'b', 'a'], 'b');
--- [ 1, 3 ]
+--> [ 1, 3 ]
 
 [0, 0, 1, 0, 0, 5, 1].filter_index(0);
--- [ 0, 1, 3, 4 ]
+--> [ 0, 1, 3, 4 ]
 ```
 
 The `array::filter_index` function can also take a [closure](/docs/reference/query-language/language-primitives/data-types/closures) for more customised filtering.
@@ -1090,7 +1131,7 @@ value = "[0, 3]"
 ].filter_index(|$v| $v.importance > 5);
 ```
 
-```surql title="Response"
+```surql title="Output"
 [0, 3]
 ```
 
@@ -1119,10 +1160,10 @@ value = "NONE"
 */
 
 array::find(['a', 'b', 'c', 'b', 'a'], 'b');
--- b
+--> 'b'
 
 [1, 2, 3].find(4);
--- [NONE]
+--> NONE
 ```
 
 The `array::find` function is most useful when a [closure](/docs/reference/query-language/language-primitives/data-types/closures) is passed in which allows for customised searching.
@@ -1150,7 +1191,7 @@ value = "{ intelligence: 15, name: 'Mardine', strength: 10 }"
 ].find(|$c| $c.strength > 9 AND $c.intelligence > 9);
 ```
 
-```surql title="Response"
+```surql title="Output"
 -------- Query --------
 
 5
@@ -1189,10 +1230,10 @@ value = "NONE"
 */
 
 array::find_index(['a', 'b', 'c', 'b', 'a'], 'b');
--- 1
+--> 1
 
 [1, 2, 3].find_index(4);
--- NONE
+--> NONE
 ```
 
 The `array::find_index` function can also take a [closure](/docs/reference/query-language/language-primitives/data-types/closures) for more customised searching.
@@ -1206,7 +1247,10 @@ value = "2"
 */
 
 [1, 2, 3].find_index(|$num| $num > 2);
--- 2
+```
+
+```surql title="Output"
+2
 ```
 
 The `array::find_index` function also be called using the alias `array::index_of`.
@@ -1220,7 +1264,10 @@ value = "3"
 */
 
 ["cat", "badger", "dog", "octopus"].index_of("octopus");
--- 3
+```
+
+```surql title="Output"
+3
 ```
 
 <br />
@@ -1245,8 +1292,10 @@ value = "'s'"
 
 
 array::first([ 's', 'u', 'r', 'r', 'e', 'a', 'l' ]);
+```
 
--- 's'
+```surql title="Output"
+'s'
 ```
 
 <br />
@@ -1280,7 +1329,7 @@ array::flatten([ [1,
   8]] ]);
 ```
 
-```surql title="Response"
+```surql title="Output"
 [ 1, 2, 3, 4, 'SurrealDB', 5, 6, [7, 8] ]
 ```
 
@@ -1304,8 +1353,8 @@ value = "53"
 
 */
 
--- Returns 53
 [10,12,10,15].fold(100, |$a, $b| $a - $b);
+--> 53
 ```
 
 The function will then perform the following operation for each step of the way.
@@ -1483,8 +1532,10 @@ array::group([1,
   8,
   8,
   9]);
+```
 
--- [ 1, 2, 3, 4, 5, 6, 7, 8, 9 ]
+```surql title="Output"
+[ 1, 2, 3, 4, 5, 6, 7, 8, 9 ]
 ```
 
 <br />
@@ -1509,7 +1560,10 @@ value = "[1, 2, 5, 3, 'and me']"
 */
 
 array::insert([1, 2, 3, 4], 'and me');
--- [1, 2, 3, 4, 'and me']
+```
+
+```surql title="Output"
+[1, 2, 3, 4, 'and me']
 ```
 
 If the value to append is followed by an index, this will be used as the location for the new value. A negative index can also be used to index from the end instead of from the beginning of an array.
@@ -1523,10 +1577,10 @@ value = "[1, 2, 3, 4, 5]"
 */
 
 array::insert([1, 2, 3, 4], 'and me', 0);
--- ['and me', 1, 2, 3, 4]
+--> ['and me', 1, 2, 3, 4]
 
 array::insert([1, 2, 3, 4], 'and me', -1);
--- [1, 2, 3, 'and me', 4]
+--> [1, 2, 3, 'and me', 4]
 ```
 
 A negative index can be provided to specify a position relative to the end of the array.
@@ -1552,8 +1606,10 @@ value = [3, 4]""
 */
 
 array::intersect([1, 2, 3, 4], [3, 4, 5, 6]);
+```
 
--- [ 3, 4 ]
+```surql title="Output"
+[ 3, 4 ]
 ```
 
 <br />
@@ -1615,8 +1671,10 @@ value = "'again and again and again'"
 */
 
 array::join(["again", "again", "again"], " and ");
+```
 
--- "again and again and again"
+```surql title="Output"
+"again and again and again"
 ```
 
 <br />
@@ -1640,8 +1698,10 @@ value = "'l'"
 */
 
 array::last([ 's', 'u', 'r', 'r', 'e', 'a', 'l' ]);
+```
 
--- 'l'
+```surql title="Output"
+'l'
 ```
 
 <br />
@@ -1665,8 +1725,10 @@ value = "9"
 */
 
 array::len([ 1, 2, 1, null, "something", 3, 3, 4, 0 ]);
+```
 
--- 9
+```surql title="Output"
+9
 ```
 
 <br />
@@ -1711,8 +1773,10 @@ array::logical_and([true,
   true,
   false,
   false]);
+```
 
--- [ true, false, false, false ]
+```surql title="Output"
+[ true, false, false, false ]
 ```
 
 For those that take two arrays, missing elements (if one array is shorter than the other) are considered `null` and thus false.
@@ -1729,8 +1793,10 @@ value = "NULL"
 */
 
 array::logical_and([0, 1], [])
+```
 
--- [ 0, NULL ]
+```surql title="Output"
+[ 0, NULL ]
 ```
 
 <br />
@@ -1776,8 +1842,10 @@ array::logical_or([true,
   true,
   false,
   false]);
+```
 
--- [ true, true, true, false ]
+```surql title="Output"
+[ true, true, true, false ]
 ```
 
 If one of the arrays is empty, the first array is returned.
@@ -1834,8 +1902,10 @@ array::logical_xor([true,
   true,
   false,
   false]);
+```
 
--- [ false, true, true, false ]
+```surql title="Output"
+[ false, true, true, false ]
 ```
 
 If one of the array is empty, the first array is returned.
@@ -1850,8 +1920,10 @@ value = "[0, 1]"
 */
 
 array::logical_xor([0, 1], [])
+```
 
--- [ 0, 1 ]
+```surql title="Output"
+[ 0, 1 ]
 ```
 
 <br />
@@ -1878,7 +1950,7 @@ value = "[2, 4, 6]"
 [1, 2, 3].map(|$v| $v * 2);
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
   2,
   4,
@@ -1906,7 +1978,7 @@ value = "[{ is_even: false, value: 1 }, { is_even: true, value: 2 }, { is_even: 
 });
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
 	{
 		is_even: false,
@@ -1952,7 +2024,7 @@ error = ""Couldn't coerce return value from function `ANONYMOUS`: Expected `int`
 [1, 2, 3].map(|$num: int| -> int { $num + 1.1 });
 ```
 
-```surql title="Response"
+```surql title="Output"
 "Couldn 't coerce return value from function `ANONYMOUS`: Expected
   `int` but found `2.1f`"
 ```
@@ -1975,7 +2047,7 @@ value = "['0: first used in the year 876', '1: the number of moons in the sky', 
   .map(|$item, $index| <string>$index + $item);
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
 	'0: first used in the year 876',
 	'1: the number of moons in the sky',
@@ -2010,8 +2082,10 @@ value = "2"
 */
 
 array::max([0, 1, 2]);
+```
 
--- 2
+```surql title="Output"
+2
 ```
 
 As any value can be compared with another value, the array can be an array of any SurrealQL value.
@@ -2026,8 +2100,10 @@ value = "9.9f"
 */
 
 array::max([NONE, NULL, 9, 9.9]);
+```
 
--- 9.9f
+```surql title="Output"
+9.9f
 ```
 
 See also:
@@ -2062,8 +2138,10 @@ value = "false"
 */
 
 array::matches([0, 1, 2], 1);
+```
 
--- [false, true, false]
+```surql title="Output"
+[false, true, false]
 ```
 
 The following example shows this function when the array contains objects.
@@ -2083,8 +2161,10 @@ value = "true"
 array::matches([{id: r"ohno:0"},
   {id: r"ohno:1"}],
   {id: r"ohno:1"});
+```
 
--- [false, true]
+```surql title="Output"
+[false, true]
 ```
 
 <br />
@@ -2108,8 +2188,10 @@ value = "0"
 */
 
 array::min([0, 1, 2]);
+```
 
--- 0
+```surql title="Output"
+0
 ```
 
 As any value can be compared with another value, the array can be an array of any SurrealQL value.
@@ -2152,8 +2234,10 @@ value = "4"
 */
 
 array::pop([ 1, 2, 3, 4 ]);
+```
 
--- 4
+```surql title="Output"
+4
 ```
 
 <br />
@@ -2177,8 +2261,10 @@ value = "[5, 1, 2, 3, 4]"
 */
 
 array::prepend([1, 2, 3, 4], 5);
+```
 
--- [ 5, 1, 2, 3, 4 ]
+```surql title="Output"
+[ 5, 1, 2, 3, 4 ]
 ```
 
 <br />
@@ -2202,8 +2288,10 @@ value = "[1, 2, 3, 4, 5]"
 */
 
 array::push([1, 2, 3, 4], 5);
+```
 
--- [ 1, 2, 3, 4, 5 ]
+```surql title="Output"
+[ 1, 2, 3, 4, 5 ]
 ```
 
 <br />
@@ -2229,8 +2317,10 @@ value = "[1, 2, 3, 4, 5, 6, 7, 8, 9]"
 */
 
 array::range(1, 10);
+```
 
--- [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ]
+```surql title="Output"
+[ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ]
 ```
 
 ```surql
@@ -2374,8 +2464,10 @@ value = "[1, 2, 4, 5]"
 */
 
 array::remove([1, 2, 3, 4, 5], 2);
+```
 
--- [ 1, 2, 4, 5 ]
+```surql title="Output"
+[ 1, 2, 4, 5 ]
 ```
 
 The following examples shows this function using a negative index.
@@ -2389,8 +2481,10 @@ value = "[1, 2, 3, 5]"
 */
 
 array::remove([1, 2, 3, 4, 5], -2);
+```
 
--- [ 1, 2, 3, 5 ]
+```surql title="Output"
+[ 1, 2, 3, 5 ]
 ```
 
 <br />
@@ -2414,8 +2508,10 @@ value = "[1, 1, 1, 1, 1, 1, 1, 1, 1, 1]"
 */
 
 array::repeat(1, 10);
+```
 
--- [ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ]
+```surql title="Output"
+[ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ]
 ```
 
 ```surql
@@ -2427,8 +2523,10 @@ value = "['hello', 'hello']"
 */
 
 array::repeat("hello", 2);
+```
 
--- [ "hello", "hello" ]
+```surql title="Output"
+[ "hello", "hello" ]
 ```
 
 <br />
@@ -2452,8 +2550,10 @@ value = "[5, 4, 3, 2, 1]"
 */
 
 array::reverse([ 1, 2, 3, 4, 5 ]);
+```
 
--- [ 5, 4, 3, 2, 1 ]
+```surql title="Output"
+[ 5, 4, 3, 2, 1 ]
 ```
 
 <br />
@@ -2473,14 +2573,20 @@ A single number passed in as an argument will create an array beginning at 0 wit
 
 ```surql
 array::sequence(5);
--- [0, 1, 2, 3, 4]
+```
+
+```surql title="Output"
+[0, 1, 2, 3, 4]
 ```
 
 If a second argument is passed into this function, the first argument will be used as the starting point for the array and the second for the length.
 
 ```surql
 array::sequence(-5, 6);
--- [-5, -4, -3, -2, -1, 0]
+```
+
+```surql title="Output"
+[-5, -4, -3, -2, -1, 0]
 ```
 
 ## `array::shuffle`
@@ -2502,8 +2608,10 @@ value = "[3, 5, 4, 1, 2]"
 */
 
 array::shuffle([ 1, 2, 3, 4, 5 ]);
+```
 
--- [ 2, 1, 4, 3, 5 ]
+```surql title="Output"
+[ 2, 1, 4, 3, 5 ]
 ```
 
 <br />
@@ -2529,8 +2637,10 @@ value = "[2, 3]"
 */
 
 array::slice([ 1, 2, 3, 4, 5 ], 1, 3);
+```
 
--- [2, 3]
+```surql title="Output"
+[2, 3]
 ```
 
 The following example shows how you can use this function with a starting position, and a negative position, which will slice off the first and last element from the array:
@@ -2559,8 +2669,10 @@ value = "[3, 4, 5]"
 */
 
 array::slice([ 1, 2, 3, 4, 5 ], 2);
+```
 
--- [ 3, 4, 5 ]
+```surql title="Output"
+[ 3, 4, 5 ]
 ```
 
 The following example shows how you can use this function with just a negative position, which will only slice from the end of the array:
@@ -2574,8 +2686,10 @@ value = "[4, 5]"
 */
 
 array::slice([ 1, 2, 3, 4, 5 ], -2);
+```
 
--- [ 4, 5 ]
+```surql title="Output"
+[ 4, 5 ]
 ```
 
 The following example shows how you can use this function with a negative position, and a length of the slice:
@@ -2597,8 +2711,10 @@ value = "['c', 'd']"
 */
 
 ['a', 'b', 'c', 'd', 'e'].slice(2..=3);
+```
 
--- [ 'c', 'd' ]
+```surql title="Output"
+[ 'c', 'd' ]
 ```
 
 <br />
@@ -2634,8 +2750,10 @@ value = "[NULL, 0, 1, 1, 2, 3, 3, 4, 'something']"
 */
 
 array::sort([ 1, 2, 1, null, "something", 3, 3, 4, 0 ]);
+```
 
--- [ null, 0, 1, 1, 2, 3, 3, 4, "something" ]
+```surql title="Output"
+[ null, 0, 1, 1, 2, 3, 3, 4, "something" ]
 ```
 
 ```surql
@@ -2647,8 +2765,10 @@ value = "['something', 4, 3, 3, 2, 1, 1, 0, NULL]"
 */
 
 array::sort([1, 2, 1, null, "something", 3, 3, 4, 0], false);
+```
 
--- [ "something", 4, 3, 3, 2, 1, 1, 9, null ]
+```surql title="Output"
+[ "something", 4, 3, 3, 2, 1, 1, 9, null ]
 ```
 
 ```surql
@@ -2660,8 +2780,10 @@ value = "[NULL, 0, 1, 1, 2, 3, 3, 4, 'something']"
 */
 
 array::sort([1, 2, 1, null, "something", 3, 3, 4, 0], "asc");
+```
 
--- [ null, 0, 1, 1, 2, 3, 3, 4, "something" ]
+```surql title="Output"
+[ null, 0, 1, 1, 2, 3, 3, 4, "something" ]
 ```
 
 ```surql
@@ -2847,8 +2969,10 @@ value = "[NULL, 0, 1, 1, 2, 3, 3, 4, 'something']"
 */
 
 array::sort::asc([ 1, 2, 1, null, "something", 3, 3, 4, 0 ]);
+```
 
--- [ null, 0, 1, 1, 2, 3, 3, 4, "something" ]
+```surql title="Output"
+[ null, 0, 1, 1, 2, 3, 3, 4, "something" ]
 ```
 
 <br />
@@ -2872,8 +2996,10 @@ value = "['something', 4, 3, 3, 2, 1, 1, 0, NULL]"
 */
 
 array::sort::desc([ 1, 2, 1, null, "something", 3, 3, 4, 0 ]);
+```
 
--- [ "something", 4, 3, 3, 2, 1, 1, 9, null ]
+```surql title="Output"
+[ "something", 4, 3, 3, 2, 1, 1, 9, null ]
 ```
 
 <br />
@@ -2928,8 +3054,10 @@ value = "[5, 2, 3, 4, 1]"
 */
 
 array::swap([ 1, 2, 3, 4, 5 ], 0, -1);
+```
 
--- [ 5, 2, 3, 4, 1 ]
+```surql title="Output"
+[ 5, 2, 3, 4, 1 ]
 ```
 
 An error will be returned if any of the indexes are invalid that informs of range of possible indexes that can be used.
@@ -2970,8 +3098,10 @@ value = "[[0, 2], [1, 3]]"
 */
 
 array::transpose([[0, 1], [2, 3]]);
+```
 
--- [ [0, 2], [1, 3] ]
+```surql title="Output"
+[ [0, 2], [1, 3] ]
 ```
 
 The layering of the above example can be visualised as follows.
@@ -3179,8 +3309,10 @@ value = "[1, 2, 6, 3, 4, 5]"
 */
 
 array::union([1, 2, 1, 6], [1, 3, 4, 5, 6]);
+```
 
--- [ 1, 2, 6, 3, 4, 5 ]
+```surql title="Output"
+[ 1, 2, 6, 3, 4, 5 ]
 ```
 
 <br /><br />
@@ -3214,7 +3346,7 @@ RETURN array::windows($array, 2);
 RETURN array::windows($array, 5);
 ```
 
-```surql title="Response"
+```surql title="Output"
 [ [1, 2], [2, 3], [3, 4] ];
 [];
 ```
@@ -3272,7 +3404,7 @@ array::push(["Again", "again"], "again");
 ["Again", "again"].push("again");
 ```
 
-```surql title="Response"
+```surql title="Output"
 ["Again", "again", "again"]
 ```
 
@@ -3296,6 +3428,6 @@ array::join(array::push(["Again", "again"], "again"), " and ");
 ["Again", "again"].push("again").join(" and ");
 ```
 
-```surql title="Response"
+```surql title="Output"
 "Again and again and again"
 ```

--- a/src/content/reference/query-language/functions/database-functions/count.mdx
+++ b/src/content/reference/query-language/functions/database-functions/count.mdx
@@ -57,8 +57,10 @@ value = "1"
 */
 
 count();
+```
 
--- 1
+```surql title="Output"
+1
 ```
 
 ```surql
@@ -70,8 +72,10 @@ value = "1"
 */
 
 count(true);
+```
 
--- 1
+```surql title="Output"
+1
 ```
 
 ```surql
@@ -83,8 +87,10 @@ value = "0"
 */
 
 count(10 > 15);
+```
 
--- 0
+```surql title="Output"
+0
 ```
 
 ```surql
@@ -123,7 +129,7 @@ FROM [
 GROUP ALL;
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
 	{ count: 3 }
 ]
@@ -147,7 +153,7 @@ FROM [
 GROUP ALL;
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
 	{ count: 2 }
 ]
@@ -176,7 +182,7 @@ FROM [
 GROUP BY country;
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
 	{
 		country: 'GBR',

--- a/src/content/reference/query-language/functions/database-functions/crypto.mdx
+++ b/src/content/reference/query-language/functions/database-functions/crypto.mdx
@@ -94,8 +94,10 @@ value = "'f75ef30a80a78016f4a4da40ac56c858c0001b3a320118adc3785972901ddce6'"
 */
 
 crypto::blake3("tobie");
+```
 
--- '85052e9aab1b67b6622d94a08441b09fd5b7aca61ee360416d70de5da67d86ca'
+```surql title="Output"
+'85052e9aab1b67b6622d94a08441b09fd5b7aca61ee360416d70de5da67d86ca'
 ```
 
 <br />
@@ -120,8 +122,10 @@ value = "2129482046"
 */
 
 crypto::joaat("tobie");
+```
 
--- 2129482046
+```surql title="Output"
+2129482046
 ```
 
 <br />
@@ -144,8 +148,10 @@ value = "'4768b3fc7ac751e03a614e2349abf3bf'"
 */
 
 crypto::md5("tobie");
+```
 
--- "4768b3fc7ac751e03a614e2349abf3bf"
+```surql title="Output"
+"4768b3fc7ac751e03a614e2349abf3bf"
 ```
 
 <br />
@@ -168,8 +174,10 @@ value = "'c6be709a1b6429472e0c5745b411f1693c4717be'"
 */
 
 crypto::sha1("tobie");
+```
 
--- "c6be709a1b6429472e0c5745b411f1693c4717be"
+```surql title="Output"
+"c6be709a1b6429472e0c5745b411f1693c4717be"
 ```
 
 <br />
@@ -192,8 +200,10 @@ value = "'33fe1859daba927ea5674813adc1cf34b9e2795f2b7e91602fae19c0d0c493af'"
 */
 
 crypto::sha256("tobie");
+```
 
--- "33fe1859daba927ea5674813adc1cf34b9e2795f2b7e91602fae19c0d0c493af"
+```surql title="Output"
+"33fe1859daba927ea5674813adc1cf34b9e2795f2b7e91602fae19c0d0c493af"
 ```
 
 <br />
@@ -238,8 +248,10 @@ The following example shows this function, and its output:
 LET $hash = "$argon2id$v=19$m=4096,t=3,p=1$pbZ6yJ2rPJKk4pyEMVwslQ$jHzpsiB+3S/H+kwFXEcr10vmOiDkBkydVCSMfRxV7CA";
 LET $pass = "this is a strong password";
 RETURN crypto::argon2::compare($hash, $pass);
+```
 
--- true
+```surql title="Output"
+true
 ```
 
 <br />

--- a/src/content/reference/query-language/functions/database-functions/duration.mdx
+++ b/src/content/reference/query-language/functions/database-functions/duration.mdx
@@ -128,8 +128,10 @@ value = "21"
 */
 
 duration::days(3w);
+```
 
--- 21
+```surql title="Output"
+21
 ```
 
 <br />
@@ -153,8 +155,10 @@ value = "504"
 
 */
 duration::hours(3w);
+```
 
--- 504
+```surql title="Output"
+504
 ```
 
 <br />
@@ -224,8 +228,10 @@ value = "1814400000000"
 
 */
 duration::micros(3w);
+```
 
--- 1814400000000
+```surql title="Output"
+1814400000000
 ```
 
 <br />
@@ -248,8 +254,10 @@ value = "1814400000"
 
 */
 duration::millis(3w);
+```
 
--- 1814400000
+```surql title="Output"
+1814400000
 ```
 
 <br />
@@ -272,8 +280,10 @@ value = "30240"
 
 */
 duration::mins(3w);
+```
 
--- 30240
+```surql title="Output"
+30240
 ```
 
 <br />
@@ -296,8 +306,10 @@ value = "1814400000000000"
 
 */
 duration::nanos(3w);
+```
 
--- 1814400000000000
+```surql title="Output"
+1814400000000000
 ```
 
 <br />
@@ -320,8 +332,10 @@ value = "1814400"
 
 */
 duration::secs(3w);
+```
 
--- 1814400
+```surql title="Output"
+1814400
 ```
 
 <br />
@@ -345,8 +359,10 @@ value = "3"
 
 */
 duration::weeks(3w);
+```
 
--- 3
+```surql title="Output"
+3
 ```
 
 <br />
@@ -370,8 +386,10 @@ value = "5"
 
 */
 duration::years(300w);
+```
 
--- 5
+```surql title="Output"
+5
 ```
 
 <br />
@@ -395,8 +413,10 @@ value = "3d"
 
 */
 duration::from_days(3);
+```
 
--- 3d
+```surql title="Output"
+3d
 ```
 
 <br />
@@ -420,8 +440,10 @@ value = "3h"
 */
 
 duration::from_hours(3);
+```
 
--- 3h
+```surql title="Output"
+3h
 ```
 
 <br />
@@ -444,8 +466,10 @@ value = "3µs"
 
 */
 duration::from_micros(3);
+```
 
--- 3μs
+```surql title="Output"
+3μs
 ```
 
 <br />
@@ -469,8 +493,10 @@ value = "3ms"
 */
 
 duration::from_millis(3);
+```
 
--- 3ms
+```surql title="Output"
+3ms
 ```
 
 <br />
@@ -494,8 +520,10 @@ value = "3m"
 */
 
 duration::from_mins(3);
+```
 
--- 3m
+```surql title="Output"
+3m
 ```
 
 <br />
@@ -518,8 +546,10 @@ value = "3ns"
 
 */
 duration::from_nanos(3);
+```
 
--- 3ns
+```surql title="Output"
+3ns
 ```
 
 <br />
@@ -542,8 +572,10 @@ value = "3s"
 
 */
 duration::from_secs(3);
+```
 
--- 3s
+```surql title="Output"
+3s
 ```
 
 <br />
@@ -566,8 +598,10 @@ value = "3w"
 
 */
 duration::from_weeks(3);
+```
 
--- 3w
+```surql title="Output"
+3w
 ```
 
 <br /><br />
@@ -595,7 +629,7 @@ duration::mins(2d6h);
 2d6h.mins();
 ```
 
-```surql title="Response"
+```surql title="Output"
 3240
 ```
 
@@ -619,6 +653,6 @@ duration::mins(duration::from_millis(98734234));
 duration::from_millis(98734234).mins();
 ```
 
-```surql title="Response"
+```surql title="Output"
 1645
 ```

--- a/src/content/reference/query-language/functions/database-functions/encoding.mdx
+++ b/src/content/reference/query-language/functions/database-functions/encoding.mdx
@@ -91,8 +91,10 @@ value = "b"32333233""
 
 */
 encoding::base64::decode("MjMyMw");
+```
 
--- b"32333233"
+```surql title="Output"
+b"32333233"
 ```
 
 You can also verify that the output of the encoded value matches the original value. 
@@ -105,8 +107,10 @@ value = "true"
 
 */
 encoding::base64::decode("aGVsbG8") = <bytes>"hello";
+```
 
--- true
+```surql title="Output"
+true
 ```
 
 <br /><br />
@@ -143,8 +147,10 @@ value = "''"
 
 */
 encoding::base64::encode(<bytes>"");
+```
 
--- ''
+```surql title="Output"
+''
 ```
 
 ```surql
@@ -155,8 +161,10 @@ value = "'MjMyMw'"
 
 */
 encoding::base64::encode(<bytes>"2323");
+```
 
--- 'MjMyMw'
+```surql title="Output"
+'MjMyMw'
 ```
 
 ```surql
@@ -167,8 +175,10 @@ value = "'aGVsbG8'"
 
 */
 encoding::base64::encode(<bytes>"hello");
+```
 
--- 'aGVsbG8'
+```surql title="Output"
+'aGVsbG8'
 ```
 
 You can pass `true` as the second argument to enable padded base64 outputs:
@@ -181,8 +191,10 @@ value = "''"
 
 */
 encoding::base64::encode(<bytes>"", true);
+```
 
--- ""
+```surql title="Output"
+""
 ```
 
 ```surql
@@ -343,7 +355,10 @@ As JSON has fewer data types tha SurrealDB, note that a round trip from SurrealQ
 
 ```surql
 encoding::json::decode(encoding::json::encode(NONE));
--- NULL
+```
+
+```surql title="Output"
+NULL
 ```
 
 If a round trip is required, a combination of JSON and CBOR functions can be used.

--- a/src/content/reference/query-language/functions/database-functions/eval.mdx
+++ b/src/content/reference/query-language/functions/database-functions/eval.mdx
@@ -83,7 +83,10 @@ INSERT RELATION INTO knows [
 
 ```surql
 eval::gql("MATCH (n:person) RETURN n.name AS name ORDER BY name");
--- [{ name: 'A' }, { name: 'B' }, { name: 'C' }]
+```
+
+```surql title="Output"
+[{ name: 'A' }, { name: 'B' }, { name: 'C' }]
 ```
 
 ### Filter on node properties
@@ -92,7 +95,10 @@ eval::gql("MATCH (n:person) RETURN n.name AS name ORDER BY name");
 
 ```surql
 eval::gql("MATCH (n:person) WHERE n.age < 25 RETURN n.name AS name ORDER BY name");
--- { name: 'B' }
+```
+
+```surql title="Output"
+{ name: 'B' }
 ```
 
 ### Traverse a typed edge
@@ -103,7 +109,10 @@ Chain node and edge patterns to walk the graph. Label both endpoints as `:person
 eval::gql(
 	"MATCH (a:person)-[k:knows]->(b:person) WHERE k.since > 2020 RETURN a.name, b.name ORDER BY a.name"
 );
--- { 'a.name': 'A', 'b.name': 'B' }
+```
+
+```surql title="Output"
+{ 'a.name': 'A', 'b.name': 'B' }
 ```
 
 ### Optional match
@@ -114,11 +123,14 @@ eval::gql(
 eval::gql(
 	"MATCH (a:person) OPTIONAL MATCH (a)-[k:knows]->(b:city) RETURN a.name AS name, b.name AS city ORDER BY name"
 );
--- [
---   { city: 'London', name: 'A' },
---   { city: NONE, name: 'B' },
---   { city: NONE, name: 'C' }
--- ]
+```
+
+```surql title="Output"
+[
+  { city: 'London', name: 'A' },
+  { city: NONE, name: 'B' },
+  { city: NONE, name: 'C' }
+]
 ```
 
 Only person `A` has a `knows` edge to the `city` node; everyone else still appears with `city: NONE`.
@@ -131,7 +143,10 @@ Count outgoing **person → person** `knows` edges per person.
 eval::gql(
 	"MATCH (a:person)-[:knows]->(b:person) RETURN a.name AS name, count(*) AS friends GROUP BY a.name ORDER BY name"
 );
--- [{ friends: 1, name: 'A' }, { friends: 2, name: 'B' }, { friends: 1, name: 'C' }]
+```
+
+```surql title="Output"
+[{ friends: 1, name: 'A' }, { friends: 2, name: 'B' }, { friends: 1, name: 'C' }]
 ```
 
 ### Multi-hop paths
@@ -143,11 +158,14 @@ In ISO GQL on SurrealDB, variable-length hops are a **postfix quantifier on the 
 eval::gql(
 	"MATCH (a:person)-[:knows]->{1,2}(b:person) WHERE a.name = 'A' RETURN a.name AS source, b.name AS target ORDER BY target"
 );
--- [
---   { source: 'A', target: 'A' },
---   { source: 'A', target: 'B' },
---   { source: 'A', target: 'C' }
--- ]
+```
+
+```surql title="Output"
+[
+  { source: 'A', target: 'A' },
+  { source: 'A', target: 'B' },
+  { source: 'A', target: 'C' }
+]
 ```
 
 One hop reaches `B`; two hops loop back to `A` via `B` or reach `C` via `B`.
@@ -161,7 +179,10 @@ eval::gql(
 	"MATCH (n:person) WHERE n.age > $min RETURN n.name AS name ORDER BY name",
 	{ min: 25 }
 );
--- { name: 'A' }
+```
+
+```surql title="Output"
+{ name: 'A' }
 ```
 
 Bindings are **isolated** from the caller's scope (same as `eval::surql`); only keys you pass in the object are visible inside the GQL query.
@@ -182,15 +203,15 @@ eval::surql(query: string, bindings: option<object>) -> any
 ```surql
 -- Simple expression
 eval::surql("RETURN 1 + 1");
--- 2
+--> 2
 
 -- Caller bindings become $parameters inside the nested query
 eval::surql("RETURN $a + $b", { a: 2, b: 3 });
--- 5
+--> 5
 
 -- Multiple statements: use a block
 eval::surql("{ LET $x = 10; RETURN $x * 2 }");
--- 20
+--> 20
 ```
 
 Nested writes run in the **caller's transaction**:
@@ -198,7 +219,10 @@ Nested writes run in the **caller's transaction**:
 ```surql
 eval::surql("CREATE person:1 SET name = 'A'");
 SELECT name FROM person;
--- [{ name: 'A' }]
+```
+
+```surql title="Output"
+[{ name: 'A' }]
 ```
 
 The evaluated query runs in an **isolated scope**: parameters visible at the call site are not inherited - only keys you pass in the bindings object are bound.
@@ -206,7 +230,10 @@ The evaluated query runs in an **isolated scope**: parameters visible at the cal
 ```surql
 LET $secret = 42;
 eval::surql("RETURN $secret ?? 'isolated'");
--- 'isolated'
+```
+
+```surql title="Output"
+'isolated'
 ```
 
 ## Notes on using eval:: functions

--- a/src/content/reference/query-language/functions/database-functions/eval.mdx
+++ b/src/content/reference/query-language/functions/database-functions/eval.mdx
@@ -203,15 +203,15 @@ eval::surql(query: string, bindings: option<object>) -> any
 ```surql
 -- Simple expression
 eval::surql("RETURN 1 + 1");
---> 2
+//- 2
 
 -- Caller bindings become $parameters inside the nested query
 eval::surql("RETURN $a + $b", { a: 2, b: 3 });
---> 5
+//- 5
 
 -- Multiple statements: use a block
 eval::surql("{ LET $x = 10; RETURN $x * 2 }");
---> 20
+//- 20
 ```
 
 Nested writes run in the **caller's transaction**:

--- a/src/content/reference/query-language/functions/database-functions/geo.mdx
+++ b/src/content/reference/query-language/functions/database-functions/geo.mdx
@@ -84,7 +84,7 @@ geo::area({
 });
 ```
 
-```surql title="Response"
+```surql title="Output"
 253317731850.3478f
 ```
 
@@ -98,8 +98,10 @@ error = "Incorrect arguments for function geo::area(). Argument 1 was the wrong 
 
 */
 geo::area(12345);
+```
 
--- 'Incorrect arguments for function geo::area(). Argument 1 was the wrong type. Expected `geometry` but found `12345`'
+```surql title="Output"
+'Incorrect arguments for function geo::area(). Argument 1 was the wrong type. Expected `geometry` but found `12345`'
 ```
 
 <br />
@@ -140,7 +142,7 @@ RETURN geo::bearing($paris, $le_puy_en_velay);
 RETURN geo::bearing($le_puy_en_velay, $paris);
 ```
 
-```surql title="Response"
+```surql title="Output"
 -- Slightly east of directly south
 164.18154786094604f
 -- Slightly west of directly north
@@ -180,7 +182,7 @@ geo::centroid({
 
 The return value is a mountainous region somewhere in Austria:
 
-```surql title="Response"
+```surql title="Output"
 (13.483896437936192, 47.07117241195589)
 ```
 
@@ -216,7 +218,7 @@ let $harare = (30.463880214538577, -17.865161568822085);
 RETURN geo::distance($london, $harare);
 ```
 
-```surql title="Response"
+```surql title="Output"
 8268604.251890703f
 ```
 
@@ -243,7 +245,7 @@ value = "(51.50986494496465, -0.11809204705059528)"
 geo::hash::decode("mpuxk4s24f51");
 ```
 
-```surql title="Response"
+```surql title="Output"
 (51.50986494496465, -0.11809204705059528)
 ```
 
@@ -273,8 +275,10 @@ value = "'mpuxk4s24f51'"
 
 */
 geo::hash::encode( (51.509865, -0.118092) );
+```
 
--- 'mpuxk4s24f51'
+```surql title="Output"
+'mpuxk4s24f51'
 ```
 
 The following example shows this function with two arguments, and its output, when used in a select statement:
@@ -288,8 +292,10 @@ value = "'mpuxk'"
 */
 
 geo::hash::encode( (51.509865, -0.118092), 5 );
+```
 
--- 'mpuxk'
+```surql title="Output"
+'mpuxk'
 ```
 
 <br />

--- a/src/content/reference/query-language/functions/database-functions/http.mdx
+++ b/src/content/reference/query-language/functions/database-functions/http.mdx
@@ -172,7 +172,7 @@ http::put('https://jsonplaceholder.typicode.com/posts/1', {
 });
 ```
 
-```surql title="Response"
+```surql title="Output"
 {
 	body: 'This is some awesome thinking!',
 	id: 1,
@@ -229,7 +229,7 @@ http::post('https://jsonplaceholder.typicode.com/posts/', {
 });
 ```
 
-```surql title="Response"
+```surql title="Output"
 {
 	body: 'This is some awesome thinking!',
 	id: 101,
@@ -286,7 +286,7 @@ http::patch('https://jsonplaceholder.typicode.com/posts/1', {
 });
 ```
 
-```surql title="RESPONSE"
+```surql title="Output"
 {
 	body: 'This is some awesome thinking!',
 	id: 1,

--- a/src/content/reference/query-language/functions/database-functions/index.mdx
+++ b/src/content/reference/query-language/functions/database-functions/index.mdx
@@ -411,7 +411,7 @@ type::is_number(10);
 type::record("cat", "mr_meow");
 ```
 
-```surql title="Response"
+```surql title="Output"
 -------- Query --------
 
 [
@@ -508,7 +508,7 @@ Some modules expose constants (fixed values) as well as functions. Consts use th
 [math::pi, math::tau, math::e];
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
 	3.141592653589793f,
 	6.283185307179586f,

--- a/src/content/reference/query-language/functions/database-functions/math.mdx
+++ b/src/content/reference/query-language/functions/database-functions/math.mdx
@@ -306,8 +306,10 @@ value = "13.746189f"
 */
 
 math::abs(-13.746189);
+```
 
--- 13.746189f
+```surql title="Output"
+13.746189f
 ```
 
 <br />
@@ -331,8 +333,10 @@ value = "1.0471975511965976f"
 */
 
 math::acos(0.5);
+```
 
--- 1.0471975511965976f
+```surql title="Output"
+1.0471975511965976f
 ```
 
 <br />
@@ -356,8 +360,10 @@ value = "0.7853981633974483f"
 */
 
 math::acot(1);
+```
 
--- 0.7853981633974483f
+```surql title="Output"
+0.7853981633974483f
 ```
 
 ## `math::asin`
@@ -379,8 +385,10 @@ value = "0.5235987755982988f"
 */
 
 math::asin(0.5);
+```
 
--- 0.5235987755982988f
+```surql title="Output"
+0.5235987755982988f
 ```
 
 <br />
@@ -403,8 +411,10 @@ value = "0.7853981633974483f"
 */
 
 math::atan(1);
+```
 
--- 0.7853981633974483f
+```surql title="Output"
+0.7853981633974483f
 ```
 
 <br />
@@ -428,8 +438,10 @@ value = "[2, 1]"
 */
 
 math::bottom([1, 2, 3], 2);
+```
 
--- [2, 1]
+```surql title="Output"
+[2, 1]
 ```
 
 <br />
@@ -453,7 +465,10 @@ value = "14f"
 */
 
 math::ceil(13.146572);
--- 14f
+```
+
+```surql title="Output"
+14f
 ```
 
 <br />
@@ -477,7 +492,10 @@ value = "5"
 */
 
 math::clamp(1, 5, 10);
--- 5
+```
+
+```surql title="Output"
+5
 ```
 
 <br />
@@ -501,7 +519,10 @@ value = "0.5403023058681398f"
 */
 
 math::cos(1);
--- 0.5403023058681398f
+```
+
+```surql title="Output"
+0.5403023058681398f
 ```
 
 <br />
@@ -525,7 +546,10 @@ value = "0.6420926159343308f"
 */
 
 math::cot(1);
--- 0.6420926159343308f
+```
+
+```surql title="Output"
+0.6420926159343308f
 ```
 
 <br />
@@ -548,7 +572,10 @@ value = "3.141592653589793f"
 */
 
 math::deg2rad(180);
--- 3.141592653589793f
+```
+
+```surql title="Output"
+3.141592653589793f
 ```
 
 <br />
@@ -572,7 +599,10 @@ value = "2.718281828459045f"
 */
 
 math::e;
--- 2.718281828459045f
+```
+
+```surql title="Output"
+2.718281828459045f
 ```
 
 <br />
@@ -596,8 +626,10 @@ value = "13.15f"
 */
 
 math::fixed(13.146572, 2);
+```
 
--- 13.15f
+```surql title="Output"
+13.15f
 ```
 
 <br />
@@ -621,7 +653,10 @@ value = "13f"
 */
 
 math::floor(13.746189);
--- 13f 
+```
+
+```surql title="Output"
+13f
 ```
 
 <br />
@@ -645,8 +680,10 @@ value = "0.3183098861837907f"
 */
 
 math::frac_1_pi;
+```
 
--- 0.3183098861837907f
+```surql title="Output"
+0.3183098861837907f
 ```
 
 <br />
@@ -670,7 +707,10 @@ value = "0.7071067811865476f"
 */
 
 math::frac_1_sqrt_2;
--- 0.7071067811865476f
+```
+
+```surql title="Output"
+0.7071067811865476f
 ```
 
 <br />
@@ -694,7 +734,10 @@ value = "0.6366197723675814f"
 */
 
 math::frac_2_pi;
--- 0.6366197723675814f
+```
+
+```surql title="Output"
+0.6366197723675814f
 ```
 
 <br />
@@ -718,7 +761,10 @@ value = "1.1283791670955126f"
 */
 
 math::frac_2_sqrt_pi;
--- 1.1283791670955126f
+```
+
+```surql title="Output"
+1.1283791670955126f
 ```
 
 <br />
@@ -742,7 +788,10 @@ value = "1.5707963267948966f"
 */
 
 math::frac_pi_2;
--- 1.5707963267948966f
+```
+
+```surql title="Output"
+1.5707963267948966f
 ```
 
 <br />
@@ -766,7 +815,10 @@ value = "1.0471975511965979f"
 */
 
 math::frac_pi_3;
--- 1.0471975511965979f
+```
+
+```surql title="Output"
+1.0471975511965979f
 ```
 
 <br />
@@ -790,7 +842,10 @@ value = "0.7853981633974483f"
 */
 
 math::frac_pi_4;
--- 0.7853981633974483f
+```
+
+```surql title="Output"
+0.7853981633974483f
 ```
 
 <br />
@@ -814,7 +869,10 @@ value = "0.5235987755982989f"
 */
 
 math::frac_pi_6;
--- 0.5235987755982989f
+```
+
+```surql title="Output"
+0.5235987755982989f
 ```
 
 <br />
@@ -838,7 +896,10 @@ value = "0.39269908169872414f"
 */
 
 math::frac_pi_8;
--- 0.39269908169872414f
+```
+
+```surql title="Output"
+0.39269908169872414f
 ```
 
 <br />
@@ -865,8 +926,10 @@ value = "Infinity"
 */
 
 math::infinity;
+```
 
--- Infinity
+```surql title="Output"
+Infinity
 ```
 
 <br />
@@ -890,7 +953,10 @@ value = "51f"
 */
 
 math::interquartile([ 1, 40, 60, 10, 2, 901 ]);
--- 51f
+```
+
+```surql title="Output"
+51f
 ```
 
 <br />
@@ -914,7 +980,10 @@ value = "5f"
 */
 
 math::lerp(0, 10, 0.5);
--- 5f
+```
+
+```surql title="Output"
+5f
 ```
 
 The function will not return an error if the third argument is not in the range of 0 to 1. Instead, it will extrapolate linearly beyond the first two numbers.
@@ -928,7 +997,10 @@ value = "20f"
 */
 
 math::lerp(0, 10, 2);
--- 20
+```
+
+```surql title="Output"
+20
 ```
 
 <br />
@@ -952,7 +1024,10 @@ value = "90f"
 */
 
 math::lerpangle(0, 180, 0.5);
--- 90f
+```
+
+```surql title="Output"
+90f
 ```
 
 <br />
@@ -975,7 +1050,10 @@ value = "2.302585092994046f"
 */
 
 math::ln(10);
--- 2.302585092994046f
+```
+
+```surql title="Output"
+2.302585092994046f
 ```
 
 <br />
@@ -999,7 +1077,10 @@ value = "2.302585092994046f"
 */
 
 math::ln_10;
--- 2.302585092994046f
+```
+
+```surql title="Output"
+2.302585092994046f
 ```
 
 <br />
@@ -1023,7 +1104,10 @@ value = "0.6931471805599453f"
 */
 
 math::ln_2;
--- 0.6931471805599453f
+```
+
+```surql title="Output"
+0.6931471805599453f
 ```
 
 <br />
@@ -1047,7 +1131,10 @@ value = "2f"
 */
 
 math::log(100, 10);
--- 2f
+```
+
+```surql title="Output"
+2f
 ```
 
 <br />
@@ -1071,7 +1158,10 @@ value = "3f"
 */
 
 math::log10(1000);
--- 3f
+```
+
+```surql title="Output"
+3f
 ```
 
 <br />
@@ -1095,7 +1185,10 @@ value = "0.3010299956639812f"
 */
 
 math::log10_2;
--- 0.3010299956639812f
+```
+
+```surql title="Output"
+0.3010299956639812f
 ```
 
 <br />
@@ -1119,8 +1212,10 @@ value = "0.4342944819032518f"
 */
 
 math::log10_e;
+```
 
--- 0.4342944819032518f
+```surql title="Output"
+0.4342944819032518f
 ```
 
 <br />
@@ -1144,7 +1239,10 @@ value = "3f"
 */
 
 math::log2(8);
--- 3f
+```
+
+```surql title="Output"
+3f
 ```
 
 <br />
@@ -1168,7 +1266,10 @@ value = "3.321928094887362f"
 */
 
 math::log2_10;
--- 3.321928094887362f
+```
+
+```surql title="Output"
+3.321928094887362f
 ```
 
 <br />
@@ -1192,7 +1293,10 @@ value = "1.4426950408889634f"
 */
 
 math::log2_e;
--- 1.4426950408889634f
+```
+
+```surql title="Output"
+1.4426950408889634f
 ```
 
 <br />
@@ -1216,7 +1320,10 @@ value = "41.42f"
 */
 
 math::max([ 26.164, 13.746189, 23, 16.4, 41.42 ]);
--- 41.42f
+```
+
+```surql title="Output"
+41.42f
 ```
 
 See also:
@@ -1243,8 +1350,10 @@ value = "24.146037800000002f"
 */
 
 math::mean([ 26.164, 13.746189, 23, 16.4, 41.42 ]);
+```
 
--- 24.146037800000002f
+```surql title="Output"
+24.146037800000002f
 ```
 
 <br />
@@ -1268,7 +1377,10 @@ value = "23f"
 */
 
 math::median([ 26.164, 13.746189, 23, 16.4, 41.42 ]);
--- 23f
+```
+
+```surql title="Output"
+23f
 ```
 
 <br />
@@ -1292,7 +1404,10 @@ value = "29.5f"
 */
 
 math::midhinge([ 1, 40, 60, 10, 2, 901 ]);
--- 29.5f
+```
+
+```surql title="Output"
+29.5f
 ```
 
 <br />
@@ -1316,7 +1431,10 @@ value = "13.746189f"
 */
 
 math::min([ 26.164, 13.746189, 23, 16.4, 41.42 ]);
--- 13.746189f
+```
+
+```surql title="Output"
+13.746189f
 ```
 
 See also:
@@ -1346,10 +1464,10 @@ value = "2"
 */
 
 math::mode([ 1, 40, 60, 10, 2, 901 ]);
--- 901
+--> 901
 
 math::mode([ 1, 40, 60, 10, 2, 901, 2 ]);
--- 2
+--> 2
 ```
 
 <br />
@@ -1373,7 +1491,10 @@ value = "40"
 */
 
 math::nearestrank([1, 40, 60, 10, 2, 901], 50);
--- 40
+```
+
+```surql title="Output"
+40
 ```
 
 A number for the percentile outside of the range 0 to 100 will return the output `NaN`.
@@ -1435,7 +1556,10 @@ value = "25f"
 */
 
 math::percentile([1, 40, 60, 10, 2, 901], 50);
--- 25f
+```
+
+```surql title="Output"
+25f
 ```
 
 A number for the percentile outside of the range 0 to 100 will return the output `NaN`.
@@ -1469,7 +1593,10 @@ value = "3.141592653589793f"
 */
 
 math::pi;
--- 3.141592653589793f
+```
+
+```surql title="Output"
+3.141592653589793f
 ```
 
 <br />
@@ -1493,7 +1620,10 @@ value = "1.9671513572895665f"
 */
 
 math::pow(1.07, 10);
--- 1.9671513572895665f
+```
+
+```surql title="Output"
+1.9671513572895665f
 ```
 
 <br />
@@ -1517,7 +1647,10 @@ value = "5619119.004884841f"
 */
 
 math::product([ 26.164, 13.746189, 23, 16.4, 41.42 ]);
--- 5619119.004884841f
+```
+
+```surql title="Output"
+5619119.004884841f
 ```
 
 <br />
@@ -1541,7 +1674,10 @@ value = "180f"
 */
 
 math::rad2deg(3.141592653589793);
--- 180f
+```
+
+```surql title="Output"
+180f
 ```
 
 <br />
@@ -1565,7 +1701,10 @@ value = "14f"
 */
 
 math::round(13.53124);
--- 14f
+```
+
+```surql title="Output"
+14f
 ```
 
 <br />
@@ -1590,7 +1729,10 @@ value = "-1"
 */
 
 math::sign(-42);
--- -1
+```
+
+```surql title="Output"
+-1
 ```
 
 <br />
@@ -1614,7 +1756,10 @@ value = "0.8414709848078965f"
 */
 
 math::sin(1);
--- 0.8414709848078965f
+```
+
+```surql title="Output"
+0.8414709848078965f
 ```
 
 <br />
@@ -1638,7 +1783,10 @@ value = "900"
 */
 
 math::spread([ 1, 40, 60, 10, 2, 901 ]);
--- 900
+```
+
+```surql title="Output"
+900
 ```
 
 <br />
@@ -1662,7 +1810,10 @@ value = "3.872983346207417f"
 */
 
 math::sqrt(15);
--- 3.872983346207417f
+```
+
+```surql title="Output"
+3.872983346207417f
 ```
 
 <br />
@@ -1686,7 +1837,10 @@ value = "1.4142135623730951f"
 */
 
 math::sqrt_2;
--- 1.4142135623730951f
+```
+
+```surql title="Output"
+1.4142135623730951f
 ```
 
 <br />
@@ -1710,7 +1864,10 @@ value = "359.37167389765153f"
 */
 
 math::stddev([ 1, 40, 60, 10, 2, 901 ]);
--- 359.37167389765153f
+```
+
+```surql title="Output"
+359.37167389765153f
 ```
 
 As of SurrealDB 3.0.0, this function can be used [inside a table view](/docs/reference/query-language/statements/select#mathstddev-and-mathvariance-in-table-views).
@@ -1747,8 +1904,10 @@ value = "120.73018900000001f"
 */
 
 math::sum([ 26.164, 13.746189, 23, 16.4, 41.42 ]);
+```
 
--- 120.730189
+```surql title="Output"
+120.730189
 ```
 
 This function on its own expects a numeric value at each point in an array, meaning that on its own it will not be able to be used on an array that contains `NONE` or `NULL` values.
@@ -1762,10 +1921,12 @@ error = "Incorrect arguments for function math::sum(). Argument 1 was the wrong 
 */
 
 math::sum([0, NONE, 10dec, 10.7, NULL]);
+```
 
--- Error: Incorrect arguments for function math::sum().
--- Argument 1 was the wrong type.
--- Expected `number` but found `NONE` when coercing an element of `array<number>`
+```surql title="Output"
+"Error: Incorrect arguments for function math::sum().
+Argument 1 was the wrong type.
+Expected `number` but found `NONE` when coercing an element of `array<number>`"
 ```
 
 However, `NONE` and `NULL` can be coalesced into a default value by using the `??` operator (the "null coalescing operator").
@@ -1823,8 +1984,10 @@ value = "20.7dec"
 math::sum([0,NONE,10dec,10.7,NULL][? $this]);
 // array::map() function
 math::sum([0, NONE, 10dec, 10.7, NULL].map(|$num| $num ?? 0));
+```
 
--- 20.7dec
+```surql title="Output"
+20.7dec
 ```
 
 <br />
@@ -1848,7 +2011,10 @@ value = "1.557407724654902f"
 */
 
 math::tan(1);
--- 1.557407724654902f
+```
+
+```surql title="Output"
+1.557407724654902f
 ```
 
 <br />
@@ -1872,7 +2038,10 @@ value = "6.283185307179586f"
 */
 
 math::tau;
--- 6.283185307179586f
+```
+
+```surql title="Output"
+6.283185307179586f
 ```
 
 <br />
@@ -1896,7 +2065,10 @@ value = "[40, 901, 60]"
 */
 
 math::top([1, 40, 60, 10, 2, 901], 3);
--- [40, 901, 60]
+```
+
+```surql title="Output"
+[40, 901, 60]
 ```
 
 <br />
@@ -1920,7 +2092,10 @@ value = "27.25f"
 */
 
 math::trimean([ 1, 40, 60, 10, 2, 901 ]);
--- 27.25f
+```
+
+```surql title="Output"
+27.25f
 ```
 
 <br />
@@ -1944,7 +2119,10 @@ value = "129148f"
 */
 
 math::variance([ 1, 40, 60, 10, 2, 901 ]);
--- 129148
+```
+
+```surql title="Output"
+129148
 ```
 
 As of SurrealDB 3.0.0, this function can be used [inside a table view](/docs/reference/query-language/statements/select#mathstddev-and-mathvariance-in-table-views).

--- a/src/content/reference/query-language/functions/database-functions/math.mdx
+++ b/src/content/reference/query-language/functions/database-functions/math.mdx
@@ -1464,10 +1464,10 @@ value = "2"
 */
 
 math::mode([ 1, 40, 60, 10, 2, 901 ]);
---> 901
+//- 901
 
 math::mode([ 1, 40, 60, 10, 2, 901, 2 ]);
---> 2
+//- 2
 ```
 
 <br />
@@ -1532,7 +1532,7 @@ value = "-Infinity"
 
 math::neg_infinity;
 
-// -Infinity
+-- -Infinity
 ```
 
 <br />
@@ -1961,9 +1961,9 @@ value = "[0, 0, 10dec, 10.7f, 0]"
 
 */
 
-// Classic array filtering, removes NONE / NULL
+-- Classic array filtering, removes NONE / NULL
 [0,NONE,10dec,10.7,NULL][? $this];
-// array::map() function, turns NONE / NULL to 0
+-- array::map() function, turns NONE / NULL to 0
 [0, NONE, 10dec, 10.7, NULL].map(|$num| $num ?? 0);
 ```
 
@@ -1980,9 +1980,9 @@ value = "20.7dec"
 
 */
 
-// Classic array filtering
+-- Classic array filtering
 math::sum([0,NONE,10dec,10.7,NULL][? $this]);
-// array::map() function
+-- array::map() function
 math::sum([0, NONE, 10dec, 10.7, NULL].map(|$num| $num ?? 0));
 ```
 

--- a/src/content/reference/query-language/functions/database-functions/not.mdx
+++ b/src/content/reference/query-language/functions/database-functions/not.mdx
@@ -40,7 +40,10 @@ value = "false"
 */
 
 not("I speak the truth");
--- false
+```
+
+```surql title="Output"
+false
 ```
 
 A value is not [truthy](/docs/reference/query-language/language-primitives/data-types/values#values-and-truthiness) if it is NONE, NULL, false, empty, or has a value of 0. As such, all the following return `true`.

--- a/src/content/reference/query-language/functions/database-functions/object.mdx
+++ b/src/content/reference/query-language/functions/database-functions/object.mdx
@@ -76,7 +76,7 @@ object::entries({
 });
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
   [ 'a', 1 ],
   [ 'b', true ],
@@ -159,7 +159,7 @@ object::from_entries([
 ]);
 ```
 
-```surql title="Response"
+```surql title="Output"
 {
   a: 1,
   b: true
@@ -269,8 +269,10 @@ object::keys({
   a: 1,
   b: true
 });
+```
 
--- [ 'a', 'b' ]
+```surql title="Output"
+[ 'a', 'b' ]
 ```
 
 <br />
@@ -297,8 +299,10 @@ object::len({
   a: 1,
   b: true
 });
+```
 
--- 2
+```surql title="Output"
+2
 ```
 
 ## `object::remove`
@@ -363,8 +367,10 @@ object::values({
   a: 1,
   b: true
 });
+```
 
--- [1, true]
+```surql title="Output"
+[1, true]
 ```
 
 <br /><br />
@@ -397,7 +403,7 @@ object::values({
 }.values();
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
   1,
   true
@@ -424,6 +430,6 @@ array::max(object::values(object::from_entries([["a", 1], ["b", 2]])));
 object::from_entries([["a", 1], ["b", 2]]).values().max();
 ```
 
-```surql title="Response"
+```surql title="Output"
 2
 ```

--- a/src/content/reference/query-language/functions/database-functions/parse.mdx
+++ b/src/content/reference/query-language/functions/database-functions/parse.mdx
@@ -73,8 +73,10 @@ value = "'surrealdb.com'"
 */
 
 parse::email::host("info@surrealdb.com");
+```
 
--- 'surrealdb.com'
+```surql title="Output"
+'surrealdb.com'
 ```
 
 <br />
@@ -98,8 +100,10 @@ value = "'info'"
 */
 
 parse::email::user("info@surrealdb.com");
+```
 
--- "info"
+```surql title="Output"
+"info"
 ```
 
 <br />
@@ -129,7 +133,7 @@ parse::url::domain("https://surrealdb.com:80/features?some=option#fragment");
 parse::url::domain("http://127.0.0.1/index.html");
 ```
 
-```surql title="Response"
+```surql title="Output"
 "surrealdb.com"
 
 NONE
@@ -155,8 +159,10 @@ value = "'fragment'"
 */
 
 parse::url::fragment("https://surrealdb.com:80/features?some=option#fragment");
+```
 
--- 'fragment'
+```surql title="Output"
+'fragment'
 ```
 
 <br />
@@ -185,7 +191,7 @@ parse::url::host("https://surrealdb.com:80/features?some=option#fragment");
 parse::url::host("http://127.0.0.1/index.html");
 ```
 
-```surql title="Response"
+```surql title="Output"
 'surrealdb.com'
 
 '127.0.0.1'
@@ -211,8 +217,10 @@ value = "'/features'"
 */
 
 parse::url::path("https://surrealdb.com:80/features?some=option#fragment");
+```
 
--- '/features'
+```surql title="Output"
+'/features'
 ```
 
 <br />
@@ -236,8 +244,10 @@ value = "80"
 */
 
 parse::url::port("https://surrealdb.com:80/features?some=option#fragment");
+```
 
--- 80
+```surql title="Output"
+80
 ```
 
 <br />
@@ -261,8 +271,10 @@ value = "'https'"
 */
 
 parse::url::scheme("https://surrealdb.com:80/features?some=option#fragment");
+```
 
--- 'https'
+```surql title="Output"
+'https'
 ```
 
 <br />
@@ -285,8 +297,10 @@ value = "'some=option'"
 */
 
 parse::url::query("https://surrealdb.com:80/features?some=option#fragment");
+```
 
--- 'some=option'
+```surql title="Output"
+'some=option'
 ```
 
 <br /><br />

--- a/src/content/reference/query-language/functions/database-functions/rand.mdx
+++ b/src/content/reference/query-language/functions/database-functions/rand.mdx
@@ -363,13 +363,13 @@ rand::time($from: datetime|number, $to: datetime|number) -> datetime
 The `rand::time` function generates a random [`datetime`](/docs/reference/query-language/language-primitives/data-types/datetimes), either a completely random datetime when no arguments are passed in, or between two bounds. With two arguments, the first is the **earliest** bound and the second is the **latest** (each may be a unix timestamp or a `datetime`).
 
 ```surql
+-- Possible output, as each call returns a different datetime
 rand::time();
+--> d'1327-07-12T01:00:32Z'
 
--- d'1327-07-12T01:00:32Z'
-
+-- Possible output, this time somewhere between the two bounds
 rand::time(198371, 1223138713);
-
--- d'1991-01-13T23:27:17Z'
+--> d'1991-01-13T23:27:17Z'
 ```
 
 <Since v="v2.2.0" />
@@ -378,8 +378,10 @@ This function can take two datetimes, returning a random datetime in between the
 
 ```surql
 rand::time(d'1970-01-01', d'2000-01-01');
+```
 
--- d'1999-05-29T17:02:16Z"
+```surql title="Output"
+d'1999-05-29T17:02:16Z"
 ```
 
 <Since v="v2.3.0" />
@@ -388,8 +390,10 @@ Either of the arguments of this function can be either a number or a datetime.
 
 ```surql
 rand::time(0, d'1990-01-01');
+```
 
--- d'1986-11-17T15:06:01Z'
+```surql title="Output"
+d'1986-11-17T15:06:01Z'
 ```
 
 As of this version, this function returns a datetime between 0000-01-01T00:00:00Z and 9999-12-31T23:59:59Z. Before this, the function returned a random datetime between 1970-01-01T00:00:00Z (0 seconds after the UNIX epoch) and +262142-12-31T23:59:59Z (the maximum possible value for a `datetime`).

--- a/src/content/reference/query-language/functions/database-functions/rand.mdx
+++ b/src/content/reference/query-language/functions/database-functions/rand.mdx
@@ -365,11 +365,11 @@ The `rand::time` function generates a random [`datetime`](/docs/reference/query-
 ```surql
 -- Possible output, as each call returns a different datetime
 rand::time();
---> d'1327-07-12T01:00:32Z'
+//- d'1327-07-12T01:00:32Z'
 
 -- Possible output, this time somewhere between the two bounds
 rand::time(198371, 1223138713);
---> d'1991-01-13T23:27:17Z'
+//- d'1991-01-13T23:27:17Z'
 ```
 
 <Since v="v2.2.0" />

--- a/src/content/reference/query-language/functions/database-functions/record.mdx
+++ b/src/content/reference/query-language/functions/database-functions/record.mdx
@@ -61,11 +61,11 @@ value = "true"
 */
 
 RETURN record::exists(r"person:tobie");
--- false
+--> false
 
 CREATE person:tobie;
 RETURN record::exists(r"person:tobie");
--- true
+--> true
 ```
 
 A longer example of `record::exists` using method syntax:
@@ -127,8 +127,10 @@ value = "'person'"
 */
 
 record::tb(person:tobie);
+```
 
--- 'person'
+```surql title="Output"
+'person'
 ```
 
 This function can also be called using the path `record::table`.
@@ -191,7 +193,7 @@ record::id(r"person:aeon");
 r"person:aeon".id();
 ```
 
-```surql title="Response"
+```surql title="Output"
 'aeon'
 ```
 
@@ -215,6 +217,6 @@ record::table(array::max([r"person:aeon", r"person:landevin"]));
 [r"person:aeon", r"person:landevin"].max().table();
 ```
 
-```surql title="Response"
+```surql title="Output"
 'person'
 ```

--- a/src/content/reference/query-language/functions/database-functions/record.mdx
+++ b/src/content/reference/query-language/functions/database-functions/record.mdx
@@ -61,11 +61,11 @@ value = "true"
 */
 
 RETURN record::exists(r"person:tobie");
---> false
+//- false
 
 CREATE person:tobie;
 RETURN record::exists(r"person:tobie");
---> true
+//- true
 ```
 
 A longer example of `record::exists` using method syntax:

--- a/src/content/reference/query-language/functions/database-functions/sequence.mdx
+++ b/src/content/reference/query-language/functions/database-functions/sequence.mdx
@@ -47,6 +47,8 @@ value = "100"
 
 DEFINE SEQUENCE mySeq2 BATCH 1000 START 100 TIMEOUT 5s;
 sequence::nextval('mySeq2');
+```
 
--- 100
+```surql title="Output"
+100
 ```

--- a/src/content/reference/query-language/functions/database-functions/set.mdx
+++ b/src/content/reference/query-language/functions/database-functions/set.mdx
@@ -136,7 +136,10 @@ value = "{'one', 'three', 'two'}"
 
 */
 set::add({"one", "two"}, "three");
--- {'one', 'three', 'two'}
+```
+
+```surql title="Output"
+{'one', 'three', 'two'}
 ```
 
 A set can also be extended with the contents of an array or another set.
@@ -154,10 +157,10 @@ value = "{1, 2, 3, 4, 5}"
 */
 
 {1, 2}.add([2, 3, 4]);
--- {1, 2, 3, 4}
+--> {1, 2, 3, 4}
 
 {1, 2, 3}.add({3, 4, 5});
--- {1, 2, 3, 4, 5}
+--> {1, 2, 3, 4, 5}
 ```
 
 ## `set::all`
@@ -185,9 +188,9 @@ value = "true"
 */
 
 set::all({ 1, 2, 3, NONE, 'SurrealDB', 5 });
--- false
+--> false
 {'all', 'clear'}.all();
--- true
+--> true
 ```
 
 The `set::all` function can also be followed with a value or a [closure](/docs/reference/query-language/language-primitives/data-types/closures) to check whether all elements conform to a condition.
@@ -208,13 +211,13 @@ value = "false"
 */
 
 {'same',}.all('same');
--- true
+--> true
 
 {"What's", 'it', 'got', 'in', 'its', 'pocketses??'}.all(|$s| $s.len() > 1);
--- true
+--> true
 
 {1, 2, 'SurrealDB'}.all(|$var| $var.is_string());
--- false
+--> false
 ```
 
 ## `set::any`
@@ -241,10 +244,10 @@ value = "false"
 
 */
 set::any({ 1, 2, 3, NONE, 'SurrealDB', 5 });
--- true
+--> true
 
 {'', 0, NONE, NULL, [], {}}.any();
--- false
+--> false
 ```
 
 The `set::any` function can also be followed with a value or a [closure](/docs/reference/query-language/language-primitives/data-types/closures) to check whether any elements conform to a condition.
@@ -265,13 +268,13 @@ value = "false"
 */
 
 {'same', 'different'}.any('same');
--- true
+--> true
 
 {'ant', 'bear', 'cat'}.any(|$s| $s.len() > 3);
--- true
+--> true
 
 {1, 2, 3}.any(|$num| $num > 10);
--- false
+--> false
 ```
 
 ## `set::at`
@@ -296,7 +299,10 @@ value = "2"
 */
 
 set::at({3, 1, 2}, 1);
--- 2
+```
+
+```surql title="Output"
+2
 ```
 
 You can also pass in a negative index.
@@ -314,10 +320,10 @@ value = "NONE"
 */
 
 {1, 2, 3}.at(-1);
--- 3
+--> 3
 
 {1, 2, 3}.at(-4);
--- NONE
+--> NONE
 ```
 
 ## `set::complement`
@@ -328,9 +334,12 @@ The `set::complement` function returns the complement of two sets, namely a sing
 set::complement(set, $other: set) -> set
 ```
 
-```surql title="Example with output"
+```surql title="Example"
 {1, 2, 3, 4}.complement({3, 4, 5, 6});
--- {1, 2}
+```
+
+```surql title="Output"
+{1, 2}
 ```
 
 ## `set::contains`
@@ -341,9 +350,12 @@ The `set::contains` function checks to see if a value is contained within a set.
 set::contains(set, $other: value) -> bool
 ```
 
-```surql title="Example with output"
+```surql title="Example"
 {1, 2, 3}.contains(3);
--- true
+```
+
+```surql title="Output"
+true
 ```
 
 ## `set::difference`
@@ -354,9 +366,12 @@ The `set::difference` function determines the symmetric difference between two s
 set::difference(set, $other: set) -> set
 ```
 
-```surql title="Example with output"
+```surql title="Example"
 {1, 2, 3, 4}.difference({3, 4, 5, 6});
--- {1, 2, 5, 6}
+```
+
+```surql title="Output"
+{1, 2, 5, 6}
 ```
 
 ## `set::filter`
@@ -379,7 +394,10 @@ value = "{0, 1, 2, 3}"
 
 */
 {1, 2, 3, NONE, 0, '', [], {}}.filter(|$v| $v.is_int());
--- {0, 1, 2, 3}
+```
+
+```surql title="Output"
+{0, 1, 2, 3}
 ```
 
 You can also pass a value to keep only exact matches.
@@ -394,7 +412,10 @@ value = "{'a',}"
 */
 
 {'a', 'b', 'c'}.filter('a');
--- {'a',}
+```
+
+```surql title="Output"
+{'a',}
 ```
 
 ## `set::find`
@@ -422,10 +443,10 @@ value = "NONE"
 
 */
 set::find({'a', 'b', 'c'}, 'b');
--- 'b'
+--> 'b'
 
 {1, 2, 3}.find(4);
--- NONE
+--> NONE
 ```
 
 The `set::find` function is most useful when a [closure](/docs/reference/query-language/language-primitives/data-types/closures) is passed in, which allows for customised searching.
@@ -443,7 +464,7 @@ value = "{ intelligence: 15, name: 'Mardine', strength: 10 }"
 */
 
 {1, 2, 5}.find(|$num| $num >= 3);
--- 5
+--> 5
 
 {
 	{ strength: 15, intelligence: 6, name: 'Dom the Magnificent' },
@@ -451,7 +472,7 @@ value = "{ intelligence: 15, name: 'Mardine', strength: 10 }"
 	{ strength: 20, intelligence: 3, name: 'Gub gub' },
 	{ strength: 10, intelligence: 18, name: 'Lumin695' }
 }.find(|$c| $c.strength > 9 AND $c.intelligence > 9);
--- { intelligence: 15, name: 'Mardine', strength: 10 }
+--> { intelligence: 15, name: 'Mardine', strength: 10 }
 ```
 
 ## `set::first`
@@ -476,7 +497,10 @@ value = "1"
 */
 
 set::first({ 3, 1, 2 });
--- 1
+```
+
+```surql title="Output"
+1
 ```
 
 ## `set::flatten`
@@ -539,7 +563,10 @@ value = "10"
 */
 
 {1, 2, 3, 4}.fold(0, |$acc, $val| $acc + $val);
--- 10
+```
+
+```surql title="Output"
+10
 ```
 
 Because `set::fold()` takes an explicit initial value, it is useful when the result type should differ from the type of the set values.
@@ -554,7 +581,10 @@ value = "'123'"
 */
 
 {1, 2, 3}.fold('', |$acc, $val| $acc + <string>$val);
--- '123'
+```
+
+```surql title="Output"
+'123'
 ```
 
 ## `set::intersect`
@@ -565,9 +595,12 @@ The `set::intersect` function calculates the values which intersect two sets, re
 set::intersect(set, $other: set) -> set
 ```
 
-```surql title="Example with output"
+```surql title="Example"
 {1, 2, 3, 4}.intersect({3, 4, 5, 6});
--- {3, 4}
+```
+
+```surql title="Output"
+{3, 4}
 ```
 
 ## `set::is_empty`
@@ -578,9 +611,12 @@ The `set::is_empty` function checks whether the set is empty or not.
 set::is_empty(set) -> bool
 ```
 
-```surql title="Example with output"
+```surql title="Example"
 {1, 2, 3, 4}.is_empty();
--- false
+```
+
+```surql title="Output"
+false
 ```
 
 ## `set::join`
@@ -603,7 +639,10 @@ value = "'1 + 2 + 3'"
 */
 
 set::join({3, 1, 2}, ' + ');
--- '1 + 2 + 3'
+```
+
+```surql title="Output"
+'1 + 2 + 3'
 ```
 
 ## `set::last`
@@ -628,7 +667,10 @@ value = "3"
 */
 
 set::last({ 3, 1, 2 });
--- 3
+```
+
+```surql title="Output"
+3
 ```
 
 ## `set::len`
@@ -641,9 +683,12 @@ If you want to only count [truthy](/docs/reference/query-language/language-primi
 set::len(set) -> number
 ```
 
-```surql title="Example with output"
+```surql title="Example"
 {1, 2, 1, null, 'something', 3, 3, 4, 0}.len();
--- 7
+```
+
+```surql title="Output"
+7
 ```
 
 ## `set::map`
@@ -668,7 +713,10 @@ value = "{2, 4, 6}"
 */
 
 {1, 2, 3}.map(|$v| $v * 2);
--- {2, 4, 6}
+```
+
+```surql title="Output"
+{2, 4, 6}
 ```
 
 An example of mapping several values to the same result.
@@ -683,7 +731,10 @@ value = "{false, true}"
 */
 
 {1, 2, 3}.map(|$val| $val % 2 = 0);
--- {false, true}
+```
+
+```surql title="Output"
+{false, true}
 ```
 
 ## `set::max`
@@ -706,7 +757,10 @@ value = "2"
 */
 
 set::max({0, 1, 2});
--- 2
+```
+
+```surql title="Output"
+2
 ```
 
 As any value can be compared with another value, the set can contain any SurrealQL value.
@@ -731,7 +785,10 @@ value = "0"
 */
 
 set::min({0, 1, 2});
--- 0
+```
+
+```surql title="Output"
+0
 ```
 
 As any value can be compared with another value, the set can contain any SurrealQL value.
@@ -758,7 +815,10 @@ value = "10"
 */
 
 {1, 2, 3, 4}.reduce(|$one, $two| $one + $two);
--- 10
+```
+
+```surql title="Output"
+10
 ```
 
 Another example showing `set::reduce()` used to build a string:
@@ -773,7 +833,10 @@ value = "'1234'"
 */
 
 {1, 2, 3, 4}.reduce(|$one, $two| <string>$one + <string>$two);
--- '1234'
+```
+
+```surql title="Output"
+'1234'
 ```
 
 ## `set::remove`
@@ -796,7 +859,10 @@ value = "{1, 5}"
 */
 
 {1, 2, 5}.remove(2);
--- {1, 5}
+```
+
+```surql title="Output"
+{1, 5}
 ```
 
 If the value does not exist, the untouched set will be returned.
@@ -811,7 +877,10 @@ value = "{1, 2, 5}"
 */
 
 {1, 2, 5}.remove(3);
--- {1, 2, 5}
+```
+
+```surql title="Output"
+{1, 2, 5}
 ```
 
 You can also remove the contents of an array or another set.
@@ -829,10 +898,10 @@ value = "{1}"
 */
 
 {1, 2, 3, 4}.remove([2, 3]);
--- {1, 4}
+--> {1, 4}
 
 {1, 2, 3, 4}.remove({2, 3, 4});
--- {1,}
+--> {1,}
 ```
 
 ## `set::slice`
@@ -863,10 +932,10 @@ value = "{3, 4, 5}"
 */
 
 set::slice({4, 1, 3, 2}, 1, 3);
--- {2, 3}
+--> {2, 3}
 
 {1, 2, 3, 4, 5}.slice(-3..);
--- {3, 4, 5}
+--> {3, 4, 5}
 ```
 
 ## `set::union`
@@ -877,7 +946,10 @@ The `set::union` function combines two sets together, removing duplicate values,
 set::union(set, $other: set) -> set
 ```
 
-```surql title="Example with output"
+```surql title="Example"
 {1, 2, 6}.union({1, 3, 4, 5, 6});
--- {1, 2, 3, 4, 5, 6}
+```
+
+```surql title="Output"
+{1, 2, 3, 4, 5, 6}
 ```

--- a/src/content/reference/query-language/functions/database-functions/set.mdx
+++ b/src/content/reference/query-language/functions/database-functions/set.mdx
@@ -157,10 +157,10 @@ value = "{1, 2, 3, 4, 5}"
 */
 
 {1, 2}.add([2, 3, 4]);
---> {1, 2, 3, 4}
+//- {1, 2, 3, 4}
 
 {1, 2, 3}.add({3, 4, 5});
---> {1, 2, 3, 4, 5}
+//- {1, 2, 3, 4, 5}
 ```
 
 ## `set::all`
@@ -188,9 +188,9 @@ value = "true"
 */
 
 set::all({ 1, 2, 3, NONE, 'SurrealDB', 5 });
---> false
+//- false
 {'all', 'clear'}.all();
---> true
+//- true
 ```
 
 The `set::all` function can also be followed with a value or a [closure](/docs/reference/query-language/language-primitives/data-types/closures) to check whether all elements conform to a condition.
@@ -211,13 +211,13 @@ value = "false"
 */
 
 {'same',}.all('same');
---> true
+//- true
 
 {"What's", 'it', 'got', 'in', 'its', 'pocketses??'}.all(|$s| $s.len() > 1);
---> true
+//- true
 
 {1, 2, 'SurrealDB'}.all(|$var| $var.is_string());
---> false
+//- false
 ```
 
 ## `set::any`
@@ -244,10 +244,10 @@ value = "false"
 
 */
 set::any({ 1, 2, 3, NONE, 'SurrealDB', 5 });
---> true
+//- true
 
 {'', 0, NONE, NULL, [], {}}.any();
---> false
+//- false
 ```
 
 The `set::any` function can also be followed with a value or a [closure](/docs/reference/query-language/language-primitives/data-types/closures) to check whether any elements conform to a condition.
@@ -268,13 +268,13 @@ value = "false"
 */
 
 {'same', 'different'}.any('same');
---> true
+//- true
 
 {'ant', 'bear', 'cat'}.any(|$s| $s.len() > 3);
---> true
+//- true
 
 {1, 2, 3}.any(|$num| $num > 10);
---> false
+//- false
 ```
 
 ## `set::at`
@@ -320,10 +320,10 @@ value = "NONE"
 */
 
 {1, 2, 3}.at(-1);
---> 3
+//- 3
 
 {1, 2, 3}.at(-4);
---> NONE
+//- NONE
 ```
 
 ## `set::complement`
@@ -443,10 +443,10 @@ value = "NONE"
 
 */
 set::find({'a', 'b', 'c'}, 'b');
---> 'b'
+//- 'b'
 
 {1, 2, 3}.find(4);
---> NONE
+//- NONE
 ```
 
 The `set::find` function is most useful when a [closure](/docs/reference/query-language/language-primitives/data-types/closures) is passed in, which allows for customised searching.
@@ -464,7 +464,7 @@ value = "{ intelligence: 15, name: 'Mardine', strength: 10 }"
 */
 
 {1, 2, 5}.find(|$num| $num >= 3);
---> 5
+//- 5
 
 {
 	{ strength: 15, intelligence: 6, name: 'Dom the Magnificent' },
@@ -472,7 +472,7 @@ value = "{ intelligence: 15, name: 'Mardine', strength: 10 }"
 	{ strength: 20, intelligence: 3, name: 'Gub gub' },
 	{ strength: 10, intelligence: 18, name: 'Lumin695' }
 }.find(|$c| $c.strength > 9 AND $c.intelligence > 9);
---> { intelligence: 15, name: 'Mardine', strength: 10 }
+//- { intelligence: 15, name: 'Mardine', strength: 10 }
 ```
 
 ## `set::first`
@@ -898,10 +898,10 @@ value = "{1}"
 */
 
 {1, 2, 3, 4}.remove([2, 3]);
---> {1, 4}
+//- {1, 4}
 
 {1, 2, 3, 4}.remove({2, 3, 4});
---> {1,}
+//- {1,}
 ```
 
 ## `set::slice`
@@ -932,10 +932,10 @@ value = "{3, 4, 5}"
 */
 
 set::slice({4, 1, 3, 2}, 1, 3);
---> {2, 3}
+//- {2, 3}
 
 {1, 2, 3, 4, 5}.slice(-3..);
---> {3, 4, 5}
+//- {3, 4, 5}
 ```
 
 ## `set::union`

--- a/src/content/reference/query-language/functions/database-functions/sleep.mdx
+++ b/src/content/reference/query-language/functions/database-functions/sleep.mdx
@@ -51,7 +51,7 @@ SELECT *,
 FROM person;
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
 	{
 		_: NONE,

--- a/src/content/reference/query-language/functions/database-functions/string.mdx
+++ b/src/content/reference/query-language/functions/database-functions/string.mdx
@@ -311,10 +311,10 @@ Note that the stringified inputs are based on their actual computed values, and 
 
 ```surql
 string::concat(not, actual, values);
---> ['NONENONENONE']
+//- ['NONENONENONE']
 
 string::concat(CREATE ONLY person:aeon RETURN VALUE id, ' is ', 'cool!');
---> ['person:aeon is cool!']
+//- ['person:aeon is cool!']
 ```
 
 <br />
@@ -493,13 +493,13 @@ LET $string = "gr(a|e)y";
 LET $regex = <regex>"gr(a|e)y";
 
 [type::of($string), type::of($regex)];
---> ['string', 'regex']
+//- ['string', 'regex']
 
 [
   string::matches($input, $string),
   string::matches($input, $regex),
 ];
---> [true, true]
+//- [true, true]
 ```
 
 <br />
@@ -840,13 +840,13 @@ LET $different = "A narrow passage holds four hidden treasures";
 LET $short     = "Hi I'm Brian";
 
 string::distance::damerau_levenshtein($first, $same);
---> 0
+//- 0
 string::distance::damerau_levenshtein($first, $close);
---> 7
+//- 7
 string::distance::damerau_levenshtein($first, $different);
---> 34
+//- 34
 string::distance::damerau_levenshtein($first, $short);
---> 38
+//- 38
 ```
 
 ## `string::distance::normalized_damerau_levenshtein`
@@ -898,13 +898,13 @@ LET $different = "A narrow passage holds four hidden treasures";
 LET $short     = "Hi I'm Brian";
 
 string::distance::normalized_damerau_levenshtein($first, $same);
---> 1f
+//- 1f
 string::distance::normalized_damerau_levenshtein($first, $close);
---> 0.8409090909090909f
+//- 0.8409090909090909f
 string::distance::normalized_damerau_levenshtein($first, $different);
---> 0.2272727272727273f
+//- 0.2272727272727273f
 string::distance::normalized_damerau_levenshtein($first, $short);
---> 0.13636363636363635f
+//- 0.13636363636363635f
 ```
 
 ## `string::distance::hamming`
@@ -956,13 +956,13 @@ LET $different = "A narrow passage holds four hidden treasures";
 LET $short     = "Hi I'm Brian";
 
 string::distance::hamming($first, $same);
---> 0
+//- 0
 string::distance::hamming($first, $close);
---> 7
+//- 7
 string::distance::hamming($first, $different);
---> 40
+//- 40
 string::distance::hamming($first, $short);
---> Error: strings must be of equal length
+//- Error: strings must be of equal length
 ```
 
 ## `string::distance::levenshtein`
@@ -1014,13 +1014,13 @@ LET $different = "A narrow passage holds four hidden treasures";
 LET $short     = "Hi I'm Brian";
 
 string::distance::levenshtein($first, $same);
---> 0
+//- 0
 string::distance::levenshtein($first, $close);
---> 7
+//- 7
 string::distance::levenshtein($first, $different);
---> 35
+//- 35
 string::distance::levenshtein($first, $short);
---> 38
+//- 38
 ```
 
 ## `string::distance::normalized_levenshtein`
@@ -1072,13 +1072,13 @@ LET $different = "A narrow passage holds four hidden treasures";
 LET $short     = "Hi I'm Brian";
 
 string::distance::normalized_levenshtein($first, $same);
---> 1
+//- 1
 string::distance::normalized_levenshtein($first, $close);
---> 0.8409090909090909f
+//- 0.8409090909090909f
 string::distance::normalized_levenshtein($first, $different);
---> 0.20454545454545459f
+//- 0.20454545454545459f
 string::distance::normalized_levenshtein($first, $short);
---> 0.13636363636363635f
+//- 0.13636363636363635f
 ```
 
 ## `string::distance::osa`
@@ -1133,13 +1133,13 @@ LET $different = "A narrow passage holds four hidden treasures";
 LET $short     = "Hi I'm Brian";
 
 string::distance::osa($first, $same);
---> 0
+//- 0
 string::distance::osa($first, $close);
---> 7
+//- 7
 string::distance::osa($first, $different);
---> 34
+//- 34
 string::distance::osa($first, $short);
---> 38
+//- 38
 ```
 
 ## `string::html::encode`
@@ -1313,10 +1313,10 @@ value = "false"
 */
 
 string::is_datetime("2015-09-05 23:56:04", "%Y-%m-%d %H:%M:%S");
---> true
+//- true
 
 string::is_datetime("1970-01-01", "%Y-%m-%d %H:%M:%S");
---> false
+//- false
 ```
 
 This can be useful when validating datetimes obtained from other sources that do not use the [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339) format.
@@ -1812,11 +1812,11 @@ value = "1"
 */
 
 string::semver::compare("1.0.0", "1.3.5");
---> -1
+//- -1
 string::semver::compare("1.0.0", "1.0.0");
---> 0
+//- 0
 string::semver::compare("3.0.0-beta.4", "2.6.0");
---> 1
+//- 1
 ```
 
 <br />
@@ -2229,13 +2229,13 @@ LET $different = "A narrow passage holds four hidden treasures";
 LET $short     = "Hi I'm Brian";
 
 string::similarity::jaro($first, $same);
---> 1
+//- 1
 string::similarity::jaro($first, $close);
---> 0.8218673218673219f
+//- 0.8218673218673219f
 string::similarity::jaro($first, $different);
---> 0.6266233766233765f
+//- 0.6266233766233765f
 string::similarity::jaro($first, $short);
---> 0.4379509379509379f
+//- 0.4379509379509379f
 ```
 
 ## `string::similarity::jaro_winkler`
@@ -2287,13 +2287,13 @@ LET $different = "A narrow passage holds four hidden treasures";
 LET $short     = "Hi I'm Brian";
 
 string::similarity::jaro_winkler($first, $same);
---> 1f
+//- 1f
 string::similarity::jaro_winkler($first, $close);
---> 0.8931203931203932f
+//- 0.8931203931203932f
 string::similarity::jaro_winkler($first, $different);
---> 0.6266233766233765f
+//- 0.6266233766233765f
 string::similarity::jaro_winkler($first, $short);
---> 0.4379509379509379f
+//- 0.4379509379509379f
 ```
 
 ## Method chaining

--- a/src/content/reference/query-language/functions/database-functions/string.mdx
+++ b/src/content/reference/query-language/functions/database-functions/string.mdx
@@ -265,8 +265,10 @@ The following example shows this function, and its output:
 
 ```surql
 string::capitalize("how to cook for forty humans");
+```
 
--- 'How To Cook For Forty Humans'
+```surql title="Output"
+'How To Cook For Forty Humans'
 ```
 
 <br />
@@ -289,25 +291,30 @@ value = "'this is a test'"
 */
 
 string::concat('this', ' ', 'is', ' ', 'a', ' ', 'test');
+```
 
--- 'this is a test'
+```surql title="Output"
+'this is a test'
 ```
 
 Any values received that are not a string will be stringified before concatenation.
 
 ```surql
 string::concat(true, [], false);
--- ['true[]false']
+```
+
+```surql title="Output"
+['true[]false']
 ```
 
 Note that the stringified inputs are based on their actual computed values, and not the input tokens themselves. Even an expression can be 
 
 ```surql
 string::concat(not, actual, values);
--- ['NONENONENONE']
+--> ['NONENONENONE']
 
 string::concat(CREATE ONLY person:aeon RETURN VALUE id, ' is ', 'cool!');
--- ['person:aeon is cool!']
+--> ['person:aeon is cool!']
 ```
 
 <br />
@@ -330,8 +337,10 @@ value = "true"
 */
 
 string::contains('abcdefg', 'cde');
+```
 
--- true
+```surql title="Output"
+true
 ```
 
 <br />
@@ -357,8 +366,10 @@ value = "true"
 */
 
 string::ends_with('some test', 'test');
+```
 
--- true
+```surql title="Output"
+true
 ```
 
 <br />
@@ -384,8 +395,10 @@ value = "'a, list, of, items'"
 */
 
 string::join(', ', 'a', 'list', 'of', 'items');
+```
 
--- "a, list, of, items"
+```surql title="Output"
+"a, list, of, items"
 ```
 
 <br />
@@ -409,8 +422,10 @@ value = "14"
 */
 
 string::len('this is a test');
+```
 
--- 14
+```surql title="Output"
+14
 ```
 
 <br />
@@ -434,8 +449,10 @@ value = "'this is a test'"
 */
 
 string::lowercase('THIS IS A TEST');
+```
 
--- 'this is a test'
+```surql title="Output"
+'this is a test'
 ```
 
 <br />
@@ -462,8 +479,10 @@ value = "[true, true]"
   string::matches("grey", "gr(a|e)y"), 
   string::matches("gray", "gr(a|e)y")
 ];
+```
 
--- [true, true]
+```surql title="Output"
+[true, true]
 ```
 
 The second argument can be either a string or a [regex](/docs/reference/query-language/language-primitives/data-types/regex).
@@ -474,13 +493,13 @@ LET $string = "gr(a|e)y";
 LET $regex = <regex>"gr(a|e)y";
 
 [type::of($string), type::of($regex)];
--- ['string', 'regex']
+--> ['string', 'regex']
 
 [
   string::matches($input, $string),
   string::matches($input, $regex),
 ];
--- [true, true]
+--> [true, true]
 ```
 
 <br />
@@ -504,8 +523,10 @@ value = "'testtesttest'"
 */
 
 string::repeat('test', 3);
+```
 
--- 'testtesttest'
+```surql title="Output"
+'testtesttest'
 ```
 
 <br />
@@ -541,8 +562,10 @@ value = "'this is awesome'"
 */
 
 string::replace('this is a test', 'a test', 'awesome');
+```
 
--- 'this is awesome'
+```surql title="Output"
+'this is awesome'
 ```
 
 As [`regexes`](/docs/reference/query-language/language-primitives/data-types/regex) are their own data type, the second argument can also be a regex instead of a string.
@@ -582,8 +605,10 @@ value = "'tset a si siht'"
 */
 
 string::reverse('this is a test');
+```
 
--- 'tset a si siht'
+```surql title="Output"
+'tset a si siht'
 ```
 
 <br />
@@ -624,8 +649,10 @@ value = "'surrealdb-cloud-has-launched-ai_native_database-awesome'"
 */
 
 string::slug('SurrealDB Cloud has launched!!! #ai_native_database #awesome');
+```
 
--- 'surrealdb-cloud-has-launched-ai_native_database-awesome'
+```surql title="Output"
+'surrealdb-cloud-has-launched-ai_native_database-awesome'
 ```
 
 <br />
@@ -649,8 +676,10 @@ value = "['this', 'is', 'a', 'list']"
 */
 
 string::split('this, is, a, list', ', ');
+```
 
--- ['this', 'is', 'a', 'list']
+```surql title="Output"
+['this', 'is', 'a', 'list']
 ```
 
 <br />
@@ -677,8 +706,10 @@ value = "true"
 */
 
 string::starts_with('some test', 'some');
+```
 
--- true
+```surql title="Output"
+true
 ```
 
 <br />
@@ -702,8 +733,10 @@ value = "'this is a test'"
 */
 
 string::trim('    this is a test    ');
+```
 
--- 'this is a test'
+```surql title="Output"
+'this is a test'
 ```
 
 <br />
@@ -727,8 +760,10 @@ value = "'THIS IS A TEST'"
 */
 
 string::uppercase('this is a test');
+```
 
--- 'THIS IS A TEST'
+```surql title="Output"
+'THIS IS A TEST'
 ```
 
 ## `string::words`
@@ -750,8 +785,10 @@ value = "['this', 'is', 'a', 'test']"
 */
 
 string::words('this is a test');
+```
 
--- ['this', 'is', 'a', 'test']
+```surql title="Output"
+['this', 'is', 'a', 'test']
 ```
 
 ## `string::distance::damerau_levenshtein`
@@ -802,14 +839,14 @@ LET $close     = "In a hole in the GROUND there lived a Hobbit";
 LET $different = "A narrow passage holds four hidden treasures";
 LET $short     = "Hi I'm Brian";
 
--- Returns 0
 string::distance::damerau_levenshtein($first, $same);
--- Returns 7
+--> 0
 string::distance::damerau_levenshtein($first, $close);
--- Returns 34
+--> 7
 string::distance::damerau_levenshtein($first, $different);
--- Returns 38
+--> 34
 string::distance::damerau_levenshtein($first, $short);
+--> 38
 ```
 
 ## `string::distance::normalized_damerau_levenshtein`
@@ -860,14 +897,14 @@ LET $close     = "In a hole in the GROUND there lived a Hobbit";
 LET $different = "A narrow passage holds four hidden treasures";
 LET $short     = "Hi I'm Brian";
 
--- Returns 1f
 string::distance::normalized_damerau_levenshtein($first, $same);
--- Returns 0.8409090909090909f
+--> 1f
 string::distance::normalized_damerau_levenshtein($first, $close);
--- Returns 0.2272727272727273f
+--> 0.8409090909090909f
 string::distance::normalized_damerau_levenshtein($first, $different);
--- Returns 0.13636363636363635f
+--> 0.2272727272727273f
 string::distance::normalized_damerau_levenshtein($first, $short);
+--> 0.13636363636363635f
 ```
 
 ## `string::distance::hamming`
@@ -918,14 +955,14 @@ LET $close     = "In a hole in the GROUND there lived a Hobbit";
 LET $different = "A narrow passage holds four hidden treasures";
 LET $short     = "Hi I'm Brian";
 
--- Returns 0
 string::distance::hamming($first, $same);
--- Returns 7
+--> 0
 string::distance::hamming($first, $close);
--- Returns 40
+--> 7
 string::distance::hamming($first, $different);
--- Error: strings must be of equal length
+--> 40
 string::distance::hamming($first, $short);
+--> Error: strings must be of equal length
 ```
 
 ## `string::distance::levenshtein`
@@ -976,14 +1013,14 @@ LET $close     = "In a hole in the GROUND there lived a Hobbit";
 LET $different = "A narrow passage holds four hidden treasures";
 LET $short     = "Hi I'm Brian";
 
--- Returns 0
 string::distance::levenshtein($first, $same);
--- Returns 7
+--> 0
 string::distance::levenshtein($first, $close);
--- Returns 35
+--> 7
 string::distance::levenshtein($first, $different);
--- Returns 38
+--> 35
 string::distance::levenshtein($first, $short);
+--> 38
 ```
 
 ## `string::distance::normalized_levenshtein`
@@ -1034,14 +1071,14 @@ LET $close     = "In a hole in the GROUND there lived a Hobbit";
 LET $different = "A narrow passage holds four hidden treasures";
 LET $short     = "Hi I'm Brian";
 
--- Returns 1
 string::distance::normalized_levenshtein($first, $same);
--- Returns 0.8409090909090909f
+--> 1
 string::distance::normalized_levenshtein($first, $close);
--- Returns 0.20454545454545459f
+--> 0.8409090909090909f
 string::distance::normalized_levenshtein($first, $different);
--- Returns 0.13636363636363635f
+--> 0.20454545454545459f
 string::distance::normalized_levenshtein($first, $short);
+--> 0.13636363636363635f
 ```
 
 ## `string::distance::osa`
@@ -1095,14 +1132,14 @@ LET $close     = "In a hole in the GROUND there lived a Hobbit";
 LET $different = "A narrow passage holds four hidden treasures";
 LET $short     = "Hi I'm Brian";
 
--- Returns 0
 string::distance::osa($first, $same);
--- Returns 7
+--> 0
 string::distance::osa($first, $close);
--- Returns 34
+--> 7
 string::distance::osa($first, $different);
--- Returns 38
+--> 34
 string::distance::osa($first, $short);
+--> 38
 ```
 
 ## `string::html::encode`
@@ -1123,8 +1160,10 @@ value = "'&lt;h1&gt;Safe&#32;Title&lt;&#47;h1&gt;&lt;script&gt;alert(&apos;XSS&a
 */
 
 string::html::encode("<h1>Safe Title</h1><script>alert('XSS')</script><p>Safe paragraph. Not safe <span onload='logout()'>event</span>.</p>");
+```
 
--- '&lt;h1&gt;Safe&#32;Title&lt;&#47;h1&gt;&lt;script&gt;alert(&apos;XSS&apos;)&lt;&#47;script&gt;&lt;p&gt;Safe&#32;paragraph.&#32;Not&#32;safe&#32;&lt;span&#32;onload&#61;&apos;logout()&apos;&gt;event&lt;&#47;span&gt;.&lt;&#47;p&gt;'
+```surql title="Output"
+'&lt;h1&gt;Safe&#32;Title&lt;&#47;h1&gt;&lt;script&gt;alert(&apos;XSS&apos;)&lt;&#47;script&gt;&lt;p&gt;Safe&#32;paragraph.&#32;Not&#32;safe&#32;&lt;span&#32;onload&#61;&apos;logout()&apos;&gt;event&lt;&#47;span&gt;.&lt;&#47;p&gt;'
 ```
 
 <br />
@@ -1147,8 +1186,10 @@ value = "'<h1>Safe Title</h1><p>Safe paragraph. Not safe <span>event</span>.</p>
 */
 
 string::html::sanitize("<h1>Safe Title</h1><script>alert('XSS')</script><p>Safe paragraph. Not safe <span onload='logout()'>event</span>.</p>");
+```
 
--- '<h1>Safe Title</h1><p>Safe paragraph. Not safe <span>event</span>.</p>'
+```surql title="Output"
+'<h1>Safe Title</h1><p>Safe paragraph. Not safe <span>event</span>.</p>'
 ```
 <br />
 
@@ -1174,8 +1215,10 @@ value = "true"
 */
 
 string::is_alphanum("ABC123");
+```
 
--- true
+```surql title="Output"
+true
 ```
 
 <br />
@@ -1201,8 +1244,10 @@ value = "true"
 */
 
 string::is_alpha("ABCDEF");
+```
 
--- true
+```surql title="Output"
+true
 ```
 
 <br />
@@ -1268,10 +1313,10 @@ value = "false"
 */
 
 string::is_datetime("2015-09-05 23:56:04", "%Y-%m-%d %H:%M:%S");
--- true
+--> true
 
 string::is_datetime("1970-01-01", "%Y-%m-%d %H:%M:%S");
--- false
+--> false
 ```
 
 This can be useful when validating datetimes obtained from other sources that do not use the [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339) format.
@@ -1287,7 +1332,7 @@ value = "true"
 string::is_datetime("5sep2024pm012345.6789", "%d%b%Y%p%I%M%S%.f");
 ```
 
-```surql title="Response"
+```surql title="Output"
 true
 ```
 
@@ -1302,7 +1347,7 @@ value = "false"
 string::is_datetime("23:56:00 2015-09-05", "%Y-%m-%d %H:%M");
 ```
 
-```surql title="Response"
+```surql title="Output"
 false
 ```
 
@@ -1331,8 +1376,10 @@ value = "true"
 */
 
 string::is_domain("surrealdb.com");
+```
 
--- true
+```surql title="Output"
+true
 ```
 
 <br />
@@ -1359,8 +1406,10 @@ value = "true"
 */
 
 string::is_email("info@surrealdb.com");
+```
 
--- true
+```surql title="Output"
+true
 ```
 
 <br />
@@ -1387,8 +1436,10 @@ value = "true"
 */
 
 string::is_hexadecimal("ff009e");
+```
 
--- true
+```surql title="Output"
+true
 ```
 
 <br />
@@ -1415,8 +1466,10 @@ value = "true"
 */
 
 string::is_ip("192.168.0.1");
+```
 
--- true
+```surql title="Output"
+true
 ```
 
 <br />
@@ -1443,8 +1496,10 @@ value = "true"
 */
 
 string::is_ipv4("192.168.0.1");
+```
 
--- true
+```surql title="Output"
+true
 ```
 
 <br />
@@ -1471,8 +1526,10 @@ value = "true"
 */
 
 string::is_ipv6("2001:0db8:85a3:0000:0000:8a2e:0370:7334");
+```
 
--- true
+```surql title="Output"
+true
 ```
 
 <br />
@@ -1499,8 +1556,10 @@ value = "true"
 */
 
 string::is_latitude("-0.118092");
+```
 
--- true
+```surql title="Output"
+true
 ```
 
 <br />
@@ -1527,8 +1586,10 @@ value = "true"
 */
 
 string::is_longitude("51.509865");
+```
 
--- true
+```surql title="Output"
+true
 ```
 
 <br />
@@ -1554,8 +1615,10 @@ value = "true"
 */
 
 string::is_numeric("1484091748");
+```
 
--- true
+```surql title="Output"
+true
 ```
 
 <br />
@@ -1582,8 +1645,10 @@ value = "true"
 */
 
 string::is_semver("1.0.0");
+```
 
--- true
+```surql title="Output"
+true
 ```
 
 <br />
@@ -1610,8 +1675,10 @@ value = "true"
 */
 
 string::is_ulid("01JCJB3TPQ50XTG32WM088NKJD");
+```
 
--- true
+```surql title="Output"
+true
 ```
 
 <br />
@@ -1638,8 +1705,10 @@ value = "true"
 */
 
 string::is_url("https://surrealdb.com");
+```
 
--- true
+```surql title="Output"
+true
 ```
 
 <br />
@@ -1708,8 +1777,10 @@ value = "true"
 */
 
 string::is_uuid("018a6680-bef9-701b-9025-e1754f296a0f");
+```
 
--- true
+```surql title="Output"
+true
 ```
 
 <br />
@@ -1741,11 +1812,11 @@ value = "1"
 */
 
 string::semver::compare("1.0.0", "1.3.5");
--- Returns -1
+--> -1
 string::semver::compare("1.0.0", "1.0.0");
--- Returns 0
+--> 0
 string::semver::compare("3.0.0-beta.4", "2.6.0");
--- Returns 1
+--> 1
 ```
 
 <br />
@@ -1769,8 +1840,10 @@ value = "3"
 */
 
 string::semver::major("3.2.6");
+```
 
--- 3
+```surql title="Output"
+3
 ```
 
 <br />
@@ -1794,8 +1867,10 @@ value = "2"
 */
 
 string::semver::minor("3.2.6");
+```
 
--- 2
+```surql title="Output"
+2
 ```
 
 <br />
@@ -1819,8 +1894,10 @@ value = "6"
 */
 
 string::semver::patch("3.2.6");
+```
 
--- 6
+```surql title="Output"
+6
 ```
 
 <br />
@@ -1844,8 +1921,10 @@ value = "'2.0.0'"
 */
 
 string::semver::inc::major("1.2.3");
+```
 
--- '2.0.0'
+```surql title="Output"
+'2.0.0'
 ```
 
 <br />
@@ -1869,8 +1948,10 @@ value = "'1.3.0'"
 */
 
 string::semver::inc::minor("1.2.3");
+```
 
--- '1.3.0'
+```surql title="Output"
+'1.3.0'
 ```
 
 <br />
@@ -1894,8 +1975,10 @@ value = "'1.2.4'"
 */
 
 string::semver::inc::patch("1.2.3");
+```
 
--- '1.2.4'
+```surql title="Output"
+'1.2.4'
 ```
 
 <br />
@@ -1919,8 +2002,10 @@ value = "'9.2.3'"
 */
 
 string::semver::set::major("1.2.3", 9);
+```
 
--- '9.2.3'
+```surql title="Output"
+'9.2.3'
 ```
 
 <br />
@@ -1943,8 +2028,10 @@ value = "'1.9.3'"
 */
 
 string::semver::set::minor("1.2.3", 9);
+```
 
--- '1.9.3'
+```surql title="Output"
+'1.9.3'
 ```
 
 <br />
@@ -1968,8 +2055,10 @@ value = "'1.2.9'"
 */
 
 string::semver::set::patch("1.2.3", 9);
+```
 
--- '1.2.9'
+```surql title="Output"
+'1.2.9'
 ```
 
 <br />
@@ -2062,7 +2151,7 @@ FOR $string IN $strings {
 SELECT of, score FROM comparison ORDER BY score DESC;
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
 	{
 		of: 'SurrealDB	surrealdb',
@@ -2139,14 +2228,14 @@ LET $close     = "In a hole in the GROUND there lived a Hobbit";
 LET $different = "A narrow passage holds four hidden treasures";
 LET $short     = "Hi I'm Brian";
 
--- Returns 1
 string::similarity::jaro($first, $same);
--- Returns 0.8218673218673219f
+--> 1
 string::similarity::jaro($first, $close);
--- Returns 0.6266233766233765f
+--> 0.8218673218673219f
 string::similarity::jaro($first, $different);
--- Returns 0.4379509379509379f
+--> 0.6266233766233765f
 string::similarity::jaro($first, $short);
+--> 0.4379509379509379f
 ```
 
 ## `string::similarity::jaro_winkler`
@@ -2197,14 +2286,14 @@ LET $close     = "In a hole in the GROUND there lived a Hobbit";
 LET $different = "A narrow passage holds four hidden treasures";
 LET $short     = "Hi I'm Brian";
 
--- Returns 0
 string::similarity::jaro_winkler($first, $same);
--- Returns 0.8931203931203932f
+--> 1f
 string::similarity::jaro_winkler($first, $close);
--- Returns 0.6266233766233765f
+--> 0.8931203931203932f
 string::similarity::jaro_winkler($first, $different);
--- Returns 0.4379509379509379f
+--> 0.6266233766233765f
 string::similarity::jaro_winkler($first, $short);
+--> 0.4379509379509379f
 ```
 
 ## Method chaining
@@ -2229,7 +2318,7 @@ string::is_alphanum("MyStrongPassword123");
 "MyStrongPassword123".is_alphanum();
 ```
 
-```surql title="Response"
+```surql title="Output"
 true
 ```
 
@@ -2260,6 +2349,6 @@ string::concat(
   .concat("!!!!");
 ```
 
-```surql title="Response"
+```surql title="Output"
 "I'LL SEND YOU A CHEQUE FOR THE CATALOGUE!!!!"
 ```

--- a/src/content/reference/query-language/functions/database-functions/time.mdx
+++ b/src/content/reference/query-language/functions/database-functions/time.mdx
@@ -313,14 +313,14 @@ time::day(d"2021-11-01T08:30:17+00:00");
 The `time::epoch` constant returns the `datetime` for the UNIX epoch (1 January 1970).
 
 ```surql
-// Return the const
+-- Return the const
 RETURN time::epoch;
---> d'1970-01-01T00:00:00Z'
+//- d'1970-01-01T00:00:00Z'
 
-// Define field using the const
+-- Define field using the const
 DEFINE FIELD since_epoch ON event COMPUTED time::now().floor(1d) - time::epoch;
 CREATE ONLY event:one SET information = "Something happened";
---> { id: event:one, information: 'Something happened', since_epoch: 55y42w6d }
+//- { id: event:one, information: 'Something happened', since_epoch: 55y42w6d }
 ```
 
 <br />
@@ -985,14 +985,14 @@ The following example shows this function, and its output:
 time::is_leap_year();
 
 time::is_leap_year(d"1987-06-22T08:30:45Z");
---> false
+//- false
 
 time::is_leap_year(d"1988-06-22T08:30:45Z");
---> true
+//- true
 
 -- Using function via method chaining
 d'2024-09-03T02:33:15.349397Z'.is_leap_year();
---> true
+//- true
 ```
 
 ## `time::from_micros`

--- a/src/content/reference/query-language/functions/database-functions/time.mdx
+++ b/src/content/reference/query-language/functions/database-functions/time.mdx
@@ -300,8 +300,10 @@ value = "1"
 */
 
 time::day(d"2021-11-01T08:30:17+00:00");
+```
 
--- 1
+```surql title="Output"
+1
 ```
 
 <br />
@@ -313,12 +315,12 @@ The `time::epoch` constant returns the `datetime` for the UNIX epoch (1 January 
 ```surql
 // Return the const
 RETURN time::epoch;
--- d'1970-01-01T00:00:00Z'
+--> d'1970-01-01T00:00:00Z'
 
 // Define field using the const
 DEFINE FIELD since_epoch ON event COMPUTED time::now().floor(1d) - time::epoch;
 CREATE ONLY event:one SET information = "Something happened";
--- { id: event:one, information: 'Something happened', since_epoch: 55y42w6d }
+--> { id: event:one, information: 'Something happened', since_epoch: 55y42w6d }
 ```
 
 <br />
@@ -342,8 +344,10 @@ value = "d'2021-10-28T00:00:00Z'"
 */
 
 time::floor(d"2021-11-01T08:30:17+00:00", 1w);
+```
 
--- d'2021-10-28T00:00:00Z'
+```surql title="Output"
+d'2021-10-28T00:00:00Z'
 ```
 
 ### Implementation details
@@ -458,8 +462,10 @@ value = "8"
 */
 
 time::hour(d"2021-11-01T08:30:17+00:00");
+```
 
--- 8
+```surql title="Output"
+8
 ```
 
 <br />
@@ -483,8 +489,10 @@ value = "d'1988-06-22T08:30:45Z'"
 */
 
 time::max([ d"1987-06-22T08:30:45Z", d"1988-06-22T08:30:45Z" ])
+```
 
--- d'1988-06-22T08:30:45Z'
+```surql title="Output"
+d'1988-06-22T08:30:45Z'
 ```
 
 See also:
@@ -563,8 +571,10 @@ value = "551349045000000"
 */
 
 time::micros(d"1987-06-22T08:30:45Z");
+```
 
--- 551349045000000
+```surql title="Output"
+551349045000000
 ```
 
 <br />
@@ -589,8 +599,10 @@ value = "551349045000"
 */
 
 time::millis(d"1987-06-22T08:30:45Z");
+```
 
--- 551349045000
+```surql title="Output"
+551349045000
 ```
 
 <br />
@@ -614,8 +626,10 @@ value = "d'1987-06-22T08:30:45Z'"
 */
 
 time::min([ d"1987-06-22T08:30:45Z", d"1988-06-22T08:30:45Z" ]);
+```
 
--- d'1987-06-22T08:30:45Z'
+```surql title="Output"
+d'1987-06-22T08:30:45Z'
 ```
 
 See also:
@@ -684,8 +698,10 @@ value = "30"
 */
 
 time::minute(d"2021-11-01T08:30:17+00:00");
+```
 
--- 30
+```surql title="Output"
+30
 ```
 
 <br />
@@ -709,8 +725,10 @@ value = "11"
 */
 
 time::month(d"2021-11-01T08:30:17+00:00");
+```
 
--- 11
+```surql title="Output"
+11
 ```
 
 <br />
@@ -736,8 +754,10 @@ value = "1635755417000000000"
 */
 
 time::nano(d"2021-11-01T08:30:17+00:00");
+```
 
--- 1635755417000000000
+```surql title="Output"
+1635755417000000000
 ```
 
 <br />
@@ -771,8 +791,10 @@ value = "d'2021-11-04T00:00:00Z'"
 */
 
 time::round(d"2021-11-01T08:30:17+00:00", 1w);
+```
 
--- d'2021-11-04T00:00:00Z'
+```surql title="Output"
+d'2021-11-04T00:00:00Z'
 ```
 
 <br />
@@ -796,8 +818,10 @@ value = "17"
 */
 
 time::second(d"2021-11-01T08:30:17+00:00");
+```
 
--- 17
+```surql title="Output"
+17
 ```
 
 <br />
@@ -830,8 +854,10 @@ value = "1635755417"
 */
 
 time::unix(d"2021-11-01T08:30:17+00:00");
+```
 
--- 1635755417
+```surql title="Output"
+1635755417
 ```
 
 <br />
@@ -855,8 +881,10 @@ value = "1"
 */
 
 time::wday(d"2021-11-01T08:30:17+00:00");
+```
 
--- 1
+```surql title="Output"
+1
 ```
 
 <br />
@@ -880,8 +908,10 @@ value = "44"
 */
 
 time::week(d"2021-11-01T08:30:17+00:00");
+```
 
--- 44
+```surql title="Output"
+44
 ```
 
 <br />
@@ -905,8 +935,10 @@ value = "305"
 */
 
 time::yday(d"2021-11-01T08:30:17+00:00");
+```
 
--- 305
+```surql title="Output"
+305
 ```
 
 <br />
@@ -930,8 +962,10 @@ value = "2021"
 */
 
 time::year(d"2021-11-01T08:30:17+00:00");
+```
 
--- 2021
+```surql title="Output"
+2021
 ```
 
 <br />
@@ -951,14 +985,14 @@ The following example shows this function, and its output:
 time::is_leap_year();
 
 time::is_leap_year(d"1987-06-22T08:30:45Z");
--- false
+--> false
 
 time::is_leap_year(d"1988-06-22T08:30:45Z");
--- true
+--> true
 
 -- Using function via method chaining
 d'2024-09-03T02:33:15.349397Z'.is_leap_year();
--- true
+--> true
 ```
 
 ## `time::from_micros`
@@ -980,8 +1014,10 @@ value = "d'1970-01-01T00:00:01Z'"
 */
 
 time::from_micros(1000000);
+```
 
--- d'1970-01-01T00:00:01Z'
+```surql title="Output"
+d'1970-01-01T00:00:01Z'
 ```
 
 <br />
@@ -1005,8 +1041,10 @@ value = "d'1970-01-01T00:00:01Z'"
 */
 
 time::from_millis(1000);
+```
 
--- d'1970-01-01T00:00:01Z'
+```surql title="Output"
+d'1970-01-01T00:00:01Z'
 ```
 
 <br />
@@ -1031,8 +1069,10 @@ value = "d'1970-01-01T00:00:00.001Z'"
 */
 
 time::from_nanos(1000000);
+```
 
--- d'1970-01-01T00:00:00.001Z'
+```surql title="Output"
+d'1970-01-01T00:00:00.001Z'
 ```
 
 <br />
@@ -1055,8 +1095,10 @@ value = "d'1970-01-01T00:16:40Z'"
 */
 
 time::from_secs(1000);
+```
 
--- d'1970-01-01T00:16:40Z'
+```surql title="Output"
+d'1970-01-01T00:16:40Z'
 ```
 
 <br />
@@ -1080,8 +1122,10 @@ value = "d'1970-01-01T00:16:40Z'"
 */
 
 time::from_unix(1000);
+```
 
--- d'1970-01-01T00:16:40Z'
+```surql title="Output"
+d'1970-01-01T00:16:40Z'
 ```
 
 <br />
@@ -1105,8 +1149,10 @@ value = "d'2025-01-09T10:57:03.593Z'"
 */
 
 time::from_ulid("01JH5BBTK9FKTGSDXHWP5YP9TQ");
+```
 
--- d'2025-01-09T10:57:03.593Z'
+```surql title="Output"
+d'2025-01-09T10:57:03.593Z'
 ```
 
 As a ULID is only precise up to the millisecond, a conversion from a ULID to a timestamp will truncate nanosecond precision.
@@ -1143,8 +1189,10 @@ value = "d'2025-01-09T10:57:58.757Z'"
 */
 
 time::from_uuid(u'01944ab6-c1e5-7760-ab6a-127d37eb1b94');
+```
 
--- d'2025-01-09T10:57:58.757Z'
+```surql title="Output"
+d'2025-01-09T10:57:58.757Z'
 ```
 
 As a UUID is only precise up to the millisecond, a conversion from a UUID to a timestamp will truncate nanosecond precision.

--- a/src/content/reference/query-language/functions/database-functions/type.mdx
+++ b/src/content/reference/query-language/functions/database-functions/type.mdx
@@ -214,8 +214,10 @@ value = "[1, 2, 3]"
 */
 
 type::array(1..=3);
+```
 
--- [1, 2, 3]
+```surql title="Output"
+[1, 2, 3]
 ```
 
 This is the equivalent of using [`<array>`](/docs/reference/query-language/language-primitives/casting#array) to cast a value to an array.
@@ -239,8 +241,10 @@ value = "true"
 */
 
 type::bool("true");
+```
 
--- true
+```surql title="Output"
+true
 ```
 
 This is the equivalent of using [`<bool>`](/docs/reference/query-language/language-primitives/casting#bool) to cast a value to a boolean.
@@ -266,8 +270,10 @@ value = "b"4120666577206279746573""
 */
 
 type::bytes("A few bytes");
+```
 
--- b"4120666577206279746573"
+```surql title="Output"
+b"4120666577206279746573"
 ```
 
 This is the equivalent of using [`<bytes>`](/docs/reference/query-language/language-primitives/casting) to cast a value to bytes.
@@ -292,8 +298,10 @@ value = "d'2022-04-27T18:12:27Z'"
 */
 
 type::datetime("2022-04-27T18:12:27+00:00");
+```
 
--- d'2022-04-27T18:12:27Z'
+```surql title="Output"
+d'2022-04-27T18:12:27Z'
 ```
 
 This is the equivalent of using [`<datetime>`](/docs/reference/query-language/language-primitives/casting#datetime) to cast a value to a datetime.
@@ -319,8 +327,10 @@ value = "12345dec"
 */
 
 type::decimal("12345");
+```
 
--- 12345dec
+```surql title="Output"
+12345dec
 ```
 
 This is the equivalent of using [`<decimal>`](/docs/reference/query-language/language-primitives/casting#decimal) to cast a value to a decimal.
@@ -345,8 +355,10 @@ value = "4h"
 */
 
 type::duration("4h");
+```
 
--- 4h
+```surql title="Output"
+4h
 ```
 
 This is the equivalent of using [`<duration>`](/docs/reference/query-language/language-primitives/casting#duration) to cast a value to a duration.
@@ -578,8 +590,10 @@ value = "true"
 */
 
 type::file("my_bucket", "file_name") == f"my_bucket:/file_name";
+```
 
--- true
+```surql title="Output"
+true
 ```
 
 Once a [bucket has been defined](/docs/reference/query-language/statements/define/indexes), operations using one of the [file functions](/docs/reference/query-language/functions/database-functions/file) can be performed on the file pointer.
@@ -629,8 +643,10 @@ value = "12345f"
 */
 
 type::float("12345");
+```
 
--- 12345f
+```surql title="Output"
+12345f
 ```
 This is the equivalent of using [`<float>`](/docs/reference/query-language/language-primitives/casting#float) to cast a value to a float.
 
@@ -654,8 +670,10 @@ value = "12345"
 */
 
 type::int("12345");
+```
 
--- 12345
+```surql title="Output"
+12345
 ```
 This is the equivalent of using [`<int>`](/docs/reference/query-language/language-primitives/casting#int) to cast a value to a int.
 
@@ -679,8 +697,10 @@ value = "12345"
 */
 
 type::number("12345");
+```
 
--- 12345
+```surql title="Output"
+12345
 ```
 
 This is the equivalent of using [`<number>`](/docs/reference/query-language/language-primitives/casting#number) to cast a value to a number.
@@ -722,8 +742,10 @@ value = "(51.509865, -0.118092)"
 */
 
 type::point([ 51.509865, -0.118092 ]);
+```
 
--- (51.509865, -0.118092)
+```surql title="Output"
+(51.509865, -0.118092)
 ```
 
 <br />
@@ -753,13 +775,13 @@ error = "Could not cast into `range` using input `[1, 9, 4]`"
 */
 
 type::range([1, 2]);
--- 1..2
+--> 1..2
 
 type::range(1..10);
--- 1..10
+--> 1..10
 
 type::range([1,9,4]);
--- 'Expected a range but cannot convert [1, 9, 4] into a range'
+--> 'Expected a range but cannot convert [1, 9, 4] into a range'
 ```
 
 <br />
@@ -827,8 +849,10 @@ If the second argument passed into `type::record` is a record ID, the latter par
 
 ```surql
 type::record("person", person:mat);
+```
 
--- person:mat
+```surql title="Output"
+person:mat
 ```
 
 The output of the above function call will thus be `person:mat`, not `person:person:mat`.
@@ -838,7 +862,10 @@ When the first argument is already a record ID and the second is a string, the s
 ```surql
 type::record(person:tobie, 'person'); -- person:tobie
 type::record(person:tobie, 'cat');
--- error: record is not in table `cat`
+```
+
+```surql title="Output"
+error: record is not in table `cat`
 ```
 
 </TabItem>
@@ -864,7 +891,7 @@ The optional second argument allows an assertation that the record passed in is 
 ```surql
 type::record('person:tobie', 'person'); -- person:tobie
 type::record('person:tobie', 'cat');
--- "Expected a record<cat> but cannot convert 'person:tobie' into a
+--> "Expected a record<cat> but cannot convert 'person:tobie' into a
   record<cat>"
 ```
 
@@ -899,8 +926,10 @@ value = "'12345'"
 */
 
 type::string(12345);
+```
 
--- '12345'
+```surql title="Output"
+'12345'
 ```
 
 This is the equivalent of using [`<string>`](/docs/reference/query-language/language-primitives/casting#string) to cast a value to a string.
@@ -989,8 +1018,10 @@ value = "[person, cat]"
   type::table("person"),
   type::table(cat:one)
 ];
+```
 
--- [person, cat]
+```surql title="Output"
+[person, cat]
 ```
 
 As of version 2.0, SurrealDB no longer eagerly parses strings into record IDs. As such, the output of the last item ("dog:two") in the following example will differ. In version 1.x, it will be eagerly parsed into a record ID after which the `dog` table name will be returned, while in later editions it will be treated as a string and converted into the table name `dog:two`. As of version 3.0, a number is no longer accepted as input, because a number on its own is not a valid table name.
@@ -1045,8 +1076,10 @@ value = "u'0191f946-936f-7223-bef5-aebbc527ad80'"
 */
 
 type::uuid("0191f946-936f-7223-bef5-aebbc527ad80");
+```
 
--- u'0191f946-936f-7223-bef5-aebbc527ad80'
+```surql title="Output"
+u'0191f946-936f-7223-bef5-aebbc527ad80'
 ```
 <br />
 
@@ -1072,8 +1105,10 @@ value = "true"
 */
 
 type::is_array([ 'a', 'b', 'c' ]);
+```
 
--- true
+```surql title="Output"
+true
 ```
 
 <br />
@@ -1100,8 +1135,10 @@ value = "true"
 */
 
 type::is_bool(true);
+```
 
--- true
+```surql title="Output"
+true
 ```
 
 <br />
@@ -1128,8 +1165,10 @@ value = "false"
 */
 
 type::is_bytes("I am not bytes");
+```
 
--- false
+```surql title="Output"
+false
 ```
 
 <br />
@@ -1157,8 +1196,10 @@ value = "false"
 */
 
 type::is_collection("I am not a collection");
+```
 
--- false
+```surql title="Output"
+false
 ```
 
 <br />
@@ -1184,8 +1225,10 @@ value = "true"
 */
 
 type::is_datetime(time::now());
+```
 
--- true
+```surql title="Output"
+true
 ```
 
 <br />
@@ -1213,8 +1256,10 @@ value = "true"
 
 type::is_decimal(<decimal>
   13.5719384719384719385639856394139476937756394756);
+```
 
--- true
+```surql title="Output"
+true
 ```
 
 <br />
@@ -1240,8 +1285,10 @@ value = "false"
 */
 
 type::is_duration('1970-01-01T00:00:00');
+```
 
--- false
+```surql title="Output"
+false
 ```
 
 <br />
@@ -1267,8 +1314,10 @@ value = "true"
 */
 
 type::is_float(<float> 41.5);
+```
 
--- true
+```surql title="Output"
+true
 ```
 
 <br />
@@ -1294,8 +1343,10 @@ value = "true"
 */
 
 type::is_geometry((-0.118092, 51.509865));
+```
 
--- true
+```surql title="Output"
+true
 ```
 
 <br />
@@ -1321,8 +1372,10 @@ value = "true"
 */
 
 type::is_int(<int> 123);
+```
 
--- true
+```surql title="Output"
+true
 ```
 
 <br />
@@ -1349,8 +1402,10 @@ value = "false"
 */
 
 type::is_line("I am not a line");
+```
 
--- false
+```surql title="Output"
+false
 ```
 
 <br />
@@ -1377,8 +1432,10 @@ value = "true"
 */
 
 type::is_none(NONE);
+```
 
--- true
+```surql title="Output"
+true
 ```
 
 <br />
@@ -1405,8 +1462,10 @@ value = "true"
 */
 
 type::is_null(NULL);
+```
 
--- true
+```surql title="Output"
+true
 ```
 
 <br />
@@ -1433,8 +1492,10 @@ value = "false"
 */
 
 type::is_multiline("I am not a multiline");
+```
 
--- false
+```surql title="Output"
+false
 ```
 
 <br />
@@ -1461,8 +1522,10 @@ value = "false"
 */
 
 type::is_multipoint("I am not a multipoint");
+```
 
--- false
+```surql title="Output"
+false
 ```
 
 <br />
@@ -1489,8 +1552,10 @@ value = "false"
 */
 
 type::is_multipolygon("I am not a multipolygon");
+```
 
--- false
+```surql title="Output"
+false
 ```
 
 <br />
@@ -1517,8 +1582,10 @@ value = "true"
 */
 
 type::is_number(123);
+```
 
--- true
+```surql title="Output"
+true
 ```
 
 <br />
@@ -1545,8 +1612,10 @@ value = "true"
 */
 
 type::is_object({ hello: 'world' });
+```
 
--- true
+```surql title="Output"
+true
 ```
 
 <br />
@@ -1573,8 +1642,10 @@ value = "true"
 */
 
 type::is_point((-0.118092, 51.509865));
+```
 
--- true
+```surql title="Output"
+true
 ```
 
 <br />
@@ -1601,8 +1672,10 @@ value = "false"
 */
 
 type::is_polygon("I am not a polygon");
+```
 
--- false
+```surql title="Output"
+false
 ```
 
 ## `type::is_range`
@@ -1628,11 +1701,11 @@ value = "true"
 */
 
 type::is_range(0..1);
--- true
+--> true
 
 // method syntax
 (0..1).is_range();
--- true
+--> true
 ```
 
 ## `type::is_record`
@@ -1657,8 +1730,10 @@ value = "true"
 */
 
 type::is_record(user:tobie);
+```
 
--- true
+```surql title="Output"
+true
 ```
 
 
@@ -1702,8 +1777,10 @@ value = "true"
 */
 
 type::is_string("abc");
+```
 
--- true
+```surql title="Output"
+true
 ```
 
 <br />
@@ -1730,8 +1807,10 @@ value = "true"
 */
 
 type::is_uuid(u"018a6680-bef9-701b-9025-e1754f296a0f");
+```
 
--- true
+```surql title="Output"
+true
 ```
 
 <br /><br />
@@ -1758,6 +1837,6 @@ type::is_record(r"person:aeon", "cat");
 r"person:aeon".is_record("cat");
 ```
 
-```surql title="Response"
+```surql title="Output"
 false
 ```

--- a/src/content/reference/query-language/functions/database-functions/type.mdx
+++ b/src/content/reference/query-language/functions/database-functions/type.mdx
@@ -775,13 +775,13 @@ error = "Could not cast into `range` using input `[1, 9, 4]`"
 */
 
 type::range([1, 2]);
---> 1..2
+//- 1..2
 
 type::range(1..10);
---> 1..10
+//- 1..10
 
 type::range([1,9,4]);
---> 'Expected a range but cannot convert [1, 9, 4] into a range'
+//- 'Expected a range but cannot convert [1, 9, 4] into a range'
 ```
 
 <br />
@@ -891,7 +891,7 @@ The optional second argument allows an assertation that the record passed in is 
 ```surql
 type::record('person:tobie', 'person'); -- person:tobie
 type::record('person:tobie', 'cat');
---> "Expected a record<cat> but cannot convert 'person:tobie' into a
+//- "Expected a record<cat> but cannot convert 'person:tobie' into a
   record<cat>"
 ```
 
@@ -1701,11 +1701,11 @@ value = "true"
 */
 
 type::is_range(0..1);
---> true
+//- true
 
-// method syntax
+-- method syntax
 (0..1).is_range();
---> true
+//- true
 ```
 
 ## `type::is_record`

--- a/src/content/reference/query-language/functions/database-functions/value.mdx
+++ b/src/content/reference/query-language/functions/database-functions/value.mdx
@@ -58,7 +58,7 @@ value = "'Something else'"
 */
 
 'SurrealDB'.chain(|$n| $n + ' 3.0');
--- 'SurrealDB 3.0'
+--> 'SurrealDB 3.0'
 
 'SurrealDB'.chain(|$n| "Something else");
 ```
@@ -78,7 +78,7 @@ value = ""{ company: 'SURREALDB!!!!!', latest_version: '3.1' }""
     .replace('SurrealDB', 'SURREALDB!!!!!');
 ```
 
-```surql title="Response"
+```surql title="Output"
 "{ company: 'SURREALDB!!!!!', latest_version: '3.1' }"
 ```
 
@@ -141,7 +141,7 @@ value = "[{ op: 'change', path: '/company', value: '@@ -2,8 +2,10 @@
   location: city:london });
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
 	{
 		op: 'change',
@@ -179,10 +179,10 @@ This function uses the original value as the first argument. If the original clo
 
 ```surql
 { name: "Loki" }.expect(|$obj| $obj.name = "Loki");
--- [{ name: 'Loki' }]
+--> [{ name: 'Loki' }]
 
 { name: "Loki" }.expect(|$obj| $obj.name = "Baldr");
--- 'An error occurred: value::expect assertion failed'
+--> 'An error occurred: value::expect assertion failed'
 ```
 
 A user-defined error string can added after the closure if more context is desired.
@@ -193,8 +193,10 @@ A user-defined error string can added after the closure if more context is desir
 		|$obj| $obj.name = "Baldr", 
 		"Norse god's name should be Loki"
 	);
+```
 
--- "An error occurred: value::expect assertion failed with message: 'Norse god's name should be Loki'"
+```surql title="Output"
+"An error occurred: value::expect assertion failed with message: 'Norse god's name should be Loki'"
 ```
 
 This method is most conveniently used when chaining methods to make assertions about the data before it reaches the end of the chain.
@@ -207,8 +209,10 @@ This method is most conveniently used when chaining methods to make assertions a
         |$words| $words.all(|$word| $word.len() <= 8),
         "Found content greater than 8 characters")
     .join('');
+```
 
--- "An error occurred: value::expect assertion failed with message: 'Found content greater than 8 characters'"
+```surql title="Output"
+"An error occurred: value::expect assertion failed with message: 'Found content greater than 8 characters'"
 ```
 
 As closures in SurrealDB take ownership of the values of their arguments, this function clones the original value in order to return it. It is thus only recommended to use when debugging or when the assertion is a simple one.
@@ -247,7 +251,7 @@ $company.patch([{
 }]);
 ```
 
-```surql title="Response"
+```surql title="Output"
 {
 	company: 'SurrealDB',
 	version: '3.0'

--- a/src/content/reference/query-language/functions/database-functions/value.mdx
+++ b/src/content/reference/query-language/functions/database-functions/value.mdx
@@ -58,7 +58,7 @@ value = "'Something else'"
 */
 
 'SurrealDB'.chain(|$n| $n + ' 3.0');
---> 'SurrealDB 3.0'
+//- 'SurrealDB 3.0'
 
 'SurrealDB'.chain(|$n| "Something else");
 ```
@@ -179,10 +179,10 @@ This function uses the original value as the first argument. If the original clo
 
 ```surql
 { name: "Loki" }.expect(|$obj| $obj.name = "Loki");
---> [{ name: 'Loki' }]
+//- [{ name: 'Loki' }]
 
 { name: "Loki" }.expect(|$obj| $obj.name = "Baldr");
---> 'An error occurred: value::expect assertion failed'
+//- 'An error occurred: value::expect assertion failed'
 ```
 
 A user-defined error string can added after the closure if more context is desired.

--- a/src/content/reference/query-language/functions/database-functions/vector.mdx
+++ b/src/content/reference/query-language/functions/database-functions/vector.mdx
@@ -129,8 +129,10 @@ value = "[2, 4, 6]"
 */
 
 vector::add([1, 2, 3], [1, 2, 3]);
+```
 
--- [2, 4, 6]
+```surql title="Output"
+[2, 4, 6]
 ```
 
 <br />
@@ -156,8 +158,10 @@ value = "0.36774908225917935f"
 */
 
 vector::angle([5, 10, 15], [10, 5, 20]);
+```
 
--- 0.36774908225917935f
+```surql title="Output"
+0.36774908225917935f
 ```
 
 <br />
@@ -211,8 +215,10 @@ value = "[2, 2]"
 */
 
 vector::divide([4, 6], [2, 3]);
+```
 
--- [2, 2]
+```surql title="Output"
+[2, 2]
 ```
 
 <br />
@@ -236,8 +242,10 @@ value = "14"
 */
 
 vector::dot([1, 2, 3], [1, 2, 3]);
+```
 
--- 14
+```surql title="Output"
+14
 ```
 
 <br />
@@ -263,8 +271,10 @@ value = "8.54400374531753f"
 */
 
 vector::magnitude([ 1, 2, 3, 3, 3, 4, 5 ]);
+```
 
--- 8.54400374531753f
+```surql title="Output"
+8.54400374531753f
 ```
 
 <br />
@@ -287,8 +297,10 @@ value = "[1, 4, 9]"
 */
 
 vector::multiply([1, 2, 3], [1, 2, 3]);
+```
 
--- [1, 4, 9]
+```surql title="Output"
+[1, 4, 9]
 ```
 
 <br />
@@ -314,8 +326,10 @@ value = "[0.8f, 0.6f]"
 */
 
 vector::normalize([ 4, 3 ]);
+```
 
--- [0.8f, 0.6f]
+```surql title="Output"
+[0.8f, 0.6f]
 ```
 
 <br />
@@ -342,8 +356,10 @@ value = "[1.6623376623376624f, 2.077922077922078f, 2.4935064935064934f]"
 */
 
 vector::project([1, 2, 3], [4, 5, 6]);
+```
 
--- [1.6623376623376624f, 2.077922077922078f, 2.4935064935064934f]
+```surql title="Output"
+[1.6623376623376624f, 2.077922077922078f, 2.4935064935064934f]
 ```
 
 <br />
@@ -367,8 +383,10 @@ value = "[15, 5, 25, -15, 35, 10]"
 */
 
 vector::scale([3, 1, 5, -3, 7, 2], 5);
+```
 
--- [15,	5, 25, -15, 35, 10]
+```surql title="Output"
+[15,	5, 25, -15, 35, 10]
 ```
 
 <br />
@@ -414,22 +432,22 @@ value = "[4, 6]"
 */
 
 vector::sum([[1, 2, 3], [4, 5, 6]]);
--- [5, 7, 9]
+--> [5, 7, 9]
 
 vector::sum([[1, 2], [3, 4], [5, 6]]);
--- [9, 12]
+--> [9, 12]
 
 vector::sum([[1.5, 2.5], [1, 1]]);
--- [2.5f, 3.5f]
+--> [2.5f, 3.5f]
 
 vector::sum([[], []]);
--- []
+--> []
 
 vector::sum([]);
--- NONE
+--> NONE
 
 [[1, 2], [3, 4]].vector_sum();
--- [4, 6]
+--> [4, 6]
 ```
 
 ### Aggregate form
@@ -514,8 +532,10 @@ value = "[1, 3, 5]"
 */
 
 vector::subtract([4, 5, 6], [3, 2, 1]);
+```
 
--- [1, 3, 5]
+```surql title="Output"
+[1, 3, 5]
 ```
 
 <br />
@@ -541,8 +561,10 @@ value = "6f"
 */
 
 vector::distance::chebyshev([2, 4, 5, 3, 8, 2], [3, 1, 5, -3, 7, 2]);
+```
 
--- 6f
+```surql title="Output"
+6f
 ```
 
 <br />
@@ -566,8 +588,10 @@ value = "432.43496620879307f"
 */
 
 vector::distance::euclidean([10, 50, 200], [400, 100, 20]);
+```
 
--- 432.43496620879307f
+```surql title="Output"
+432.43496620879307f
 ```
 
 <br />
@@ -591,8 +615,10 @@ value = "1"
 */
 
 vector::distance::hamming([1, 2, 2], [1, 2, 3]);
+```
 
--- 1
+```surql title="Output"
+1
 ```
 
 <br />
@@ -632,14 +658,14 @@ SELECT id, vector::distance::knn() AS dist FROM pts
 
 ```surql title="Output"
 [
-			{
-				id: pts:1,
-				dist: 2f
-			},
-			{
-				id: pts:2,
-				dist: 4f
-			}
+	{
+		id: pts:1,
+		dist: 2f
+	},
+	{
+		id: pts:2,
+		dist: 4f
+	}
 ]
 ```
 
@@ -664,8 +690,10 @@ value = "13"
 */
 
 vector::distance::manhattan([10, 20, 15, 10, 5], [12, 24, 18, 8, 7]);
+```
 
--- 13
+```surql title="Output"
+13
 ```
 
 <br />
@@ -698,14 +726,15 @@ value = "0f"
 
 */
 
+-- An identity covariance matrix gives the same result as euclidean
 vector::distance::mahalanobis([1, 2], [3, 4], [[1, 0], [0, 1]]);
--- 2.8284271247461903f  (same as euclidean for identity covariance)
+--> 2.8284271247461903f
 
 vector::distance::mahalanobis([1, 2], [3, 4], [[2, 1], [1, 2]]);
--- 1.632993161855452f
+--> 1.632993161855452f
 
 vector::distance::mahalanobis([1, 2], [1, 2], [[2, 1], [1, 2]]);
--- 0f
+--> 0f
 ```
 
 A non-square matrix, a matrix that is not symmetric positive-definite, empty vectors, or a dimension mismatch returns an error.
@@ -732,8 +761,10 @@ value = "4.862944131094279f"
 */
 
 vector::distance::minkowski([10, 20, 15, 10, 5], [12, 24, 18, 8, 7], 3);
+```
 
--- 4.862944131094279f
+```surql title="Output"
+4.862944131094279f
 ```
 
 <br />
@@ -758,8 +789,10 @@ value = "0.15258215962441316f"
 */
 
 vector::similarity::cosine([10, 50, 200], [400, 100, 20]);
+```
 
--- 0.15258215962441316f
+```surql title="Output"
+0.15258215962441316f
 ```
 
 <br />
@@ -788,10 +821,11 @@ value = "0.5f"
 */
 
 vector::similarity::jaccard([0,1,2,5,6], [0,2,3,4,5,7,9]);
--- 0.3333333333333333f
+--> 0.3333333333333333f
 
+-- The sets are {1,2} and {2}: one item in the intersection, two in the union
 vector::similarity::jaccard([1, 2], [2, 2]);
--- 0.5f  (sets {1,2} and {2}; intersection 1, union 2)
+--> 0.5f
 ```
 
 <br />
@@ -818,8 +852,10 @@ value = "0.9819805060619659f"
 */
 
 vector::similarity::pearson([1,2,3], [1,5,7]);
+```
 
--- 0.9819805060619659f
+```surql title="Output"
+0.9819805060619659f
 ```
 
 <br />
@@ -853,13 +889,14 @@ value = "0.9486832980505138f"
 */
 
 vector::similarity::spearman([1, 2, 3], [1, 10, 100]);
--- 1f
+--> 1f
 
 vector::similarity::spearman([1, 2, 3], [3, 2, 1]);
--- -1f
+--> -1f
 
+-- Ties use average ranks
 vector::similarity::spearman([1, 2, 2, 3], [1, 2, 3, 4]);
--- 0.9486832980505138f  (ties use average ranks)
+--> 0.9486832980505138f
 ```
 
 <br />

--- a/src/content/reference/query-language/functions/database-functions/vector.mdx
+++ b/src/content/reference/query-language/functions/database-functions/vector.mdx
@@ -432,22 +432,22 @@ value = "[4, 6]"
 */
 
 vector::sum([[1, 2, 3], [4, 5, 6]]);
---> [5, 7, 9]
+//- [5, 7, 9]
 
 vector::sum([[1, 2], [3, 4], [5, 6]]);
---> [9, 12]
+//- [9, 12]
 
 vector::sum([[1.5, 2.5], [1, 1]]);
---> [2.5f, 3.5f]
+//- [2.5f, 3.5f]
 
 vector::sum([[], []]);
---> []
+//- []
 
 vector::sum([]);
---> NONE
+//- NONE
 
 [[1, 2], [3, 4]].vector_sum();
---> [4, 6]
+//- [4, 6]
 ```
 
 ### Aggregate form
@@ -728,13 +728,13 @@ value = "0f"
 
 -- An identity covariance matrix gives the same result as euclidean
 vector::distance::mahalanobis([1, 2], [3, 4], [[1, 0], [0, 1]]);
---> 2.8284271247461903f
+//- 2.8284271247461903f
 
 vector::distance::mahalanobis([1, 2], [3, 4], [[2, 1], [1, 2]]);
---> 1.632993161855452f
+//- 1.632993161855452f
 
 vector::distance::mahalanobis([1, 2], [1, 2], [[2, 1], [1, 2]]);
---> 0f
+//- 0f
 ```
 
 A non-square matrix, a matrix that is not symmetric positive-definite, empty vectors, or a dimension mismatch returns an error.
@@ -821,11 +821,11 @@ value = "0.5f"
 */
 
 vector::similarity::jaccard([0,1,2,5,6], [0,2,3,4,5,7,9]);
---> 0.3333333333333333f
+//- 0.3333333333333333f
 
 -- The sets are {1,2} and {2}: one item in the intersection, two in the union
 vector::similarity::jaccard([1, 2], [2, 2]);
---> 0.5f
+//- 0.5f
 ```
 
 <br />
@@ -889,14 +889,14 @@ value = "0.9486832980505138f"
 */
 
 vector::similarity::spearman([1, 2, 3], [1, 10, 100]);
---> 1f
+//- 1f
 
 vector::similarity::spearman([1, 2, 3], [3, 2, 1]);
---> -1f
+//- -1f
 
 -- Ties use average ranks
 vector::similarity::spearman([1, 2, 2, 3], [1, 2, 3, 4]);
---> 0.9486832980505138f
+//- 0.9486832980505138f
 ```
 
 <br />

--- a/src/content/reference/query-language/language-primitives/data-types/arrays.mdx
+++ b/src/content/reference/query-language/language-primitives/data-types/arrays.mdx
@@ -83,7 +83,7 @@ error = "Expected a single result output when using the ONLY keyword"
 SELECT * FROM 9;
 -- Use the `ONLY` clause to return a single item
 SELECT * FROM ONLY 9;
--- Error: array has more than one item
+-- `ONLY` errors when the array holds more than one item
 SELECT * FROM ONLY [1,9];
 ```
 
@@ -152,7 +152,7 @@ CREATE team:one SET employees = [
 ];
 ```
 
-```surql title="Response"
+```surql title="Output"
 "Couldn't coerce value for field `employees` of `team:one`:
 Expected `array<record<employee>,5>` but found a collection of length
   `6`"
@@ -187,8 +187,10 @@ value = "[1, 2]"
 */
 
 [1,2,NONE][? $this];
+```
 
--- [1, 2]
+```surql title="Output"
+[1, 2]
 ```
 
 Filtering can be repeated if desired.
@@ -250,8 +252,10 @@ value = "[3, 5]"
 
 [1,3,5].filter(|$val| $val > 2);
 [1,3,5][WHERE $this > 2];
+```
 
--- [3,5]
+```surql title="Output"
+[3,5]
 ```
 
 While the [array functions](/docs/reference/query-language/functions/database-functions/array) section of the documentation contains the full details of each function, the following examples provide a glimpse into how they are commonly used.
@@ -267,8 +271,10 @@ value = "[2, 3, 4]"
 */
 
 [1,2,3].map(|$item| $item + 1);
+```
 
--- [2,3,4]
+```surql title="Output"
+[2,3,4]
 ```
 
 If desired, a second parameter can be passed in that holds the index of the item.

--- a/src/content/reference/query-language/language-primitives/data-types/booleans.mdx
+++ b/src/content/reference/query-language/language-primitives/data-types/booleans.mdx
@@ -32,7 +32,7 @@ FROM
     CREATE person SET name = "Billy";
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
 	{
 		id: person:7j4t4higwb141v1v2xum,

--- a/src/content/reference/query-language/language-primitives/data-types/bytes.mdx
+++ b/src/content/reference/query-language/language-primitives/data-types/bytes.mdx
@@ -87,7 +87,7 @@ b"486F6262697473";
 
 "There was a problem with the database: Parse error: Unexpected
   character `T` expected hexidecimal digit
- --> [1:11]
+ //- [1:11]
   |
 1 | <string>b\"This won't work though\";
   |           ^ 

--- a/src/content/reference/query-language/language-primitives/data-types/closures.mdx
+++ b/src/content/reference/query-language/language-primitives/data-types/closures.mdx
@@ -113,7 +113,7 @@ value = "2000"
     .chain(|$num| <number>$num * 1000);
 ```
 
-```surql title="Response"
+```surql title="Output"
 2000
 ```
 
@@ -143,7 +143,7 @@ value = "'true'"
     .chain(|$v| <string>$v);
 ```
 
-```surql title="Response"
+```surql title="Output"
 'true'
 ```
 
@@ -172,7 +172,10 @@ fn::test_create("direct_call");
 -- 3. Call the function inside .map() - fails
 LET $names = ["Alice", "Bob", "Charlie"];
 $names.map(|$n| fn::test_create($n));
--- Error: "Couldn't write to a read only transaction"
+```
+
+```surql title="Output"
+Error: "Couldn't write to a read only transaction"
 ```
 
 In many cases, a closure can be substituted by another operation such as a `FOR` loop or a regular `SELECT` statement.
@@ -213,7 +216,7 @@ LET $names = ["Alice", "Bob", "Charlie"];
 $names.map(|$n| fn::test_create($n));
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
 	{ created: true, name: 'Alice' },
 	{ created: true, name: 'Bob' },

--- a/src/content/reference/query-language/language-primitives/data-types/datetimes.mdx
+++ b/src/content/reference/query-language/language-primitives/data-types/datetimes.mdx
@@ -68,7 +68,7 @@ skip-record-id-key = true
 CREATE event SET time = <datetime>"2025-07-03T07:18:52.841147Z";
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
     { 
         id: event:jwm8ncmfi30nrxdf24ws, 
@@ -90,7 +90,7 @@ error = "'"Expected `datetime` but found a `'2025-07-03T07:18:52.841147'`"'"
 CREATE event SET time = <datetime>"2025-07-03T07:18:52.841147";
 ```
 
-```surql title="Response"
+```surql title="Output"
 "Expected a datetime but cannot convert '2025-07-03T07:18:52.841147' into a datetime"
 ```
 
@@ -108,7 +108,7 @@ skip-record-id-key = true
 CREATE event SET time = <datetime>"2024-04-03";
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
     { 
         id: event:4t50wjjlne9v8km2qcwq, 
@@ -137,7 +137,7 @@ DEFINE FIELD time ON event TYPE datetime;
 CREATE event SET time = "2025-07-03T07:18:52.841147";
 ```
 
-```surql title="Response"
+```surql title="Output"
 "Couldn't coerce value for field `time` of `event:qv8qcjf0w9oowekl36w6`:
 Expected `datetime` but found `'2025-07-03T07:18:52.841147'`"
 ```
@@ -161,7 +161,7 @@ DEFINE FIELD time ON event TYPE datetime;
 CREATE event SET time = d"2025-07-03T07:18:52.84114Z";
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
     { 
         id: event:w2lhv58f7c9z7xo4nqkq, 
@@ -177,7 +177,7 @@ A datetime can be compared with another using SurrealDB operators.
 d"2025-07-03T07:18:52Z" < d"2025-07-03T07:18:52.84114Z";
 ```
     
-```surql title="Response"
+```surql title="Output"
 true
 ```
 
@@ -197,7 +197,7 @@ skip-record-id-key = true
 CREATE event SET time = d"2025-07-03T07:18:52Z" + 2w;
 ```
     
-```surql title="Response"
+```surql title="Output"
 [
     { 
         id: event:`9ey7v8r0fd46xblf9dsf`, 
@@ -221,7 +221,7 @@ CREATE event SET
     time = d"2025-07-03T07:18:52.841147Z" + 1h30m20s1350ms;
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
     { 
         id: event:5uuzy32t48yutxyszi7p, 

--- a/src/content/reference/query-language/language-primitives/data-types/durations.mdx
+++ b/src/content/reference/query-language/language-primitives/data-types/durations.mdx
@@ -74,14 +74,20 @@ For example, a duration that includes `12h` two times will be evaluated as `1d`.
 
 ```surql
 1d1d12h12h;
--- 3d
+```
+
+```surql title="Output"
+3d
 ```
 
 A duration can also be created by casting a string.
 
 ```surql
 <duration>"1d1d12h12h";
--- 3d
+```
+
+```surql title="Output"
+3d
 ```
 
 A duration can be zero, but cannot be negative.
@@ -95,17 +101,17 @@ The maximum possible duration can be accessed via the const [`duration::max`](/d
 
 ```surql
 duration::max;
--- 584942417355y3w5d7h15s999ms999µs999ns
+--> 584942417355y3w5d7h15s999ms999µs999ns
 
 duration::max + 1ns
--- 'Failed to compute: "584942417355y3w5d7h15s999ms999µs999ns + 1ns", as the operation results in an arithmetic overflow.'
+--> 'Failed to compute: "584942417355y3w5d7h15s999ms999µs999ns + 1ns", as the operation results in an arithmetic overflow.'
 ```
 
 Durations can be added to and subtracted from other durations as well as datetimes.
 
 ```surql
 d'1970-01-01' + 1d;
--- d'1970-01-02T00:00:00Z'
+--> d'1970-01-02T00:00:00Z'
 
 1y - 6w;
 46w1d;
@@ -119,8 +125,8 @@ A duration can be multiplied and divided by a number.
 
 ```surql
 1d / 24;
--- 1h
+--> 1h
 
 1d * 5.5;
--- 5d12h
+--> 5d12h
 ```

--- a/src/content/reference/query-language/language-primitives/data-types/durations.mdx
+++ b/src/content/reference/query-language/language-primitives/data-types/durations.mdx
@@ -101,17 +101,17 @@ The maximum possible duration can be accessed via the const [`duration::max`](/d
 
 ```surql
 duration::max;
---> 584942417355y3w5d7h15s999ms999µs999ns
+//- 584942417355y3w5d7h15s999ms999µs999ns
 
 duration::max + 1ns
---> 'Failed to compute: "584942417355y3w5d7h15s999ms999µs999ns + 1ns", as the operation results in an arithmetic overflow.'
+//- 'Failed to compute: "584942417355y3w5d7h15s999ms999µs999ns + 1ns", as the operation results in an arithmetic overflow.'
 ```
 
 Durations can be added to and subtracted from other durations as well as datetimes.
 
 ```surql
 d'1970-01-01' + 1d;
---> d'1970-01-02T00:00:00Z'
+//- d'1970-01-02T00:00:00Z'
 
 1y - 6w;
 46w1d;
@@ -125,8 +125,8 @@ A duration can be multiplied and divided by a number.
 
 ```surql
 1d / 24;
---> 1h
+//- 1h
 
 1d * 5.5;
---> 5d12h
+//- 5d12h
 ```

--- a/src/content/reference/query-language/language-primitives/data-types/geometries.mdx
+++ b/src/content/reference/query-language/language-primitives/data-types/geometries.mdx
@@ -59,14 +59,17 @@ There are two main points to keep in mind when creating a `geometry` type in Sur
 This can be shown by calling the [`type::is_geometry()`](/docs/reference/query-language/functions/database-functions/type#typeis_geometry) function on some sample objects.
 
 ```surql
--- true: has `type` and `coordinates` field with valid data
+-- Has both a `type` and a `coordinates` field, each with valid data
 { type: "Point", coordinates: [-0.118092, 51.509865] }.is_geometry();
+--> true
 
--- false: lacks 'type' field
+-- Lacks a `type` field
 { coordinates: [-0.118092, 51.509865] }.is_geometry();
+--> false
 
--- false: has an extra field
+-- Carries a field beyond `type` and `coordinates`
 { type: "Point", coordinates: [-0.118092, 51.509865], unnecessary: "data" }.is_geometry();
+--> false
 ```
 
 ## `Point`

--- a/src/content/reference/query-language/language-primitives/data-types/geometries.mdx
+++ b/src/content/reference/query-language/language-primitives/data-types/geometries.mdx
@@ -61,15 +61,15 @@ This can be shown by calling the [`type::is_geometry()`](/docs/reference/query-l
 ```surql
 -- Has both a `type` and a `coordinates` field, each with valid data
 { type: "Point", coordinates: [-0.118092, 51.509865] }.is_geometry();
---> true
+//- true
 
 -- Lacks a `type` field
 { coordinates: [-0.118092, 51.509865] }.is_geometry();
---> false
+//- false
 
 -- Carries a field beyond `type` and `coordinates`
 { type: "Point", coordinates: [-0.118092, 51.509865], unnecessary: "data" }.is_geometry();
---> false
+//- false
 ```
 
 ## `Point`

--- a/src/content/reference/query-language/language-primitives/data-types/literals.mdx
+++ b/src/content/reference/query-language/language-primitives/data-types/literals.mdx
@@ -27,7 +27,7 @@ LET $nine: 9 = 9;
 LET $nine: 9 = 10;
 ```
 
-```surql title="Response"
+```surql title="Output"
 -------- Query --------
 
 NONE
@@ -50,7 +50,7 @@ error = ""Tried to set `$nine`, but couldn't coerce value: Expected `9 | '9' | '
 LET $nine: 9 | "9" | "nine" = "Nein";
 ```
 
-```surql title="Response"
+```surql title="Output"
 "Tried to set `$nine`, but couldn't coerce value: Expected `9 | '9' | 'nine'` but found `'Nein'`"
 ```
 
@@ -115,7 +115,7 @@ CREATE information SET
 	error_info = "You shouldn't use this anymore";
 ```
 
-```surql title="Response"
+```surql title="Output"
 -------- Query --------
 
 [

--- a/src/content/reference/query-language/language-primitives/data-types/none-and-null.mdx
+++ b/src/content/reference/query-language/language-primitives/data-types/none-and-null.mdx
@@ -108,7 +108,7 @@ value = "NONE"
 */
 
 DEFINE FUNCTION fn::do_stuff() -> NONE {
-  // Code that should return nothing
+  -- Code that should return nothing
 };
 
 DEFINE FIELD middle_name

--- a/src/content/reference/query-language/language-primitives/data-types/numbers.mdx
+++ b/src/content/reference/query-language/language-primitives/data-types/numbers.mdx
@@ -105,8 +105,10 @@ value = "13.571938471938472f"
 */
 
 13.5719384719384719385639856394139476937756394756;
+```
 
--- 13.571938471938472f
+```surql title="Output"
+13.571938471938472f
 ```
 
 In addition, when using floating point numbers specifically, mathematical operations can result in a loss of precision (as is normal with other databases).
@@ -120,8 +122,10 @@ value = "0.9999999999999999f"
 */
 
 0.3 + 0.3 + 0.3 + 0.1;
+```
 
--- 0.9999999999999999f
+```surql title="Output"
+0.9999999999999999f
 ```
 
 Common rounding errors can be avoided by performing calculations using decimals.
@@ -135,8 +139,10 @@ value = "1.0dec"
 */
 
 0.3dec + 0.3dec + 0.3dec + 0.1dec;
+```
 
--- 1.0dec
+```surql title="Output"
+1.0dec
 ```
 
 ## Underscores
@@ -145,13 +151,13 @@ As a convenience, underscores are ignored when using a number. This allows input
 
 ```surql
 RELATE dr:evil->bribes->other:character SET dollars = 1_000_000.99;
--- [{ dollars: 1000000.99, id: bribes:4bfld2ukwnja24dzrpw9, in: dr:evil, out: other:character }]
+--> [{ dollars: 1000000.99, id: bribes:4bfld2ukwnja24dzrpw9, in: dr:evil, out: other:character }]
 
 -- Input Korean currency counted in units of 10000, not 1000
 RELATE korean:purchaser->buys_house_from->korean:seller
               -- 10억 4천만 5천
     SET amount = 10_4000_5000;
--- [{ amount: 1040005000, id: buys_house_from:9070t2ctgwwg202cpw1z, in: korean:purchaser, out: korean:seller }]
+--> [{ amount: 1040005000, id: buys_house_from:9070t2ctgwwg202cpw1z, in: korean:purchaser, out: korean:seller }]
 ```
 
 ## Mathematical constants

--- a/src/content/reference/query-language/language-primitives/data-types/numbers.mdx
+++ b/src/content/reference/query-language/language-primitives/data-types/numbers.mdx
@@ -151,13 +151,13 @@ As a convenience, underscores are ignored when using a number. This allows input
 
 ```surql
 RELATE dr:evil->bribes->other:character SET dollars = 1_000_000.99;
---> [{ dollars: 1000000.99, id: bribes:4bfld2ukwnja24dzrpw9, in: dr:evil, out: other:character }]
+//- [{ dollars: 1000000.99, id: bribes:4bfld2ukwnja24dzrpw9, in: dr:evil, out: other:character }]
 
 -- Input Korean currency counted in units of 10000, not 1000
 RELATE korean:purchaser->buys_house_from->korean:seller
               -- 10억 4천만 5천
     SET amount = 10_4000_5000;
---> [{ amount: 1040005000, id: buys_house_from:9070t2ctgwwg202cpw1z, in: korean:purchaser, out: korean:seller }]
+//- [{ amount: 1040005000, id: buys_house_from:9070t2ctgwwg202cpw1z, in: korean:purchaser, out: korean:seller }]
 ```
 
 ## Mathematical constants

--- a/src/content/reference/query-language/language-primitives/data-types/record-ids.mdx
+++ b/src/content/reference/query-language/language-primitives/data-types/record-ids.mdx
@@ -76,16 +76,16 @@ skip-record-id-key = true
 */
 
 
-// Generate a random record ID 20 characters in length
-// Charset: `abcdefghijklmnopqrstuvwxyz0123456789`
+-- Generate a random record ID 20 characters in length
+-- Charset: `abcdefghijklmnopqrstuvwxyz0123456789`
 CREATE temperature:rand() SET time = time::now(), celsius = 37.5;
-// Identical to the above CREATE statement, because
-// :rand() is the default random ID format
+-- Identical to the above CREATE statement, because
+-- :rand() is the default random ID format
 CREATE temperature SET time = time::now(), celsius = 37.5;
 
-// Generate a ULID-based record ID
+-- Generate a ULID-based record ID
 CREATE temperature:ulid() SET time = time::now(), celsius = 37.5;
-// Generate a UUIDv7-based record ID
+-- Generate a UUIDv7-based record ID
 CREATE temperature:uuid() SET time = time::now(), celsius = 37.5;
 ```
 

--- a/src/content/reference/query-language/language-primitives/data-types/sets.mdx
+++ b/src/content/reference/query-language/language-primitives/data-types/sets.mdx
@@ -27,7 +27,10 @@ value = "{1, 2, 6}"
 */
 
 {1, 6, 6, 2};
--- {1, 2, 6}
+```
+
+```surql title="Output"
+{1, 2, 6}
 ```
 
 To create a set with zero items or a single item, add a comma.
@@ -176,8 +179,10 @@ value = "{3, 5}"
 */
 
 {1,3,5}.filter(|$val| $val > 2);
+```
 
--- {3,5}
+```surql title="Output"
+{3,5}
 ```
 
 ## Adding sets
@@ -220,8 +225,8 @@ When the field has a [`VALUE`](/docs/reference/query-language/statements/define/
 ```surql
 DEFINE FIELD OVERWRITE tags.* ON test TYPE string VALUE string::trim($value);
 
-UPDATE test:one SET tags += ' admin ';
 -- tags is still { 'admin', 'editor' }: the trimmed value already exists
+UPDATE test:one SET tags += ' admin ';
 ```
 
 > [!NOTE]

--- a/src/content/reference/query-language/language-primitives/data-types/strings.mdx
+++ b/src/content/reference/query-language/language-primitives/data-types/strings.mdx
@@ -103,7 +103,7 @@ value = "person:john"
 r"person:john";
 ```
 
-```surql title="Response"
+```surql title="Output"
 -------- Query 1 --------
 
 person:john
@@ -130,7 +130,7 @@ type::is_string("person:john");
 type::is_record("person:john");
 type::is_record(r"person:john");
 ```
-```surql title="Response"
+```surql title="Output"
 -------- Query 1 --------
 
 true
@@ -171,7 +171,7 @@ d"2025-11-28T11:41:20.262-04:00";  --- Sub-second precision included, timezone s
 d"2025-11-28T11:41:20Z";           --- Sub-second precision excluded, timezone defaulted to UTC
 d"2025-11-28T11:41:20+04:00";      --- Sub-second precision excluded, timezone specified as UTC + 4:00
 ```
-```surql title="Response"
+```surql title="Output"
 -------- Query 1 --------
 
 d'2025-11-28T11:41:20.262Z'
@@ -209,7 +209,7 @@ value = "u'8c54161f-d4fe-4a74-9409-ed1e137040c1'"
 u"8c54161f-d4fe-4a74-9409-ed1e137040c1";
 ```
 
-```surql title="Response"
+```surql title="Output"
 -------- Query 1 --------
 
 u'8c54161f-d4fe-4a74-9409-ed1e137040c1'
@@ -249,7 +249,7 @@ As a result, incorrect input with a cast will generate an error:
 <uuid>"018f0e6a_9b95-7ecc-8a38-aea7bf3627dd";
 <datetime>"2024_06-06T12:00:00Z";
 ```
-```surql title="Response"
+```surql title="Output"
 -------- Query 1 --------
 
 "Expected a uuid but cannot convert '018f0e6a-9b95-7ecc-8a38-aea7bf3627d' into a uuid"

--- a/src/content/reference/query-language/language-primitives/data-types/strings.mdx
+++ b/src/content/reference/query-language/language-primitives/data-types/strings.mdx
@@ -245,7 +245,7 @@ String prefixes seem outwardly similar to casting, but differ in behaviour. A st
 As a result, incorrect input with a cast will generate an error:
 
 ```surql
-// Change _ to - in both examples to fix the input
+-- Change _ to - in both examples to fix the input
 <uuid>"018f0e6a_9b95-7ecc-8a38-aea7bf3627dd";
 <datetime>"2024_06-06T12:00:00Z";
 ```
@@ -262,7 +262,7 @@ As a result, incorrect input with a cast will generate an error:
 But the same input using a string prefix will not even parse until the input is valid.
 
 ```surql
-// Will not parse in either case until _ is changed to -
+-- Will not parse in either case until _ is changed to -
 u"018f0e6a_9b95-7ecc-8a38-aea7bf3627dd";
 d"2024_06-06T12:00:00Z";
 ```

--- a/src/content/reference/query-language/language-primitives/formatters.mdx
+++ b/src/content/reference/query-language/language-primitives/formatters.mdx
@@ -368,7 +368,7 @@ value = "true"
 string::is_datetime("5sep2024pm012345.6789", "%d%b%Y%p%I%M%S%.f");
 ```
 
-```surql title="Response"
+```surql title="Output"
 true
 ```
 
@@ -385,7 +385,7 @@ value = "false"
 string::is_datetime("23:56:00 2015-09-05", "%Y-%m-%d %H:%M");
 ```
 
-```surql title="Response"
+```surql title="Output"
 false
 ```
 
@@ -402,6 +402,6 @@ value = "'2021-11-01'"
 time::format(d"2021-11-01T08:30:17+00:00", "%Y-%m-%d");
 ```
 
-```surql title="Response"
+```surql title="Output"
 "2021-11-01"
 ```

--- a/src/content/reference/query-language/language-primitives/idioms.mdx
+++ b/src/content/reference/query-language/language-primitives/idioms.mdx
@@ -359,7 +359,7 @@ With this done, attempting to insert a non-number value into any property of `ob
 ```surql
 CREATE test:1 SET obj.a = 'a';
 
-// Error
+-- Error
 "Couldn't coerce value for field `obj.*` of `test:1`: Expected `number` but found `'a'`"
 ```
 
@@ -981,32 +981,32 @@ Take the following example that creates one planet, two countries, two states/pr
 
 ```surql
 CREATE
-	// One planet
+	-- One planet
 	planet:earth,
-	// Two countries
+	-- Two countries
 	country:us, country:canada,
-	// Four states/provinces
+	-- Four states/provinces
 	state:california, state:texas,
 	province:ontario, province:bc,
-	// Eight cities
+	-- Eight cities
 	city:los_angeles, city:san_francisco,
 	city:houston,     city:dallas,
 	city:vancouver,   city:victoria,
 	city:toronto,     city:ottawa
-		// Give them each names like 'earth', 'us', 'bc', etc.
+		-- Give them each names like 'earth', 'us', 'bc', etc.
 	SET name = id.id();
 
-// Record and graph links from planet to country
+-- Record and graph links from planet to country
 UPDATE planet:earth     SET next = [country:us, country:canada];
 RELATE planet:earth     ->has->    [country:us, country:canada];
 
-// Record and graph links from country to state/province
+-- Record and graph links from country to state/province
 UPDATE country:us       SET next = [state:california, state:texas];
 UPDATE country:canada   SET next = [province:ontario, province:bc];
 RELATE country:us       ->has->    [state:california, state:texas];
 RELATE country:canada   ->has->    [province:bc, province:ontario];
 
-// Record and graph links from state/province to city
+-- Record and graph links from state/province to city
 UPDATE state:california SET next = [city:los_angeles, city:san_francisco];
 UPDATE state:texas      SET next = [city:houston, city:dallas];
 UPDATE province:ontario SET next = [city:toronto, city:ottawa];
@@ -1136,9 +1136,9 @@ The number of steps can be any integer from 1 to 256.
 
 ```surql
 planet:earth.{0}->has->(?);
---> 'Found 0 for bound but expected at least 1.'
+//- 'Found 0 for bound but expected at least 1.'
 planet:earth.{500}->has->(?);
---> 'Found 500 for bound but expected 256 at most.'
+//- 'Found 500 for bound but expected 256 at most.'
 ```
 
 A range can be inserted into the braces to indicate a desired minimum and maximum depth.
@@ -1424,15 +1424,15 @@ FOR $person IN SELECT * FROM person {
 };
 
 LET $third_degree = person:1.{..3}.{ id, connections: ->friends_with->person.@ };
-// Object containing array of arrays of arrays of 'person'
+-- Object containing array of arrays of arrays of 'person'
 RETURN $third_degree;
-// All connections: an array of arrays of arrays of 'person'
+-- All connections: an array of arrays of arrays of 'person'
 RETURN $third_degree.connections;
-// Secondary connections: an array of arrays of 'person'
+-- Secondary connections: an array of arrays of 'person'
 RETURN $third_degree.{2}.connections;
-// Tertiary connections: an array of 'person'
+-- Tertiary connections: an array of 'person'
 RETURN $third_degree.{3}.connections;
-// Tertiary connections with aliased fields and original 'person' info
+-- Tertiary connections with aliased fields and original 'person' info
 RETURN $third_degree.{
 		original_person: id, 
 		third_degree_friends: connections.{2}.connections

--- a/src/content/reference/query-language/language-primitives/idioms.mdx
+++ b/src/content/reference/query-language/language-primitives/idioms.mdx
@@ -52,7 +52,7 @@ CREATE person CONTENT {
 };
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
 	{
 		address: {
@@ -72,7 +72,7 @@ To access the `city` field within the `address` object, you can use the followin
 SELECT address.city FROM person;
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
   {
     "address": {
@@ -105,7 +105,7 @@ CREATE student SET results = [
 ];
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
 	{
 		id: student:urxaykt4qkbr8rs2o68j,
@@ -142,7 +142,7 @@ To access the first student in the `results` array, you can use the following id
 SELECT results[0].score FROM student;
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
   {
     results: [
@@ -164,7 +164,7 @@ To access all elements in an array or all fields in an object, use `.*`. This is
 SELECT results.* FROM student;
 ```
 
-```surql title="Response"
+```surql title="Output"
 {
 	results: [
 		{
@@ -299,7 +299,7 @@ value = "{ a: 1, b: 2 }"
 <Tabs>
 <TabItem label="SurrealDB 3.x">
 
-```surql title="Response"
+```surql title="Output"
 { a: 1, b: 2 }
 ```
 
@@ -307,7 +307,7 @@ value = "{ a: 1, b: 2 }"
 
 <TabItem label="SurrealDB 2.x">
 
-```surql title="Response"
+```surql title="Output"
 [1, 2]
 ```
 
@@ -327,8 +327,10 @@ value = "[1, 2]"
 */
 
 { a: 1, b: 2 }.values();
+```
 
--- [1, 2]
+```surql title="Output"
+[1, 2]
 ```
 
 #### Defining fields with `.*`
@@ -427,7 +429,7 @@ Referring to the `student` record above, the following idiom returns the score o
 SELECT results[$].score FROM student;
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
 	{
 		results: {
@@ -470,7 +472,7 @@ CREATE person CONTENT {
 SELECT *, name.uppercase() FROM person;
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
   {
     "person": {
@@ -554,7 +556,7 @@ SELECT
 FROM explorer:drake;
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
 	{
 		actions: [
@@ -600,7 +602,7 @@ value = "[{ age: 21, id: person:1, name: 'John', obj: { a: 1, b: 2, c: { d: 3, e
 CREATE person:1 SET name = 'John', age = 21, obj = { a: 1, b: 2, c: { d: 3, e: 4, f: 5 } };
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
 	{
 		age: 21,
@@ -623,7 +625,7 @@ CREATE person:1 SET name = 'John', age = 21, obj = { a: 1, b: 2, c: { d: 3, e: 4
 SELECT obj.{ a, c.{ e, f } } FROM ONLY person:1;
 ```
 
-```surql title="Response"
+```surql title="Output"
 {
 	obj: {
 		a: 1,
@@ -641,7 +643,7 @@ You can also OMIT fields that you don't want to destructure using the `OMIT` cla
 SELECT * OMIT obj.c.{ d, f } FROM ONLY person:1;
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
 	{
 		age: 21,
@@ -665,7 +667,7 @@ SELECT ->visited->city.{name, id}
 FROM explorer:drake;
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
 	{
 		"->visited": {
@@ -1027,7 +1029,7 @@ SELECT
 FROM planet:earth;
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
 	{
 		cities: [
@@ -1133,10 +1135,10 @@ planet:earth.{2}->has->(?);
 The number of steps can be any integer from 1 to 256.
 
 ```surql
--- 'Found 0 for bound but expected at least 1.'
 planet:earth.{0}->has->(?);
--- 'Found 500 for bound but expected 256 at most.'
+--> 'Found 0 for bound but expected at least 1.'
 planet:earth.{500}->has->(?);
+--> 'Found 500 for bound but expected 256 at most.'
 ```
 
 A range can be inserted into the braces to indicate a desired minimum and maximum depth.
@@ -1829,7 +1831,7 @@ CREATE person:5 CONTENT {
 };
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
 	{
 		friends: [
@@ -1861,7 +1863,7 @@ To get the names of friends who are over 18:
 SELECT friends[WHERE age > 18].name FROM person WHERE id = person:5;
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
 	{
 		friends: {

--- a/src/content/reference/query-language/language-primitives/operators.mdx
+++ b/src/content/reference/query-language/language-primitives/operators.mdx
@@ -517,8 +517,10 @@ value = "30"
 */
 
 SELECT * FROM 10 AND 20 AND 30;
+```
 
--- 30
+```surql title="Output"
+30
 ```
 
 <br />
@@ -535,8 +537,10 @@ value = "[10]"
 */
 
 SELECT * FROM 0 OR false OR 10;
+```
 
--- 10
+```surql title="Output"
+10
 ```
 
 <br />
@@ -556,10 +560,10 @@ value = "[false]"
 */
 
 SELECT * FROM !(TRUE OR FALSE);
--- false
+--> false
 
 SELECT * FROM !"Has a value";
--- false
+--> false
 ```
 
 <br />
@@ -576,7 +580,10 @@ value = "[true]"
 */
 
 SELECT * FROM !!"Has a value";
--- true
+```
+
+```surql title="Output"
+true
 ```
 
 ## `??`
@@ -591,8 +598,10 @@ value = "[0]"
 */
 
 SELECT * FROM NULL ?? 0 ?? false ?? 10;
+```
 
--- 0
+```surql title="Output"
+0
 ```
 
 <br />
@@ -609,8 +618,10 @@ value = "[10]"
 */
 
 SELECT * FROM NULL ?: 0 ?: false ?: 10;
+```
 
--- 10
+```surql title="Output"
+10
 ```
 
 <br />
@@ -627,7 +638,10 @@ value = "[false]"
 */
 
 SELECT * FROM true = "true";
--- false
+```
+
+```surql title="Output"
+false
 ```
 
 ```surql
@@ -639,7 +653,10 @@ value = "[false]"
 */
 
 SELECT * FROM 10 = "10";
--- false
+```
+
+```surql title="Output"
+false
 ```
 
 ```surql
@@ -651,7 +668,10 @@ value = "[true]"
 */
 
 SELECT * FROM 10 = 10.00;
--- true
+```
+
+```surql title="Output"
+true
 ```
 ```surql
 /**[test]
@@ -662,7 +682,10 @@ value = "[false]"
 */
 
 SELECT * FROM 10 = "10.3";
--- false
+```
+
+```surql title="Output"
+false
 ```
 
 ```surql
@@ -674,7 +697,10 @@ value = "[true]"
 */
 
 SELECT * FROM [1, 2, 3] = [1, 2, 3];
--- true
+```
+
+```surql title="Output"
+true
 ```
 
 ```surql
@@ -686,7 +712,10 @@ value = "[false]"
 */
 
 SELECT * FROM [1, 2, 3] = [1, 2, 3, 4];
--- false
+```
+
+```surql title="Output"
+false
 ```
 
 ```surql
@@ -698,7 +727,10 @@ value = "[true]"
 */
 
 SELECT * FROM { this: "object" } = { this: "object" };
--- true
+```
+
+```surql title="Output"
+true
 ```
 
 ```surql
@@ -710,7 +742,10 @@ value = "[false]"
 */
 
 SELECT * FROM { this: "object" } = { another: "object" };
--- false
+```
+
+```surql title="Output"
+false
 ```
 
 <br />
@@ -727,7 +762,10 @@ value = "[true]"
 */
 
 SELECT * FROM 10 != "15";
--- true
+```
+
+```surql title="Output"
+true
 ```
 
 ```surql
@@ -739,7 +777,10 @@ value = "[true]"
 */
 
 SELECT * FROM 10 != "test";
--- true
+```
+
+```surql title="Output"
+true
 ```
 
 ```surql
@@ -751,7 +792,10 @@ value = "[true]"
 */
 
 SELECT * FROM [1, 2, 3] != [3, 4, 5];
--- true
+```
+
+```surql title="Output"
+true
 ```
 
 <br />
@@ -768,7 +812,10 @@ value = "[true]"
 */
 
 SELECT * FROM 10 == 10;
--- true
+```
+
+```surql title="Output"
+true
 ```
 
 ```surql
@@ -780,7 +827,10 @@ value = "[false]"
 */
 
 SELECT * FROM 10 == "10";
--- false
+```
+
+```surql title="Output"
+false
 ```
 
 ```surql
@@ -792,7 +842,10 @@ value = "[false]"
 */
 
 SELECT * FROM true == "true";
--- false
+```
+
+```surql title="Output"
+false
 ```
 
 <br />
@@ -809,7 +862,10 @@ value = "[true]"
 */
 
 SELECT * FROM [10, 15, 20] ?= 10;
--- true
+```
+
+```surql title="Output"
+true
 ```
 
 <br />
@@ -826,7 +882,10 @@ value = ""
 */
 
 SELECT * FROM [10, 10, 10] *= 10;
--- true
+```
+
+```surql title="Output"
+true
 ```
 
 <br />
@@ -850,7 +909,10 @@ value = "true"
 let $threshold = 10;
 
 string::similarity::smithwaterman("test text", "Test") > $threshold;
--- true
+```
+
+```surql title="Output"
+true
 ```
 
 <br />
@@ -867,7 +929,10 @@ value = "[true]"
 */
 
 SELECT * FROM 10 < 15;
--- true
+```
+
+```surql title="Output"
+true
 ```
 
 <br />
@@ -884,7 +949,10 @@ value = "[true]"
 */
 
 SELECT * FROM 10 <= 15;
--- true
+```
+
+```surql title="Output"
+true
 ```
 
 <br />
@@ -901,7 +969,10 @@ value = "[true]"
 */
 
 SELECT * FROM 15 > 10;
--- true
+```
+
+```surql title="Output"
+true
 ```
 
 <br />
@@ -918,7 +989,10 @@ value = "[true]"
 */
 
 SELECT * FROM 15 >= 10;
--- true
+```
+
+```surql title="Output"
+true
 ```
 
 <br />
@@ -935,7 +1009,10 @@ value = "[20]"
 */
 
 SELECT * FROM 10 + 10;
--- 20
+```
+
+```surql title="Output"
+20
 ```
 
 ```surql
@@ -947,7 +1024,10 @@ value = "['test this']"
 */
 
 SELECT * FROM "test" + " " + "this";
--- "test this"
+```
+
+```surql title="Output"
+"test this"
 ```
 
 ```surql
@@ -959,7 +1039,10 @@ value = "[13h30m]"
 */
 
 SELECT * FROM 13h + 30m;
--- "13h30m"
+```
+
+```surql title="Output"
+"13h30m"
 ```
 
 <br />
@@ -976,7 +1059,10 @@ value = "[10]"
 */
 
 SELECT * FROM 20 - 10;
--- 10
+```
+
+```surql title="Output"
+10
 ```
 
 ```surql
@@ -988,7 +1074,10 @@ value = "[1m]""
 */
 
 SELECT * FROM 2m - 1m;
--- 1m
+```
+
+```surql title="Output"
+1m
 ```
 
 <br />
@@ -1005,7 +1094,10 @@ value = "[40]"
 */
 
 SELECT * FROM 20 * 2;
--- 40
+```
+
+```surql title="Output"
+40
 ```
 
 <br />
@@ -1022,7 +1114,10 @@ value = "[10]"
 */
 
 SELECT * FROM 20 / 2;
--- 10
+```
+
+```surql title="Output"
+10
 ```
 
 <br />
@@ -1039,7 +1134,10 @@ value = "[8000]"
 */
 
 SELECT * FROM 20 ** 3;
--- 8000
+```
+
+```surql title="Output"
+8000
 ```
 
 <br />
@@ -1056,7 +1154,10 @@ value = "[true]"
 */
 
 SELECT * FROM [10, 20, 30] CONTAINS 10;
--- true
+```
+
+```surql title="Output"
+true
 ```
 
 ```surql
@@ -1068,7 +1169,10 @@ value = "[true]"
 */
 
 SELECT * FROM "this is some text" CONTAINS "text";
--- true
+```
+
+```surql title="Output"
+true
 ```
 
 ```surql
@@ -1087,8 +1191,10 @@ SELECT * FROM {
 		[-0.38314819, 51.37692386]
 	]]
 } CONTAINS (-0.118092, 51.509865);
+```
 
--- true
+```surql title="Output"
+true
 ```
 
 <br />
@@ -1105,7 +1211,10 @@ value = "[true]"
 */
 
 SELECT * FROM [10, 20, 30] CONTAINSNOT 15;
--- true
+```
+
+```surql title="Output"
+true
 ```
 
 ```surql
@@ -1117,7 +1226,10 @@ value = "[true]"
 */
 
 SELECT * FROM "this is some text" CONTAINSNOT "other";
--- true
+```
+
+```surql title="Output"
+true
 ```
 
 ```surql
@@ -1136,8 +1248,10 @@ SELECT * FROM {
 		[-0.38314819, 51.37692386]
 	]]
 } CONTAINSNOT (-0.518092, 53.509865);
+```
 
--- true
+```surql title="Output"
+true
 ```
 
 <br />
@@ -1154,7 +1268,10 @@ value = "[true]"
 */
 
 SELECT * FROM [10, 20, 30] CONTAINSALL [10, 20, 10];
--- true
+```
+
+```surql title="Output"
+true
 ```
 
 <br />
@@ -1171,7 +1288,10 @@ value = "[true]"
 */
 
 SELECT * FROM [10, 20, 30] CONTAINSANY [10, 15, 25];
--- true
+```
+
+```surql title="Output"
+true
 ```
 
 <br />
@@ -1188,7 +1308,10 @@ value = "[true]"
 */
 
 SELECT * FROM [10, 20, 30] CONTAINSNONE [15, 25, 35];
--- true
+```
+
+```surql title="Output"
+true
 ```
 
 <br />
@@ -1205,7 +1328,10 @@ value = "[true]"
 */
 
 SELECT * FROM 10 INSIDE [10, 20, 30];
--- true
+```
+
+```surql title="Output"
+true
 ```
 
 ```surql
@@ -1217,7 +1343,10 @@ value = "[true]"
 */
 
 SELECT * FROM "text" INSIDE "this is some text";
--- true
+```
+
+```surql title="Output"
+true
 ```
 
 ```surql
@@ -1254,8 +1383,10 @@ value = "[true]"
     name: "Riga",
     country: "Latvia"
 };
+```
 
--- true
+```surql title="Output"
+true
 ```
 
 `IN` can also be used with a record ID as long as the ID is expanded to include the fields. Both of the following queries will return `true`.
@@ -1294,7 +1425,10 @@ value = "[true]"
 */
 
 SELECT * FROM 15 NOTINSIDE [10, 20, 30];
--- true
+```
+
+```surql title="Output"
+true
 ```
 
 ```surql
@@ -1306,7 +1440,10 @@ value = "[true]"
 */
 
 SELECT * FROM "other" NOTINSIDE "this is some text";
--- true
+```
+
+```surql title="Output"
+true
 ```
 
 ```surql
@@ -1325,8 +1462,10 @@ SELECT * FROM (-0.518092, 53.509865) NOTINSIDE {
 		[-0.38314819, 51.37692386]
 	]]
 };
+```
 
--- true
+```surql title="Output"
+true
 ```
 
 <br />
@@ -1343,7 +1482,10 @@ value = "[true]"
 */
 
 SELECT * FROM [10, 20, 10] ALLINSIDE [10, 20, 30];
--- true
+```
+
+```surql title="Output"
+true
 ```
 
 <br />
@@ -1360,7 +1502,10 @@ value = "[true]"
 */
 
 SELECT * FROM [10, 15, 25] ANYINSIDE [10, 20, 30];
--- true
+```
+
+```surql title="Output"
+true
 ```
 
 <br />
@@ -1377,7 +1522,10 @@ value = "[true]"
 */
 
 SELECT * FROM [15, 25, 35] NONEINSIDE [10, 20, 30];
--- true
+```
+
+```surql title="Output"
+true
 ```
 
 <br />
@@ -1401,8 +1549,10 @@ SELECT * FROM (-0.518092, 53.509865) OUTSIDE {
 		[-0.38314819, 51.37692386]
 	]]
 };
+```
 
--- true
+```surql title="Output"
+true
 ```
 
 <br />
@@ -1433,8 +1583,10 @@ SELECT * FROM {
 		[-0.11123657, 51.53160074]
 	]]
 };
+```
 
--- true
+```surql title="Output"
+true
 ```
 
 <br />

--- a/src/content/reference/query-language/language-primitives/operators.mdx
+++ b/src/content/reference/query-language/language-primitives/operators.mdx
@@ -560,10 +560,10 @@ value = "[false]"
 */
 
 SELECT * FROM !(TRUE OR FALSE);
---> false
+//- false
 
 SELECT * FROM !"Has a value";
---> false
+//- false
 ```
 
 <br />

--- a/src/content/reference/query-language/language-primitives/parameters.mdx
+++ b/src/content/reference/query-language/language-primitives/parameters.mdx
@@ -34,7 +34,7 @@ CREATE person SET name = "Tobie " + $suffix;
 CREATE person SET name = string::join(" ", "Jaime", $suffix);
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
     {
         "id": "person:3vs17lb9eso9m7gd8mml",
@@ -61,7 +61,7 @@ $founders.{
 };
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
 	{
 		company: 'SurrealDB',
@@ -199,9 +199,9 @@ LET $nums = [
     RETURN $nums;
 };
 
--- Returns original unflattened $nums:
--- [[1,2], [3,4]]
+-- Returns the original unflattened $nums
 RETURN $nums;
+--> [[1,2], [3,4]]
 ```
 
 Even a parameter defined using a [`DEFINE PARAM`](/docs/reference/query-language/statements/define/param) statement can be shadowed.
@@ -350,7 +350,7 @@ UPDATE cat SET nicknames += "Snuggles"
   WHERE name = "Mr. Meow" RETURN $before, $after;
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
     {
         "after": {
@@ -475,7 +475,7 @@ SELECT name,
     WHERE name = "User1";
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
     {
         "group_members": [
@@ -511,7 +511,7 @@ SELECT
     FROM person;
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
     {
         "id": "person:hwffcckiv61ylwiw43yf",
@@ -577,7 +577,7 @@ CREATE user SET
     on_database = $session.db;
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
     {
         "id": "user:wa3ajflozlqoyurc4i4v",

--- a/src/content/reference/query-language/language-primitives/parameters.mdx
+++ b/src/content/reference/query-language/language-primitives/parameters.mdx
@@ -162,7 +162,7 @@ RETURN $my_name;
 ```surql title="Output"
 'There was a problem with the database: Parse error: Variable
   declaration without `let` is deprecated
- --> [4:1]
+ //- [4:1]
   |
 4 | $my_name = "Sypha";
   | ^^^^^^^^^^^^^^^^^^^ replace with `let $my_name = ..`
@@ -201,7 +201,7 @@ LET $nums = [
 
 -- Returns the original unflattened $nums
 RETURN $nums;
---> [[1,2], [3,4]]
+//- [[1,2], [3,4]]
 ```
 
 Even a parameter defined using a [`DEFINE PARAM`](/docs/reference/query-language/statements/define/param) statement can be shadowed.
@@ -680,7 +680,7 @@ value = "NONE"
 
 FOR $table IN ["test_user", "test_client"] {
     DEFINE TABLE $table;
-    // Do some tests
+    -- Do some tests
     REMOVE TABLE $table;
 };
 ```
@@ -711,8 +711,8 @@ FOR $field IN (INFO FOR TABLE test).fields.keys() {
 
 ```surql
 DEFINE FUNCTION fn::get_timeout() -> duration {
-    // Do some HTTP call to get status
-    // Simulate the output with rand::enum() function
+    -- Do some HTTP call to get status
+    -- Simulate the output with rand::enum() function
     rand::enum(100ms, 1s, 5s)
 };
 

--- a/src/content/reference/query-language/language-primitives/record-links.mdx
+++ b/src/content/reference/query-language/language-primitives/record-links.mdx
@@ -21,8 +21,10 @@ skip-record-id-key = true
 */
 
 CREATE person SET name = 'Tobie';
+```
 
--- person:aio58g22n3upq16hsani
+```surql title="Output"
+person:aio58g22n3upq16hsani
 ```
 
 It's also possible to specify a specific record id when creating or updating records.
@@ -36,8 +38,10 @@ value = "[{ id: person:tester, name: 'Tobie' }]"
 */
 
 CREATE person:tester SET name = 'Tobie';
+```
 
--- person:tester
+```surql title="Output"
+person:tester
 ```
 
 ## Select directly off of record IDs

--- a/src/content/reference/query-language/statements/access.mdx
+++ b/src/content/reference/query-language/statements/access.mdx
@@ -62,7 +62,7 @@ DEFINE ACCESS api
 ACCESS api GRANT FOR USER automation;
 ```
 
-```surql title="Response"
+```surql title="Output"
 -- Query 1
 NONE
 -- Query 2
@@ -98,7 +98,7 @@ DEFINE ACCESS api
 ACCESS api GRANT FOR RECORD user:1;
 ```
 
-```surql title="Response"
+```surql title="Output"
 -- Query 1
 [
         {
@@ -150,7 +150,7 @@ DEFINE ACCESS api
 ACCESS api GRANT FOR RECORD user:1;
 ```
 
-```surql title="Response"
+```surql title="Output"
 -- Query 1
 [
         {
@@ -184,7 +184,7 @@ NONE
 ACCESS api SHOW GRANT JdvDFKMCVYoM;
 ```
 
-```surql title="Response"
+```surql title="Output"
 {
         ac: 'api',
         creation: d'2024-12-16T16:17:24.903832476Z',
@@ -218,7 +218,7 @@ ACCESS api GRANT FOR RECORD user:1;
 ACCESS api GRANT FOR RECORD user:2;
 ```
 
-```surql title="Response"
+```surql title="Output"
 -- Query 1
 [
         {
@@ -276,7 +276,7 @@ NONE
 ACCESS api SHOW WHERE subject.record.name = "tobie";
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
         {
                 ac: 'api',
@@ -318,7 +318,7 @@ DEFINE ACCESS api
 ACCESS api GRANT FOR RECORD user:1;
 ```
 
-```surql title="Response"
+```surql title="Output"
 -- Query 1
 [
         {
@@ -352,7 +352,7 @@ NONE
 ACCESS api REVOKE GRANT NJ2I2d7OXxN9;
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
         [
                 {
@@ -390,7 +390,7 @@ ACCESS api GRANT FOR RECORD user:1;
 ACCESS api GRANT FOR RECORD user:2;
 ```
 
-```surql title="Response"
+```surql title="Output"
 -- Query 1
 [
         {
@@ -448,7 +448,7 @@ NONE
 ACCESS api REVOKE WHERE subject.record.name = "tobie";
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
         [
                 {

--- a/src/content/reference/query-language/statements/alter/database.mdx
+++ b/src/content/reference/query-language/statements/alter/database.mdx
@@ -42,7 +42,10 @@ A successful compaction will return `NONE`.
 
 ```surql
 ALTER DATABASE COMPACT;
--- NONE
+```
+
+```surql title="Output"
+NONE
 ```
 
 ## See also

--- a/src/content/reference/query-language/statements/alter/namespace.mdx
+++ b/src/content/reference/query-language/statements/alter/namespace.mdx
@@ -44,7 +44,10 @@ A successful compaction will return `NONE`.
 
 ```surql
 ALTER NAMESPACE COMPACT;
--- NONE
+```
+
+```surql title="Output"
+NONE
 ```
 
 ## See also

--- a/src/content/reference/query-language/statements/alter/system.mdx
+++ b/src/content/reference/query-language/statements/alter/system.mdx
@@ -55,8 +55,10 @@ FOR $_ IN 0..1000 {
         CREATE |person:1000|;
     }
 };
+```
 
--- 'The query was not executed because it exceeded the timeout: 1ms'
+```surql title="Output"
+'The query was not executed because it exceeded the timeout: 1ms'
 ```
 
 ## COMPACT clause
@@ -75,5 +77,8 @@ A successful compaction will return `NONE`.
 
 ```surql
 ALTER SYSTEM COMPACT;
--- NONE
+```
+
+```surql title="Output"
+NONE
 ```

--- a/src/content/reference/query-language/statements/alter/table.mdx
+++ b/src/content/reference/query-language/statements/alter/table.mdx
@@ -57,7 +57,10 @@ A successful compaction will return `NONE`.
 
 ```surql
 ALTER TABLE user COMPACT;
--- NONE
+```
+
+```surql title="Output"
+NONE
 ```
 
 ## See also

--- a/src/content/reference/query-language/statements/create.mdx
+++ b/src/content/reference/query-language/statements/create.mdx
@@ -52,7 +52,7 @@ skip-record-id-key = true
 CREATE person;
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
     {
         "id": "person:2vvgzt6m24s952yiy7x8"
@@ -73,7 +73,7 @@ value = "[{ id: person:one }]"
 CREATE person:one;
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
 	{
 		id: person:one
@@ -133,7 +133,7 @@ CREATE person:tobie SET
 
 The above will create a new record with the ID `person:tobie` and the specified data.
 
-```surql title="Response"
+```surql title="Output"
 [
 	{
 		"id": "person:tobie",
@@ -174,7 +174,7 @@ UPDATE townsperson, cat, dog SET
     name = "Just a " + record::tb(id);
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
     {
         "created_at": "2024-03-19T03:12:05.079Z",
@@ -211,7 +211,7 @@ skip-record-id-key = true
 CREATE |townsperson:3|;
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
 	{
 		id: townsperson:hzkt0piy3f72xo5dl2jf
@@ -233,7 +233,7 @@ The other method is by using the `..` range syntax after the `:` instead of a si
 CREATE |townsperson:1..4|;
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
 	{
 		id: townsperson:1
@@ -255,7 +255,7 @@ CREATE dog, |cat:2|, |townsperson:1..3| SET
     name = "Just a " + record::tb(id);
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
 	{
 		created_at: '2024-08-13T04:14:44.135Z',
@@ -308,7 +308,7 @@ CREATE ONLY person:tobie SET
     skills = ['Rust', 'Go', 'JavaScript'];
 ```
 
-```surql title="Response"
+```surql title="Output"
 -------- Query --------
 
 [
@@ -362,7 +362,7 @@ value = "[[{ op: 'replace', path: '', value: { age: 46, id: person:2wm77z4dn1wjh
 CREATE person SET age = 46, username = "john-smith" RETURN DIFF;
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
 	[
 		{
@@ -432,7 +432,7 @@ CREATE |person:5|
 RETURN VALUE age;
 ```
 
-```surql title="Response"
+```surql title="Output"
 -------- Query --------
 
 [
@@ -482,7 +482,7 @@ INFO FOR DB;
 RETURN $session;
 ```
 
-```surql title="Response"
+```surql title="Output"
 -------- Query --------
 
 {
@@ -571,7 +571,7 @@ INFO FOR NS;
 INFO FOR DB;
 ```
 
-```surql title="Response"
+```surql title="Output"
 -------- Query --------
 
 {

--- a/src/content/reference/query-language/statements/define/access/bearer.mdx
+++ b/src/content/reference/query-language/statements/define/access/bearer.mdx
@@ -51,7 +51,7 @@ DEFINE ACCESS api ON DATABASE TYPE BEARER FOR USER DURATION FOR GRANT 10d;
 ACCESS api GRANT FOR USER automation;
 ```
 
-```surql title="Response"
+```surql title="Output"
 {
 	ac: 'api',
 	creation: d'2025-10-07T04:52:36.157Z',
@@ -118,7 +118,7 @@ DEFINE ACCESS api ON DATABASE TYPE BEARER FOR RECORD DURATION FOR GRANT 10d;
 ACCESS api GRANT FOR RECORD user:1;
 ```
 
-```surql title="Response"
+```surql title="Output"
 -- Query 1
 [
         {

--- a/src/content/reference/query-language/statements/define/access/record.mdx
+++ b/src/content/reference/query-language/statements/define/access/record.mdx
@@ -255,7 +255,7 @@ curl -X POST \
 	http://localhost:8000/signup
 ```
 
-```json title="Response"
+```json title="Output"
 {
 	"code":200,
 	"details":"Authentication succeeded",
@@ -273,7 +273,7 @@ curl -X POST \
 	http://localhost:8000/signin
 ```
 
-```json title="Response"
+```json title="Output"
 {
 	"code":200,
 	"details":"Authentication succeeded",

--- a/src/content/reference/query-language/statements/define/api.mdx
+++ b/src/content/reference/query-language/statements/define/api.mdx
@@ -130,7 +130,7 @@ Each HTTP method may appear in at most one `FOR` clause on a `DEFINE API` statem
 DEFINE API "/foo"
   FOR get THEN $x
   FOR get THEN $y;
---> Error: duplicate `get` across FOR clauses
+//- Error: duplicate `get` across FOR clauses
 ```
 
 ## API paths

--- a/src/content/reference/query-language/statements/define/api.mdx
+++ b/src/content/reference/query-language/statements/define/api.mdx
@@ -127,10 +127,10 @@ api::invoke("/test", {
 Each HTTP method may appear in at most one `FOR` clause on a `DEFINE API` statement. Overlapping methods - including duplicates inside a comma-separated list - are rejected at define time with a clear error instead of silently routing to only the first matching action.
 
 ```surql
--- Error: duplicate `get` across FOR clauses
 DEFINE API "/foo"
   FOR get THEN $x
   FOR get THEN $y;
+--> Error: duplicate `get` across FOR clauses
 ```
 
 ## API paths

--- a/src/content/reference/query-language/statements/define/bucket.mdx
+++ b/src/content/reference/query-language/statements/define/bucket.mdx
@@ -127,7 +127,7 @@ DEFINE BUCKET my_bucket BACKEND "memory";
 INFO FOR DB;
 ```
 
-```surql title="Response"
+```surql title="Output"
 {
   accesses: {},
   analyzers: {},

--- a/src/content/reference/query-language/statements/define/config.mdx
+++ b/src/content/reference/query-language/statements/define/config.mdx
@@ -399,7 +399,7 @@ DEFINE CONFIG GRAPHQL FUNCTIONS EXCLUDE [debugFunction, testFunction];
 
 If you attempt to access the GraphQL endpoint without defining the GraphQL configuration, you will receive a `NotConfigured` error.
 
-```surql title="Error Response"
+```surql title="Error output"
 {
   "error": "NotConfigured: GraphQL endpoint is not configured. Please
     define the GraphQL configuration using DEFINE CONFIG GRAPHQL."
@@ -417,7 +417,7 @@ DEFINE CONFIG GRAPHQL TABLES AUTO FUNCTIONS AUTO;
 
 If you have defined the GraphQL configuration but no tables are defined in the database, you will receive an error stating "No tables found in database" when attempting to use the GraphQL API. You can fix this by defining at least one table in your database using the [`DEFINE TABLE`](/docs/reference/query-language/statements/define/table) statement.
 
-```surql title="Error Response"
+```surql title="Error output"
 {
   "error": "No tables found in database. Please define at least one
     table to use the GraphQL API."

--- a/src/content/reference/query-language/statements/define/event.mdx
+++ b/src/content/reference/query-language/statements/define/event.mdx
@@ -93,9 +93,9 @@ DEFINE EVENT OVERWRITE test
   ON TABLE user WHEN $before.email != $after.email THEN (
     CREATE log SET 
         user       = $value.id,
-        // Turn events like "CREATE" into string "email created"
+        -- Turn events like "CREATE" into string "email created"
         action     = 'email' + ' ' + $event.lowercase() + 'd',
-        // `email` field may be NONE, log as '' if so
+        -- `email` field may be NONE, log as '' if so
         old_email  = $before.email ?? '',
         new_email  = $after.email  ?? '',
         at         = time::now()

--- a/src/content/reference/query-language/statements/define/field.mdx
+++ b/src/content/reference/query-language/statements/define/field.mdx
@@ -133,11 +133,11 @@ DEFINE FIELD `nómine`.prim ON user TYPE string;
 DEFINE FIELD `nómine.prim` ON user TYPE string;
 
 CREATE user:one SET 
-	// Nested field
+	-- Nested field
     name.first = "Billy",
-	// Also nested
+	-- Also nested
     `nómine`.prim = "Billy",
-	// Not nested
+	-- Not nested
     `nómine.prim` = "Billy";
 ```
 
@@ -1037,7 +1037,7 @@ DEFINE FIELD last_name
 DEFINE FIELD name      
   ON TABLE person             VALUE first_name + ' ' + last_name;
 
-// Creates a `person` with the name "bob bobson"
+-- Creates a `person` with the name "bob bobson"
 CREATE person SET first_name = "BOB", last_name = "BOBSON";
 ```
 
@@ -1109,7 +1109,7 @@ DEFINE FIELD last_name
 DEFINE FIELD full_name 
   ON TABLE person             VALUE first_name + ' ' + last_name;
 
-// Creates a `person` with `full_name` of "bob BOBSON", not "bob bobson"
+-- Creates a `person` with `full_name` of "bob BOBSON", not "bob bobson"
 CREATE person SET first_name = "Bob", last_name = "BOBSON";
 ```
 

--- a/src/content/reference/query-language/statements/define/field.mdx
+++ b/src/content/reference/query-language/statements/define/field.mdx
@@ -375,7 +375,7 @@ As of version 3.0, the statement now returns an error upon finding the first fie
 
 With `FLEXIBLE`, the field accepts any extra keys on `metadata` while still requiring `name` and a valid `metadata.user_id`.
 
-```surql title="Response"
+```surql title="Output"
 {
 	id: user:lsdk473e279oik1k484b,
 	metadata: {
@@ -503,7 +503,7 @@ UPSERT post:test SET tags += { name: 'test' };
 UPSERT post:test SET tags += { name: 'test', color: 'blue' };
 ```
 
-```surql title="Response"
+```surql title="Output"
 [{ id: post:test, tags: [] }]
 
 [{ id: post:test, tags: [{ color: 'red', name: 'test' }] }]
@@ -865,7 +865,7 @@ DEFINE FIELD some_info ON TABLE some_table TYPE string;
 INFO FOR TABLE some_table;
 ```
 
-```surql title="Response"
+```surql title="Output"
 {
 	events: {},
 	fields: {
@@ -1139,7 +1139,7 @@ CREATE order:good SET coffee = { special_order: "Venti Quadruple Ristretto Half-
 CREATE order:bad SET coffee = "small";
 ```
 
-```surql title="Response"
+```surql title="Output"
 -------- Query --------
 
 [

--- a/src/content/reference/query-language/statements/define/function.mdx
+++ b/src/content/reference/query-language/statements/define/function.mdx
@@ -97,10 +97,10 @@ DEFINE FUNCTION fn::last_option($required: number, $optional: option<number>) {
 };
 
 RETURN fn::last_option(1, 2);
--- { required_present: true, optional_present: true }
+--> { required_present: true, optional_present: true }
 
 RETURN fn::last_option(1);
--- { required_present: true, optional_present: false };
+--> { required_present: true, optional_present: false };
 ```
 
 ## Adding a return value

--- a/src/content/reference/query-language/statements/define/function.mdx
+++ b/src/content/reference/query-language/statements/define/function.mdx
@@ -97,10 +97,10 @@ DEFINE FUNCTION fn::last_option($required: number, $optional: option<number>) {
 };
 
 RETURN fn::last_option(1, 2);
---> { required_present: true, optional_present: true }
+//- { required_present: true, optional_present: true }
 
 RETURN fn::last_option(1);
---> { required_present: true, optional_present: false };
+//- { required_present: true, optional_present: false };
 ```
 
 ## Adding a return value
@@ -142,12 +142,12 @@ error = "Couldn't coerce return value from function `fn::combine_any`: Expected 
 
 */
 
-// Arguments must be of type 'number'
+-- Arguments must be of type 'number'
 DEFINE FUNCTION fn::combine($one: number, $two: number) -> number {
   $one + $two
 };
 
-// Accepts any value but expects the return type 'number'
+-- Accepts any value but expects the return type 'number'
 DEFINE FUNCTION fn::combine_any($one: any, $two: any) -> number {
   $one + $two
 };

--- a/src/content/reference/query-language/statements/define/indexes.mdx
+++ b/src/content/reference/query-language/statements/define/indexes.mdx
@@ -111,7 +111,7 @@ As we defined a `UNIQUE` index on the `email` column, a duplicate entry for that
 CREATE user:1 SET email = 'test@surrealdb.com';
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
     {
         "email": "test@surrealdb.com",
@@ -127,7 +127,7 @@ Creating another record with the same email ID will throw an error.
 CREATE user:2 SET email = 'test@surrealdb.com';
 ```
 
-```surql title="Response"
+```surql title="Output"
 Database index `userEmailIndex` already contains 'test@surrealdb.com',
 with record `user:1`
 ```
@@ -600,7 +600,7 @@ When building an index concurrently, SurrealDB starts the index creation as a ba
 INFO FOR INDEX test ON user;
 ```
 
-```surql title="Possible response"
+```surql title="Possible output"
 -- Query
 
 {

--- a/src/content/reference/query-language/statements/define/indexes.mdx
+++ b/src/content/reference/query-language/statements/define/indexes.mdx
@@ -317,7 +317,7 @@ DEFINE INDEX idx2 ON person FIELD name;
 
 ```surql title="Output"
 'There was a problem with the database: Parse error: Unexpected token `FIELD`, expected Eof
- --> [1:29]
+ //- [1:29]
   |
 1 | DEFINE INDEX idx2 ON person FIELD name;
   |                             ^^^^^ 

--- a/src/content/reference/query-language/statements/define/module.mdx
+++ b/src/content/reference/query-language/statements/define/module.mdx
@@ -99,10 +99,10 @@ They will then be accessible using the following paths.
 
 ```surql
 mod::test::returns_true();
---> true
+//- true
 
 mod::test::check_num_size(100);
---> 100
+//- 100
 ```
 
 ## The UNSIGNED keyword

--- a/src/content/reference/query-language/statements/define/module.mdx
+++ b/src/content/reference/query-language/statements/define/module.mdx
@@ -99,10 +99,10 @@ They will then be accessible using the following paths.
 
 ```surql
 mod::test::returns_true();
--- true
+--> true
 
 mod::test::check_num_size(100);
--- 100
+--> 100
 ```
 
 ## The UNSIGNED keyword

--- a/src/content/reference/query-language/statements/define/sequence.mdx
+++ b/src/content/reference/query-language/statements/define/sequence.mdx
@@ -59,12 +59,12 @@ The `BATCH`, `START`, and `TIMEOUT` clauses can be included to configure the seq
 ```surql
 DEFINE SEQUENCE mySeq2 BATCH 1000 START 100 TIMEOUT 5s;
 sequence::nextval('mySeq2');
---> 100
+//- 100
 
 DEFINE SEQUENCE mySeq3 BATCH 1000 START 100 TIMEOUT 0ns;
 -- Possible output, since the timeout may or may not be exceeded
 sequence::nextval('mySeq3');
---> 'The query was not executed because it exceeded the timeout'
+//- 'The query was not executed because it exceeded the timeout'
 ```
 
 Sequences are never rolled back, even in a failed transaction. This differs from an approach like a single record with a manually incrementing value.

--- a/src/content/reference/query-language/statements/define/sequence.mdx
+++ b/src/content/reference/query-language/statements/define/sequence.mdx
@@ -59,11 +59,12 @@ The `BATCH`, `START`, and `TIMEOUT` clauses can be included to configure the seq
 ```surql
 DEFINE SEQUENCE mySeq2 BATCH 1000 START 100 TIMEOUT 5s;
 sequence::nextval('mySeq2');
--- Output: 100
+--> 100
 
 DEFINE SEQUENCE mySeq3 BATCH 1000 START 100 TIMEOUT 0ns;
+-- Possible output, since the timeout may or may not be exceeded
 sequence::nextval('mySeq3');
--- Possible output: 'The query was not executed because it exceeded the timeout'
+--> 'The query was not executed because it exceeded the timeout'
 ```
 
 Sequences are never rolled back, even in a failed transaction. This differs from an approach like a single record with a manually incrementing value.

--- a/src/content/reference/query-language/statements/define/table.mdx
+++ b/src/content/reference/query-language/statements/define/table.mdx
@@ -115,7 +115,7 @@ SHOW CHANGES FOR TABLE reading SINCE d"2025-09-07T01:23:52Z" LIMIT 10;
 SHOW CHANGES FOR TABLE reading SINCE 0 LIMIT 10;
 ```
 
-```surql title="Response without INCLUDE ORIGINAL"
+```surql title="Output without INCLUDE ORIGINAL"
 [
 	{
 		changes: [
@@ -187,7 +187,7 @@ SHOW CHANGES FOR TABLE reading SINCE 0 LIMIT 10;
 ]
 ```
 
-```surql title="Response with INCLUDE ORIGINAL"
+```surql title="Output with INCLUDE ORIGINAL"
 [
 	{
 		changes: [
@@ -510,7 +510,7 @@ DEFINE TABLE some_other_table;
 INFO FOR DB;
 ```
 
-```surql title="Response"
+```surql title="Output"
 {
 	analyzers: {},
 	functions: {},

--- a/src/content/reference/query-language/statements/define/table.mdx
+++ b/src/content/reference/query-language/statements/define/table.mdx
@@ -429,7 +429,7 @@ DEFINE FIELD last_name
 DEFINE FIELD name      
   ON TABLE person             VALUE first_name + ' ' + last_name;
 
-// Creates a `person` with the name "Bob Bobson"
+-- Creates a `person` with the name "Bob Bobson"
 CREATE person SET first_name = "Bob", last_name = "Bobson";
 ```
 

--- a/src/content/reference/query-language/statements/delete.mdx
+++ b/src/content/reference/query-language/statements/delete.mdx
@@ -98,7 +98,10 @@ value = "NONE"
 
 CREATE ONLY person:tobie;
 DELETE ONLY person:tobie;
--- NONE
+```
+
+```surql title="Output"
+NONE
 ```
 
 A record that is already gone also returns `NONE`, so the statement is safe to repeat.
@@ -120,7 +123,10 @@ value = "NONE"
 CREATE ONLY person:tobie;
 DELETE ONLY person:tobie;
 DELETE ONLY person:tobie;
--- NONE
+```
+
+```surql title="Output"
+NONE
 ```
 
   </TabItem>
@@ -154,7 +160,10 @@ value = "{ id: person:tobie }"
 
 CREATE ONLY person:tobie;
 DELETE ONLY person:tobie RETURN BEFORE;
--- { id: person:tobie }
+```
+
+```surql title="Output"
+{ id: person:tobie }
 ```
 
 As `ONLY` checks the output and not the target, it raises an error when a `RETURN` clause yields more than one record.

--- a/src/content/reference/query-language/statements/for.mdx
+++ b/src/content/reference/query-language/statements/for.mdx
@@ -119,7 +119,7 @@ LET $init = [];
 FOR $num IN 1..=3 {
 	$init += $num;
 };
--- Error: 'assignment operators are only allowed in SET and DUPLICATE KEY UPDATE clauses'
+--> Error: 'assignment operators are only allowed in SET and DUPLICATE KEY UPDATE clauses'
 
 RETURN $init;
 ```

--- a/src/content/reference/query-language/statements/for.mdx
+++ b/src/content/reference/query-language/statements/for.mdx
@@ -119,7 +119,7 @@ LET $init = [];
 FOR $num IN 1..=3 {
 	$init += $num;
 };
---> Error: 'assignment operators are only allowed in SET and DUPLICATE KEY UPDATE clauses'
+//- Error: 'assignment operators are only allowed in SET and DUPLICATE KEY UPDATE clauses'
 
 RETURN $init;
 ```

--- a/src/content/reference/query-language/statements/if-else.mdx
+++ b/src/content/reference/query-language/statements/if-else.mdx
@@ -100,7 +100,7 @@ IF !type::is_datetime($badly_formatted_datetime) {
 };
 ```
 
-```surql title="Response"
+```surql title="Output"
 "An error occurred: Whoops, that isn't a real datetime"
 ```
 

--- a/src/content/reference/query-language/statements/insert.mdx
+++ b/src/content/reference/query-language/statements/insert.mdx
@@ -261,7 +261,7 @@ INSERT INTO company {
 } RETURN DIFF;
 ```
 
-```surql title="Response"
+```surql title="Output"
 -------- Query 1 --------
 
 [
@@ -360,7 +360,7 @@ INSERT INTO planet [
 ] RETURN VALUE temp_55_km_up;
 ```
 
-```surql title="Response"
+```surql title="Output"
 -------- Query --------
 
 [

--- a/src/content/reference/query-language/statements/kill.mdx
+++ b/src/content/reference/query-language/statements/kill.mdx
@@ -37,7 +37,7 @@ The `KILL` statement expects the UUID of a running [live select](/docs/reference
 ```surql
 -- Possible output, as every live query is given its own id
 LIVE SELECT DIFF FROM person;
---> u'0189d6e3-8eac-703a-9a48-d9faa78b44b9'
+//- u'0189d6e3-8eac-703a-9a48-d9faa78b44b9'
 
 -- Some time later...
 KILL u"0189d6e3-8eac-703a-9a48-d9faa78b44b9";
@@ -74,7 +74,7 @@ A separate notification is sent out when a `KILL` statement is enacted on a live
 ```surql
 -- Possible output, as every live query is given its own id
 LIVE SELECT * FROM person;
---> u'cf447091-9463-4d75-b32a-08513eb2a07c'
+//- u'cf447091-9463-4d75-b32a-08513eb2a07c'
 
 KILL u'cf447091-9463-4d75-b32a-08513eb2a07c';
 ```

--- a/src/content/reference/query-language/statements/kill.mdx
+++ b/src/content/reference/query-language/statements/kill.mdx
@@ -35,8 +35,9 @@ KILL @value;
 The `KILL` statement expects the UUID of a running [live select](/docs/reference/query-language/statements/live-select) query to be passed. This UUID can be found in the output of the `LIVE` statement, and can thereafter be passed into a `KILL` statement once it is no longer needed.
 
 ```surql
+-- Possible output, as every live query is given its own id
 LIVE SELECT DIFF FROM person;
--- output: u'0189d6e3-8eac-703a-9a48-d9faa78b44b9'
+--> u'0189d6e3-8eac-703a-9a48-d9faa78b44b9'
 
 -- Some time later...
 KILL u"0189d6e3-8eac-703a-9a48-d9faa78b44b9";
@@ -71,10 +72,9 @@ KILL u'9276b05b-e59a-49cd-9dd1-17c6fd15c28f';
 A separate notification is sent out when a `KILL` statement is enacted on a live query ID.
 
 ```surql
+-- Possible output, as every live query is given its own id
 LIVE SELECT * FROM person;
-
--- Output is a UUID:
--- u'cf447091-9463-4d75-b32a-08513eb2a07c'
+--> u'cf447091-9463-4d75-b32a-08513eb2a07c'
 
 KILL u'cf447091-9463-4d75-b32a-08513eb2a07c';
 ```

--- a/src/content/reference/query-language/statements/let.mdx
+++ b/src/content/reference/query-language/statements/let.mdx
@@ -99,7 +99,10 @@ LET $num_type =
     ELSE IF type::is_float($num)   { "float"   };
 
 RETURN $num_type;
--- 'integer'
+```
+
+```surql title="Output"
+'integer'
 ```
 
 ## Anonymous functions

--- a/src/content/reference/query-language/statements/live-select.mdx
+++ b/src/content/reference/query-language/statements/live-select.mdx
@@ -60,8 +60,10 @@ skip-uuid = true
 */
 
 LIVE SELECT * FROM person;
+```
 
--- 'b1f1d115-ad0f-460d-8cbf-dbc7ce48851c'
+```surql title="Output"
+'b1f1d115-ad0f-460d-8cbf-dbc7ce48851c'
 ```
 
 The result of the above query will be a UUID. This UUID is the Live Query Unique ID, and is used to differentate between different Live Queries. You will want to keep track of this ID, so that you can differentiate between different notifications being received after this query. You can also use this UUID to [KILL](/docs/reference/query-language/statements/kill) (stop) the Live Query. The protocol will then send messages that are of a Notification format.
@@ -82,8 +84,10 @@ skip-uuid = true
 */
 
 LIVE SELECT DIFF FROM person;
+```
 
--- 'b87cbb0d-ca15-4f0a-8f86-caa680672aa5'
+```surql title="Output"
+'b87cbb0d-ca15-4f0a-8f86-caa680672aa5'
 ```
 
 ### Filter the live query

--- a/src/content/reference/query-language/statements/relate.mdx
+++ b/src/content/reference/query-language/statements/relate.mdx
@@ -119,7 +119,7 @@ CREATE person:aristotle, article:on_sleep_and_sleeplessness;
 RELATE person:aristotle->wrote->article:on_sleep_and_sleeplessness;
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
 	{
 		id: wrote:bpbrj5kd7smu3ahlf55r,
@@ -135,7 +135,7 @@ There is no relationship information stored in either the `person` or `article` 
 SELECT * FROM person, article;
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
 	{
 		id: person:aristotle
@@ -154,7 +154,7 @@ SELECT * FROM wrote;
 
 The structure `in -> id -> out` mirrors the record IDs from the `RELATE` statement, with the addition of the automatically generated ID for the `wrote` edge table.
 
-```surql title="Response"
+```surql title="Output"
 [
 	{
 		id: wrote:bpbrj5kd7smu3ahlf55r,
@@ -176,7 +176,7 @@ SELECT id, ->wrote->article FROM person;
 RETURN person:aristotle->wrote->article;
 ```
 
-```surql title="Response"
+```surql title="Output"
 -------- Query --------
 
 [
@@ -270,7 +270,7 @@ RELATE [cat:mr_meow, cat:mrs_meow]->parent_of->cat:kitten;
 However, the query works just fine. Instead of trying to create a single `parent_of` graph edge, it will create one for each record in the first array: one between `cat:mr_meow` and `cat:kitten`, and another between `cat:mrs_meow` and `cat:kitten`.
 
 
-```surql title="Response"
+```surql title="Output"
 [
 	{
 		id: parent_of:uahudi4qr68k640fcjbg,
@@ -303,7 +303,7 @@ CREATE cat:kitten2;
 RELATE [cat:mr_meow, cat:mrs_meow]->parent_of->[cat:kitten, cat:kitten2];
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
 	{
 		id: parent_of:ysbab20nv5568ogba6ns,
@@ -362,7 +362,7 @@ RELATE person:l19zjikkw1p1h9o6ixrg->wrote->article:8nkk6uj4yprt49z7y3zm
 		metadata.location = "Tallinn";
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
 	{
 		id: wrote:rva8hentypdu8lcgwjmf,
@@ -384,7 +384,7 @@ UPDATE wrote SET
     metadata.description = record::tb(out) + ' written by ' + <string>in;
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
 	{
 		id: wrote:k9d8ynbfxgb8jqjv2ob5,
@@ -425,7 +425,7 @@ RELATE person:l19zjikkw1p1h9o6ixrg->wrote->article:8nkk6uj4yprt49z7y3zm
     };
 ```
 
-```surql title="Response"
+```surql title="Output"
     {
         "id": "wrote:ctwsll49k37a7rmqz9rr",
         "in": "person:l19zjikkw1p1h9o6ixrg",
@@ -456,7 +456,7 @@ RELATE person:l19zjikkw1p1h9o6ixrg->wrote->article:8nkk6uj4yprt49z7y3zm
     SET time.written = $time;
 ```
 
-```surql title="Response"
+```surql title="Output"
 {
 	"id": "wrote:ctwsll49k37a7rmqz9rr",
 	"in": "person:l19zjikkw1p1h9o6ixrg",
@@ -484,7 +484,7 @@ skip-record-id-key = true
 RELATE ONLY person:l19zjikkw1p1h9o6ixrg->wrote->article:8nkk6uj4yprt49z7y3zm;
 ```
 
-```surql title="Response"
+```surql title="Output"
 {
 	id: wrote:k9f1rqn3oikolr1560u3,
 	in: person:l19zjikkw1p1h9o6ixrg,
@@ -616,7 +616,7 @@ skip-record-id-key = true
 RELATE person:tobie->bought->product:iphone;
 ```
 
-```surql title="Response"
+```surql title="Output"
 
 [
 	{
@@ -1178,7 +1178,7 @@ In such a case, a query on the relationship makes it appear as if one city has a
 SELECT id, ->sister_of->city AS sister_cities FROM city;
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
 	{
 		id: city:calgary,
@@ -1227,7 +1227,7 @@ SELECT id, array::complement(<->sister_of<->city, [id]) AS sister_cities
   FROM city;
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
 	{
 		id: city:calgary,
@@ -1266,7 +1266,10 @@ With the index in place, a relation set from one record to the other now cannot 
 ```surql
 RELATE city:calgary->sister_of->city:daejeon; -- OK
 RELATE city:daejeon->sister_of->city:calgary;
--- "Database index `only_one_sister_city` already contains '[city:calgary, city:daejeon]', with record `sister_of:npab0uoxogmrvpwsvfoa`"
+```
+
+```surql title="Output"
+"Database index `only_one_sister_city` already contains '[city:calgary, city:daejeon]', with record `sister_of:npab0uoxogmrvpwsvfoa`"
 ```
 
 ### Refining the `in` and `out` fields of a relation
@@ -1550,7 +1553,7 @@ SELECT
  FROM person:one;
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
 	{
 		dated_and_same_school: [
@@ -1638,7 +1641,7 @@ While it is possible to manually move three levels down this road network, it in
 SELECT ->to->city->to->city->to->city AS fourth_city FROM city:1;
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
 	{
 		fourth_city: [
@@ -1660,7 +1663,7 @@ A traditional query to show the final road info from `city:1` to the city three 
 SELECT ->to->city->to->city->to.* AS third_journey FROM city:1;
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
 	{
 		fourth_city: [
@@ -1690,7 +1693,7 @@ A range can be added inside the `{}` braces. The following query that uses a ran
 city:1.{1..20}->to->city;
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
 	city:5
 ]
@@ -1706,7 +1709,7 @@ SELECT @.{1..5}.{
 } FROM city;
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
 	{
 		id: city:1,
@@ -1806,7 +1809,7 @@ RELATE person:two->likes->person:one;
 person:one.{..}->likes->person;
 ```
 
-```surql title="Response"
+```surql title="Output"
 'Exceeded the idiom recursion limit of 256.'
 ```
 
@@ -1827,7 +1830,7 @@ RETURN [
 ];
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
 	[
 		person:1,

--- a/src/content/reference/query-language/statements/relate.mdx
+++ b/src/content/reference/query-language/statements/relate.mdx
@@ -800,7 +800,7 @@ RELATE person:aristotle->wrote->[
 		article:on_sleep_and_sleeplessness,
 		article:on_dreams
 	]
-	// Written sometime around the year 330 BC
+	-- Written sometime around the year 330 BC
 	SET time_written = d"-0330-01-01";
 ```
 
@@ -1380,7 +1380,7 @@ SELECT ->friends_with->cat->friends_with->cat AS friends_of_friends
 ```
 
 ```surql
-// Output without alias
+-- Output without alias
 {
 	"->friends_with": {
 		"->cat": {
@@ -1393,7 +1393,7 @@ SELECT ->friends_with->cat->friends_with->cat AS friends_of_friends
 	}
 }
 
-// Output with alias
+-- Output with alias
 {
 	friends_of_friends: [
 		cat:three
@@ -2118,11 +2118,11 @@ RELATE character:one->speaks_to:ulid()->character:two SET content = "Greetings, 
 RELATE character:one->speaks_to:ulid()->character:two SET content = "Can you please help me? My sheep have run amok.";
 
 SELECT
-	// Grab the latter part of the record ID, turn it into a datetime
+	-- Grab the latter part of the record ID, turn it into a datetime
     time::from_ulid(id.id()) AS at,
     content
 FROM
-    // ULID from 2025-04-25, well before today's date
+    -- ULID from 2025-04-25, well before today's date
     character:one->speaks_to:01JSNG0KZSY3HJ5QSZ7JSMQMGR..;
 ```
 

--- a/src/content/reference/query-language/statements/remove.mdx
+++ b/src/content/reference/query-language/statements/remove.mdx
@@ -201,7 +201,7 @@ DEFINE TABLE pc_agg AS SELECT count(), class FROM pc GROUP BY class;
 CREATE |pc:3| SET class = "Wizard";
 CREATE |pc:10| SET class = "Warrior";
 SELECT * FROM pc_agg;
---> Error: pc_agg requires pc to work
+//- Error: pc_agg requires pc to work
 REMOVE TABLE pc;
 REMOVE TABLE pc_agg;
 -- pc_agg is now gone, pc can be removed too
@@ -251,7 +251,7 @@ REMOVE FIELD name ON person;
 
 SELECT * FROM person; -- 'name' data is still there
 UPDATE person; -- Does nothing
---> [{ id: person:one, name: 'Billy' }]
+//- [{ id: person:one, name: 'Billy' }]
 UPDATE person SET name = NONE; -- Must unset to remove 'name' data
 ```
 

--- a/src/content/reference/query-language/statements/remove.mdx
+++ b/src/content/reference/query-language/statements/remove.mdx
@@ -201,7 +201,7 @@ DEFINE TABLE pc_agg AS SELECT count(), class FROM pc GROUP BY class;
 CREATE |pc:3| SET class = "Wizard";
 CREATE |pc:10| SET class = "Warrior";
 SELECT * FROM pc_agg;
--- Error: pc_agg requires pc to work
+--> Error: pc_agg requires pc to work
 REMOVE TABLE pc;
 REMOVE TABLE pc_agg;
 -- pc_agg is now gone, pc can be removed too
@@ -251,7 +251,7 @@ REMOVE FIELD name ON person;
 
 SELECT * FROM person; -- 'name' data is still there
 UPDATE person; -- Does nothing
--- [{ id: person:one, name: 'Billy' }]
+--> [{ id: person:one, name: 'Billy' }]
 UPDATE person SET name = NONE; -- Must unset to remove 'name' data
 ```
 

--- a/src/content/reference/query-language/statements/select.mdx
+++ b/src/content/reference/query-language/statements/select.mdx
@@ -588,11 +588,11 @@ SELECT * FROM person SPLIT name GROUP BY name;
 
 ```surql title="Output"
 'Parse error: SPLIT and GROUP are mutually exclusive
- --> [6:22]
+ //- [6:22]
   |
 6 | SELECT * FROM person SPLIT name GROUP BY name;
   |                      ^^^^^^^^^^ SPLIT cannot be used with GROUP
- --> [6:33]
+ //- [6:33]
   |
 6 | SELECT * FROM person SPLIT name GROUP BY name;
   |                                 ^^^^^^^^^^^^^ GROUP cannot be used with SPLIT

--- a/src/content/reference/query-language/statements/select.mdx
+++ b/src/content/reference/query-language/statements/select.mdx
@@ -766,7 +766,7 @@ value = "[5, 6, 7, 8, 9]"
 SELECT * FROM [1,2,3,4,5,6,7,8,9,10] LIMIT 5 START 4; 
 ```
 
-```surql title="Result"
+```surql title="Output"
 [
 	5,
 	6,

--- a/src/content/reference/query-language/statements/show.mdx
+++ b/src/content/reference/query-language/statements/show.mdx
@@ -58,7 +58,7 @@ SHOW CHANGES FOR TABLE reading SINCE 1 LIMIT 10;
 
 Assuming the datetime above matches with the one when the changefeed was established, the response for both queries will be as follows.
 
-```surql title="Response"
+```surql title="Output"
 [
 	{
 		changes: [
@@ -116,7 +116,7 @@ Assuming the datetime above matches with the one when the changefeed was establi
 ]
 ```
 
-```surql title="Response if INCLUDE ORIGINAL set on changefeed"
+```surql title="Output if INCLUDE ORIGINAL set on changefeed"
 [
 	{
 		changes: [
@@ -193,7 +193,7 @@ DELETE original_tb:1;
 SHOW CHANGES FOR TABLE original_tb SINCE 0;
 ```
 
-```surql title="Response"
+```surql title="Output"
 [
 	{
 		changes: [

--- a/src/content/reference/query-language/statements/throw.mdx
+++ b/src/content/reference/query-language/statements/throw.mdx
@@ -88,7 +88,7 @@ CREATE event:two SET time = d'2025-10-08T07:15:04.996995Z';
 THROW SELECT * FROM event;
 ```
 
-```surql title="Response"
+```surql title="Output"
 "An error occurred: [{ id: event:one, time: d'2025-10-08T07:15:04.994633Z' }, { id: event:two, time: d'2025-10-08T07:15:04.996995Z' }]"
 ```
 

--- a/src/content/reference/rest-api/http-protocol.mdx
+++ b/src/content/reference/rest-api/http-protocol.mdx
@@ -239,7 +239,7 @@ The CLI [`surreal isready`](/docs/reference/cli/surrealdb-cli/commands/isready) 
 curl -I http://localhost:8000/ready
 ```
 
-```bash title="Sample output (ready)"
+```bash title="Output (ready)"
 HTTP/1.1 200 OK
 vary: origin, access-control-request-method, access-control-request-headers
 access-control-allow-origin: *
@@ -248,7 +248,7 @@ server: SurrealDB
 content-length: 0
 ```
 
-```bash title="Sample output (still starting)"
+```bash title="Output (still starting)"
 HTTP/1.1 503 Service Unavailable
 retry-after: 1
 content-length: 0

--- a/src/utils/collections.ts
+++ b/src/utils/collections.ts
@@ -148,7 +148,7 @@ const DOCS_ORIGIN = "https://surrealdb.com";
 export function composeFullCorpusMarkdown(sdkVersions?: SdkVersionMap): string {
     const sections: string[] = [
         "# SurrealDB documentation - full corpus",
-        `> The complete SurrealDB documentation as a single markdown document. Each page starts with a "Source:" line naming its canonical URL. The page index is at ${DOCS_ORIGIN}/docs/llms.txt, and every page is also available individually by appending \`.md\` to its URL.`,
+        `> The complete SurrealDB documentation as a single markdown document. Each page starts with a "Source:" line naming its canonical URL. The page index is at ${DOCS_ORIGIN}/docs/llms.txt, and every page is also available individually by appending \`.md\` to its URL. In code examples, a fenced block whose title contains "output" holds the result of the block above it rather than runnable code, and a qualifier such as "Sample output" or "Possible output" means the value shown is one of several possible ones. Inside a block, a "//-" comment marks a value the statement above it returned, while "--" is an ordinary comment.`,
     ];
 
     for (const { prefix, id } of COLLECTION_ROUTES) {

--- a/src/utils/markdown.tsx
+++ b/src/utils/markdown.tsx
@@ -10,6 +10,7 @@ import { AgentBanner } from "~/components/AgentBanner";
 import { AgentPicker } from "~/components/AgentPicker";
 import { AgentPrompt } from "~/components/AgentPrompt";
 import { Boxes } from "~/components/Boxes";
+import { CodeWithOutput } from "~/components/CodeWithOutput";
 import { Edition } from "~/components/Edition";
 import { IconBox } from "~/components/IconBox";
 import { OptionsTable } from "~/components/OptionsTable";
@@ -127,9 +128,106 @@ function inlineSynopsisCommands(markdown: string): string {
     });
 }
 
+/**
+ * A fence title that marks the block as the result of the block above it.
+ *
+ * `output` matches anywhere in the title, because a qualifier carries information a
+ * bare label cannot: `Sample output` and `Possible output` say the value shown is one
+ * of several the reader might see, from a generated record id, a datetime or a live
+ * API. `Response` and `Result` have to be anchored, because several code blocks are
+ * titled for what they do with a response - `Handle Individual Responses`,
+ * `Map results onto a dataclass` - and pairing one of those would attach a second
+ * example to the first as though it were its output.
+ */
+const OUTPUT_TITLE = /\btitle="(?:[^"]*\boutput\b[^"]*|(?:Response|Result)\b[^"]*)"/i;
+
+/** Opening fence marker of a line, or `null` when the line does not open a fence. */
+function fenceMarker(line: string): string | null {
+    return line.match(/^(`{3,}|~{3,})/)?.[1] ?? null;
+}
+
+/** Index of the closing fence line, and whether the fence closed at all. */
+function readFence(
+    lines: string[],
+    open: number,
+    marker: string,
+): { end: number; unterminated: boolean } {
+    const closing = new RegExp(`^${marker[0] === "`" ? "`" : "~"}{${marker.length},}\\s*$`);
+
+    for (let i = open + 1; i < lines.length; i++) {
+        if (closing.test(lines[i] ?? "")) {
+            return { end: i, unterminated: false };
+        }
+    }
+
+    return { end: lines.length - 1, unterminated: true };
+}
+
+/**
+ * Wrap a code fence and the output fence that follows it in `<CodeWithOutput>`, so the
+ * pair renders as one block with a divider rather than as two separate blocks.
+ *
+ * Both fences still render through the viewer's own code path - the wrapper only
+ * supplies the surrounding chrome - so a paired block is highlighted and spaced like
+ * every other fence on the page, and its copy button still yields the code alone.
+ *
+ * The pairing is deliberately confined to the render path. `composeRawMarkdown` shares
+ * only the strip passes, so the `.md` endpoints and `llms-full.txt` keep the two fences
+ * an agent can tell apart: runnable code in one, the result it produces in the other.
+ */
+export function wrapOutputPairs(markdown: string): string {
+    const lines = markdown.split("\n");
+    const out: string[] = [];
+    let i = 0;
+
+    while (i < lines.length) {
+        const marker = fenceMarker(lines[i] ?? "");
+
+        if (!marker) {
+            out.push(lines[i] ?? "");
+            i++;
+            continue;
+        }
+
+        const code = readFence(lines, i, marker);
+        const gap = (lines[code.end + 1] ?? "").trim() === "" ? 1 : 0;
+        const outputOpen = code.end + 1 + gap;
+        const outputMarker = fenceMarker(lines[outputOpen] ?? "");
+        const output = outputMarker === null ? null : readFence(lines, outputOpen, outputMarker);
+
+        const pairs =
+            !code.unterminated &&
+            output !== null &&
+            !output.unterminated &&
+            !OUTPUT_TITLE.test(lines[i] ?? "") &&
+            OUTPUT_TITLE.test(lines[outputOpen] ?? "");
+
+        if (!pairs || output === null) {
+            out.push(...lines.slice(i, code.end + 1));
+            i = code.end + 1;
+            continue;
+        }
+
+        out.push(
+            "<CodeWithOutput>",
+            "",
+            ...lines.slice(i, code.end + 1),
+            "",
+            ...lines.slice(outputOpen, output.end + 1),
+            "",
+            "</CodeWithOutput>",
+        );
+        i = output.end + 1;
+    }
+
+    return out.join("\n");
+}
+
 export function resolveMarkdown(markdown: string) {
     const content = injectIconScope(
-        inlineSynopsisCommands(stripLanguageTestComments(stripLeadingH1(markdown))),
+        inlineSynopsisCommands(
+            wrapOutputPairs(stripLanguageTestComments(stripLeadingH1(markdown))),
+        ),
     );
     const tree = parseMarkdownTree(content);
     const source = markdownSourceFromString(content);
@@ -183,6 +281,7 @@ export function registerMarkdownComponents(): MarkdownComponents {
         AgentPrompt: { component: AgentPrompt, block: true },
         IconBox: { component: IconBox, block: true },
         Boxes: { component: Boxes, block: true, preserveNewlines: false },
+        CodeWithOutput: { component: CodeWithOutput, block: true, preserveNewlines: false },
         Synopsis: { component: Synopsis, block: true },
         OptionsTable: { component: OptionsTable, block: true },
         Edition: { component: Edition },


### PR DESCRIPTION
Docs examples right now show results generally in three different ways:

*  a separate fence titled Response or Output,
* a trailing -- comment,
* output written as bare uncommented text inside the fence.

This PR settles on one convention per situation, and makes the rendered form compact enough that there is less temptation to use -- to keep the output compact.

## One label

Output is now the label everywhere, with 190 renames across 50 files (Response, Result, RESPONSE, Sample output, Expected output, Possible response, Error Response). Response survives only on the four HTTP and RPC pages, where it is the counterpart of a Request block rather than a synonym for output - 51 uses.

Qualifiers are kept and encouraged where they carry information: "Sample output" and "Possible output" when the value is one of several a reader might see, "Expected output" for a value a test asserts, etc. The pairing matches any title containing the word output. Response and Result only match at the start of a title, because several code blocks are named for what they do with a response (Handle Individual Responses, Map results onto a dataclass) and would otherwise be joined to the example above them.

## The pair renders as one block

Using -- inside an example was originally because having one ```surql example and then ```surql title="Output" had some awkward empty space between them.

Before, note the space between the query and output in the first example and the use of -- in the second:

<img width="2292" height="1406" alt="image" src="https://github.com/user-attachments/assets/75adf4ab-c4d7-47a9-9378-33feace26911" />

After, now both are in the same block with "Output" between them:

<img width="1778" height="1282" alt="image" src="https://github.com/user-attachments/assets/e77891c6-7f05-43e0-81f8-ab5e6702d45d" />


Details:

> wrapOutputPairs wraps an adjacent code-plus-output pair in a new <CodeWithOutput> component while parsing, so the two render as a single block with the output fence's caption acting as a divider. Both panes still go through the viewer's own fence renderer, so highlighting matches every other block on the page and each pane's copy button yields its own half - copying the query no longer drags the result along.

> The pass is confined to the render path. composeRawMarkdown shares the strip passes but not this one, so the .md endpoints and llms-full.txt still serve two separate fences that an agent can tell apart: runnable code in one, the result in the other.

## Trailing comments became fences

The trailing -- 120.730189 form is lexically identical to an explanatory comment, so nothing distinguished a result from a remark - and one plausible reading teaches an agent to write results as comments. Those converted to Output fences across 38 files. Rejections were reported rather than guessed at: prose, commented-out alternative code, and one PEM footer inside a string literal that only looked like a comment.

### -- for explanations, //- for a result

Where several statements in one block each return something, no fence can say which value came from which statement, so the result stays a comment - marked so it is not read as commentary. SurrealQL takes --, // and # as equivalent line comments, and this spends two of them: -- for prose, //- for a result. A bare // now means something was missed, which makes it auditable with one grep.

//- rather than --> for three reasons:

* -- is a prefix of -->, so a matcher has to test the longer form first, and getting that ordering wrong fails in the worse direction - a prose detector keyed on ^-- swallows results and reads them as commentary.
* A > is entity-encoded in the rendered page, so --> appears there as --&gt; and grepping the rendered HTML for it silently finds nothing. //- matches identically in the source, the raw .md and the rendered page.
* --> is already SurrealDB's own parse-error location pointer ( --> [3:12]), quoted inside error output on about ten pages.

(Also considered //> but that looked somewhat ugly)

Position carries the same information as the marker, so either decodes alone: //- refers to the statement directly above it, and a -- label describes the statement directly below it. 19 results that sat above their statement moved, and everything after //- is now the value verbatim - no Returns, no trailing note, no parenthetical.

Here's an example showing both -- for a comment and //- for output together:

```
-- "U" is capitalized so not a match
"Umple" IN "Rumplestiltskin";
//- false
```

Three places keep //: the // highlight-next-line family, which the viewer's highlighter matches literally; comments inside embedded JavaScript function() { … } bodies, where -- is a syntax error; and the Comments reference page, whose subject is the three forms.

Also updates AGENTS.md and related files to explain how it works.

