### PR TITLE
docs(agent-memory): apply the client SDK Spectron → Agent Memory renames

### DIFF
--- a/src/content/agent-memory/cookbooks/build/customer-support-agent.mdx
+++ b/src/content/agent-memory/cookbooks/build/customer-support-agent.mdx
@@ -9,9 +9,6 @@ description: "Ticket-linked memory with authoritative knowledge policies."
 This guide walks through building a customer support agent that uses SurrealDB Agent Memory for two distinct purposes: **authoritative knowledge** holds the authoritative product knowledge - FAQs, policies, and the product catalogue - and **experiential memory** holds per-customer memory accumulated over every interaction. The result is an agent that answers product questions correctly and remembers each customer's history without manual context injection.
 
 > [!NOTE]
-> `Spectron` was the project name for SurrealDB Agent Memory. These type names
-> will be renamed in a future release.
-
 ## What you are building
 
 - A Context configured for extraction, holding customer, product, and ticket records.
@@ -141,15 +138,15 @@ Each customer conversation is a session scoped to that customer's `user_id`. The
 ### Initialise the client
 
 ```python
-from surrealdb import Spectron
+from surrealdb.memory import Memory
 
-memory = Spectron(context="support", api_key="sk-...")
+memory = Memory(context="support", api_key="sk-...")
 ```
 
 ```typescript
-import { Spectron } from "@surrealdb/spectron";
+import { AgentMemory } from "@surrealdb/memory";
 
-const memory = new Spectron({ context: "support", apiKey: "sk-..." });
+const memory = new AgentMemory({ context: "support", apiKey: "sk-..." });
 ```
 
 ### Create a session per conversation
@@ -184,7 +181,7 @@ Use the context below to answer accurately.
     # 3. Call your LLM
     response = your_llm(system=system, user=user_message)
 
-    # 4. Record both turns so Spectron extracts memory from the exchange
+    # 4. Record both turns so Memory extracts memory from the exchange
     await memory.remember(user_message, session_id=session.id, role="user")
     await memory.remember(response, session_id=session.id, role="assistant")
 

--- a/src/content/agent-memory/cookbooks/build/long-running-research-agent.mdx
+++ b/src/content/agent-memory/cookbooks/build/long-running-research-agent.mdx
@@ -9,9 +9,6 @@ description: "Sessions across days with reflection."
 Research agents accumulate findings across many sessions, often spanning days or weeks. This guide shows how to structure sessions and use reflection to distil growing memory into durable, queryable knowledge.
 
 > [!NOTE]
-> `Spectron` was the project name for SurrealDB Agent Memory. These type names
-> will be renamed in a future release.
-
 ## The challenge
 
 A research agent that works on a topic over multiple sessions faces a core tension:
@@ -42,9 +39,9 @@ Day 3 session → profile → load context → research → reflect → updated 
 ### Starting a session
 
 ```python
-from surrealdb import AsyncSpectron
+from surrealdb.memory import AsyncMemory
 
-client = AsyncSpectron(
+client = AsyncMemory(
     context="acme-prod",
     endpoint="https://spectron.example.com",
     api_key="sk-...",
@@ -64,12 +61,12 @@ Continue from where we left off."""
 ### JavaScript equivalent
 
 ```javascript
-import { Spectron } from "@surrealdb/spectron";
+import { AgentMemory } from "@surrealdb/memory";
 
-const client = new Spectron({
-    endpoint: process.env.SPECTRON_ENDPOINT!,
+const client = new AgentMemory({
+    endpoint: process.env.AGENT_MEMORY_ENDPOINT!,
     context: "acme-prod",
-    apiKey: process.env.SPECTRON_API_KEY!,
+    apiKey: process.env.AGENT_MEMORY_API_KEY!,
 });
 
 const session = await client.sessions.create({

--- a/src/content/agent-memory/cookbooks/build/multi-agent-shared-memory.mdx
+++ b/src/content/agent-memory/cookbooks/build/multi-agent-shared-memory.mdx
@@ -9,9 +9,6 @@ description: "Supervisors, reflection, and shared scopes."
 When multiple agents collaborate on a shared task, they need access to the same memory. SurrealDB Agent Memory's scope model makes this natural: agents that share a scope dimension (such as `project`) can all read from and write to the same experiential memory, while retaining individual isolation where needed.
 
 > [!NOTE]
-> `Spectron` was the project name for SurrealDB Agent Memory. These type names
-> will be renamed in a future release.
-
 ## Patterns
 
 There are two common patterns for multi-agent memory sharing:
@@ -26,9 +23,9 @@ There are two common patterns for multi-agent memory sharing:
 The simplest approach - all agents are given the same scope when creating sessions. Memory written by one agent is immediately visible to others operating in the same scope.
 
 ```python
-from surrealdb import AsyncSpectron
+from surrealdb.memory import AsyncMemory
 
-client = AsyncSpectron(
+client = AsyncMemory(
     context="acme-prod",
     endpoint="https://spectron.example.com",
     api_key="sk-...",
@@ -62,7 +59,7 @@ A supervisor agent orchestrates several workers. Each worker operates in its own
 ```python
 SUPERVISOR_SCOPE = ["org/acme/project/research-pipeline"]
 
-async def run_worker(topic: str, worker_id: str, client: AsyncSpectron) -> str:
+async def run_worker(topic: str, worker_id: str, client: AsyncMemory) -> str:
     worker_scope = [*SUPERVISOR_SCOPE, f"agent/{worker_id}"]
     async with client.sessions.create(scopes=worker_scope) as session:
         # Worker researches its topic
@@ -83,7 +80,7 @@ async def run_worker(topic: str, worker_id: str, client: AsyncSpectron) -> str:
         )
         return reflection.reflection
 
-async def supervisor(client: AsyncSpectron):
+async def supervisor(client: AsyncMemory):
     topics = ["pricing trends", "competitor features", "customer sentiment"]
 
     # Run workers concurrently
@@ -194,12 +191,12 @@ The persisted reflection becomes part of the shared scope's long-term memory and
 ## JavaScript example
 
 ```javascript
-import { Spectron } from "@surrealdb/spectron";
+import { AgentMemory } from "@surrealdb/memory";
 
-const client = new Spectron({
-    endpoint: process.env.SPECTRON_ENDPOINT!,
+const client = new AgentMemory({
+    endpoint: process.env.AGENT_MEMORY_ENDPOINT!,
     context: "acme-prod",
-    apiKey: process.env.SPECTRON_API_KEY!,
+    apiKey: process.env.AGENT_MEMORY_API_KEY!,
 });
 
 const sharedScope = ["org/acme/project/market-research-q3"];

--- a/src/content/agent-memory/cookbooks/build/personal-ai-assistant.mdx
+++ b/src/content/agent-memory/cookbooks/build/personal-ai-assistant.mdx
@@ -9,9 +9,6 @@ description: "End-user scoped memory with profiles and preferences."
 This guide covers building a personal AI assistant that learns from every conversation and retains that knowledge across sessions. The assistant accumulates user preferences, biographical facts, current projects, and behavioural instructions. It injects relevant context automatically at the start of each new session so the experience feels continuous.
 
 > [!NOTE]
-> `Spectron` was the project name for SurrealDB Agent Memory. These type names
-> will be renamed in a future release.
-
 ## What you are building
 
 - A single-user Context scoped by `user_id`.
@@ -24,9 +21,9 @@ This guide covers building a personal AI assistant that learns from every conver
 Each conversation is a new session. The scope ties the session to the user so all extracted facts are associated with them.
 
 ```python
-from surrealdb import Spectron
+from surrealdb.memory import Memory
 
-memory = Spectron(context="assistant", api_key="sk-...")
+memory = Memory(context="assistant", api_key="sk-...")
 
 async def start_conversation(user_id: str):
     session = await memory.sessions.create(
@@ -36,9 +33,9 @@ async def start_conversation(user_id: str):
 ```
 
 ```typescript
-import { Spectron } from "@surrealdb/spectron";
+import { AgentMemory } from "@surrealdb/memory";
 
-const memory = new Spectron({ context: "assistant", apiKey: "sk-..." });
+const memory = new AgentMemory({ context: "assistant", apiKey: "sk-..." });
 
 async function startConversation(userId: string) {
     const session = await memory.sessions.create({

--- a/src/content/agent-memory/cookbooks/migrate/from-langmem.mdx
+++ b/src/content/agent-memory/cookbooks/migrate/from-langmem.mdx
@@ -9,9 +9,6 @@ description: "Moving LangChain memory to SurrealDB Agent Memory."
 LangMem is LangChain's in-process memory library, typically backed by a local vector store or an in-memory store. This guide covers the concept mapping and migration path to SurrealDB Agent Memory.
 
 > [!NOTE]
-> `Spectron` was the project name for SurrealDB Agent Memory. These type names
-> will be renamed in a future release.
-
 ## Concept mapping
 
 | LangMem concept | SurrealDB Agent Memory equivalent | Notes |
@@ -51,9 +48,9 @@ results = await memory.asearch("communication style")
 ### SurrealDB Agent Memory equivalent
 
 ```python
-from surrealdb import AsyncSpectron
+from surrealdb.memory import AsyncMemory
 
-client = AsyncSpectron(
+client = AsyncMemory(
     context="dev",
     endpoint="https://spectron.example.com",
     api_key="sk-...",
@@ -89,12 +86,12 @@ SurrealDB Agent Memory ships a LangChain memory adapter (planned). Until it is r
 
 ```python
 from langchain_core.messages import SystemMessage
-from surrealdb import AsyncSpectron
+from surrealdb.memory import AsyncMemory
 
-client = AsyncSpectron(context="dev", endpoint="...", api_key="...")
+client = AsyncMemory(context="dev", endpoint="...", api_key="...")
 
 class SpectronMemory:
-    def __init__(self, client: AsyncSpectron, scope: list[str]):
+    def __init__(self, client: AsyncMemory, scope: list[str]):
         self.client = client
         self.scope = scope
 
@@ -126,7 +123,7 @@ If you are using the older LangChain `ConversationBufferMemory` or similar in-co
 memory = ConversationBufferMemory()
 chain = ConversationChain(llm=llm, memory=memory)
 
-# After: Spectron-based
+# After: Memory-based
 async with client.sessions.create(scopes=[f"user/{user_id}"]) as session:
     # At turn start, recall relevant context
     context = await client.recall(user_message, k=5)

--- a/src/content/agent-memory/cookbooks/migrate/from-mem0.mdx
+++ b/src/content/agent-memory/cookbooks/migrate/from-mem0.mdx
@@ -9,9 +9,6 @@ description: "Mapping concepts and incremental migration."
 This guide maps Mem0 concepts to their SurrealDB Agent Memory equivalents, then an incremental migration that can run both systems in parallel.
 
 > [!NOTE]
-> `Spectron` was the project name for SurrealDB Agent Memory. These type names
-> will be renamed in a future release.
-
 ## Concept mapping
 
 | Mem0 concept | SurrealDB Agent Memory equivalent | Notes |
@@ -41,9 +38,9 @@ results = m.search("What are Alice's food preferences?", user_id="alice")
 
 **SurrealDB Agent Memory:**
 ```python
-from surrealdb import AsyncSpectron
+from surrealdb.memory import AsyncMemory
 
-client = AsyncSpectron(
+client = AsyncMemory(
     context="dev",
     endpoint="http://localhost:9090",
     api_key="sk-...",
@@ -68,12 +65,12 @@ const results = await m.search("food preferences", { user_id: "alice" });
 
 **SurrealDB Agent Memory:**
 ```javascript
-import { Spectron } from "@surrealdb/spectron";
+import { AgentMemory } from "@surrealdb/memory";
 
-const client = new Spectron({
-  endpoint: process.env.SPECTRON_ENDPOINT!,
+const client = new AgentMemory({
+  endpoint: process.env.AGENT_MEMORY_ENDPOINT!,
   context: "dev",
-  apiKey: process.env.SPECTRON_API_KEY!,
+  apiKey: process.env.AGENT_MEMORY_API_KEY!,
 });
 
 await client.remember("I prefer vegetarian food.", { scopes: ["user/alice"] });

--- a/src/content/agent-memory/cookbooks/migrate/from-vector-store.mdx
+++ b/src/content/agent-memory/cookbooks/migrate/from-vector-store.mdx
@@ -156,7 +156,7 @@ You do not need to cut over immediately. Run SurrealDB Agent Memory and your vec
 
 ```python
 async def retrieve_context(user_id: str, query: str) -> str:
-    # Try Spectron first
+    # Try Memory first
     ctx = await session.context(query=query)
     if ctx.items:
         return ctx.formatted

--- a/src/content/agent-memory/cookbooks/patterns/adding-memory-to-existing-app.mdx
+++ b/src/content/agent-memory/cookbooks/patterns/adding-memory-to-existing-app.mdx
@@ -9,9 +9,6 @@ description: "Introduce turns without replacing your LLM client."
 Most teams do not rebuild their application to add memory. This guide covers the minimal integration path: intercepting existing LLM calls to extract memory, injecting context before those calls, and gradually expanding the integration without disrupting what already works.
 
 > [!NOTE]
-> `Spectron` was the project name for SurrealDB Agent Memory. These type names
-> will be renamed in a future release.
-
 ## The minimal integration
 
 SurrealDB Agent Memory's minimum viable integration is two operations around your existing LLM call:
@@ -22,9 +19,9 @@ SurrealDB Agent Memory's minimum viable integration is two operations around you
 No sessions are required for the first pass. You keep your existing data model and LLM client; SurrealDB Agent Memory sits beside them as the memory layer.
 
 ```python
-from surrealdb import Spectron
+from surrealdb.memory import Memory
 
-memory = Spectron(context="my-app", api_key="sk-...")
+memory = Memory(context="my-app", api_key="sk-...")
 
 CONTEXT_ID = "my-app"
 DEFAULT_SCOPE = ["org/my-org"]  # Start with a single scope
@@ -55,9 +52,9 @@ async def call_llm_with_memory(user_message: str,
 ```
 
 ```typescript
-import { Spectron } from "@surrealdb/spectron";
+import { AgentMemory } from "@surrealdb/memory";
 
-const memory = new Spectron({ context: "my-app", apiKey: "sk-..." });
+const memory = new AgentMemory({ context: "my-app", apiKey: "sk-..." });
 
 const DEFAULT_SCOPE = ["org/my-org"];
 

--- a/src/content/agent-memory/cookbooks/patterns/knowledge-grounded-agents.mdx
+++ b/src/content/agent-memory/cookbooks/patterns/knowledge-grounded-agents.mdx
@@ -9,9 +9,6 @@ description: "Combine authoritative knowledge retrieval with experiential memory
 A knowledge-grounded agent answers from authoritative sources before consulting conversational memory. This pattern uses SurrealDB Agent Memory's authoritative knowledge to store canonical knowledge - product data, policies, technical documentation - and relies on the authority hierarchy to prevent conversational drift from corrupting those facts.
 
 > [!NOTE]
-> `Spectron` was the project name for SurrealDB Agent Memory. These type names
-> will be renamed in a future release.
-
 ## Why ground agents in authoritative knowledge
 
 Without a knowledge layer, agents hallucinate or rely on stale training data for domain-specific questions. The common workaround - embedding documents in a vector store and retrieving chunks - improves recall but loses structure, provenance, and the ability to enforce authority.
@@ -65,7 +62,7 @@ formData.append("content_type", "product_data");
 
 await fetch("https://spectron.surrealdb.com/api/v1/my-context/documents", {
     method: "POST",
-    headers: { "Authorization": `Bearer ${process.env.SPECTRON_API_KEY}` },
+    headers: { "Authorization": `Bearer ${process.env.AGENT_MEMORY_API_KEY}` },
     body: formData,
 });
 ```
@@ -75,9 +72,9 @@ await fetch("https://spectron.surrealdb.com/api/v1/my-context/documents", {
 Before generating a response, search authoritative knowledge for relevant passages. Use `documents.query` for natural-language search over document chunks, or an entity read for exact lookups.
 
 ```python
-from surrealdb import Spectron
+from surrealdb.memory import Memory
 
-memory = Spectron(context="my-context", api_key="sk-...")
+memory = Memory(context="my-context", api_key="sk-...")
 
 async def grounded_response(session, user_message: str) -> str:
     # Search authoritative knowledge for relevant authoritative knowledge

--- a/src/content/agent-memory/cookbooks/patterns/reflection-loops.mdx
+++ b/src/content/agent-memory/cookbooks/patterns/reflection-loops.mdx
@@ -9,9 +9,6 @@ description: "Scheduled or triggered reflect jobs."
 Reflection is SurrealDB Agent Memory's mechanism for synthesising higher-order insights from accumulated memory. Unlike retrieval - which surfaces facts that already exist - reflection runs an LLM reasoning pass over a scope's memory and produces new insights that can be persisted back as experiential memory attributes. It is how SurrealDB Agent Memory moves from storing individual facts to producing understanding.
 
 > [!NOTE]
-> `Spectron` was the project name for SurrealDB Agent Memory. These type names
-> will be renamed in a future release.
-
 ## What reflection does
 
 A reflection request takes a query, a scope, and optional parameters, then:
@@ -26,9 +23,9 @@ This is different from `context()`, which retrieves and ranks existing facts. Re
 ## Basic reflection call
 
 ```python
-from surrealdb import Spectron
+from surrealdb.memory import Memory
 
-memory = Spectron(context="support", api_key="sk-...")
+memory = Memory(context="support", api_key="sk-...")
 
 result = await memory.reflect(
     query="What are Alice's most frequently reported frustrations?",
@@ -38,9 +35,9 @@ print(result.reflection)
 ```
 
 ```typescript
-import { Spectron } from "@surrealdb/spectron";
+import { AgentMemory } from "@surrealdb/memory";
 
-const memory = new Spectron({ context: "support", apiKey: "sk-..." });
+const memory = new AgentMemory({ context: "support", apiKey: "sk-..." });
 
 const result = await memory.reflect({
     query: "What are Alice's most frequently reported frustrations?",
@@ -79,7 +76,7 @@ just raw facts.
 Supervisor API keys have broader scope access - they can reflect across multiple users or the entire organisation scope. This enables pattern analysis across your user base.
 
 ```python
-supervisor_memory = Spectron(
+supervisor_memory = Memory(
     context="support",
     api_key="supervisor_sk_...",
 )
@@ -90,7 +87,7 @@ result = await supervisor_memory.reflect(  # No user - reflects across all users
 ```
 
 ```typescript
-const supervisorMemory = new Spectron({
+const supervisorMemory = new AgentMemory({
     context: "support",
     apiKey: "supervisor_sk_...",
 });

--- a/src/content/agent-memory/cookbooks/patterns/stateful-workflows.mdx
+++ b/src/content/agent-memory/cookbooks/patterns/stateful-workflows.mdx
@@ -9,9 +9,6 @@ description: "Diff-friendly state for workflow UIs."
 SurrealDB Agent Memory is not limited to conversational memory. Its entity-attribute model and temporal validity system make it a natural fit for tracking the state of long-running, multi-step agent workflows - processes that span hours or days, survive restarts, and need to avoid repeating completed steps.
 
 > [!NOTE]
-> `Spectron` was the project name for SurrealDB Agent Memory. These type names
-> will be renamed in a future release.
-
 ## Why use SurrealDB Agent Memory for workflow state
 
 Traditional approaches to workflow state - Redis keys, database records, task queue metadata - require purpose-built state management. SurrealDB Agent Memory adds:
@@ -37,9 +34,9 @@ Map your workflow steps to entity types and attributes. A research workflow migh
 Use a `project` or `task` scope dimension to isolate each workflow's state:
 
 ```python
-from surrealdb import Spectron
+from surrealdb.memory import Memory
 
-memory = Spectron(context="workflows", api_key="sk-...")
+memory = Memory(context="workflows", api_key="sk-...")
 
 # Each workflow run gets its own scope
 workflow_scope = ["org/acme/project/market-analysis-q1-2025"]
@@ -48,9 +45,9 @@ session = await memory.sessions.create(scopes=workflow_scope)
 ```
 
 ```typescript
-import { Spectron } from "@surrealdb/spectron";
+import { AgentMemory } from "@surrealdb/memory";
 
-const memory = new Spectron({ context: "workflows", apiKey: "sk-..." });
+const memory = new AgentMemory({ context: "workflows", apiKey: "sk-..." });
 
 const workflowScope = ["org/acme/project/market-analysis-q1-2025"];
 const session = await memory.sessions.create({ scopes: workflowScope });

--- a/src/content/agent-memory/cookbooks/patterns/user-memory-in-chat.mdx
+++ b/src/content/agent-memory/cookbooks/patterns/user-memory-in-chat.mdx
@@ -9,9 +9,6 @@ description: "Per-user scopes and profile injection."
 Adding per-user persistent memory to a chat application is the most common SurrealDB Agent Memory integration. This guide covers the two integration shapes - one driven by SurrealDB Agent Memory, one driven by the caller - and shows how to inject memory into system prompts and how memory accumulates across multiple sessions.
 
 > [!NOTE]
-> `Spectron` was the project name for SurrealDB Agent Memory. These type names
-> will be renamed in a future release.
-
 ## The pattern
 
 The core pattern is:
@@ -33,9 +30,9 @@ this shape. If you need your own model, prompt, or tool loop, use integration
 shape 2 below.
 
 ```python
-from surrealdb import Spectron
+from surrealdb.memory import Memory
 
-memory = Spectron(context="chat", api_key="sk-...")
+memory = Memory(context="chat", api_key="sk-...")
 
 # Per conversation
 session = await memory.sessions.create(scopes=[f"user/{user_id}"])
@@ -47,9 +44,9 @@ print(result["memoryUpdates"])   # extraction diff from the user turn
 ```
 
 ```typescript
-import { Spectron } from "@surrealdb/spectron";
+import { AgentMemory } from "@surrealdb/memory";
 
-const memory = new Spectron({ context: "chat", apiKey: "sk-..." });
+const memory = new AgentMemory({ context: "chat", apiKey: "sk-..." });
 
 const session = await memory.sessions.create({ scopes: [`user/${userId}`] });
 
@@ -63,9 +60,9 @@ console.log(result.memoryUpdates);
 Use this shape when you already manage the conversation loop and want to inject SurrealDB Agent Memory into your existing flow without restructuring it.
 
 ```python
-from surrealdb import Spectron
+from surrealdb.memory import Memory
 
-memory = Spectron(context="chat", api_key="sk-...")
+memory = Memory(context="chat", api_key="sk-...")
 
 async def handle_message(user_id: str, session_id: str | None,
     user_message: str) -> str:

--- a/src/content/agent-memory/index/architecture/surface-security-and-models.mdx
+++ b/src/content/agent-memory/index/architecture/surface-security-and-models.mdx
@@ -26,7 +26,7 @@ Trace listing: `GET /api/v1/{ctx}/traces`, `GET /api/v1/{ctx}/traces/stats` (sup
 
 ## Integrations
 
-- **Generated SDKs** - Python (`surrealdb`) and TypeScript (`@surrealdb/spectron`), both produced from SurrealDB Agent Memory’s OpenAPI specification so types track the server surface.
+- **Generated SDKs** - Python (`surrealdb`) and TypeScript (`@surrealdb/memory`), both produced from SurrealDB Agent Memory’s OpenAPI specification so types track the server surface.
 - **MCP over HTTP** - tools wrapping the same handlers; shared Bearer auth. See [MCP server](/docs/agent-memory/integrations/mcp-server/install).
 - **Harness adapters** - LangChain, Claude Code hook, OpenAI Agents, Vercel AI SDK, n8n - flush conversations into `/facts/batch`.
 

--- a/src/content/agent-memory/index/index.mdx
+++ b/src/content/agent-memory/index/index.mdx
@@ -11,7 +11,7 @@ SurrealDB Agent Memory is a memory and knowledge layer for AI agents. It is an a
 Use this hub to go from principles to running code, then dive into the product sections (memory & knowledge, integrations, cookbooks, reference).
 
 > [!NOTE]
-> SurrealDB Agent Memory was developed under the project name **Spectron**, and that name is retained throughout the shipped interface: the `spectron` and `spectrond` binaries, the `SPECTRON_*` environment variables, the `spectron_*` MCP tool names, and SDK packages such as `@surrealdb/spectron`. The rule of thumb is that prose uses the product name and anything you type or configure uses `spectron`. These names will be renamed in a future release.
+> SurrealDB Agent Memory was developed under the project name **Spectron**, and that name is retained throughout the shipped interface: the `spectron` and `spectrond` binaries, the `SPECTRON_*` environment variables, the `spectron_*` MCP tool names, and the `X-Spectron-*` request headers. The client SDKs have already been renamed - the JavaScript package is `@surrealdb/memory`, the Python one `surrealdb-memory`, and so on. The rule of thumb is that prose and SDKs use the product name, while anything you type at a shell or set as configuration still uses `spectron`. Those remaining names will be renamed in a future release.
 
 ## Architecture
 

--- a/src/content/agent-memory/index/ingest/authoritative/bulk-import.mdx
+++ b/src/content/agent-memory/index/ingest/authoritative/bulk-import.mdx
@@ -9,9 +9,6 @@ description: "Importing large quantities of documents or knowledge nodes into Su
 When populating a new Context or migrating from an existing system, you typically need to ingest many documents or knowledge nodes at once. SurrealDB Agent Memory's ingestion pipeline is designed for concurrent usage, and both the document upload endpoint and the triple-write path on `/facts` support high-throughput ingestion patterns.
 
 > [!NOTE]
-> `Spectron` was the project name for SurrealDB Agent Memory. These type names
-> will be renamed in a future release.
-
 ## Uploading many documents
 
 `POST /api/v1/{context_id}/documents` accepts one document per request. For bulk uploads, issue multiple requests concurrently and track their status independently.
@@ -20,9 +17,9 @@ When populating a new Context or migrating from an existing system, you typicall
 
 ```python
 import asyncio
-from surrealdb import Spectron
+from surrealdb.memory import Memory
 
-memory = Spectron(context="acme-prod",
+memory = Memory(context="acme-prod",
     api_key=os.environ["SPECTRON_API_KEY"])
 
 files = [
@@ -46,10 +43,10 @@ print(f"Queued {len(doc_ids)} documents")
 ```
 
 ```javascript
-import { Spectron } from "@surrealdb/spectron";
+import { AgentMemory } from "@surrealdb/memory";
 
-const memory = new Spectron({ context: "acme-prod",
-    apiKey: process.env.SPECTRON_API_KEY });
+const memory = new AgentMemory({ context: "acme-prod",
+    apiKey: process.env.AGENT_MEMORY_API_KEY });
 
 const files = [
     { path: "returns-policy.pdf", title: "Returns Policy" },

--- a/src/content/agent-memory/index/ingest/experiential/remember.mdx
+++ b/src/content/agent-memory/index/ingest/experiential/remember.mdx
@@ -9,9 +9,6 @@ description: "Ingesting facts and conversations into the unified substrate."
 SurrealDB Agent Memory stores memory by **extracting** structured entities, attributes, and relations from text - not by accepting opaque key-value blobs. Every write runs through the reconciler (calibration, supersession, uncertainty on conflict).
 
 > [!NOTE]
-> `Spectron` was the project name for SurrealDB Agent Memory. These type names
-> will be renamed in a future release.
-
 Conversation turns (`/facts`, `/facts/batch`, `/chat`) and document uploads share one extraction contract: the same JSON schema, confidence and temporal fields, and reconciler. Adapters supply the input kind and trust posture (spoken turn vs curated document); they do not invent parallel entity-type vocabularies. That keeps a person named in a policy PDF and the same person named in chat as one node when normalisation matches.
 
 Register scope paths before first write:
@@ -95,7 +92,7 @@ Returns **`extractions`**, **`sessionId`**, and **`turnIds`**.
 ## SDK (Python)
 
 ```python
-# from surrealdb import Spectron - see Python SDK guide
+# from surrealdb.memory import Memory - see Python SDK guide
 await client.remember(
     text="Alice was promoted to CTO.",
     infer="full",

--- a/src/content/agent-memory/index/operations/profiles.mdx
+++ b/src/content/agent-memory/index/operations/profiles.mdx
@@ -9,9 +9,6 @@ description: "Auto-maintained entity profiles aggregated from memory and knowled
 A profile is a computed view over the memory store for a given entity - typically a user. It aggregates the entity's most relevant attributes, preferences, and active instructions into a structured object that can be injected directly into an LLM system prompt.
 
 > [!NOTE]
-> `Spectron` was the project name for SurrealDB Agent Memory. These type names
-> will be renamed in a future release.
-
 Profiles are not a separate store. They are assembled on demand from the same attribute, instruction, and knowledge tables that back all other SurrealDB Agent Memory operations. There is no synchronisation lag and no risk of a profile drifting out of step with the underlying data.
 
 ## Sections
@@ -45,9 +42,9 @@ print(profile.instructions)  # list of {"id":…, "label":…, "description":…
 ```
 
 ```typescript
-import { Spectron } from "@surrealdb/spectron";
+import { AgentMemory } from "@surrealdb/memory";
 
-const memory = new Spectron({ context: "ctx_01jt4kx...", apiKey: "sk-..." });
+const memory = new AgentMemory({ context: "ctx_01jt4kx...", apiKey: "sk-..." });
 
 const profile = await memory.profile();
 

--- a/src/content/agent-memory/index/operations/reflect.mdx
+++ b/src/content/agent-memory/index/operations/reflect.mdx
@@ -9,9 +9,6 @@ description: "Synthesise insights from patterns across stored memories."
 Reflection is a reasoning operation over the memory store. Unlike retrieval, which surfaces existing facts that match a query, reflection asks SurrealDB Agent Memory to examine a set of memories and draw conclusions from them - to reason about patterns, identify trends, and synthesise insights that do not exist as explicit stored attributes.
 
 > [!NOTE]
-> `Spectron` was the project name for SurrealDB Agent Memory. These type names
-> will be renamed in a future release.
-
 The result is a synthesised text insight backed by evidence citations. If `persist` is enabled, the synthesised insights are also stored as new experiential memory attributes, making them available to future queries.
 
 ## How it works
@@ -37,9 +34,9 @@ print(out.evidence)     # list of supporting memory hits
 ```
 
 ```typescript
-import { Spectron } from "@surrealdb/spectron";
+import { AgentMemory } from "@surrealdb/memory";
 
-const memory = new Spectron({ context: "ctx_01jt4kx...", apiKey: "sk-..." });
+const memory = new AgentMemory({ context: "ctx_01jt4kx...", apiKey: "sk-..." });
 
 const out = await memory.reflect({
     query: "What patterns do you see in customer complaints this month?",

--- a/src/content/agent-memory/index/quickstarts/embedded.mdx
+++ b/src/content/agent-memory/index/quickstarts/embedded.mdx
@@ -10,7 +10,7 @@ SurrealDB Agent Memory runs as a **horizontally scalable service** in front of S
 
 - **HTTP** - `/api/v1/{context_id}/...` ([REST API](/docs/agent-memory/integrations/surfaces/rest))
 - **MCP** - `/mcp` on the same port
-- **Generated SDKs** - Python (`surrealdb`) and TypeScript (`@surrealdb/spectron`)
+- **Generated SDKs** - Python (`surrealdb`) and TypeScript (`@surrealdb/memory`)
 - **Harness adapters** - LangChain, Vercel AI SDK, OpenAI Agents, n8n, Claude Code hook ([Integrations](/docs/agent-memory/integrations))
 
 ## In-process library

--- a/src/content/agent-memory/index/quickstarts/hosted.mdx
+++ b/src/content/agent-memory/index/quickstarts/hosted.mdx
@@ -9,9 +9,6 @@ description: "Get up and running with SurrealDB Agent Memory on SurrealDB Cloud 
 This guide takes you from a blank terminal to your first **remember** and **recall** calls against **SurrealDB Agent Memory on SurrealDB Cloud**. Cloud runs the SurrealDB Agent Memory data plane, SurrealDB, and object store per context - you do not provision infrastructure yourself.
 
 > [!NOTE]
-> `Spectron` was the project name for SurrealDB Agent Memory. These type names
-> will be renamed in a future release.
-
 > [!NOTE]
 > SurrealDB Agent Memory contexts are created in **[SurrealDB Studio](https://studio.surrealdb.com)** (organisation → **Contexts**). See [SurrealDB Agent Memory on SurrealDB Cloud](/docs/agent-memory/quickstarts/surrealdb-cloud) for context setup and API keys. This page assumes you already have a **context host**, **context id**, and **API key** from the **API keys** view.
 
@@ -97,7 +94,7 @@ curl -sS "$SPECTRON_URL/api/v1/$SPECTRON_CONTEXT_ID/chat" \
 
 ## SDKs
 
-Official clients: **`surrealdb`** (Python, includes `Spectron` / `AsyncSpectron`) and **`@surrealdb/spectron`** (TypeScript). Point them at `endpoint: process.env.SPECTRON_URL` (your context host). See [Integrations](/docs/agent-memory/integrations).
+Official clients: **`surrealdb[memory]`** (Python, provides `Memory` / `AsyncMemory`) and **`@surrealdb/memory`** (TypeScript). Point them at `endpoint: process.env.SPECTRON_URL` (your context host). See [Integrations](/docs/agent-memory/integrations).
 
 ## Next steps
 

--- a/src/content/agent-memory/index/retrieve/hybrid-search.mdx
+++ b/src/content/agent-memory/index/retrieve/hybrid-search.mdx
@@ -9,9 +9,6 @@ description: "Using vector, BM25, and graph-density retrieval modes in SurrealDB
 SurrealDB Agent Memory exposes four retrieval modes for **document passages** (`POST .../documents/query`) and for the **unified** read path (`POST .../query`, which also ranks experiential facts). Each mode trades coverage, precision, and computational cost differently. See [Recalling memories](/docs/agent-memory/retrieve/recall) for unified recall; this page focuses on mode selection and graph-density signals.
 
 > [!NOTE]
-> `Spectron` was the project name for SurrealDB Agent Memory. These type names
-> will be renamed in a future release.
-
 ## Answer size vs search breadth
 
 **`k`** (and **`limit`** on `/query`) controls how many hits are returned after fusion - the **answer size**. Default **10**, maximum **50** (`SPECTRON_MAX_QUERY_K`, clamp-down only).
@@ -81,9 +78,9 @@ Responses may report `hybrid_graph` on individual hits when several signals comb
 ## Basic query
 
 ```python
-from surrealdb import Spectron
+from surrealdb.memory import Memory
 
-memory = Spectron(context="acme-prod", api_key=os.environ["SPECTRON_API_KEY"])
+memory = Memory(context="acme-prod", api_key=os.environ["SPECTRON_API_KEY"])
 
 hits = await memory.documents.query(
     query="what is the return window for unopened items?",
@@ -98,9 +95,9 @@ for hit in hits:
 ```
 
 ```javascript
-import { Spectron } from "@surrealdb/spectron";
+import { AgentMemory } from "@surrealdb/memory";
 
-const memory = new Spectron({ context: "acme-prod", apiKey: process.env.SPECTRON_API_KEY });
+const memory = new AgentMemory({ context: "acme-prod", apiKey: process.env.AGENT_MEMORY_API_KEY });
 
 const hits = await memory.documents.query({
     query: "what is the return window for unopened items?",

--- a/src/content/agent-memory/index/retrieve/keywords-and-bm25.mdx
+++ b/src/content/agent-memory/index/retrieve/keywords-and-bm25.mdx
@@ -9,9 +9,6 @@ description: "Using keyword extraction and full-text search in SurrealDB Agent M
 SurrealDB Agent Memory combines two statistical retrieval mechanisms - RAKE keyword extraction and BM25 full-text search - to complement dense vector retrieval. Together, they ensure that exact terms, product identifiers, technical phrases, and domain vocabulary are reliably findable even when their embedding representation is weak.
 
 > [!NOTE]
-> `Spectron` was the project name for SurrealDB Agent Memory. These type names
-> will be renamed in a future release.
-
 ## RAKE keyword extraction
 
 During document ingestion, SurrealDB Agent Memory applies RAKE (Rapid Automatic Keyword Extraction) to each document. RAKE is a statistical, language-agnostic algorithm that identifies multi-word keyphrases by exploiting word co-occurrence and word frequency without requiring a language model or training data.
@@ -33,9 +30,9 @@ Keywords extracted by RAKE also serve as seeds for `hybrid_graph` retrieval. Whe
 Retrieve the keyphrases extracted from a specific document:
 
 ```python
-from surrealdb import Spectron
+from surrealdb.memory import Memory
 
-memory = Spectron(context="acme-prod", api_key=os.environ["SPECTRON_API_KEY"])
+memory = Memory(context="acme-prod", api_key=os.environ["SPECTRON_API_KEY"])
 
 keywords = await memory.documents.keywords.for_document(doc.id)
 for kw in keywords:
@@ -48,9 +45,9 @@ for kw in keywords:
 ```
 
 ```javascript
-import { Spectron } from "@surrealdb/spectron";
+import { AgentMemory } from "@surrealdb/memory";
 
-const memory = new Spectron({ context: "acme-prod", apiKey: process.env.SPECTRON_API_KEY });
+const memory = new AgentMemory({ context: "acme-prod", apiKey: process.env.AGENT_MEMORY_API_KEY });
 
 const keywords = await memory.documents.keywords.forDocument(doc.id);
 for (const kw of keywords) {

--- a/src/content/agent-memory/index/sessions/chat-sessions.mdx
+++ b/src/content/agent-memory/index/sessions/chat-sessions.mdx
@@ -9,9 +9,6 @@ description: "Using chat() for conversation loops managed by SurrealDB Agent Mem
 The `chat` endpoint lets SurrealDB Agent Memory manage the entire LLM conversation loop in a single call. Rather than recording a turn, retrieving context, calling your LLM, and recording the assistant's reply separately, you hand all of that to SurrealDB Agent Memory and receive the model's reply along with a memory diff in one response.
 
 > [!NOTE]
-> `Spectron` was the project name for SurrealDB Agent Memory. These type names
-> will be renamed in a future release.
-
 ## Two integration patterns
 
 SurrealDB Agent Memory supports two ways to integrate memory into a conversation:
@@ -94,9 +91,9 @@ The extraction diff from the user turn (the assistant reply is stored with `infe
 ## Python SDK
 
 ```python
-from surrealdb import Spectron
+from surrealdb.memory import Memory
 
-memory = Spectron(context="acme-prod",
+memory = Memory(context="acme-prod",
     api_key=os.environ["SPECTRON_API_KEY"])
 session = await memory.sessions.create(scopes=["org/acme/user/alice"])
 
@@ -110,10 +107,10 @@ print(reply["memoryUpdates"])  # Entities, attributes, relations, corrections
 ## JavaScript SDK
 
 ```javascript
-import { Spectron } from "@surrealdb/spectron";
+import { AgentMemory } from "@surrealdb/memory";
 
-const memory = new Spectron({ context: "acme-prod",
-    apiKey: process.env.SPECTRON_API_KEY });
+const memory = new AgentMemory({ context: "acme-prod",
+    apiKey: process.env.AGENT_MEMORY_API_KEY });
 const session = await memory.sessions.create({ scopes: ["org/acme/user/alice"] });
 
 const reply = await memory.chat("What do you know about me?", { sessionId: session.id });
@@ -129,9 +126,9 @@ The following pattern shows a minimal chat loop using `chat()`:
 
 ```python
 import os
-from surrealdb import Spectron
+from surrealdb.memory import Memory
 
-memory = Spectron(context="acme-prod",
+memory = Memory(context="acme-prod",
     api_key=os.environ["SPECTRON_API_KEY"])
 session = await memory.sessions.create(scopes=["org/acme/user/alice"])
 
@@ -152,10 +149,10 @@ await session.close()
 
 ```javascript
 import * as readline from "node:readline";
-import { Spectron } from "@surrealdb/spectron";
+import { AgentMemory } from "@surrealdb/memory";
 
-const memory = new Spectron({ context: "acme-prod",
-    apiKey: process.env.SPECTRON_API_KEY });
+const memory = new AgentMemory({ context: "acme-prod",
+    apiKey: process.env.AGENT_MEMORY_API_KEY });
 const session = await memory.sessions.create({ scopes: ["org/acme/user/alice"] });
 
 const rl = readline.createInterface({ input: process.stdin,

--- a/src/content/agent-memory/index/sessions/creating-sessions.mdx
+++ b/src/content/agent-memory/index/sessions/creating-sessions.mdx
@@ -9,9 +9,6 @@ description: "How to create and manage conversation sessions in SurrealDB Agent 
 A **session** is the fundamental unit of conversation in SurrealDB Agent Memory. It is a scoped, persistent container that groups all turns, extracted facts, and derived knowledge from a single conversational thread. Every entity, attribute, relation, instruction, and uncertainty produced by SurrealDB Agent Memory carries a reference to the session and turn it was extracted from, giving the memory layer complete provenance.
 
 > [!NOTE]
-> `Spectron` was the project name for SurrealDB Agent Memory. These type names
-> will be renamed in a future release.
-
 ## Why sessions exist
 
 SurrealDB Agent Memory stores memory as a structured graph of discrete facts rather than a bag of text chunks. For that model to be useful, each fact must answer two questions:
@@ -65,9 +62,9 @@ The `metadata` field is optional. Use it to attach arbitrary operational data - 
 ### Python SDK
 
 ```python
-from surrealdb import Spectron
+from surrealdb.memory import Memory
 
-memory = Spectron(context="acme-prod", api_key=os.environ["SPECTRON_API_KEY"])
+memory = Memory(context="acme-prod", api_key=os.environ["SPECTRON_API_KEY"])
 
 session = await memory.sessions.create(
     scopes=["org/acme/user/alice"],
@@ -81,9 +78,9 @@ print(session.scope)    # ["org/acme/user/alice"]
 ### JavaScript SDK
 
 ```javascript
-import { Spectron } from "@surrealdb/spectron";
+import { AgentMemory } from "@surrealdb/memory";
 
-const memory = new Spectron({ context: "acme-prod", apiKey: process.env.SPECTRON_API_KEY });
+const memory = new AgentMemory({ context: "acme-prod", apiKey: process.env.AGENT_MEMORY_API_KEY });
 
 const session = await memory.sessions.create({
     scopes: [["org/acme/user/alice"]],

--- a/src/content/agent-memory/integrations/ai-sdks/cloudflare-workers-ai.mdx
+++ b/src/content/agent-memory/integrations/ai-sdks/cloudflare-workers-ai.mdx
@@ -6,19 +6,16 @@ description: "Using SurrealDB Agent Memory from a Cloudflare Worker alongside Wo
 
 # Cloudflare Workers AI
 
-A Cloudflare Worker can run a model with [Workers AI](https://developers.cloudflare.com/workers-ai/) and back it with SurrealDB Agent Memory in the same request. The [JavaScript SDK](/docs/agent-memory/integrations/sdks/javascript-and-typescript) (`@surrealdb/spectron`) uses platform `fetch` and ships no runtime dependencies, so it runs on the Workers runtime unchanged.
+A Cloudflare Worker can run a model with [Workers AI](https://developers.cloudflare.com/workers-ai/) and back it with SurrealDB Agent Memory in the same request. The [JavaScript SDK](/docs/agent-memory/integrations/sdks/javascript-and-typescript) (`@surrealdb/memory`) uses platform `fetch` and ships no runtime dependencies, so it runs on the Workers runtime unchanged.
 
 > [!NOTE]
-> `Spectron` was the project name for SurrealDB Agent Memory. These type names
-> will be renamed in a future release.
-
 > [!NOTE]
 > This is an integration guide. There is no first-party Cloudflare package; the code wires the SurrealDB Agent Memory SDK into a Worker. It applies equally to the [Cloudflare Agents SDK](https://developers.cloudflare.com/agents/): construct the client the same way inside your agent.
 
 ## Installation
 
 ```bash
-npm install @surrealdb/spectron
+npm install @surrealdb/memory
 ```
 
 Store the SurrealDB Agent Memory API key as a secret rather than in `wrangler.toml`:
@@ -43,13 +40,13 @@ SPECTRON_CONTEXT = "acme-prod"
 Recall context, run a Workers AI model with that context, then store the exchange:
 
 ```typescript
-import { Spectron } from "@surrealdb/spectron";
+import { AgentMemory } from "@surrealdb/memory";
 
 interface Env {
     AI: Ai;
-    SPECTRON_ENDPOINT: string;
+    AGENT_MEMORY_ENDPOINT: string;
     SPECTRON_CONTEXT: string;
-    SPECTRON_API_KEY: string;
+    AGENT_MEMORY_API_KEY: string;
 }
 
 export default {
@@ -57,10 +54,10 @@ export default {
         const { userId, message } = await request.json();
         const scope = [`org/acme/user/${userId}`];
 
-        const spectron = new Spectron({
-            endpoint: env.SPECTRON_ENDPOINT,
+        const spectron = new AgentMemory({
+            endpoint: env.AGENT_MEMORY_ENDPOINT,
             context: env.SPECTRON_CONTEXT,
-            apiKey: env.SPECTRON_API_KEY,
+            apiKey: env.AGENT_MEMORY_API_KEY,
         });
 
         // 1. Recall relevant memory as a context block.

--- a/src/content/agent-memory/integrations/ai-sdks/tanstack-ai.mdx
+++ b/src/content/agent-memory/integrations/ai-sdks/tanstack-ai.mdx
@@ -6,19 +6,16 @@ description: "Adding SurrealDB Agent Memory to a TanStack AI application."
 
 # TanStack AI
 
-[`@tanstack/ai`](https://tanstack.com/ai) is a type-safe, provider-agnostic AI SDK for streaming chat, tool calling, and agents. SurrealDB Agent Memory adds long-term memory to a `chat()` call: recall relevant context before a generation, then store the exchange afterwards. There is no dedicated adapter. The [JavaScript SDK](/docs/agent-memory/integrations/sdks/javascript-and-typescript) (`@surrealdb/spectron`) runs in any server handler that calls `chat()`.
+[`@tanstack/ai`](https://tanstack.com/ai) is a type-safe, provider-agnostic AI SDK for streaming chat, tool calling, and agents. SurrealDB Agent Memory adds long-term memory to a `chat()` call: recall relevant context before a generation, then store the exchange afterwards. There is no dedicated adapter. The [JavaScript SDK](/docs/agent-memory/integrations/sdks/javascript-and-typescript) (`@surrealdb/memory`) runs in any server handler that calls `chat()`.
 
 > [!NOTE]
-> `Spectron` was the project name for SurrealDB Agent Memory. These type names
-> will be renamed in a future release.
-
 > [!NOTE]
 > This is an integration guide. There is no first-party TanStack package; the code below wires the SurrealDB Agent Memory SDK into a `@tanstack/ai` handler, and you can adapt it to your server shape.
 
 ## Installation
 
 ```bash
-npm install @surrealdb/spectron @tanstack/ai @tanstack/ai-openai
+npm install @surrealdb/memory @tanstack/ai @tanstack/ai-openai
 ```
 
 SurrealDB Agent Memory holds an API key, so construct the client only on the server, never in a component or loader that ships to the browser.
@@ -29,14 +26,14 @@ Recall context, prepend it to the system prompt, generate, then store the turn:
 
 ```typescript
 // src/routes/api/chat.ts
-import { Spectron } from "@surrealdb/spectron";
+import { AgentMemory } from "@surrealdb/memory";
 import { chat, toServerSentEventsResponse } from "@tanstack/ai";
 import { openaiText } from "@tanstack/ai-openai";
 
-const spectron = new Spectron({
-    endpoint: process.env.SPECTRON_ENDPOINT!,
+const spectron = new AgentMemory({
+    endpoint: process.env.AGENT_MEMORY_ENDPOINT!,
     context: "acme-prod",
-    apiKey: process.env.SPECTRON_API_KEY!,
+    apiKey: process.env.AGENT_MEMORY_API_KEY!,
 });
 
 export async function POST(request: Request) {

--- a/src/content/agent-memory/integrations/ai-sdks/vercel-ai-sdk.mdx
+++ b/src/content/agent-memory/integrations/ai-sdks/vercel-ai-sdk.mdx
@@ -7,9 +7,6 @@ description: "SurrealDB Agent Memory for the Vercel AI SDK, via language-model m
 # Vercel AI SDK
 
 > [!NOTE]
-> `Spectron` was the project name for SurrealDB Agent Memory. These type names
-> will be renamed in a future release.
-
 `@surrealdb/spectron-vercel-ai` integrates SurrealDB Agent Memory with the [Vercel AI SDK](https://ai-sdk.dev). Keep using your own model provider (`@ai-sdk/openai`, `@ai-sdk/anthropic`, and so on) with `generateText` / `streamText`, and let SurrealDB Agent Memory transparently:
 
 - **inject** relevant long-term memory (and the user's profile) into the prompt before generation, and
@@ -22,7 +19,7 @@ The API is `createSpectron()` → `.middleware()` / `.tools()`.
 ## Installation
 
 ```bash
-npm i @surrealdb/spectron-vercel-ai ai @surrealdb/spectron
+npm i @surrealdb/spectron-vercel-ai ai @surrealdb/memory
 # plus your model provider, e.g.
 npm i @ai-sdk/openai
 ```
@@ -46,9 +43,9 @@ import { createSpectron } from "@surrealdb/spectron-vercel-ai";
 const spectron = createSpectron({ defaultScopes: "user/tobie" });
 
 // Or pass config / a preconstructed client explicitly:
-import { Spectron } from "@surrealdb/spectron-vercel-ai";
+import { AgentMemory } from "@surrealdb/spectron-vercel-ai";
 const spectron = createSpectron({
-    client: new Spectron({ endpoint, apiKey, context }),
+    client: new AgentMemory({ endpoint, apiKey, context }),
 });
 ```
 
@@ -130,7 +127,7 @@ spectron.middleware({ scopes: ["team/eng", "user/x"] }); // OR of two
 
 ## Direct client access
 
-`spectron.client` is the underlying `@surrealdb/spectron` client for anything not wrapped here: documents, sessions, entities, `chat`, and so on. See the [JavaScript SDK](/docs/agent-memory/integrations/sdks/javascript-and-typescript) for the full surface.
+`spectron.client` is the underlying `@surrealdb/memory` client for anything not wrapped here: documents, sessions, entities, `chat`, and so on. See the [JavaScript SDK](/docs/agent-memory/integrations/sdks/javascript-and-typescript) for the full surface.
 
 ## Next steps
 

--- a/src/content/agent-memory/integrations/automation/zo-computer.mdx
+++ b/src/content/agent-memory/integrations/automation/zo-computer.mdx
@@ -14,9 +14,6 @@ description: "Adding SurrealDB Agent Memory to a Zo Computer skill."
 ## Installation
 
 > [!NOTE]
-> `Spectron` was the project name for SurrealDB Agent Memory. These type names
-> will be renamed in a future release.
-
 Add the dependency to your skill and set the connection details as environment variables in Zo:
 
 ```bash
@@ -43,9 +40,9 @@ Expose three functions a Zo workflow can call: store a turn, ask a question of m
 
 ```python
 import os
-from surrealdb import Spectron
+from surrealdb.memory import Memory
 
-memory = Spectron(
+memory = Memory(
     endpoint=os.environ["SPECTRON_ENDPOINT"],
     context=os.environ["SPECTRON_CONTEXT"],
     api_key=os.environ["SPECTRON_API_KEY"],

--- a/src/content/agent-memory/integrations/frameworks/agno.mdx
+++ b/src/content/agent-memory/integrations/frameworks/agno.mdx
@@ -14,9 +14,6 @@ description: "Adding persistent memory to Agno agents with the SurrealDB Agent M
 ## Installation
 
 > [!NOTE]
-> `Spectron` was the project name for SurrealDB Agent Memory. These type names
-> will be renamed in a future release.
-
 ```bash
 pip install agno openai
 pip install --pre surrealdb
@@ -36,9 +33,9 @@ Agno agents take a `tools` list. Pass functions that call the SurrealDB Agent Me
 import os
 from agno.agent import Agent
 from agno.models.openai import OpenAIChat
-from surrealdb import Spectron
+from surrealdb.memory import Memory
 
-memory = Spectron(
+memory = Memory(
     endpoint=os.environ["SPECTRON_ENDPOINT"],
     context=os.environ["SPECTRON_CONTEXT"],
     api_key=os.environ["SPECTRON_API_KEY"],

--- a/src/content/agent-memory/integrations/frameworks/autogen.mdx
+++ b/src/content/agent-memory/integrations/frameworks/autogen.mdx
@@ -14,9 +14,6 @@ description: "Adding persistent memory to Microsoft AutoGen agents with the Surr
 ## Installation
 
 > [!NOTE]
-> `Spectron` was the project name for SurrealDB Agent Memory. These type names
-> will be renamed in a future release.
-
 ```bash
 pip install autogen-agentchat 'autogen-ext[openai]'
 pip install --pre surrealdb
@@ -36,9 +33,9 @@ Wrap the SurrealDB Agent Memory client in plain functions and pass them to the a
 import os
 from autogen_agentchat.agents import AssistantAgent
 from autogen_ext.models.openai import OpenAIChatCompletionClient
-from surrealdb import Spectron
+from surrealdb.memory import Memory
 
-memory = Spectron(
+memory = Memory(
     endpoint=os.environ["SPECTRON_ENDPOINT"],
     context=os.environ["SPECTRON_CONTEXT"],
     api_key=os.environ["SPECTRON_API_KEY"],

--- a/src/content/agent-memory/integrations/frameworks/camel-ai.mdx
+++ b/src/content/agent-memory/integrations/frameworks/camel-ai.mdx
@@ -14,9 +14,6 @@ description: "Adding persistent memory to Camel AI agents with the SurrealDB Age
 ## Installation
 
 > [!NOTE]
-> `Spectron` was the project name for SurrealDB Agent Memory. These type names
-> will be renamed in a future release.
-
 ```bash
 pip install camel-ai
 pip install --pre surrealdb
@@ -36,9 +33,9 @@ Expose SurrealDB Agent Memory through CAMEL's `FunctionTool` so an agent can rec
 import os
 from camel.agents import ChatAgent
 from camel.toolkits import FunctionTool
-from surrealdb import Spectron
+from surrealdb.memory import Memory
 
-memory = Spectron(
+memory = Memory(
     endpoint=os.environ["SPECTRON_ENDPOINT"],
     context=os.environ["SPECTRON_CONTEXT"],
     api_key=os.environ["SPECTRON_API_KEY"],

--- a/src/content/agent-memory/integrations/frameworks/crewai.mdx
+++ b/src/content/agent-memory/integrations/frameworks/crewai.mdx
@@ -9,9 +9,6 @@ description: "CrewAI integration for SurrealDB Agent Memory, with memory tools a
 SurrealDB Agent Memory gives [CrewAI](https://www.crewai.com/) agents persistent, provenance-first memory. The integration offers two approaches that compose: tools an agent calls explicitly, and automatic memory that recalls before each task, writes back after it, and consolidates when the crew finishes, without changing your agents or tasks.
 
 > [!NOTE]
-> `Spectron` was the project name for SurrealDB Agent Memory. These type names
-> will be renamed in a future release.
-
 Package: **`spectron-crew-ai`** (PyPI). It pulls in CrewAI and the SurrealDB SDK (`surrealdb` v3, which bundles SurrealDB Agent Memory).
 
 ## Requirements

--- a/src/content/agent-memory/integrations/frameworks/eve.mdx
+++ b/src/content/agent-memory/integrations/frameworks/eve.mdx
@@ -39,7 +39,7 @@ export default spectronMemoryInstructions();
 ```
 
 ```typescript
-// agent/hooks/memory.ts: persists the conversation back to Spectron
+// agent/hooks/memory.ts: persists the conversation back to AgentMemory
 import { spectronMemoryHook } from "@surrealdb/spectron-eve";
 export default spectronMemoryHook();
 ```

--- a/src/content/agent-memory/integrations/frameworks/google-adk.mdx
+++ b/src/content/agent-memory/integrations/frameworks/google-adk.mdx
@@ -9,9 +9,6 @@ description: "SurrealDB Agent Memory as tools for Google's Agent Development Kit
 SurrealDB Agent Memory gives [Google ADK](https://github.com/google/adk-python) agents persistent memory that survives restarts and separate conversations. The package wraps SurrealDB Agent Memory's verbs as ADK tools; it handles entity extraction, knowledge-graph storage, temporal facts, and hybrid retrieval.
 
 > [!NOTE]
-> `Spectron` was the project name for SurrealDB Agent Memory. These type names
-> will be renamed in a future release.
-
 Package: **`spectron-google-adk`** (PyPI). It pulls in `google-adk` and `surrealdb`.
 
 ## Installation
@@ -86,10 +83,10 @@ agent = Agent(model="gemini-2.5-flash", name="assistant", tools=[toolset])
 **`get_spectron_tools`** returns a plain list of tools for quick scripts. Pass your own `client` to control its lifecycle:
 
 ```python
-from surrealdb import AsyncSpectron
+from surrealdb.memory import AsyncMemory
 from spectron_google_adk import get_spectron_tools
 
-client = AsyncSpectron(context="acme-prod", endpoint="...", api_key="sk-...")
+client = AsyncMemory(context="acme-prod", endpoint="...", api_key="sk-...")
 tools = get_spectron_tools(client=client)
 ```
 

--- a/src/content/agent-memory/integrations/frameworks/langchain.mdx
+++ b/src/content/agent-memory/integrations/frameworks/langchain.mdx
@@ -6,12 +6,9 @@ description: "LangChain and LangGraph integration for SurrealDB Agent Memory, wi
 
 # LangChain
 
-SurrealDB ships an official integration for the [LangChain.js](https://js.langchain.com) and [LangGraph.js](https://langchain-ai.github.io/langgraphjs/) ecosystems. It wraps the [`@surrealdb/spectron`](https://www.npmjs.com/package/@surrealdb/spectron) client so a chain or agent can retrieve from SurrealDB Agent Memory's knowledge base, expose memory as tools, and read memory through a LangGraph store.
+SurrealDB ships an official integration for the [LangChain.js](https://js.langchain.com) and [LangGraph.js](https://langchain-ai.github.io/langgraphjs/) ecosystems. It wraps the [`@surrealdb/memory`](https://www.npmjs.com/package/@surrealdb/memory) client so a chain or agent can retrieve from SurrealDB Agent Memory's knowledge base, expose memory as tools, and read memory through a LangGraph store.
 
 > [!NOTE]
-> `Spectron` was the project name for SurrealDB Agent Memory. These type names
-> will be renamed in a future release.
-
 The integration is TypeScript. Python applications call SurrealDB Agent Memory through the [Python SDK](/docs/agent-memory/integrations/sdks/python) or the [REST API](/docs/agent-memory/integrations/surfaces/rest) instead.
 
 ## Packages
@@ -30,7 +27,7 @@ The integration is TypeScript. Python applications call SurrealDB Agent Memory t
 ## Installation
 
 ```bash
-bun add @surrealdb/langchain @surrealdb/langgraph @surrealdb/spectron
+bun add @surrealdb/langchain @surrealdb/langgraph @surrealdb/memory
 ```
 
 ## Configure the client
@@ -38,12 +35,12 @@ bun add @surrealdb/langchain @surrealdb/langgraph @surrealdb/spectron
 Construct a client directly, or resolve one from the environment:
 
 ```typescript
-import { Spectron } from "@surrealdb/langchain-core";
+import { AgentMemory } from "@surrealdb/langchain-core";
 
-const spectron = new Spectron({
+const spectron = new AgentMemory({
     context: "acme-prod",
-    apiKey: process.env.SPECTRON_API_KEY!,
-    endpoint: process.env.SPECTRON_ENDPOINT!,
+    apiKey: process.env.AGENT_MEMORY_API_KEY!,
+    endpoint: process.env.AGENT_MEMORY_ENDPOINT!,
 });
 ```
 

--- a/src/content/agent-memory/integrations/frameworks/llamaindex.mdx
+++ b/src/content/agent-memory/integrations/frameworks/llamaindex.mdx
@@ -14,9 +14,6 @@ description: "Adding persistent memory to LlamaIndex agents with the SurrealDB A
 ## Installation
 
 > [!NOTE]
-> `Spectron` was the project name for SurrealDB Agent Memory. These type names
-> will be renamed in a future release.
-
 ```bash
 pip install llama-index
 pip install --pre surrealdb
@@ -37,9 +34,9 @@ import os
 from llama_index.core.agent.workflow import FunctionAgent
 from llama_index.core.tools import FunctionTool
 from llama_index.llms.openai import OpenAI
-from surrealdb import Spectron
+from surrealdb.memory import Memory
 
-memory = Spectron(
+memory = Memory(
     endpoint=os.environ["SPECTRON_ENDPOINT"],
     context=os.environ["SPECTRON_CONTEXT"],
     api_key=os.environ["SPECTRON_API_KEY"],

--- a/src/content/agent-memory/integrations/frameworks/mastra.mdx
+++ b/src/content/agent-memory/integrations/frameworks/mastra.mdx
@@ -9,9 +9,6 @@ description: "SurrealDB Agent Memory as a memory provider and tools for Mastra, 
 `@surrealdb/mastra-ai` is the SurrealDB integration for [Mastra](https://mastra.ai). It ships two things that can be used separately or together: a **storage adapter** backed by a SurrealDB instance you run, and an **SurrealDB Agent Memory** memory provider backed by the hosted agent memory service.
 
 > [!NOTE]
-> `Spectron` was the project name for SurrealDB Agent Memory. These type names
-> will be renamed in a future release.
-
 ## Requirements
 
 - Bun 1+ or Node.js 22+
@@ -45,9 +42,9 @@ const agent = new Agent({
     instructions: "You are a helpful assistant with long-term memory.",
     model: anthropic("claude-sonnet-4-5"),
     memory: new SpectronMemory({
-        endpoint: process.env.SPECTRON_ENDPOINT!,
+        endpoint: process.env.AGENT_MEMORY_ENDPOINT!,
         context: process.env.SPECTRON_CONTEXT!,
-        apiKey: process.env.SPECTRON_API_KEY!,
+        apiKey: process.env.AGENT_MEMORY_API_KEY!,
     }),
 });
 ```
@@ -61,9 +58,9 @@ const store = new SurrealDBStore({ id: "spectron-demo", url: "ws://localhost:800
 await store.init();
 
 const memory = new SpectronMemory({
-    endpoint: process.env.SPECTRON_ENDPOINT!,
+    endpoint: process.env.AGENT_MEMORY_ENDPOINT!,
     context: process.env.SPECTRON_CONTEXT!,
-    apiKey: process.env.SPECTRON_API_KEY!,
+    apiKey: process.env.AGENT_MEMORY_API_KEY!,
     storage: store, // durable verbatim history; omit to keep it in-process
 });
 ```
@@ -73,12 +70,12 @@ const memory = new SpectronMemory({
 Let an agent call SurrealDB Agent Memory explicitly to store, recall, forget, fetch context, and search documents:
 
 ```typescript
-import { Spectron, createSpectronTools } from "@surrealdb/mastra-ai/spectron";
+import { AgentMemory, createSpectronTools } from "@surrealdb/mastra-ai/spectron";
 
-const client = new Spectron({
-    endpoint: process.env.SPECTRON_ENDPOINT!,
+const client = new AgentMemory({
+    endpoint: process.env.AGENT_MEMORY_ENDPOINT!,
     context: process.env.SPECTRON_CONTEXT!,
-    apiKey: process.env.SPECTRON_API_KEY!,
+    apiKey: process.env.AGENT_MEMORY_API_KEY!,
 });
 
 const agent = new Agent({

--- a/src/content/agent-memory/integrations/frameworks/openai-agents.mdx
+++ b/src/content/agent-memory/integrations/frameworks/openai-agents.mdx
@@ -9,9 +9,6 @@ description: "SurrealDB Agent Memory for agents built with the OpenAI Agents SDK
 SurrealDB Agent Memory gives agents built with the [OpenAI Agents SDK](https://openai.github.io/openai-agents-python/) a durable, shared memory. An agent can remember across runs, recall what it needs before answering, and share memory with other agents through a common scope.
 
 > [!NOTE]
-> `Spectron` was the project name for SurrealDB Agent Memory. These type names
-> will be renamed in a future release.
-
 Package: **`spectron-openai-agents-sdk`** (PyPI). Memory works two ways, and they compose: function tools the agent calls itself, and automatic memory wrapped around a run.
 
 ## Installation

--- a/src/content/agent-memory/integrations/frameworks/pydantic-ai.mdx
+++ b/src/content/agent-memory/integrations/frameworks/pydantic-ai.mdx
@@ -9,9 +9,6 @@ description: "SurrealDB Agent Memory for Pydantic AI, via a toolset, auto-recall
 SurrealDB Agent Memory connects to [Pydantic AI](https://ai.pydantic.dev) through the framework's own extension points, so an agent can remember facts across runs, recall them when relevant, and keep a durable record of its conversations.
 
 > [!NOTE]
-> `Spectron` was the project name for SurrealDB Agent Memory. These type names
-> will be renamed in a future release.
-
 Package: **`spectron-pydantic-ai`** (PyPI). It gives you three surfaces, usable on their own or together:
 
 - **Memory tools** (`SpectronToolset`): expose `recall`, `context`, `remember`, and more as tools the agent calls when it decides to.

--- a/src/content/agent-memory/integrations/frameworks/strands-agents.mdx
+++ b/src/content/agent-memory/integrations/frameworks/strands-agents.mdx
@@ -9,9 +9,6 @@ description: "SurrealDB Agent Memory as tools for the Strands Agents SDK."
 SurrealDB Agent Memory exposes its memory operations as [Strands Agents](https://strandsagents.com) tools, so any Strands agent can store and retrieve long-term memory with a single line of setup.
 
 > [!NOTE]
-> `Spectron` was the project name for SurrealDB Agent Memory. These type names
-> will be renamed in a future release.
-
 Package: **`spectron-strands-agents`** (PyPI). It pulls in `strands-agents` and `surrealdb` (which provides the SurrealDB Agent Memory client).
 
 ```python
@@ -51,7 +48,7 @@ export SPECTRON_CONTEXT="acme-prod"
 You can also pass the values directly, or hand in a client you already have:
 
 ```python
-from surrealdb import Spectron
+from surrealdb.memory import Memory
 from spectron_strands import spectron_tools
 
 # From explicit arguments.
@@ -62,7 +59,7 @@ tools = spectron_tools(
 )
 
 # Or reuse an existing client.
-client = Spectron(context="acme-prod", endpoint="...", api_key="...")
+client = Memory(context="acme-prod", endpoint="...", api_key="...")
 tools = spectron_tools(client=client)
 ```
 

--- a/src/content/agent-memory/integrations/index.mdx
+++ b/src/content/agent-memory/integrations/index.mdx
@@ -29,13 +29,13 @@ Call SurrealDB Agent Memory directly from application code.
 | Language | Package |
 | --- | --- |
 | Dart | `surrealdb` (import `spectron.dart`) |
-| Elixir | `:surrealdb` (`SurrealDB.Spectron`) |
+| Elixir | `:surrealdb` (`SurrealDB.Memory`) |
 | Go | `spectron` package in `surrealdb.go` |
 | Haskell | `surrealdb-spectron` |
-| JavaScript / TypeScript | `@surrealdb/spectron` |
+| JavaScript / TypeScript | `@surrealdb/memory` |
 | Kotlin | bundled in `com.surrealdb:kotlin` |
 | Python | `surrealdb` (SurrealDB Agent Memory ships inside it) |
-| Swift | `Spectron` product in `surrealdb.swift` |
+| Swift | `AgentMemory` product in `surrealdb.swift` |
 
 → [Dart](/docs/agent-memory/integrations/sdks/dart) · [Elixir](/docs/agent-memory/integrations/sdks/elixir) · [Go](/docs/agent-memory/integrations/sdks/go) · [Haskell](/docs/agent-memory/integrations/sdks/haskell) · [JavaScript & TypeScript](/docs/agent-memory/integrations/sdks/javascript-and-typescript) · [Kotlin](/docs/agent-memory/integrations/sdks/kotlin) · [Python](/docs/agent-memory/integrations/sdks/python) · [Swift](/docs/agent-memory/integrations/sdks/swift)
 
@@ -44,7 +44,7 @@ Call SurrealDB Agent Memory directly from application code.
 Drop-in memory for the popular TypeScript AI SDKs, with recall and storage wrapped around your model calls.
 
 - **Cloudflare Workers AI**: the client inside a Worker, alongside Workers AI models.
-- **TanStack AI**: the `@surrealdb/spectron` client in TanStack Start server routes.
+- **TanStack AI**: the `@surrealdb/memory` client in TanStack Start server routes.
 - **Vercel AI SDK**: `@surrealdb/spectron-vercel-ai`, via `wrapLanguageModel` middleware and a tool set.
 
 → [Cloudflare Workers AI](/docs/agent-memory/integrations/ai-sdks/cloudflare-workers-ai) · [TanStack AI](/docs/agent-memory/integrations/ai-sdks/tanstack-ai) · [Vercel AI SDK](/docs/agent-memory/integrations/ai-sdks/vercel-ai-sdk)

--- a/src/content/agent-memory/integrations/mcp-server/install.mdx
+++ b/src/content/agent-memory/integrations/mcp-server/install.mdx
@@ -63,7 +63,7 @@ Some clients use a different key or shape - `serverUrl` in Windsurf and Antigrav
 | Situation | Use |
 | --- | --- |
 | Coding assistant with native MCP | `install-mcp` or manual `/mcp` config |
-| Application code (Python/TS) | `surrealdb` / `@surrealdb/spectron` |
+| Application code (Python/TS) | `surrealdb` / `@surrealdb/memory` |
 | Agent framework with harness adapter | `spectron-crew-ai`, `@surrealdb/spectron-vercel-ai`, … |
 | Custom infrastructure | [REST API](/docs/agent-memory/reference/rest-api) |
 

--- a/src/content/agent-memory/integrations/observability/agentops.mdx
+++ b/src/content/agent-memory/integrations/observability/agentops.mdx
@@ -9,9 +9,6 @@ description: "Using SurrealDB Agent Memory in an agent instrumented by AgentOps.
 [AgentOps](https://www.agentops.ai/) monitors AI agents: session replay, LLM cost tracking, and tool-call telemetry across most agent frameworks. It is complementary to SurrealDB Agent Memory: AgentOps observes the run; SurrealDB Agent Memory provides the memory. This guide uses both together with the [Python SDK](/docs/agent-memory/integrations/sdks/python) (`surrealdb`).
 
 > [!NOTE]
-> `Spectron` was the project name for SurrealDB Agent Memory. These type names
-> will be renamed in a future release.
-
 ## Installation
 
 > [!NOTE]
@@ -37,12 +34,12 @@ export SPECTRON_API_KEY="sk-spec-..."
 import os
 import agentops
 from openai import OpenAI
-from surrealdb import Spectron
+from surrealdb.memory import Memory
 
 agentops.init(os.environ["AGENTOPS_API_KEY"])
 
 llm = OpenAI()
-memory = Spectron(
+memory = Memory(
     endpoint=os.environ["SPECTRON_ENDPOINT"],
     context=os.environ["SPECTRON_CONTEXT"],
     api_key=os.environ["SPECTRON_API_KEY"],

--- a/src/content/agent-memory/integrations/observability/respan.mdx
+++ b/src/content/agent-memory/integrations/observability/respan.mdx
@@ -14,9 +14,6 @@ description: "Using SurrealDB Agent Memory alongside Respan tracing and the Resp
 ## Installation
 
 > [!NOTE]
-> `Spectron` was the project name for SurrealDB Agent Memory. These type names
-> will be renamed in a future release.
-
 ```bash
 pip install openai
 pip install --pre surrealdb
@@ -36,7 +33,7 @@ Point your model client's base URL at the Respan gateway so every call is traced
 ```python
 import os
 from openai import OpenAI
-from surrealdb import Spectron
+from surrealdb.memory import Memory
 
 # Model calls flow through Respan (traced, logged, cost-attributed).
 llm = OpenAI(
@@ -44,8 +41,8 @@ llm = OpenAI(
     api_key=os.environ["RESPAN_API_KEY"],
 )
 
-# Memory is handled by Spectron.
-memory = Spectron(
+# Memory is handled by Memory.
+memory = Memory(
     endpoint=os.environ["SPECTRON_ENDPOINT"],
     context=os.environ["SPECTRON_CONTEXT"],
     api_key=os.environ["SPECTRON_API_KEY"],

--- a/src/content/agent-memory/integrations/sdks/dart.mdx
+++ b/src/content/agent-memory/integrations/sdks/dart.mdx
@@ -9,9 +9,6 @@ description: "Using SurrealDB Agent Memory from Dart and Flutter applications."
 The SurrealDB Agent Memory client ships in the [`surrealdb`](https://github.com/surrealdb/surrealdb.dart) package on pub, as a standalone import that does not depend on the database driver. It works in any Dart project and on every Flutter target (Android, iOS, web, and desktop).
 
 > [!NOTE]
-> `Spectron` was the project name for SurrealDB Agent Memory. These type names
-> will be renamed in a future release.
-
 ## Installation
 
 Add the package to `pubspec.yaml`:
@@ -32,16 +29,16 @@ flutter pub get
 Import the SurrealDB Agent Memory entry point directly. The client is pinned to one context and talks to SurrealDB Agent Memory's REST API over HTTPS:
 
 ```dart
-import 'package:surrealdb/spectron.dart';
+import 'package:surrealdb/memory.dart';
 
-final client = Spectron(
-  endpoint: 'https://api.spectron.example',
+final client = AgentMemory(
+  endpoint: 'https://api.memory.example',
   context: 'acme-prod',
   apiKey: 'sp-your-key',
 );
 ```
 
-Importing `package:surrealdb/spectron.dart` pulls in only the SurrealDB Agent Memory client, not the SurrealDB database driver.
+Importing `package:surrealdb/memory.dart` pulls in only the SurrealDB Agent Memory client, not the SurrealDB database driver.
 
 ## Remember, recall, and chat
 

--- a/src/content/agent-memory/integrations/sdks/elixir.mdx
+++ b/src/content/agent-memory/integrations/sdks/elixir.mdx
@@ -6,12 +6,9 @@ description: "Using SurrealDB Agent Memory from Elixir applications."
 
 # Elixir SDK
 
-The SurrealDB Agent Memory client ships in the [`:surrealdb`](https://github.com/surrealdb/surrealdb.elixir) package on Hex as a typed REST client. It aims for feature parity with the JavaScript SDKs (`surrealdb` and `@surrealdb/spectron`).
+The SurrealDB Agent Memory client ships in the [`:surrealdb`](https://github.com/surrealdb/surrealdb.elixir) package on Hex as a typed REST client. It aims for feature parity with the JavaScript SDKs (`surrealdb` and `@surrealdb/memory`).
 
 > [!NOTE]
-> `Spectron` was the project name for SurrealDB Agent Memory. These type names
-> will be renamed in a future release.
-
 ## Installation
 
 Add `:surrealdb` to your `mix.exs`:
@@ -30,25 +27,25 @@ Create a client pinned to one context and pass it to every call:
 
 ```elixir
 client =
-  SurrealDB.Spectron.new(
-    endpoint: System.fetch_env!("SPECTRON_ENDPOINT"),
+  SurrealDB.Memory.new(
+    endpoint: System.fetch_env!("AGENT_MEMORY_ENDPOINT"),
     context: "acme-prod",
-    api_key: System.fetch_env!("SPECTRON_API_KEY")
+    api_key: System.fetch_env!("AGENT_MEMORY_API_KEY")
   )
 ```
 
 ## Remember, recall, and chat
 
 ```elixir
-{:ok, _} = SurrealDB.Spectron.remember(client, "I just got promoted to CTO", scopes: "user/tobie")
-{:ok, hits} = SurrealDB.Spectron.recall(client, "What is Tobie's role?", k: 10)
-{:ok, %{"reply" => reply}} = SurrealDB.Spectron.chat(client, "What do you know about me?")
+{:ok, _} = SurrealDB.Memory.remember(client, "I just got promoted to CTO", scopes: "user/tobie")
+{:ok, hits} = SurrealDB.Memory.recall(client, "What is Tobie's role?", k: 10)
+{:ok, %{"reply" => reply}} = SurrealDB.Memory.chat(client, "What do you know about me?")
 ```
 
 Stream the chat loop with `stream: true`:
 
 ```elixir
-{:ok, stream} = SurrealDB.Spectron.chat(client, "Tell me a story", stream: true)
+{:ok, stream} = SurrealDB.Memory.chat(client, "Tell me a story", stream: true)
 
 for chunk <- stream do
   IO.write(chunk["delta"])
@@ -60,9 +57,9 @@ end
 Grouped operations live in dedicated modules, each taking the client first:
 
 ```elixir
-{:ok, doc} = SurrealDB.Spectron.Documents.upload(client, title: "Handbook", file: "handbook.pdf")
-{:ok, session} = SurrealDB.Spectron.Sessions.create(client)
-{:ok, minted} = SurrealDB.Spectron.Keys.create(client, name: "ci", ttl_seconds: 3600)
+{:ok, doc} = SurrealDB.Memory.Documents.upload(client, title: "Handbook", file: "handbook.pdf")
+{:ok, session} = SurrealDB.Memory.Sessions.create(client)
+{:ok, minted} = SurrealDB.Memory.Keys.create(client, name: "ci", ttl_seconds: 3600)
 ```
 
 The available namespaces are `Documents`, `Entities`, `Sessions`, `Lifecycle`, `Traces`, `Principals`, `Scopes`, and `Keys`.
@@ -72,10 +69,10 @@ The available namespaces are `Documents`, `Entities`, `Sessions`, `Lifecycle`, `
 `on_behalf_of/2` returns a new client whose requests carry the `X-Spectron-On-Behalf-Of` header; the original client is unchanged:
 
 ```elixir
-as_alex = SurrealDB.Spectron.on_behalf_of(client, "principal:alex")
-{:ok, _} = SurrealDB.Spectron.remember(as_alex, "Reviewed the Q3 plan")
+as_alex = SurrealDB.Memory.on_behalf_of(client, "principal:alex")
+{:ok, _} = SurrealDB.Memory.remember(as_alex, "Reviewed the Q3 plan")
 ```
 
 ## Errors
 
-SurrealDB Agent Memory calls return `{:error, %SurrealDB.Spectron.Error{}}` whose `kind` is one of `:auth`, `:validation`, `:not_found`, `:rate_limit`, `:scope`, `:server`, or `:connection`. Each error carries the response `trace_id` when the server provided one.
+SurrealDB Agent Memory calls return `{:error, %SurrealDB.Memory.Error{}}` whose `kind` is one of `:auth`, `:validation`, `:not_found`, `:rate_limit`, `:scope`, `:server`, or `:connection`. Each error carries the response `trace_id` when the server provided one.

--- a/src/content/agent-memory/integrations/sdks/go.mdx
+++ b/src/content/agent-memory/integrations/sdks/go.mdx
@@ -6,29 +6,29 @@ description: "Using SurrealDB Agent Memory from Go applications and agents."
 
 # Go SDK
 
-The SurrealDB Agent Memory client ships **inside** the Go SDK, in the `spectron` package of [`surrealdb.go`](https://github.com/surrealdb/surrealdb.go). It is a typed REST client whose types track the SurrealDB Agent Memory OpenAPI specification. Every method takes a `context.Context`, and a `*spectron.Client` is safe for concurrent use.
+The SurrealDB Agent Memory client ships **inside** the Go SDK, in the `spectron` package of [`surrealdb.go`](https://github.com/surrealdb/surrealdb.go). It is a typed REST client whose types track the SurrealDB Agent Memory OpenAPI specification. Every method takes a `context.Context`, and a `*memory.Client` is safe for concurrent use.
 
 ## Installation
 
 ```bash
-go get github.com/surrealdb/surrealdb.go/spectron
+go get github.com/surrealdb/surrealdb.go/memory
 ```
 
 ```go
-import "github.com/surrealdb/surrealdb.go/spectron"
+import "github.com/surrealdb/surrealdb.go/memory"
 ```
 
 ## Client construction
 
-A `*spectron.Client` is pinned to a single context and calls `/api/v1/{context}/...`:
+A `*memory.Client` is pinned to a single context and calls `/api/v1/{context}/...`:
 
 ```go
-client, err := spectron.New(
+client, err := memory.New(
     "acme-prod",                    // context id
-    "https://api.spectron.example", // endpoint
+    "https://api.memory.example", // endpoint
     "sk-spec-...",                  // api key
-    spectron.WithTimeout(30*time.Second),
-    spectron.WithMaxRetries(3),
+    memory.WithTimeout(30*time.Second),
+    memory.WithMaxRetries(3),
 )
 if err != nil {
     return err
@@ -47,24 +47,24 @@ defer client.Close()
 ```go
 ctx := context.Background()
 
-client.Remember(ctx, &spectron.RememberRequest{
+client.Remember(ctx, &memory.RememberRequest{
     Text:   "Acme acquired Beta",
-    Scopes: spectron.ScopeSets{{"team/acme"}},
-    Infer:  spectron.InferFull,
+    Scopes: memory.ScopeSets{{"team/acme"}},
+    Infer:  memory.InferFull,
 })
 
-client.RememberMany(ctx, &spectron.RememberManyRequest{
-    Messages: []spectron.BatchMessage{
-        {Role: spectron.RoleUser, Content: "I just got promoted to CTO"},
-        {Role: spectron.RoleAssistant, Content: "Congratulations!"},
+client.RememberMany(ctx, &memory.RememberManyRequest{
+    Messages: []memory.BatchMessage{
+        {Role: memory.RoleUser, Content: "I just got promoted to CTO"},
+        {Role: memory.RoleAssistant, Content: "Congratulations!"},
     },
-    Extract: spectron.ExtractWholeConversation,
+    Extract: memory.ExtractWholeConversation,
 })
 
-res, err := client.Recall(ctx, &spectron.RecallRequest{
+res, err := client.Recall(ctx, &memory.RecallRequest{
     Query: "what role do I have at Acme",
     K:     10,
-    Mode:  spectron.MemoryModeHybrid,
+    Mode:  memory.MemoryModeHybrid,
 })
 for _, hit := range res.Hits {
     fmt.Println(hit.Score, hit.Source, hit.Text)
@@ -76,11 +76,11 @@ for _, hit := range res.Hits {
 ## Chat
 
 ```go
-reply, _ := client.Chat(ctx, &spectron.ChatRequest{Message: "what's my role?"})
+reply, _ := client.Chat(ctx, &memory.ChatRequest{Message: "what's my role?"})
 fmt.Println(reply.Reply)
 
 // Streaming via Go 1.23 range-over-func.
-for chunk, err := range client.ChatStream(ctx, &spectron.ChatRequest{Message: "what's my role?"}) {
+for chunk, err := range client.ChatStream(ctx, &memory.ChatRequest{Message: "what's my role?"}) {
     if err != nil {
         return err
     }
@@ -101,8 +101,8 @@ f, _ := os.Open("returns.pdf")
 defer f.Close()
 
 doc, err := client.Documents().Upload(ctx, f,
-    spectron.WithFilename("returns.pdf"),
-    spectron.WithContentType("application/pdf"),
+    memory.WithFilename("returns.pdf"),
+    memory.WithContentType("application/pdf"),
 )
 fmt.Println(doc.ID, doc.Status)
 ```
@@ -121,12 +121,12 @@ Top-level verbs also include `Forget`, `QueryContext`, `Consolidate`, `Reflect`,
 
 ## Errors
 
-Failures wrap `*spectron.APIError` and match sentinel errors such as `spectron.ErrNotFound`:
+Failures wrap `*memory.APIError` and match sentinel errors such as `memory.ErrNotFound`:
 
 ```go
-_, err := client.Recall(ctx, &spectron.RecallRequest{Query: "x"})
-if errors.Is(err, spectron.ErrNotFound) {
-    var api *spectron.APIError
+_, err := client.Recall(ctx, &memory.RecallRequest{Query: "x"})
+if errors.Is(err, memory.ErrNotFound) {
+    var api *memory.APIError
     if errors.As(err, &api) {
         fmt.Printf("not found (trace=%s)\n", api.TraceID)
     }

--- a/src/content/agent-memory/integrations/sdks/haskell.mdx
+++ b/src/content/agent-memory/integrations/sdks/haskell.mdx
@@ -6,12 +6,9 @@ description: "Using SurrealDB Agent Memory from Haskell applications."
 
 # Haskell SDK
 
-The SurrealDB Agent Memory client ships as the `surrealdb-spectron` package in the [SurrealDB Haskell SDK](https://github.com/surrealdb/surrealdb.haskell). It is a typed client for the SurrealDB Agent Memory platform: store and recall memories, drive the chat loop, and manage documents, entities, sessions, lifecycle, traces, principals, scopes, and keys.
+The SurrealDB Agent Memory client ships as the `surrealdb-memory` package in the [SurrealDB Haskell SDK](https://github.com/surrealdb/surrealdb.haskell). It is a typed client for the SurrealDB Agent Memory platform: store and recall memories, drive the chat loop, and manage documents, entities, sessions, lifecycle, traces, principals, scopes, and keys.
 
 > [!NOTE]
-> `Spectron` was the project name for SurrealDB Agent Memory. These type names
-> will be renamed in a future release.
-
 ## Installation
 
 There are no package-manager releases yet, so add the package from the repository. With cabal, in `cabal.project`:
@@ -22,26 +19,26 @@ packages: .
 source-repository-package
   type: git
   location: https://github.com/surrealdb/surrealdb.haskell
-  subdir: surrealdb-spectron
+  subdir: surrealdb-memory
 ```
 
-Then add `surrealdb-spectron` to your component's `build-depends`. The project builds with GHC 9.4 and 9.6.
+Then add `surrealdb-memory` to your component's `build-depends`. The project builds with GHC 9.4 and 9.6.
 
 ## Client construction
 
 ```haskell
 {-# LANGUAGE OverloadedStrings #-}
 
-import Spectron
+import AgentMemory
 
 main :: IO ()
 main = do
-  client <- newSpectron
-    (defaultSpectronOptions "acme-prod" "sk_your_api_key" "https://api.spectron.example")
+  client <- newAgentMemory
+    (defaultAgentMemoryOptions "acme-prod" "sk_your_api_key" "https://api.memory.example")
   ...
 ```
 
-`defaultSpectronOptions` takes the context id, the API key, and the endpoint.
+`defaultAgentMemoryOptions` takes the context id, the API key, and the endpoint.
 
 ## Remember, recall, and chat
 
@@ -71,4 +68,4 @@ Act on behalf of another principal, which sends the `X-Spectron-On-Behalf-Of` he
 
 ## Errors
 
-The SurrealDB Agent Memory client throws `SpectronError`, classified by HTTP status into kinds such as `AuthFailed`, `ScopeRejected`, `RateLimited`, and `ServerFailed`.
+The SurrealDB Agent Memory client throws `AgentMemoryError`, classified by HTTP status into kinds such as `AuthFailed`, `ScopeRejected`, `RateLimited`, and `ServerFailed`.

--- a/src/content/agent-memory/integrations/sdks/javascript-and-typescript.mdx
+++ b/src/content/agent-memory/integrations/sdks/javascript-and-typescript.mdx
@@ -6,19 +6,16 @@ description: "Using SurrealDB Agent Memory from JavaScript and TypeScript applic
 
 # JavaScript and TypeScript SDK
 
-Published package: **`@surrealdb/spectron`**, a typed REST client for the SurrealDB Agent Memory end-user API. It uses platform `fetch`, ships no runtime dependencies, and aligns with SurrealDB Agent Memory’s OpenAPI specification.
+Published package: **`@surrealdb/memory`**, a typed REST client for the SurrealDB Agent Memory end-user API. It uses platform `fetch`, ships no runtime dependencies, and aligns with SurrealDB Agent Memory’s OpenAPI specification.
 
 > [!NOTE]
-> `Spectron` was the project name for SurrealDB Agent Memory. These type names
-> will be renamed in a future release.
-
-> **npm:** The client is published under the **`@surrealdb`** scope (`@surrealdb/spectron`), so no third party can squat the namespace. The bare name `spectron` on npm is unrelated.
+> **npm:** The client is published under the **`@surrealdb`** scope (`@surrealdb/memory`), so no third party can squat the namespace. It was previously published as `@surrealdb/spectron`; that package is deprecated.
 
 ## Installation
 
 ```bash
-npm install @surrealdb/spectron
-# or: pnpm / yarn / bun add @surrealdb/spectron
+npm install @surrealdb/memory
+# or: pnpm / yarn / bun add @surrealdb/memory
 ```
 
 Node.js 18+ or a modern bundler for browser use.
@@ -26,12 +23,12 @@ Node.js 18+ or a modern bundler for browser use.
 ## Client construction
 
 ```typescript
-import { Spectron } from "@surrealdb/spectron";
+import { AgentMemory } from "@surrealdb/memory";
 
-const client = new Spectron({
-  endpoint: process.env.SPECTRON_ENDPOINT!,
+const client = new AgentMemory({
+  endpoint: process.env.AGENT_MEMORY_ENDPOINT!,
   context: "acme-prod",
-  apiKey: process.env.SPECTRON_API_KEY!,
+  apiKey: process.env.AGENT_MEMORY_API_KEY!,
 });
 ```
 
@@ -111,9 +108,9 @@ import {
   RateLimitError,
   ScopeError,
   ServerError,
-  SpectronError,
+  AgentMemoryError,
   ValidationError,
-} from "@surrealdb/spectron";
+} from "@surrealdb/memory";
 
 try {
   const hits = await client.recall("what is my name?", { scope: ["user/alice"] });
@@ -125,13 +122,13 @@ try {
   else if (err instanceof RateLimitError) { console.log(err.retryAfter); }
   else if (err instanceof ServerError) { /* 5xx after retries */ }
   else if (err instanceof ConnectionError) { /* network / timeout */ }
-  else if (err instanceof SpectronError) { /* other */ }
+  else if (err instanceof AgentMemoryError) { /* other */ }
 }
 ```
 
 | Exception | HTTP | When it occurs |
 | --- | --- | --- |
-| `SpectronError` | n/a | Base class |
+| `AgentMemoryError` | n/a | Base class |
 | `AuthError` | 401 | Invalid or missing API key |
 | `ScopeError` | 403 | Scope or principal denial |
 | `NotFoundError` | 404 | Resource not found |
@@ -143,7 +140,7 @@ try {
 `GET` requests and idempotent writes (`remember`, `rememberMany`) retry automatically on connection errors and 5xx responses: up to `maxRetries` attempts (default 3) with 250 ms, 500 ms, 1000 ms backoff. Other writes and 4xx responses are not retried. Tune or disable on the constructor:
 
 ```typescript
-const client = new Spectron({ ..., maxRetries: 0, timeout: 10000 });
+const client = new AgentMemory({ ..., maxRetries: 0, timeout: 10000 });
 ```
 
 The default timeout is 30,000 ms; streaming chat disables the read timeout while tokens arrive. On a 429, read `RateLimitError.retryAfter` and back off before retrying manually. All errors follow [RFC 7807 Problem Details](/docs/agent-memory/reference/errors).

--- a/src/content/agent-memory/integrations/sdks/kotlin.mdx
+++ b/src/content/agent-memory/integrations/sdks/kotlin.mdx
@@ -6,12 +6,9 @@ description: "Using SurrealDB Agent Memory from Kotlin applications and agents o
 
 # Kotlin SDK
 
-The SurrealDB Agent Memory client for Kotlin ships inside the [SurrealDB Kotlin SDK](/docs/reference/kotlin); there is no separate package. It lives in the `com.surrealdb.kotlin.spectron` package and talks to SurrealDB Agent Memory's HTTP API directly, independently of the SurrealDB RPC engine. Like the rest of the Kotlin SDK, it is [Kotlin Multiplatform](https://kotlinlang.org/docs/multiplatform.html) (JVM, Android, iOS) and every method is a `suspend` function.
+The SurrealDB Agent Memory client for Kotlin ships inside the [SurrealDB Kotlin SDK](/docs/reference/kotlin); there is no separate package. It lives in the `com.surrealdb.kotlin.memory` package and talks to SurrealDB Agent Memory's HTTP API directly, independently of the SurrealDB RPC engine. Like the rest of the Kotlin SDK, it is [Kotlin Multiplatform](https://kotlinlang.org/docs/multiplatform.html) (JVM, Android, iOS) and every method is a `suspend` function.
 
 > [!NOTE]
-> `Spectron` was the project name for SurrealDB Agent Memory. These type names
-> will be renamed in a future release.
-
 > [!NOTE]
 > The Kotlin SDK is in early development (`0.1.0-SNAPSHOT`) and the SurrealDB Agent Memory client is not yet released. The APIs below are provisional.
 
@@ -27,15 +24,15 @@ dependencies {
 
 ## Configuration
 
-Construct a [`Spectron`](/docs/agent-memory/reference/sdk-kotlin) client with a context id, an API key, and your endpoint. Authentication uses the **`Authorization: Bearer`** header on every request.
+Construct a [`AgentMemory`](/docs/agent-memory/reference/sdk-kotlin) client with a context id, an API key, and your endpoint. Authentication uses the **`Authorization: Bearer`** header on every request.
 
 ```kotlin
-import com.surrealdb.kotlin.spectron.Spectron
+import com.surrealdb.kotlin.memory.AgentMemory
 
-val memory = Spectron(
+val memory = AgentMemory(
     contextId = "acme-prod",
     apiKey = "sk-spec-...",
-    endpoint = "https://api.spectron.example",
+    endpoint = "https://api.memory.example",
 )
 ```
 
@@ -43,7 +40,7 @@ val memory = Spectron(
 | --- | --- | --- |
 | `contextId` | required | The context to operate in, e.g. `"acme-prod"`. |
 | `apiKey` | required | Bearer token. Mutable; takes effect on the next request. |
-| `endpoint` | required | Base URL, e.g. `"https://api.spectron.example"`. |
+| `endpoint` | required | Base URL, e.g. `"https://api.memory.example"`. |
 | `timeout` | `30s` | Per-request timeout. |
 | `maxRetries` | `3` | GET-only retries on 5xx and connection errors. |
 | `httpClient` | platform default | Optional Ktor `HttpClient` to inject. |
@@ -56,15 +53,15 @@ Wrap calls in a coroutine (for example `runBlocking { ... }` from a synchronous 
 Store a free-form fact (extracted server-side) or caller-supplied triples.
 
 ```kotlin
-import com.surrealdb.kotlin.spectron.model.InferMode
+import com.surrealdb.kotlin.memory.model.InferMode
 
 // Free-form fact, extracted server-side.
 memory.remember("Christian was promoted to CTO", infer = InferMode.FULL)
 ```
 
 ```kotlin
-import com.surrealdb.kotlin.spectron.model.Triple
-import com.surrealdb.kotlin.spectron.model.TripleEntity
+import com.surrealdb.kotlin.memory.model.Triple
+import com.surrealdb.kotlin.memory.model.TripleEntity
 
 // Caller-supplied triples, no LLM.
 memory.remember(
@@ -78,8 +75,8 @@ memory.remember(
 Ingest a whole conversation in one call with `rememberMany`:
 
 ```kotlin
-import com.surrealdb.kotlin.spectron.model.BatchMessage
-import com.surrealdb.kotlin.spectron.model.TurnRole
+import com.surrealdb.kotlin.memory.model.BatchMessage
+import com.surrealdb.kotlin.memory.model.TurnRole
 
 memory.rememberMany(
     messages = listOf(
@@ -119,7 +116,7 @@ memory.documents.list(status = "ready", mimeType = "application/pdf")
 ```
 
 ```kotlin
-import com.surrealdb.kotlin.spectron.model.QueryMode
+import com.surrealdb.kotlin.memory.model.QueryMode
 
 val hits = memory.documents.query(
     "what is the return window for unopened items?",
@@ -142,7 +139,7 @@ println(reply.reply)
 Create a session handle and either let SurrealDB Agent Memory drive the turn or drive it yourself.
 
 ```kotlin
-import com.surrealdb.kotlin.spectron.model.TurnRole
+import com.surrealdb.kotlin.memory.model.TurnRole
 
 val session = memory.sessions.create(scope = listOf("user/tobie"))
 
@@ -159,7 +156,7 @@ val ctx = session.context("What is Tobie's role?")
 Scopes are hierarchical slash-path strings. Build them with the `scopePaths` helper:
 
 ```kotlin
-import com.surrealdb.kotlin.spectron.scopePaths
+import com.surrealdb.kotlin.memory.scopePaths
 
 scopePaths("team" to "eng", "org" to "acme") // ["team/eng", "org/acme"]
 ```
@@ -173,17 +170,17 @@ memory.documents.list(status = "ready", onBehalfOf = "alpha-bot")
 
 ## Error handling
 
-All failures throw a subclass of `SpectronException`. See the [Kotlin SDK reference](/docs/agent-memory/reference/sdk-kotlin#errors) for the full exception to status mapping, and [error responses](/docs/agent-memory/reference/errors) for the shared RFC 7807 format.
+All failures throw a subclass of `AgentMemoryException`. See the [Kotlin SDK reference](/docs/agent-memory/reference/sdk-kotlin#errors) for the full exception to status mapping, and [error responses](/docs/agent-memory/reference/errors) for the shared RFC 7807 format.
 
 ```kotlin
-import com.surrealdb.kotlin.spectron.SpectronNotFoundException
-import com.surrealdb.kotlin.spectron.SpectronRateLimitException
+import com.surrealdb.kotlin.memory.AgentMemoryNotFoundException
+import com.surrealdb.kotlin.memory.AgentMemoryRateLimitException
 
 try {
     memory.documents.get("doc:missing")
-} catch (e: SpectronNotFoundException) {
+} catch (e: AgentMemoryNotFoundException) {
     println("${e.status}: ${e.title}")
-} catch (e: SpectronRateLimitException) {
+} catch (e: AgentMemoryRateLimitException) {
     println("retry after ${e.retryAfter}")
 }
 ```

--- a/src/content/agent-memory/integrations/sdks/python.mdx
+++ b/src/content/agent-memory/integrations/sdks/python.mdx
@@ -6,32 +6,32 @@ description: "Using SurrealDB Agent Memory from Python applications and agents."
 
 # Python SDK
 
-The SurrealDB Agent Memory client ships **inside the main SurrealDB Python package** (`surrealdb`). Install one package and import `Spectron` or `AsyncSpectron` alongside the database driver.
+The SurrealDB Agent Memory client ships as its own distribution, **`surrealdb-memory`**, pulled in through the `surrealdb[memory]` extra. It is versioned independently of the database driver and imported as `surrealdb.memory`.
 
 > [!NOTE]
-> `Spectron` was the project name for SurrealDB Agent Memory. These type names
-> will be renamed in a future release.
-
-> **Package naming:** On [PyPI](https://pypi.org), the SurrealDB Agent Memory client ships in the **`surrealdb`** package alongside the database driver. It lands in the **3.x** line, which is still prerelease, so the install needs **`--pre`** - a bare `pip install surrealdb` resolves to the 2.x stable release, which carries no SurrealDB Agent Memory client. The bare name **`spectron`** belongs to an unrelated project; do not install it for SurrealDB Agent Memory.
+> **Package naming:** On [PyPI](https://pypi.org), the client is **`surrealdb-memory`**, installed through the **`surrealdb[memory]`** extra rather than by name. The SDK lands in the **3.x** line, which is still prerelease, so the install needs **`--pre`** - a bare `pip install surrealdb` resolves to the 2.x stable release, which has no `memory` extra.
 
 ## Installation
 
 ```bash
-pip install --pre surrealdb
+pip install --pre 'surrealdb[memory]'
+
+# Using uv
+uv add --prerelease=allow 'surrealdb[memory]'
 ```
 
 Python 3.10+ recommended.
 
 ## Clients
 
-`Spectron` is synchronous (uses `requests`). `AsyncSpectron` is async (uses `aiohttp`). Both expose the same method names; add `await` on the async client.
+`Memory` is synchronous (uses `requests`). `AsyncMemory` is async (uses `aiohttp`). Both expose the same method names; add `await` on the async client.
 
 ```python
-from surrealdb import Spectron, AsyncSpectron
+from surrealdb.memory import Memory, AsyncMemory
 
-with Spectron(
+with Memory(
     context="acme-prod",
-    endpoint="https://api.spectron.example",
+    endpoint="https://api.memory.example",
     api_key="sk-spec-...",
 ) as memory:
     memory.remember("Alice was promoted to CTO.")
@@ -39,9 +39,9 @@ with Spectron(
     for hit in hits.hits:
         print(hit.score, hit.text)
 
-async with AsyncSpectron(
+async with AsyncMemory(
     context="acme-prod",
-    endpoint="https://api.spectron.example",
+    endpoint="https://api.memory.example",
     api_key="sk-spec-...",
 ) as memory:
     await memory.remember("Alice was promoted to CTO.")
@@ -62,7 +62,7 @@ The Python client accepts:
 | Argument | Default | Description |
 | --- | --- | --- |
 | `context` | required | Context id, e.g. `"acme-prod"`. |
-| `endpoint` | required | SurrealDB Agent Memory host URL, e.g. `"https://api.spectron.example"`. |
+| `endpoint` | required | SurrealDB Agent Memory host URL, e.g. `"https://api.memory.example"`. |
 | `api_key` | required | Bearer token (`Authorization: Bearer …`). |
 | `timeout` | `30.0` | Per-request timeout in seconds. |
 | `max_retries` | `3` | Retries for GETs and idempotent writes. |
@@ -146,44 +146,44 @@ Grouped resources: `memory.documents`, `memory.sessions`, `memory.entities`, `me
 The SDK raises typed exceptions so you can handle auth, scope, and not-found cases precisely.
 
 ```python
-from surrealdb import SpectronAPIError, SpectronAuthError, SpectronNotFoundError, SpectronScopeError
+from surrealdb.memory import MemoryAPIError, MemoryAuthError, MemoryNotFoundError, MemoryScopeError
 
 try:
     hits = memory.recall("what is my name?", lens=["user/alice"])
-except SpectronAuthError as exc:
+except MemoryAuthError as exc:
     print(exc.status_code, exc.message)
-except SpectronScopeError as exc:
+except MemoryScopeError as exc:
     print(exc.status_code, exc.message)
-except SpectronNotFoundError as exc:
+except MemoryNotFoundError as exc:
     print(exc.status_code, exc.message)
-except SpectronAPIError as exc:
+except MemoryAPIError as exc:
     print(exc.status_code, exc.message, exc.trace_id, exc.body)
 ```
 
 | Exception | HTTP | When it occurs |
 | --- | --- | --- |
-| `SpectronError` | n/a | Base class |
-| `SpectronAPIError` | Other non-2xx | Generic API failure; carries `status_code`, `message`, `trace_id`, `body` |
-| `SpectronAuthError` | 401 | Missing or invalid API key |
-| `SpectronScopeError` | 403 | Scope floor or principal rejects the call |
-| `SpectronNotFoundError` | 404 | Context, session, document, or other resource not found |
+| `MemoryServiceError` | n/a | Base class |
+| `MemoryAPIError` | Other non-2xx | Generic API failure; carries `status_code`, `message`, `trace_id`, `body` |
+| `MemoryAuthError` | 401 | Missing or invalid API key |
+| `MemoryScopeError` | 403 | Scope floor or principal rejects the call |
+| `MemoryNotFoundError` | 404 | Context, session, document, or other resource not found |
 
-Responses of 400, 422, 429, and 5xx that are not mapped to a subclass surface as `SpectronAPIError`. Inspect `status_code` and `body` (RFC 7807 problem details) for validation and rate-limit information. The async client raises the same exceptions.
+Responses of 400, 422, 429, and 5xx that are not mapped to a subclass surface as `MemoryAPIError`. Inspect `status_code` and `body` (RFC 7807 problem details) for validation and rate-limit information. The async client raises the same exceptions.
 
 `GET` requests and idempotent writes (`remember`, `remember_many`) retry automatically on connection errors and 5xx responses: up to `max_retries` attempts (default 3) with 250 ms, 500 ms, 1000 ms backoff. Other writes and 4xx responses are not retried. Tune or disable on the constructor:
 
 ```python
-memory = Spectron(..., max_retries=0, timeout=10.0)
+memory = Memory(..., max_retries=0, timeout=10.0)
 ```
 
 The default timeout is 30 seconds; streaming chat disables the read timeout while tokens arrive. On a 429, read the problem-detail `body` and back off before retrying manually. All errors follow [RFC 7807 Problem Details](/docs/agent-memory/reference/errors).
 
 ## Response types
 
-Typed dataclasses include `RememberResponse`, `RecallResponse`, `RecallHit`, `ChatResponse`, `Document`, `Chunk`, `StateResponse`, and others. Import from `surrealdb.spectron` when you need explicit types:
+Typed dataclasses include `RememberResponse`, `RecallResponse`, `RecallHit`, `ChatResponse`, `Document`, `Chunk`, `StateResponse`, and others. Import from `surrealdb.memory` when you need explicit types:
 
 ```python
-from surrealdb.spectron import RecallResponse, RecallHit
+from surrealdb.memory import RecallResponse, RecallHit
 ```
 
 ## Harness adapters (zero prompt change)

--- a/src/content/agent-memory/integrations/sdks/swift.mdx
+++ b/src/content/agent-memory/integrations/sdks/swift.mdx
@@ -6,24 +6,21 @@ description: "Using SurrealDB Agent Memory from Swift applications and agents."
 
 # Swift SDK
 
-The `Spectron` client is shipped alongside the SurrealDB Swift SDK in the [surrealdb.swift](https://github.com/surrealdb/surrealdb.swift) package. It is a separate product that talks to the SurrealDB Agent Memory API, built on Swift async/await and `URLSession` with a swappable `HTTPClient` for testing. The client is `Sendable`.
+The `AgentMemory` client is shipped alongside the SurrealDB Swift SDK in the [surrealdb.swift](https://github.com/surrealdb/surrealdb.swift) package. It is a separate product that talks to the SurrealDB Agent Memory API, built on Swift async/await and `URLSession` with a swappable `HTTPClient` for testing. The client is `Sendable`.
 
 > [!NOTE]
-> `Spectron` was the project name for SurrealDB Agent Memory. These type names
-> will be renamed in a future release.
-
 ## Installation
 
-Add the `Spectron` product to your target's dependencies:
+Add the `AgentMemory` product to your target's dependencies:
 
 ```swift
-.product(name: "Spectron", package: "surrealdb.swift")
+.product(name: "AgentMemory", package: "surrealdb.swift")
 ```
 
 Then import it:
 
 ```swift
-import Spectron
+import AgentMemory
 ```
 
 See the [SurrealDB Swift SDK installation guide](/docs/reference/swift/installation) for how to add the package itself.
@@ -31,9 +28,9 @@ See the [SurrealDB Swift SDK installation guide](/docs/reference/swift/installat
 ## Configuration
 
 ```swift
-let memory = try Spectron(
+let memory = try AgentMemory(
     context: "acme-prod",
-    endpoint: "https://api.spectron.example",
+    endpoint: "https://api.memory.example",
     apiKey: "sk-spec-..."
 )
 ```
@@ -170,14 +167,14 @@ let me = try await memory.whoami(onBehalfOf: "agent:reader")
 
 ## Error handling
 
-All failures throw `SpectronError`, whose `kind` maps the HTTP status to `.base`, `.auth`, `.scope`, `.notFound`, `.validation`, `.rateLimit` or `.server`:
+All failures throw `AgentMemoryError`, whose `kind` maps the HTTP status to `.base`, `.auth`, `.scope`, `.notFound`, `.validation`, `.rateLimit` or `.server`:
 
 ```swift
 do {
     _ = try await memory.documents.get("doc:missing")
-} catch let error as SpectronError where error.isNotFound {
+} catch let error as AgentMemoryError where error.isNotFound {
     print(error.status, error.title)
-} catch let error as SpectronError where error.isRateLimit {
+} catch let error as AgentMemoryError where error.isRateLimit {
     print("retry after", error.retryAfter ?? 0, "seconds")
 }
 ```

--- a/src/content/agent-memory/integrations/surfaces/embedded-library.mdx
+++ b/src/content/agent-memory/integrations/surfaces/embedded-library.mdx
@@ -12,7 +12,7 @@ SurrealDB Agent Memory runs as a **horizontally scalable HTTP service** in front
 | --- | --- |
 | **REST** | `/api/v1/{context_id}/...` |
 | **MCP** | `/mcp` on the same port |
-| **SDKs** | `surrealdb`, `@surrealdb/spectron` |
+| **SDKs** | `surrealdb`, `@surrealdb/memory` |
 | **Harness adapters** | LangChain, Vercel AI SDK, OpenAI Agents, n8n, Claude Code hook |
 
 There is no supported in-process library that runs extraction and recall inside your binary without the SurrealDB Agent Memory server.

--- a/src/content/agent-memory/integrations/voice/elevenlabs.mdx
+++ b/src/content/agent-memory/integrations/voice/elevenlabs.mdx
@@ -9,9 +9,6 @@ description: "Giving an ElevenLabs Conversational AI agent memory with SurrealDB
 [ElevenLabs Conversational AI](https://elevenlabs.io/docs/conversational-ai/overview) runs the voice agent on ElevenLabs' side and reaches your systems through **server tools** (webhooks it calls mid-conversation) and **post-call webhooks** (fired when a conversation ends). SurrealDB Agent Memory sits behind both: a server tool for recall during the call, and a post-call webhook to store the transcript. There is no dedicated adapter. You expose a small HTTP endpoint that forwards to SurrealDB Agent Memory.
 
 > [!NOTE]
-> `Spectron` was the project name for SurrealDB Agent Memory. The npm package keeps the legacy name (`@surrealdb/spectron`).
-
-> [!NOTE]
 > This is an integration guide. It shows the two webhook shapes ElevenLabs calls and how each maps to SurrealDB Agent Memory; wire them to your own hosting.
 
 ## Recall as a server tool
@@ -19,7 +16,7 @@ description: "Giving an ElevenLabs Conversational AI agent memory with SurrealDB
 Add a [server tool](https://elevenlabs.io/docs/conversational-ai/customization/tools) to the agent (for example `recall_memory(query)`) pointing at an endpoint you host. When the agent decides it needs context, ElevenLabs calls the tool and passes the return value back into the conversation. Handle it with the [JavaScript SDK](/docs/agent-memory/integrations/sdks/javascript-and-typescript):
 
 ```typescript
-import { AgentMemory } from "@surrealdb/spectron";
+import { AgentMemory } from "@surrealdb/memory";
 
 const memory = new AgentMemory({
     endpoint: process.env.AGENT_MEMORY_ENDPOINT!,

--- a/src/content/agent-memory/reference/agents.mdx
+++ b/src/content/agent-memory/reference/agents.mdx
@@ -9,9 +9,6 @@ description: "Instructions for coding agents integrating with SurrealDB Agent Me
 This page is written for **coding agents** (Cursor, Claude Code, Copilot, and similar) building on SurrealDB Agent Memory. Humans can read it too, but the tone is imperative: what to do, what not to do, and where the sharp edges are.
 
 > [!NOTE]
-> `Spectron` was the project name for SurrealDB Agent Memory. These type names
-> will be renamed in a future release.
-
 **Use it as a Cursor skill:** copy this file into `.cursor/rules/spectron.mdc`, add it as a project rule, or save it under `.cursor/skills/spectron/SKILL.md` with a short `description` in the frontmatter so the agent loads it when working on SurrealDB Agent Memory integrations.
 
 Full product docs can be found at [SurrealDB Agent Memory documentation](/docs/agent-memory). This guide is the minimum viable canon for “vibe coding” without reading all of it.
@@ -171,18 +168,18 @@ See [Cursor](/docs/agent-memory/integrations/mcp-server/coding-assistants/cursor
 Prefer an official SDK over raw HTTP when available:
 
 ```python
-from surrealdb import Spectron
+from surrealdb.memory import Memory
 
-memory = Spectron(context="acme-prod",
+memory = Memory(context="acme-prod",
     api_key=os.environ["SPECTRON_API_KEY"])
 await memory.sessions.create(scopes=["org/acme/user/alice"])
 ```
 
 ```javascript
-import { Spectron } from "@surrealdb/spectron";
+import { AgentMemory } from "@surrealdb/memory";
 
-const memory = new Spectron({ context: "acme-prod",
-    apiKey: process.env.SPECTRON_API_KEY });
+const memory = new AgentMemory({ context: "acme-prod",
+    apiKey: process.env.AGENT_MEMORY_API_KEY });
 ```
 
 Model assignment is **per Context** for LLM stages; **embedding is deployment-fixed** - do not try to set `models.embedding` in config patches.

--- a/src/content/agent-memory/reference/errors.mdx
+++ b/src/content/agent-memory/reference/errors.mdx
@@ -9,9 +9,6 @@ description: "Error codes and troubleshooting."
 SurrealDB Agent Memory uses standard HTTP status codes and follows [RFC 7807 Problem Details](https://www.rfc-editor.org/rfc/rfc7807) for all error responses.
 
 > [!NOTE]
-> `Spectron` was the project name for SurrealDB Agent Memory. These type names
-> will be renamed in a future release.
-
 ## Error response format
 
 All errors return a JSON body with the following fields:
@@ -211,13 +208,13 @@ Only the delta-seconds form is emitted. A client that encounters the HTTP-date f
 | `SpectronAPIError` | Other non-2xx | Generic API failure (includes 400, 409, 429, 5xx) |
 
 ```python
-from surrealdb import SpectronNotFoundError, SpectronAPIError
+from surrealdb.memory import MemoryNotFoundError, MemoryAPIError
 
 try:
     doc = await client.documents.get("document:nonexistent")
-except SpectronNotFoundError as e:
+except MemoryNotFoundError as e:
     print(f"Document not found: {e.message}")
-except SpectronAPIError as e:
+except MemoryAPIError as e:
     if e.status_code == 429:
         print(f"Rate limit exceeded: {e.body}")
 ```
@@ -237,7 +234,7 @@ See the SDK error sections for [Python](/docs/agent-memory/integrations/sdks/pyt
 | `ConnectionError` | - | Network failure or timeout |
 
 ```javascript
-import { NotFoundError, RateLimitError } from "@surrealdb/spectron";
+import { NotFoundError, RateLimitError } from "@surrealdb/memory";
 
 try {
     const doc = await client.documents.get("document:nonexistent");

--- a/src/content/agent-memory/reference/sdk-javascript.mdx
+++ b/src/content/agent-memory/reference/sdk-javascript.mdx
@@ -1,36 +1,33 @@
 ---
 position: 5
 title: JavaScript SDK reference
-description: "Package layout and configuration for @surrealdb/spectron."
+description: "Package layout and configuration for @surrealdb/memory."
 ---
 
 # JavaScript SDK reference
 
 > [!NOTE]
-> `Spectron` was the project name for SurrealDB Agent Memory. These type names
-> will be renamed in a future release.
-
 | Item | Value |
 | --- | --- |
-| npm package | `@surrealdb/spectron` |
+| npm package | `@surrealdb/memory` |
 | Source | [`surrealdb.js/packages/spectron`](https://github.com/surrealdb/surrealdb.js/tree/main/packages/spectron) |
 | OpenAPI input | `packages/spectron/spec/openapi.json` |
 
 ## Install
 
 ```bash
-npm install @surrealdb/spectron
+npm install @surrealdb/memory
 ```
 
 ## Configuration
 
 ```typescript
-import { Spectron } from "@surrealdb/spectron";
+import { AgentMemory } from "@surrealdb/memory";
 
-const client = new Spectron({
-  endpoint: process.env.SPECTRON_ENDPOINT!,
+const client = new AgentMemory({
+  endpoint: process.env.AGENT_MEMORY_ENDPOINT!,
   context: "acme-prod",
-  apiKey: process.env.SPECTRON_API_KEY!,
+  apiKey: process.env.AGENT_MEMORY_API_KEY!,
   timeout: 30000,
   maxRetries: 3,
 });
@@ -76,7 +73,7 @@ Python names `query_context` as `context` here. Python exposes `whoami()` and `k
 
 | Class | Typical cause |
 | --- | --- |
-| `SpectronError` | Base |
+| `AgentMemoryError` | Base |
 | `AuthError` | 401 |
 | `ScopeError` | 403 |
 | `NotFoundError` | 404 |

--- a/src/content/agent-memory/reference/sdk-kotlin.mdx
+++ b/src/content/agent-memory/reference/sdk-kotlin.mdx
@@ -7,28 +7,25 @@ description: "Package layout, configuration, and error model for the SurrealDB A
 # Kotlin SDK reference
 
 > [!NOTE]
-> `Spectron` was the project name for SurrealDB Agent Memory. These type names
-> will be renamed in a future release.
-
 | Item | Value |
 | --- | --- |
-| Package | `com.surrealdb.kotlin.spectron` |
+| Package | `com.surrealdb.kotlin.memory` |
 | Distribution | Bundled in `com.surrealdb:kotlin` |
-| Models | `com.surrealdb.kotlin.spectron.model` |
-| Sub-clients | `com.surrealdb.kotlin.spectron.ns` |
+| Models | `com.surrealdb.kotlin.memory.model` |
+| Sub-clients | `com.surrealdb.kotlin.memory.ns` |
 
 The SurrealDB Agent Memory client ships inside the [SurrealDB Kotlin SDK](/docs/reference/kotlin) - there is no separate artifact. It is independent of the SurrealDB RPC engine and speaks SurrealDB Agent Memory's HTTP API directly.
 
 ## Constructor
 
 ```kotlin
-import com.surrealdb.kotlin.spectron.Spectron
+import com.surrealdb.kotlin.memory.AgentMemory
 import kotlin.time.Duration.Companion.seconds
 
-val memory = Spectron(
+val memory = AgentMemory(
     contextId = "acme-prod",
     apiKey = "sk-spec-...",
-    endpoint = "https://api.spectron.example",
+    endpoint = "https://api.memory.example",
     timeout = 30.seconds,
     maxRetries = 3,
 )
@@ -48,27 +45,27 @@ Authentication uses the **`Authorization: Bearer`** header. Call `close()` to re
 
 ## Surface
 
-Top-level `suspend` verbs on `Spectron`: `remember`, `rememberMany`, `recall`, `queryContext`, `state`, `profile`, `reflect`, `forget`, `chat`, `consolidate`, `elaborate`, `inspect`, `audit`, `whoami`, `health`.
+Top-level `suspend` verbs on `AgentMemory`: `remember`, `rememberMany`, `recall`, `queryContext`, `state`, `profile`, `reflect`, `forget`, `chat`, `consolidate`, `elaborate`, `inspect`, `audit`, `whoami`, `health`.
 
 Namespaced sub-clients:
 
 | Property | Type | Purpose |
 | --- | --- | --- |
-| `documents` | `SpectronDocuments` | Upload, query, chunk, and manage documents (plus `documents.keywords`). |
-| `sessions` | `SpectronSessions` | Create and drive chat sessions. |
-| `entities` | `SpectronEntities` | List, fetch, and delete extracted entities. |
-| `lifecycle` | `SpectronLifecycle` | Expire, decay, and `fsck` maintenance. |
-| `traces` | `SpectronTraces` | Inspect decision traces and stats. |
-| `principals` | `SpectronPrincipals` | List grants and grant/revoke access. |
-| `scopes` | `SpectronScopes` | Register and manage scope nodes. |
-| `keys` | `SpectronKeys` | Self-service API key creation and rotation. |
+| `documents` | `DocumentsNamespace` | Upload, query, chunk, and manage documents (plus `documents.keywords`). |
+| `sessions` | `SessionsNamespace` | Create and drive chat sessions. |
+| `entities` | `EntitiesNamespace` | List, fetch, and delete extracted entities. |
+| `lifecycle` | `LifecycleNamespace` | Expire, decay, and `fsck` maintenance. |
+| `traces` | `TracesNamespace` | Inspect decision traces and stats. |
+| `principals` | `PrincipalsNamespace` | List grants and grant/revoke access. |
+| `scopes` | `ScopesNamespace` | Register and manage scope nodes. |
+| `keys` | `KeysNamespace` | Self-service API key creation and rotation. |
 
 ## Scopes and delegation
 
 Scopes are hierarchical `key/value` slash-paths passed as a `List<String>`; an empty list targets the caller's default write region. Build them with `scopePaths`:
 
 ```kotlin
-import com.surrealdb.kotlin.spectron.scopePaths
+import com.surrealdb.kotlin.memory.scopePaths
 
 scopePaths(listOf("org/acme"))                 // ["org/acme"]
 scopePaths(mapOf("org" to "acme"))             // ["org/acme"]
@@ -83,21 +80,21 @@ GET requests retry on connection errors and 5xx responses with 250 ms / 500 ms /
 
 ## Errors
 
-All failures throw a subclass of the sealed `SpectronException`, modelled on RFC 7807 problem details. Each carries `status`, `title`, `detail`, `typeUri`, `instance`, and `extensions: Map<String, JsonElement>`.
+All failures throw a subclass of the sealed `AgentMemoryException`, modelled on RFC 7807 problem details. Each carries `status`, `title`, `detail`, `typeUri`, `instance`, and `extensions: Map<String, JsonElement>`.
 
 | Exception | HTTP status |
 | --- | --- |
-| `SpectronAuthException` | 401 |
-| `SpectronScopeException` | 403 |
-| `SpectronNotFoundException` | 404 |
-| `SpectronValidationException` | 400, 422 |
-| `SpectronRateLimitException` | 429 (with `retryAfter: Duration?`) |
-| `SpectronServerException` | 5xx and unmatched |
-| `SpectronTransportException` | 0 (connection or parse failure) |
+| `AgentMemoryAuthException` | 401 |
+| `AgentMemoryScopeException` | 403 |
+| `AgentMemoryNotFoundException` | 404 |
+| `AgentMemoryValidationException` | 400, 422 |
+| `AgentMemoryRateLimitException` | 429 (with `retryAfter: Duration?`) |
+| `AgentMemoryServerException` | 5xx and unmatched |
+| `AgentMemoryTransportException` | 0 (connection or parse failure) |
 
 ## Models
 
-Response and request types live under `com.surrealdb.kotlin.spectron.model`, all `@Serializable`:
+Response and request types live under `com.surrealdb.kotlin.memory.model`, all `@Serializable`:
 
 - **Enums** - `QueryMode`, `DocumentStatus`, `TurnRole`, `MemoryCategory`, `InferMode`, `GraphEdgeKind`, and others.
 - **Facts** - `Triple`, `TripleEntity`, `BatchMessage`, `FactsResponseJson`, `FactsBatchResponseJson`.

--- a/src/content/agent-memory/reference/sdk-python.mdx
+++ b/src/content/agent-memory/reference/sdk-python.mdx
@@ -7,24 +7,21 @@ description: "Package layout and configuration for the SurrealDB Agent Memory cl
 # Python SDK reference
 
 > [!NOTE]
-> `Spectron` was the project name for SurrealDB Agent Memory. These type names
-> will be renamed in a future release.
-
 | Item | Value |
 | --- | --- |
-| PyPI package | [`surrealdb`](https://pypi.org/project/surrealdb/) (SurrealDB Agent Memory client bundled with the driver) |
-| Install | `pip install --pre surrealdb` |
-| Import | `from surrealdb import Spectron, AsyncSpectron` |
-| Submodule | `surrealdb.spectron` (models, namespaces, errors) |
+| PyPI package | [`surrealdb-memory`](https://pypi.org/project/surrealdb-memory/) (its own distribution, pulled in by the `surrealdb[memory]` extra) |
+| Install | `pip install --pre 'surrealdb[memory]'` |
+| Import | `from surrealdb.memory import Memory, AsyncMemory` |
+| Submodule | `surrealdb.memory` (models, namespaces, errors) |
 
-On PyPI, **`spectron`** is a different project. Install **`surrealdb`** for SurrealDB and SurrealDB Agent Memory - not `pip install spectron`.
+The client is versioned independently of the driver, so the extra pins `>=`, not `==`; `surrealdb` alone installs the driver without it.
 
 ## Constructor
 
 ```python
-Spectron(context: str, endpoint: str, api_key: str,
+Memory(context: str, endpoint: str, api_key: str,
     timeout: float = 30.0, max_retries: int = 3)
-AsyncSpectron(...)  # same arguments; methods are async
+AsyncMemory(...)  # same arguments; methods are async
 ```
 
 Requests use `Authorization: Bearer <api_key>`. Optional `on_behalf_of` on every verb sets `X-Spectron-On-Behalf-Of` for delegation.
@@ -67,7 +64,7 @@ Full REST tables: [REST API](/docs/agent-memory/reference/rest-api).
 
 ## Response models
 
-Import from `surrealdb.spectron`:
+Import from `surrealdb.memory`:
 
 | Model | Used for |
 | --- | --- |
@@ -90,11 +87,11 @@ Nested graph and extraction payloads may remain `dict` values where the server s
 
 | Class | HTTP |
 | --- | --- |
-| `SpectronError` | Base |
-| `SpectronAPIError` | Any non-2xx without a subclass (`status_code`, `message`, `trace_id`, `body`) |
-| `SpectronAuthError` | 401 |
-| `SpectronScopeError` | 403 |
-| `SpectronNotFoundError` | 404 |
+| `MemoryServiceError` | Base |
+| `MemoryAPIError` | Any non-2xx without a subclass (`status_code`, `message`, `trace_id`, `body`) |
+| `MemoryAuthError` | 401 |
+| `MemoryScopeError` | 403 |
+| `MemoryNotFoundError` | 404 |
 
 → [Errors and retries](/docs/agent-memory/integrations/sdks/python#errors-and-retries)
 

--- a/src/content/agent-memory/reference/sdk-swift.mdx
+++ b/src/content/agent-memory/reference/sdk-swift.mdx
@@ -7,22 +7,19 @@ description: "Package layout and configuration for the SurrealDB Agent Memory Sw
 # Swift SDK reference
 
 > [!NOTE]
-> `Spectron` was the project name for SurrealDB Agent Memory. These type names
-> will be renamed in a future release.
-
 | Item | Value |
 | --- | --- |
 | Package | `surrealdb.swift` |
-| Product | `Spectron` |
-| Install | `.product(name: "Spectron", package: "surrealdb.swift")` |
-| Import | `import Spectron` |
+| Product | `AgentMemory` |
+| Install | `.product(name: "AgentMemory", package: "surrealdb.swift")` |
+| Import | `import AgentMemory` |
 
 ## Configuration
 
 ```swift
-let memory = try Spectron(
+let memory = try AgentMemory(
     context: "acme-prod",
-    endpoint: "https://api.spectron.example",
+    endpoint: "https://api.memory.example",
     apiKey: "sk-spec-..."
 )
 ```
@@ -60,7 +57,7 @@ Full tables: [REST API](/docs/agent-memory/reference/rest-api).
 
 ## Errors
 
-All failures throw `SpectronError` with fields `status`, `title`, `detail`, `retryAfter`, `typeURI`, `instance` and `extensions`. The `kind` maps to `.base`, `.auth`, `.scope`, `.notFound`, `.validation`, `.rateLimit` or `.server`. See [Errors](/docs/agent-memory/reference/errors).
+All failures throw `AgentMemoryError` with fields `status`, `title`, `detail`, `retryAfter`, `typeURI`, `instance` and `extensions`. The `kind` maps to `.base`, `.auth`, `.scope`, `.notFound`, `.validation`, `.rateLimit` or `.server`. See [Errors](/docs/agent-memory/reference/errors).
 
 ## User guide
 


### PR DESCRIPTION
Applies the client-SDK renames from the eight SDK PRs to the Agent Memory docs, and removes the placeholder notes [#1936](https://github.com/surrealdb/docs.surrealdb.com/pull/1936) left behind promising exactly this.

That PR renamed the prose and moved the docs to `/docs/agent-memory`, but the code samples still used the old type names, guarded by this note in 50 places:

> `Spectron` was the project name for SurrealDB Agent Memory. These type names will be renamed in a future release.

That release has now shipped, so the note is gone and the samples are updated.

## The SDK PRs this tracks

| SDK | PR | Rename |
| --- | --- | --- |
| JavaScript | [surrealdb.js#666](https://github.com/surrealdb/surrealdb.js/pull/666) | `@surrealdb/spectron` → `@surrealdb/memory`, `Spectron` → `AgentMemory` |
| Python | [surrealdb.py#346](https://github.com/surrealdb/surrealdb.py/pull/346) | separate `surrealdb-memory` dist via `surrealdb[memory]`, `Spectron` → `Memory` |
| Go | [surrealdb.go#416](https://github.com/surrealdb/surrealdb.go/pull/416) | `…/spectron` → `…/memory` |
| Swift | [surrealdb.swift#8](https://github.com/surrealdb/surrealdb.swift/pull/8) | `Spectron` → `AgentMemory` module |
| Kotlin | [surrealdb.kotlin#9](https://github.com/surrealdb/surrealdb.kotlin/pull/9) | `…kotlin.spectron` → `…kotlin.memory` |
| Dart | [surrealdb.dart#1](https://github.com/surrealdb/surrealdb.dart/pull/1) | `surrealdb/spectron.dart` → `surrealdb/memory.dart` |
| Elixir | [surrealdb.elixir#1](https://github.com/surrealdb/surrealdb.elixir/pull/1) | `SurrealDB.Spectron` → `SurrealDB.Memory` |
| Haskell | [surrealdb.haskell#1](https://github.com/surrealdb/surrealdb.haskell/pull/1) | `surrealdb-spectron` → `surrealdb-memory` |

60 files changed. The Python packaging sections needed real rewriting rather than a substitution: the client is no longer bundled in `surrealdb`, it is its own `surrealdb-memory` distribution pulled in by the `surrealdb[memory]` extra, so the install commands, the "Package naming" note and the `surrealdb.spectron` submodule references all changed meaning.

## What deliberately did **not** change

Most of the remaining "spectron" in these docs belongs to something that was **not** renamed, and rewriting it would make the docs wrong:

| Kept | Why |
| --- | --- |
| `spectron` / `spectrond` binaries, `surrealctl spectron` | the binaries really are still named that |
| `SPECTRON_*` environment variables | `bin/spectron/main.rs` reads `SPECTRON_API_KEY`, `SPECTRON_URL`, `SPECTRON_CONTEXT`, `SPECTRON_CONTEXT_ID`; the server reads the rest |
| `X-Spectron-Context`, `X-Spectron-On-Behalf-Of`, `X-Spectron-Trace-Id` | wire contract, server-owned |
| `https://spectron.dev/errors/…` | the `type` URIs the server puts in RFC 7807 responses |
| `spectron_remember`, `spectron_recall`, … | MCP tool names |
| `spectron-crew-ai`, `@surrealdb/spectron-vercel-ai`, `SpectronToolset`, `SpectronMemory`, `createSpectron`, … | the nine framework integration packages, none of which were renamed |
| `write:cloud-spectron`, `surrealctl spectron …` under `/docs/reference` | Cloud scopes and CLI, untouched by the SDK PRs |

Two consequences worth knowing:

- **Env vars only changed inside JS/TS and Elixir samples**, because those are the only two SDKs whose PRs renamed them (`SPECTRON_ENDPOINT`/`SPECTRON_API_KEY` → `AGENT_MEMORY_*`). Python's SDK reads no environment at all, so its samples keep whatever the page already used. `index/quickstarts/hosted.mdx` is the one page carrying both a CLI block and an SDK block, and it is deliberately mixed for that reason.
- **`api.spectron.example` → `api.memory.example` only on the Go/Kotlin/Swift/Dart/Haskell/Python SDK pages**, since those PRs changed the placeholder. The integration pages still use the old placeholder; worth a follow-up sweep, but it is not a rename this PR is tracking.

`index/index.mdx` and `reference/configuration.mdx` still carry the naming note, now narrowed to the things that genuinely keep the old name.

## Verification

- `bun run qau` (biome) — clean, no source files touched
- `bun run build` — exit 0, `dist/client` produced

`public/llms.txt` is regenerated by `prebuild`; its diff against `main` is unrelated drift (Mastra copy, a new Errors page), so it is left out of this PR and CI will regenerate it.
