### PR TITLE
Modify and no longer show description

### DIFF
--- a/.github/workflows/reindex-docs.yml
+++ b/.github/workflows/reindex-docs.yml
@@ -23,7 +23,7 @@ on:
 
 # Only what `actions/checkout` needs. The job itself never calls the GitHub API;
 # `{}` would be tempting but sets every scope to none, and checkout documents
-# `contents: read` as its requirement — relying on this repository staying
+# `contents: read` as its requirement - relying on this repository staying
 # public to get away with less is not a guarantee worth taking.
 permissions:
   contents: read
@@ -56,7 +56,7 @@ jobs:
           DOCS_WEBHOOK_SECRET: ${{ secrets.DOCS_WEBHOOK_SECRET }}
           # A push carries no inputs, so this arrives empty and the script picks
           # production. Read through `github.event` rather than the `inputs`
-          # context, which is only populated for workflow_dispatch — and the
+          # context, which is only populated for workflow_dispatch - and the
           # environment-to-host mapping lives in the script, because a workflow
           # expression cannot be tested and this workflow never runs on a pull
           # request.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,6 +118,17 @@ and who it is for. Reference pages put syntax or API surface near the top, then
 work through examples. Guides and quickstarts use prerequisites, numbered steps,
 and expected output. Troubleshooting pages follow symptom → cause → resolution.
 
+That opening sentence is the only orientation a reader gets, because the
+frontmatter `description` is **not rendered on the page**. It feeds
+`<meta name="description">`, the search index and `llms.txt`, all of which want
+dense front-loaded terms, and it was displayed as a subtitle between April and
+September 2026. Rendering it gave every page two openers, and on an eighth of
+them the description restated the first `##` sitting directly beneath it. So
+write the description for a search result and an index, and write the first
+paragraph for the reader - a page that dives straight into its first `##` now
+has nothing to orient anyone. `bun run generate:llms` regenerates the index
+after a description changes.
+
 **Prose style.** Short paragraphs, mostly declarative sentences. Define terms on
 first use. Prefer concrete claims ("datetimes drop from nanoseconds to
 milliseconds") over vague importance ("crucial for modern workflows"). Use
@@ -726,12 +737,12 @@ entries) - add one for every new page group.
 Four things advertise the markdown rendering, and they are easy to break one at
 a time:
 
-| What | Where |
-| --- | --- |
-| `<link rel="describedby">` and `rel="llms-txt"` | `src/pages/+Head.tsx` |
-| `Link:` header on every response | the `app.use("*")` middleware in `src/pages/+server.ts` |
-| `> Full SurrealDB documentation index: …` atop each `.md` | `withIndexPointer` in `src/utils/collections.ts` |
-| The index itself | `public/llms.txt` |
+| What                                                      | Where                                                   |
+| --------------------------------------------------------- | ------------------------------------------------------- |
+| `<link rel="describedby">` and `rel="llms-txt"`           | `src/pages/+Head.tsx`                                   |
+| `Link:` header on every response                          | the `app.use("*")` middleware in `src/pages/+server.ts` |
+| `> Full SurrealDB documentation index: …` atop each `.md` | `withIndexPointer` in `src/utils/collections.ts`        |
+| The index itself                                          | `public/llms.txt`                                       |
 
 The first three exist because the fourth is useless to an agent that never
 learns it is there. Content negotiation, `.md` URLs, `x-markdown-tokens` and

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -14,38 +14,38 @@ Working notes:
 
 ## Get started
 
-- [Getting started](https://surrealdb.com/docs): The official documentation for SurrealDB, a multi-model database for...
+- [Getting started](https://surrealdb.com/docs): The official documentation for SurrealDB, a multi-model database.
 - [Agent setup](https://surrealdb.com/docs/agents): Connect your agents to SurrealDB with Agent Skills and MCP.
-- [SDKs](https://surrealdb.com/docs/languages): The official SurrealDB SDKs, one per language, each with a quickstart...
+- [SDKs](https://surrealdb.com/docs/languages): One official SurrealDB SDK per language.
 - [What is SurrealDB](https://surrealdb.com/docs/what-is-surrealdb): SurrealDB is a multi-model database written in Rust.
-- [Claude Code](https://surrealdb.com/docs/agents/claude-code): Set up Claude Code for SurrealDB with the hosted MCP server and the...
-- [Codex](https://surrealdb.com/docs/agents/codex): Set up the OpenAI Codex CLI for SurrealDB with the hosted MCP server...
-- [Cursor](https://surrealdb.com/docs/agents/cursor): Set up Cursor for SurrealDB with the hosted MCP server and the...
-- [GitHub Copilot](https://surrealdb.com/docs/agents/github-copilot): Set up GitHub Copilot agent mode for SurrealDB with the hosted MCP...
-- [Visual Studio Code](https://surrealdb.com/docs/agents/vscode): Set up Visual Studio Code for SurrealDB with the hosted MCP server...
-- [Windsurf](https://surrealdb.com/docs/agents/windsurf): Set up Windsurf for SurrealDB with the hosted MCP server and the...
-- [Zed](https://surrealdb.com/docs/agents/zed): Set up the Zed editor for SurrealDB with the hosted MCP server and...
+- [Claude Code](https://surrealdb.com/docs/agents/claude-code): Hosted MCP server and Agent Skills setup for Claude Code.
+- [Codex](https://surrealdb.com/docs/agents/codex): Hosted MCP server and Agent Skills setup for the Codex CLI.
+- [Cursor](https://surrealdb.com/docs/agents/cursor): Hosted MCP server and Agent Skills setup for Cursor.
+- [GitHub Copilot](https://surrealdb.com/docs/agents/github-copilot): Hosted MCP server and Agent Skills setup for GitHub Copilot.
+- [Visual Studio Code](https://surrealdb.com/docs/agents/vscode): Hosted MCP server and Agent Skills setup for VS Code.
+- [Windsurf](https://surrealdb.com/docs/agents/windsurf): Hosted MCP server and Agent Skills setup for Windsurf.
+- [Zed](https://surrealdb.com/docs/agents/zed): Hosted MCP server and Agent Skills setup for Zed.
 - [Expo](https://surrealdb.com/docs/frameworks/expo): Connect an Expo app to SurrealDB and run your first queries.
 - [React Native](https://surrealdb.com/docs/frameworks/react-native): Connect a React Native app to SurrealDB and run your first queries.
-- [Community SDKs](https://surrealdb.com/docs/languages/community): Community-maintained and experimental SurrealDB clients for languages...
+- [Community SDKs](https://surrealdb.com/docs/languages/community): Community-maintained and experimental SurrealDB clients.
 - [.NET quickstart](https://surrealdb.com/docs/languages/dotnet): Connect to SurrealDB and run your first queries with the .NET SDK.
 - [Go quickstart](https://surrealdb.com/docs/languages/golang): Connect to SurrealDB and run your first queries with the Go SDK.
 - [Java quickstart](https://surrealdb.com/docs/languages/java): Connect to SurrealDB and run your first queries with the Java SDK.
-- [JavaScript quickstart](https://surrealdb.com/docs/languages/javascript): Connect to SurrealDB and run your first queries with the JavaScript...
+- [JavaScript quickstart](https://surrealdb.com/docs/languages/javascript): Connect and run your first queries with the JavaScript SDK.
 - [Kotlin quickstart](https://surrealdb.com/docs/languages/kotlin): Connect to SurrealDB and run your first queries with the Kotlin SDK.
 - [Mojo quickstart](https://surrealdb.com/docs/languages/mojo): Connect to SurrealDB and run your first queries with the Mojo SDK.
 - [PHP quickstart](https://surrealdb.com/docs/languages/php): Connect to SurrealDB and run your first queries with the PHP SDK.
 - [Python quickstart](https://surrealdb.com/docs/languages/python): Connect to SurrealDB and run your first queries with the Python SDK.
 - [Rust quickstart](https://surrealdb.com/docs/languages/rust): Connect to SurrealDB and run your first queries with the Rust SDK.
 - [Swift quickstart](https://surrealdb.com/docs/languages/swift): Connect to SurrealDB and run your first queries with the Swift SDK.
-- [SurrealDB Cloud](https://surrealdb.com/docs/running/cloud): Get a free managed SurrealDB instance with an email sign-in -...
+- [SurrealDB Cloud](https://surrealdb.com/docs/running/cloud): Get a free managed SurrealDB instance with an email sign-in.
 - [Docker](https://surrealdb.com/docs/running/docker): Use this tutorial to get started with SurrealDB from within Docker.
-- [File-backed](https://surrealdb.com/docs/running/file-backed): For the purposes of getting started with SurrealDB quickly, we will...
-- [In-memory](https://surrealdb.com/docs/running/in-memory): For the purposes of getting started with SurrealDB quickly, we will...
-- [Installation](https://surrealdb.com/docs/running/installation): Install the SurrealDB server on your machine: macOS, Windows, Linux...
-- [Multi-node](https://surrealdb.com/docs/running/multi-node): Run SurrealDB against distributed storage for horizontally scalable...
-- [Running SurrealDB](https://surrealdb.com/docs/running/overview): Ways to run SurrealDB - from a browser sandbox to a managed cloud...
-- [SurrealDB Studio Sandbox](https://surrealdb.com/docs/running/sandbox): Try SurrealDB in the browser with the SurrealDB Studio Sandbox - no...
+- [File-backed](https://surrealdb.com/docs/running/file-backed): Start a RocksDB database that persists data on the filesystem.
+- [In-memory](https://surrealdb.com/docs/running/in-memory): Start an in-memory SurrealDB database.
+- [Installation](https://surrealdb.com/docs/running/installation): Install the SurrealDB server on your machine: macOS, Windows, Linux.
+- [Multi-node](https://surrealdb.com/docs/running/multi-node): Run SurrealDB against distributed storage: horizontally scalable.
+- [Running SurrealDB](https://surrealdb.com/docs/running/overview): Ways to run SurrealDB, from a browser sandbox to managed cloud.
+- [SurrealDB Studio Sandbox](https://surrealdb.com/docs/running/sandbox): Try SurrealDB in the browser with the Studio Sandbox.
 - [Linux](https://surrealdb.com/docs/running/installation/linux)
 - [macOS](https://surrealdb.com/docs/running/installation/macos)
 - [Nightly](https://surrealdb.com/docs/running/installation/nightly)
@@ -53,14 +53,14 @@ Working notes:
 
 ## Learn
 
-- [Learn](https://surrealdb.com/docs/learn): How SurrealDB stores, queries and secures data: SurrealQL, schema...
-- [Data Models](https://surrealdb.com/docs/learn/data-models): Store and query document, graph, vector, time-series, and geospatial...
-- [Extensions](https://surrealdb.com/docs/learn/extensions): Extend SurrealDB with custom modules and WASM plugins through the...
-- [Querying](https://surrealdb.com/docs/learn/querying): Query SurrealDB with SurrealQL, SDKs or GraphQL - SQL-like syntax...
-- [Schema management](https://surrealdb.com/docs/learn/schema-management): How to shape data in SurrealDB: tables, fields, indexes, events...
-- [Security](https://surrealdb.com/docs/learn/security): Learn how to secure your SurrealDB deployment with authentication...
-- [Architecture](https://surrealdb.com/docs/learn/data-models/architecture)
-- [Schema design](https://surrealdb.com/docs/learn/schema-management/schema-design)
+- [Learn](https://surrealdb.com/docs/learn): How SurrealDB stores, queries and secures data: SurrealQL and schema.
+- [Data Models](https://surrealdb.com/docs/learn/data-models): Store and query document, graph, vector, time-series, geospatial.
+- [Extensions](https://surrealdb.com/docs/learn/extensions): Extend SurrealDB with custom modules and WASM plugins.
+- [Querying](https://surrealdb.com/docs/learn/querying): SurrealQL, the SDKs and GraphQL: SQL-like syntax for SurrealDB.
+- [Schema management](https://surrealdb.com/docs/learn/schema-management): Tables, fields, indexes and events: how to shape data in SurrealDB.
+- [Security](https://surrealdb.com/docs/learn/security): Secure a SurrealDB deployment with authentication and authorisation.
+- [Architecture](https://surrealdb.com/docs/learn/data-models/architecture): How SurrealDB separates compute from storage.
+- [Schema design](https://surrealdb.com/docs/learn/schema-management/schema-design): What DEFINE does in SurrealDB.
 - [Common patterns](https://surrealdb.com/docs/learn/data-models/document/common-patterns)
 - [Nested objects and arrays](https://surrealdb.com/docs/learn/data-models/document/nested-objects-and-arrays)
 - [Document model](https://surrealdb.com/docs/learn/data-models/document/overview)
@@ -164,17 +164,17 @@ Working notes:
 
 ## Build
 
-- [Build](https://surrealdb.com/docs/build): Putting SurrealDB into an application: embedding the engine...
-- [AI agents](https://surrealdb.com/docs/build/ai-agents): The ways SurrealDB fits into AI tooling - MCP servers, Agent Skills...
-- [Embedding SurrealDB](https://surrealdb.com/docs/build/embedding): In this section, you will find detailed instructions on how to embed...
-- [Integrations](https://surrealdb.com/docs/build/integrations): Integrations that connect SurrealDB to AI frameworks, embeddings...
-- [Migrating to SurrealDB](https://surrealdb.com/docs/build/migrating): Moving data into SurrealDB from other databases, older SurrealDB...
-- [Agent Skills](https://surrealdb.com/docs/build/ai-agents/agent-skills)
-- [AI frameworks](https://surrealdb.com/docs/build/ai-agents/ai-frameworks)
-- [SurrealDB MCP Server](https://surrealdb.com/docs/build/ai-agents/mcp)
-- [Storage engines](https://surrealdb.com/docs/build/embedding/storage-engines)
+- [Build](https://surrealdb.com/docs/build): Putting SurrealDB into an application: embedding the engine.
+- [AI agents](https://surrealdb.com/docs/build/ai-agents): MCP servers, Agent Skills, and framework integrations for SurrealDB.
+- [Embedding SurrealDB](https://surrealdb.com/docs/build/embedding): How to embed SurrealDB into your application.
+- [Integrations](https://surrealdb.com/docs/build/integrations): Integrations connecting SurrealDB to AI frameworks and embeddings.
+- [Migrating to SurrealDB](https://surrealdb.com/docs/build/migrating): Moving data into SurrealDB from other databases, or older releases.
+- [Agent Skills](https://surrealdb.com/docs/build/ai-agents/agent-skills): Official SurrealDB agent skills for use in agentic coding workflows.
+- [AI frameworks](https://surrealdb.com/docs/build/ai-agents/ai-frameworks): Framework integrations for AI and machine learning libraries.
+- [SurrealDB MCP Server](https://surrealdb.com/docs/build/ai-agents/mcp): Connect Claude, Cursor, and other AI tools to SurrealDB Cloud.
+- [Storage engines](https://surrealdb.com/docs/build/embedding/storage-engines): What a storage engine does for SurrealDB.
 - [Agent rules](https://surrealdb.com/docs/build/integrations/agent-rules): Agent rules for working with SurrealDB.
-- [Migrating](https://surrealdb.com/docs/build/migrating/from-files-and-streams)
+- [Migrating](https://surrealdb.com/docs/build/migrating/from-files-and-streams): Migrating
 - [MCP in Claude](https://surrealdb.com/docs/build/ai-agents/mcp/claude)
 - [MCP in Cursor](https://surrealdb.com/docs/build/ai-agents/mcp/cursor)
 - [Embedded MCP](https://surrealdb.com/docs/build/ai-agents/mcp/embedded)
@@ -228,19 +228,19 @@ Working notes:
 
 ## Manage
 
-- [Manage](https://surrealdb.com/docs/manage): Running SurrealDB in production: managed instances, organisations and...
-- [Enterprise Edition](https://surrealdb.com/docs/manage/enterprise): What SurrealDB Enterprise Edition adds over Community: distributed...
-- [Instances](https://surrealdb.com/docs/manage/instances): What an instance is, how the Start and Scale plans differ, and where...
-- [Observability](https://surrealdb.com/docs/manage/observability): Logging, Prometheus pull, OTLP push, Enterprise pipelines, metric...
-- [Organisations](https://surrealdb.com/docs/manage/organisations): The container for instances, members, usage, and billing, and what...
-- [SurrealKit schema migration](https://surrealdb.com/docs/manage/schema-migration): SurrealKit is the official schema management and migration CLI for...
-- [Self-hosted](https://surrealdb.com/docs/manage/self-hosted): Deploy and operate SurrealDB on your own infrastructure: deployment...
-- [surrealctl](https://surrealdb.com/docs/manage/surrealctl): The control-plane CLI: what surrealctl does, when to reach for it...
-- [Architecture](https://surrealdb.com/docs/manage/instances/architecture)
-- [Backups and recovery](https://surrealdb.com/docs/manage/instances/backups)
-- [Configure an instance](https://surrealdb.com/docs/manage/instances/configure)
-- [Connect to an instance](https://surrealdb.com/docs/manage/instances/connect)
-- [Create an instance](https://surrealdb.com/docs/manage/instances/create)
+- [Manage](https://surrealdb.com/docs/manage): Running SurrealDB in production: managed instances and organisations.
+- [Enterprise Edition](https://surrealdb.com/docs/manage/enterprise): What Enterprise Edition adds over Community: distributed live queries.
+- [Instances](https://surrealdb.com/docs/manage/instances): What a SurrealDB Cloud instance is.
+- [Observability](https://surrealdb.com/docs/manage/observability): Production visibility for SurrealDB Community and Enterprise.
+- [Organisations](https://surrealdb.com/docs/manage/organisations): The container for instances, members, usage, and billing.
+- [SurrealKit schema migration](https://surrealdb.com/docs/manage/schema-migration): SurrealKit is the official schema migration CLI for SurrealDB.
+- [Self-hosted](https://surrealdb.com/docs/manage/self-hosted): SurrealDB deployment models on your own infrastructure.
+- [surrealctl](https://surrealdb.com/docs/manage/surrealctl): What the surrealctl control-plane CLI does.
+- [Architecture](https://surrealdb.com/docs/manage/instances/architecture): The topologies behind the Start and Scale plans.
+- [Backups and recovery](https://surrealdb.com/docs/manage/instances/backups): Automated snapshots and retention tiers.
+- [Configure an instance](https://surrealdb.com/docs/manage/instances/configure): Instance settings in SurrealDB Studio.
+- [Connect to an instance](https://surrealdb.com/docs/manage/instances/connect): The four routes to a SurrealDB Cloud instance.
+- [Create an instance](https://surrealdb.com/docs/manage/instances/create): Deploy an instance from SurrealDB Studio.
 - [High availability](https://surrealdb.com/docs/manage/instances/high-availability)
 - [Import and export](https://surrealdb.com/docs/manage/instances/import-and-export)
 - [Monitoring](https://surrealdb.com/docs/manage/instances/monitoring)
@@ -248,7 +248,7 @@ Working notes:
 - [Private connectivity](https://surrealdb.com/docs/manage/instances/private-connectivity)
 - [Scaling](https://surrealdb.com/docs/manage/instances/scaling)
 - [Versions and upgrades](https://surrealdb.com/docs/manage/instances/versions-and-upgrades)
-- [Audit logging](https://surrealdb.com/docs/manage/observability/audit-logging)
+- [Audit logging](https://surrealdb.com/docs/manage/observability/audit-logging): The Enterprise audit log pipeline.
 - [Configuration reference](https://surrealdb.com/docs/manage/observability/configuration)
 - [Enterprise observability](https://surrealdb.com/docs/manage/observability/enterprise-observability)
 - [Logging](https://surrealdb.com/docs/manage/observability/logging)
@@ -298,13 +298,13 @@ Working notes:
 
 ## Explore
 
-- [Explore](https://surrealdb.com/docs/explore): Tools and worked examples: SurrealDB Studio, video tutorials and...
+- [Explore](https://surrealdb.com/docs/explore): SurrealDB Studio, video tutorials and demos, and worked examples.
 - [SurrealDB Labs](https://surrealdb.com/docs/labs): Talks, videos and experiments from the team and the community.
-- [Introduction](https://surrealdb.com/docs/explore/ml-models): SurrealML stores and runs trained ML models in SurrealDB - train in...
+- [Introduction](https://surrealdb.com/docs/explore/ml-models): SurrealML runs trained ML models in SurrealDB: train in Python.
 - [Introduction](https://surrealdb.com/docs/explore/studio): SurrealDB Studio is the official visual interface for SurrealDB.
-- [Demos and tutorials](https://surrealdb.com/docs/explore/tutorials): Hands-on demo applications and tutorials to learn SurrealDB by...
-- [Search and shortcuts](https://surrealdb.com/docs/explore/studio/search-and-shortcuts)
-- [SurrealQL editors](https://surrealdb.com/docs/explore/studio/surrealql-editors)
+- [Demos and tutorials](https://surrealdb.com/docs/explore/tutorials): Hands-on demo applications and tutorials.
+- [Search and shortcuts](https://surrealdb.com/docs/explore/studio/search-and-shortcuts): The SurrealDB Studio command palette and its keyboard shortcuts.
+- [SurrealQL editors](https://surrealdb.com/docs/explore/studio/surrealql-editors): SurrealQL editor shortcuts in SurrealDB Studio.
 - [Computation](https://surrealdb.com/docs/explore/ml-models/surrealml/computation)
 - [Storage](https://surrealdb.com/docs/explore/ml-models/surrealml/storage)
 - [Blink note-taking app](https://surrealdb.com/docs/explore/tutorials/demos/blink)
@@ -327,20 +327,20 @@ Working notes:
 
 ## Reference
 
-- [Reference](https://surrealdb.com/docs/reference): Complete syntax and API surface: SurrealQL statements and functions...
-- [CLI Tools](https://surrealdb.com/docs/reference/cli): Reference for the three SurrealDB command-line tools: surrealctl for...
-- [.NET SDK](https://surrealdb.com/docs/reference/dotnet): The SurrealDB SDK for .NET provides a number of methods for...
-- [Go SDK](https://surrealdb.com/docs/reference/golang): The SurrealDB SDK for Go enables simple and advanced querying of a...
-- [Java SDK](https://surrealdb.com/docs/reference/java): The SurrealDB SDK for Java enables simple and advanced querying of a...
-- [JavaScript SDK](https://surrealdb.com/docs/reference/javascript): The SurrealDB SDK for JavaScript enables simple and advanced querying...
-- [Kotlin SDK](https://surrealdb.com/docs/reference/kotlin): The SurrealDB SDK for Kotlin is a coroutine-based, Kotlin...
-- [Mojo SDK](https://surrealdb.com/docs/reference/mojo): The SurrealDB SDK for Mojo enables simple and advanced querying of a...
-- [PHP SDK](https://surrealdb.com/docs/reference/php): The SurrealDB SDK for PHP lets you query a remote SurrealDB instance...
-- [Python SDK](https://surrealdb.com/docs/reference/python): The SurrealDB SDK for Python enables simple and advanced querying of...
-- [SurrealQL](https://surrealdb.com/docs/reference/query-language): Reference for SurrealQL, SurrealDB's query language: statements...
-- [REST API](https://surrealdb.com/docs/reference/rest-api): SurrealDB exposes an HTTP-based REST API for executing queries...
-- [Rust SDK](https://surrealdb.com/docs/reference/rust): The SurrealDB SDK for Rust enables you to interact with SurrealDB...
-- [Swift SDK](https://surrealdb.com/docs/reference/swift): The SurrealDB SDK for Swift enables simple and advanced querying of a...
+- [Reference](https://surrealdb.com/docs/reference): SurrealQL statements and functions, and the full API surface.
+- [CLI Tools](https://surrealdb.com/docs/reference/cli): Reference for surrealctl, surreal and surqlfmt.
+- [.NET SDK](https://surrealdb.com/docs/reference/dotnet): The official SurrealDB SDK for .NET.
+- [Go SDK](https://surrealdb.com/docs/reference/golang): The official SurrealDB SDK for Go.
+- [Java SDK](https://surrealdb.com/docs/reference/java): The official SurrealDB SDK for Java.
+- [JavaScript SDK](https://surrealdb.com/docs/reference/javascript): The official SurrealDB SDK for JavaScript.
+- [Kotlin SDK](https://surrealdb.com/docs/reference/kotlin): The official SurrealDB SDK for Kotlin.
+- [Mojo SDK](https://surrealdb.com/docs/reference/mojo): The official SurrealDB SDK for Mojo.
+- [PHP SDK](https://surrealdb.com/docs/reference/php): The official SurrealDB SDK for PHP.
+- [Python SDK](https://surrealdb.com/docs/reference/python): The official SurrealDB SDK for Python.
+- [SurrealQL](https://surrealdb.com/docs/reference/query-language): SurrealQL statements, clauses, functions and language primitives.
+- [REST API](https://surrealdb.com/docs/reference/rest-api): The SurrealDB REST API: executing queries over HTTP.
+- [Rust SDK](https://surrealdb.com/docs/reference/rust): The official SurrealDB SDK for Rust.
+- [Swift SDK](https://surrealdb.com/docs/reference/swift): The official SurrealDB SDK for Swift.
 - [SDK concepts](https://surrealdb.com/docs/reference/dotnet/core)
 - [Data types](https://surrealdb.com/docs/reference/dotnet/data-types)
 - [Embedding](https://surrealdb.com/docs/reference/dotnet/embedding)
@@ -912,37 +912,37 @@ Working notes:
 
 ## Agent Memory
 
-- [Agent Memory](https://surrealdb.com/docs/agent-memory): Principles, architecture, quickstarts, and mental model for SurrealDB...
+- [Agent Memory](https://surrealdb.com/docs/agent-memory): Memory and knowledge for AI agents on SurrealDB.
 - [Cookbooks](https://surrealdb.com/docs/agent-memory/cookbooks): Opinionated recipes and migration guides.
-- [Agent Memory integrations](https://surrealdb.com/docs/agent-memory/integrations): Connecting SurrealDB Agent Memory to your stack - SDKs, MCP server...
-- [Memory & knowledge](https://surrealdb.com/docs/agent-memory/memory-and-knowledge): Ingest, retrieve, reason, and tune agent memory on SurrealDB Agent...
+- [Agent Memory integrations](https://surrealdb.com/docs/agent-memory/integrations): SDKs, the MCP server, AI SDKs and agent frameworks.
+- [Memory & knowledge](https://surrealdb.com/docs/agent-memory/memory-and-knowledge): Ingest, retrieve, reason, and tune agent memory.
 - [Agent Memory reference](https://surrealdb.com/docs/agent-memory/reference): Complete API and configuration reference for SurrealDB Agent Memory.
-- [Coherence, retrieval, and cost tiers](https://surrealdb.com/docs/agent-memory/architecture/coherence-retrieval-and-tiers): Five coherence dimensions, hybrid structural retrieval, and the...
-- [Eight pillars and six categories](https://surrealdb.com/docs/agent-memory/architecture/eight-pillars-and-categories): The primitives SurrealDB Agent Memory operationalises - pillars of...
-- [Agent Memory glossary](https://surrealdb.com/docs/agent-memory/architecture/glossary): Alphabetical definitions of terms used across SurrealDB Agent Memory...
-- [Principles and goals](https://surrealdb.com/docs/agent-memory/architecture/principles-and-goals): What SurrealDB Agent Memory is built to do - and what it deliberately...
-- [Surface, models, and security](https://surrealdb.com/docs/agent-memory/architecture/surface-security-and-models): HTTP ingest and read verbs, integrations, model hooks, and security...
-- [Traces and memory evolution](https://surrealdb.com/docs/agent-memory/architecture/traces-and-evolution): Graph-resident traces, reflection, elaboration, consolidation, and...
-- [Tri-temporal model](https://surrealdb.com/docs/agent-memory/architecture/tri-temporal-model): System time, known time, and valid time - supersession, aging, and...
-- [Contexts and scope](https://surrealdb.com/docs/agent-memory/mental-model/contexts-and-scope): How Contexts isolate tenants and how scope tags partition memory...
-- [Memory categories](https://surrealdb.com/docs/agent-memory/mental-model/memory-categories): Episodic raw turns plus five extracted experiential categories -...
+- [Coherence, retrieval, and cost tiers](https://surrealdb.com/docs/agent-memory/architecture/coherence-retrieval-and-tiers): Five coherence dimensions and hybrid structural retrieval.
+- [Eight pillars and six categories](https://surrealdb.com/docs/agent-memory/architecture/eight-pillars-and-categories): The primitives SurrealDB Agent Memory operationalises.
+- [Agent Memory glossary](https://surrealdb.com/docs/agent-memory/architecture/glossary): Alphabetical definitions of SurrealDB Agent Memory terms.
+- [Principles and goals](https://surrealdb.com/docs/agent-memory/architecture/principles-and-goals): What SurrealDB Agent Memory deliberately is and is not.
+- [Surface, models, and security](https://surrealdb.com/docs/agent-memory/architecture/surface-security-and-models): HTTP ingest and read verbs, integrations, and model hooks.
+- [Traces and memory evolution](https://surrealdb.com/docs/agent-memory/architecture/traces-and-evolution): Graph-resident traces, reflection, elaboration, consolidation.
+- [Tri-temporal model](https://surrealdb.com/docs/agent-memory/architecture/tri-temporal-model): System and valid time, supersession, ageing, and explicit forget.
+- [Contexts and scope](https://surrealdb.com/docs/agent-memory/mental-model/contexts-and-scope): How scope tags partition memory, and how Contexts isolate tenants.
+- [Memory categories](https://surrealdb.com/docs/agent-memory/mental-model/memory-categories): Episodic raw turns plus five extracted experiential categories.
 - [Supersession, decay, and forget](https://surrealdb.com/docs/agent-memory/mental-model/memory-lifecycle): Three mechanisms for how beliefs change, fade, and are removed.
-- [Provenance and traceability](https://surrealdb.com/docs/agent-memory/mental-model/provenance-and-traceability): The source object on every record - kinds, spans, trust, derivation...
+- [Provenance and traceability](https://surrealdb.com/docs/agent-memory/mental-model/provenance-and-traceability): The source object carried on every record.
 - [Sessions and turns](https://surrealdb.com/docs/agent-memory/mental-model/sessions-and-turns): How conversations map to sessions, turns, and provenance.
-- [Unified substrate and authority](https://surrealdb.com/docs/agent-memory/mental-model/two-layer-architecture): One SurrealDB graph for authoritative and experiential knowledge -...
-- [Forgetting memories](https://surrealdb.com/docs/agent-memory/operations/forget): How to retire or permanently erase memories - default forget, purge...
+- [Unified substrate and authority](https://surrealdb.com/docs/agent-memory/mental-model/two-layer-architecture): One SurrealDB graph for authoritative and experiential knowledge.
+- [Forgetting memories](https://surrealdb.com/docs/agent-memory/operations/forget): Default forget, purge, and scoped erasure.
 - [Profiles](https://surrealdb.com/docs/agent-memory/operations/profiles): Auto-maintained entity profiles aggregated from memory and knowledge.
 - [Reflection](https://surrealdb.com/docs/agent-memory/operations/reflect): Synthesise insights from patterns across stored memories.
 - [Embedded library quickstart](https://surrealdb.com/docs/agent-memory/quickstarts/embedded): Integration surfaces for SurrealDB Agent Memory.
-- [Hosted quickstart](https://surrealdb.com/docs/agent-memory/quickstarts/hosted): Get up and running with SurrealDB Agent Memory on SurrealDB Cloud in...
-- [Agent Memory on SurrealDB Cloud](https://surrealdb.com/docs/agent-memory/quickstarts/surrealdb-cloud): How SurrealDB Agent Memory contexts, authentication, and APIs work on...
-- [Authority when pillars meet](https://surrealdb.com/docs/agent-memory/reasoning/authority-hierarchy): How the Authoritative and Experiential pillars interact -...
-- [Cross-layer linking](https://surrealdb.com/docs/agent-memory/reasoning/cross-layer-linking): How authoritative documents and experiential facts relate in the...
-- [Extraction pipeline](https://surrealdb.com/docs/agent-memory/reasoning/extraction-pipeline): How SurrealDB Agent Memory classifies and extracts structured memory...
-- [Instructions and uncertainties](https://surrealdb.com/docs/agent-memory/reasoning/instructions-and-uncertainties): How SurrealDB Agent Memory captures behavioural directives and tracks...
-- [Reconciliation and supersession](https://surrealdb.com/docs/agent-memory/reasoning/reconciliation-and-supersession): How SurrealDB Agent Memory deduplicates entities, detects conflicts...
-- [Temporal validity](https://surrealdb.com/docs/agent-memory/reasoning/temporal-validity): How SurrealDB Agent Memory tracks when facts were true using...
-- [Agent guide (AGENTS.md)](https://surrealdb.com/docs/agent-memory/reference/agents): Instructions for coding agents integrating with SurrealDB Agent...
+- [Hosted quickstart](https://surrealdb.com/docs/agent-memory/quickstarts/hosted): Get SurrealDB Agent Memory running in five minutes.
+- [Agent Memory on SurrealDB Cloud](https://surrealdb.com/docs/agent-memory/quickstarts/surrealdb-cloud): How contexts, authentication and the APIs work on SurrealDB Cloud.
+- [Authority when pillars meet](https://surrealdb.com/docs/agent-memory/reasoning/authority-hierarchy): How the Authoritative and Experiential pillars interact.
+- [Cross-layer linking](https://surrealdb.com/docs/agent-memory/reasoning/cross-layer-linking): How authoritative documents and experiential facts relate.
+- [Extraction pipeline](https://surrealdb.com/docs/agent-memory/reasoning/extraction-pipeline): How structured memory is extracted from conversation turns.
+- [Instructions and uncertainties](https://surrealdb.com/docs/agent-memory/reasoning/instructions-and-uncertainties): How behavioural directives are captured and tracked.
+- [Reconciliation and supersession](https://surrealdb.com/docs/agent-memory/reasoning/reconciliation-and-supersession): How entities are deduplicated and conflicts detected.
+- [Temporal validity](https://surrealdb.com/docs/agent-memory/reasoning/temporal-validity): How SurrealDB Agent Memory tracks when facts were true.
+- [Agent guide (AGENTS.md)](https://surrealdb.com/docs/agent-memory/reference/agents): Copy these into your Cursor rules or agent skills.
 - [CLI](https://surrealdb.com/docs/agent-memory/reference/cli): Command-line interface reference.
 - [Configuration](https://surrealdb.com/docs/agent-memory/reference/configuration): Context config, models, and limits.
 - [Data model and schema](https://surrealdb.com/docs/agent-memory/reference/data-model-and-schema): Tables, relations, and indexes in SurrealDB.
@@ -950,26 +950,26 @@ Working notes:
 - [Glossary](https://surrealdb.com/docs/agent-memory/reference/glossary): Terminology used across SurrealDB Agent Memory docs.
 - [Management API](https://surrealdb.com/docs/agent-memory/reference/management-api): Contexts, keys, and operator lifecycle.
 - [MCP tools](https://surrealdb.com/docs/agent-memory/reference/mcp-tools): Tool payloads and ACL alignment.
-- [REST API](https://surrealdb.com/docs/agent-memory/reference/rest-api): End-user HTTP endpoints on the unified SurrealDB Agent Memory...
+- [REST API](https://surrealdb.com/docs/agent-memory/reference/rest-api): End-user HTTP endpoints on the unified substrate.
 - [JavaScript SDK reference](https://surrealdb.com/docs/agent-memory/reference/sdk-javascript): Package layout and configuration for @surrealdb/memory.
-- [Kotlin SDK reference](https://surrealdb.com/docs/agent-memory/reference/sdk-kotlin): Package layout, configuration, and error model for the SurrealDB...
-- [Python SDK reference](https://surrealdb.com/docs/agent-memory/reference/sdk-python): Package layout and configuration for the SurrealDB Agent Memory...
-- [Swift SDK reference](https://surrealdb.com/docs/agent-memory/reference/sdk-swift): Package layout and configuration for the SurrealDB Agent Memory Swift...
+- [Kotlin SDK reference](https://surrealdb.com/docs/agent-memory/reference/sdk-kotlin): The SurrealDB Agent Memory Kotlin client.
+- [Python SDK reference](https://surrealdb.com/docs/agent-memory/reference/sdk-python): The SurrealDB Agent Memory client inside the surrealdb package.
+- [Swift SDK reference](https://surrealdb.com/docs/agent-memory/reference/sdk-swift): The SurrealDB Agent Memory Swift client.
 - [Graph traversal](https://surrealdb.com/docs/agent-memory/retrieve/graph-traversal): Structural edges in the knowledge layer and how retrieval uses them.
-- [Hybrid search](https://surrealdb.com/docs/agent-memory/retrieve/hybrid-search): Using vector, BM25, and graph-density retrieval modes in SurrealDB...
-- [Keywords and BM25](https://surrealdb.com/docs/agent-memory/retrieve/keywords-and-bm25): Using keyword extraction and full-text search in SurrealDB Agent...
+- [Hybrid search](https://surrealdb.com/docs/agent-memory/retrieve/hybrid-search): Vector, BM25, and graph-density retrieval modes.
+- [Keywords and BM25](https://surrealdb.com/docs/agent-memory/retrieve/keywords-and-bm25): Keyword extraction and full-text search.
 - [Recalling memories](https://surrealdb.com/docs/agent-memory/retrieve/recall): Unified retrieval over facts and document passages.
-- [Adding turns](https://surrealdb.com/docs/agent-memory/sessions/adding-turns)
-- [Chat sessions](https://surrealdb.com/docs/agent-memory/sessions/chat-sessions)
-- [Creating sessions](https://surrealdb.com/docs/agent-memory/sessions/creating-sessions)
-- [State and diffs](https://surrealdb.com/docs/agent-memory/sessions/state-and-diffs)
-- [Caching and invalidation](https://surrealdb.com/docs/agent-memory/tuning/caching-and-invalidation)
-- [Models per stage](https://surrealdb.com/docs/agent-memory/tuning/models-per-stage)
-- [Extraction vocabulary](https://surrealdb.com/docs/agent-memory/tuning/ontology-grounding)
-- [The accuracy promise](https://surrealdb.com/docs/agent-memory/welcome/accuracy-promise)
-- [How it works in five minutes](https://surrealdb.com/docs/agent-memory/welcome/how-it-works)
-- [What is SurrealDB Agent Memory?](https://surrealdb.com/docs/agent-memory/welcome/what-is-surrealdb-agent-memory)
-- [Why agentic memory?](https://surrealdb.com/docs/agent-memory/welcome/why-agentic-memory)
+- [Adding turns](https://surrealdb.com/docs/agent-memory/sessions/adding-turns): How to add conversation turns.
+- [Chat sessions](https://surrealdb.com/docs/agent-memory/sessions/chat-sessions): Using chat() for conversation loops managed by SurrealDB Agent Memory.
+- [Creating sessions](https://surrealdb.com/docs/agent-memory/sessions/creating-sessions): How to create and manage conversation sessions.
+- [State and diffs](https://surrealdb.com/docs/agent-memory/sessions/state-and-diffs): Reading structured memory state.
+- [Caching and invalidation](https://surrealdb.com/docs/agent-memory/tuning/caching-and-invalidation): How the semantic response cache works.
+- [Models per stage](https://surrealdb.com/docs/agent-memory/tuning/models-per-stage): Configure which LLM runs at each processing stage.
+- [Extraction vocabulary](https://surrealdb.com/docs/agent-memory/tuning/ontology-grounding): How entity names and attribute keys stay consistent.
+- [The accuracy promise](https://surrealdb.com/docs/agent-memory/welcome/accuracy-promise): Defensible correctness in SurrealDB Agent Memory.
+- [How it works in five minutes](https://surrealdb.com/docs/agent-memory/welcome/how-it-works): From a message to structured substrate state.
+- [What is SurrealDB Agent Memory?](https://surrealdb.com/docs/agent-memory/welcome/what-is-surrealdb-agent-memory): A memory and knowledge layer for AI agents.
+- [Why agentic memory?](https://surrealdb.com/docs/agent-memory/welcome/why-agentic-memory): Why conversational agents need structured memory.
 - [Coding agent with project memory](https://surrealdb.com/docs/agent-memory/cookbooks/build/coding-agent-with-project-memory)
 - [Customer support agent](https://surrealdb.com/docs/agent-memory/cookbooks/build/customer-support-agent)
 - [Long-running research agent](https://surrealdb.com/docs/agent-memory/cookbooks/build/long-running-research-agent)

--- a/scripts/trigger-reindex.ts
+++ b/scripts/trigger-reindex.ts
@@ -21,7 +21,7 @@ const ENDPOINT_PATH = "/api/docs/v1/reindex";
 /**
  * Resolved from REINDEX_ENVIRONMENT, which the workflow fills from its
  * workflow_dispatch input. A push carries no input, so the value arrives empty
- * and production is used — the same choice a merge should make.
+ * and production is used - the same choice a merge should make.
  */
 const HOSTS = {
     production: "https://api.surrealdb.com",
@@ -40,7 +40,7 @@ function isEnvironment(value: string): value is Environment {
  *
  * This lives here rather than in a workflow expression so it can be exercised.
  * A GitHub expression is untestable, and this workflow only ever runs after a
- * merge — there is no run on the pull request to catch a mistake in it.
+ * merge - there is no run on the pull request to catch a mistake in it.
  */
 function resolveUrl(): string {
     const override = process.env.REINDEX_URL?.trim();
@@ -169,7 +169,7 @@ for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
 
         // The endpoint took the delivery and discarded it. That means this
         // script sent the wrong event name or the wrong ref, which is a bug
-        // here rather than a transient failure — do not retry it.
+        // here rather than a transient failure - do not retry it.
         fail(
             `The endpoint discarded the request (reason: ${body.reason ?? "unknown"}). ` +
                 `Check the X-GitHub-Event header and the ref in the payload.`,
@@ -199,7 +199,7 @@ for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
     if (attempt < MAX_ATTEMPTS) {
         const note =
             response.status === 409 ? "another index run holds the lease" : "the endpoint is busy";
-        log(`Attempt ${attempt} got ${response.status} — ${note}. Waiting to try again.`);
+        log(`Attempt ${attempt} got ${response.status} - ${note}. Waiting to try again.`);
         await sleep(RETRY_DELAY_MS);
     }
 }

--- a/search/README.md
+++ b/search/README.md
@@ -151,7 +151,7 @@ search is retired, a merge to `main` updates both:
 | This one | `postbuild` on the Vercel production build | `/docs/api/search`, which the site's UI calls today |
 | The API's | `.github/workflows/reindex-docs.yml` calling `POST /api/docs/v1/reindex` | `api.surrealdb.com/api/docs/v1/search`, and the `search_documentation` MCP tool |
 
-The two do not collide, because they write to different databases — but both pay
+The two do not collide, because they write to different databases - but both pay
 for OpenAI embeddings, so retiring this one is worth doing.
 
 The workflow signs its request the way a GitHub webhook would: HMAC-SHA256 over
@@ -173,7 +173,7 @@ script treats that as success.
 | `OPENAI_API_KEY`      | OpenAI API key for embeddings           |
 
 `DOCS_WEBHOOK_SECRET` is a GitHub Actions repository secret rather than a
-Vercel variable, because the workflow — not the build — is what uses it.
+Vercel variable, because the workflow - not the build - is what uses it.
 
 ## File structure
 

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -124,7 +124,18 @@ export function DefaultLayout({
                                 </Title>
                                 <CopyPageMenu />
                             </Group>
-                            {data.description && <Text fz="xl">{data.description}</Text>}
+                            {/*
+                             * The frontmatter description is deliberately not
+                             * rendered. It feeds `<meta name="description">`,
+                             * the search index and `llms.txt`, which all want
+                             * dense front-loaded terms, while the orienting
+                             * sentence a reader needs is the page's own opening
+                             * paragraph - which the docs voice already
+                             * requires. Rendering both gave every page two
+                             * openers, and on an eighth of them the
+                             * description restated the first H2 sitting
+                             * directly beneath it.
+                             */}
                             <Box
                                 mt="xl"
                                 component="main"

--- a/src/content/agent-memory/index/architecture/coherence-retrieval-and-tiers.mdx
+++ b/src/content/agent-memory/index/architecture/coherence-retrieval-and-tiers.mdx
@@ -1,7 +1,7 @@
 ---
 position: 3
 title: Coherence, retrieval, and cost tiers
-description: "Five coherence dimensions, hybrid structural retrieval, and the four-tier query ladder."
+description: "Five coherence dimensions and hybrid structural retrieval. Also covers the four-tier query ladder."
 ---
 
 # Coherence, retrieval, and cost tiers

--- a/src/content/agent-memory/index/architecture/eight-pillars-and-categories.mdx
+++ b/src/content/agent-memory/index/architecture/eight-pillars-and-categories.mdx
@@ -1,7 +1,7 @@
 ---
 position: 2
 title: Eight pillars and six categories
-description: "The primitives SurrealDB Agent Memory operationalises - pillars of agent memory and typed experiential sub-stores."
+description: "The primitives SurrealDB Agent Memory operationalises. Pillars of agent memory, and typed experiential sub-stores."
 ---
 
 # Eight pillars and six categories

--- a/src/content/agent-memory/index/architecture/glossary.mdx
+++ b/src/content/agent-memory/index/architecture/glossary.mdx
@@ -1,7 +1,7 @@
 ---
 position: 7
 title: Agent Memory glossary
-description: "Alphabetical definitions of terms used across SurrealDB Agent Memory architecture and memory docs."
+description: "Alphabetical definitions of SurrealDB Agent Memory terms. Covers the architecture and memory documentation."
 ---
 
 # Glossary

--- a/src/content/agent-memory/index/architecture/principles-and-goals.mdx
+++ b/src/content/agent-memory/index/architecture/principles-and-goals.mdx
@@ -1,7 +1,7 @@
 ---
 position: 1
 title: Principles and goals
-description: "What SurrealDB Agent Memory is built to do - and what it deliberately is not."
+description: "What SurrealDB Agent Memory deliberately is and is not. The goals it is built to meet."
 ---
 
 # Principles and goals

--- a/src/content/agent-memory/index/architecture/surface-security-and-models.mdx
+++ b/src/content/agent-memory/index/architecture/surface-security-and-models.mdx
@@ -1,7 +1,7 @@
 ---
 position: 6
 title: Surface, models, and security
-description: "HTTP ingest and read verbs, integrations, model hooks, and security properties."
+description: "HTTP ingest and read verbs, integrations, and model hooks. Security properties are covered too."
 ---
 
 # Surface, models, and security

--- a/src/content/agent-memory/index/architecture/traces-and-evolution.mdx
+++ b/src/content/agent-memory/index/architecture/traces-and-evolution.mdx
@@ -1,10 +1,12 @@
 ---
 position: 4
 title: Traces and memory evolution
-description: "Graph-resident traces, reflection, elaboration, consolidation, and semantic response reuse."
+description: "Graph-resident traces, reflection, elaboration, consolidation. Also semantic response reuse."
 ---
 
 # Traces and memory evolution
+
+SurrealDB Agent Memory keeps a record of what it retrieved, what it decided, and what it answered, and treats those records as memory rather than as logs. This page covers the three trace kinds, the three mechanisms that build new memory out of them, and how a prior answer can be reused while the facts behind it still hold.
 
 ## Tracing as graph-resident memory
 

--- a/src/content/agent-memory/index/architecture/tri-temporal-model.mdx
+++ b/src/content/agent-memory/index/architecture/tri-temporal-model.mdx
@@ -1,7 +1,7 @@
 ---
 position: 5
 title: Tri-temporal model
-description: "System time, known time, and valid time - supersession, aging, and explicit forget."
+description: "System and valid time, supersession, ageing, and explicit forget. How known time fits alongside them."
 ---
 
 # Tri-temporal model

--- a/src/content/agent-memory/index/index.mdx
+++ b/src/content/agent-memory/index/index.mdx
@@ -1,7 +1,7 @@
 ---
 position: 0
 title: Agent Memory
-description: "Principles, architecture, quickstarts, and mental model for SurrealDB Agent Memory - memory and knowledge for AI agents on SurrealDB."
+description: "Memory and knowledge for AI agents on SurrealDB. Principles, architecture, quickstarts, and the mental model."
 ---
 
 # SurrealDB Agent Memory documentation

--- a/src/content/agent-memory/index/memory-and-knowledge.mdx
+++ b/src/content/agent-memory/index/memory-and-knowledge.mdx
@@ -1,7 +1,7 @@
 ---
 position: 1
 title: "Memory & knowledge"
-description: "Ingest, retrieve, reason, and tune agent memory on SurrealDB Agent Memory's unified substrate."
+description: "Ingest, retrieve, reason, and tune agent memory. All on SurrealDB Agent Memory's unified substrate."
 ---
 
 # Memory & knowledge

--- a/src/content/agent-memory/index/mental-model/contexts-and-scope.mdx
+++ b/src/content/agent-memory/index/mental-model/contexts-and-scope.mdx
@@ -1,7 +1,7 @@
 ---
 position: 2
 title: Contexts and scope
-description: "How Contexts isolate tenants and how scope tags partition memory within a Context."
+description: "How scope tags partition memory, and how Contexts isolate tenants. Both operate within a Context."
 ---
 
 # Contexts and scope

--- a/src/content/agent-memory/index/mental-model/memory-categories.mdx
+++ b/src/content/agent-memory/index/mental-model/memory-categories.mdx
@@ -1,7 +1,7 @@
 ---
 position: 4
 title: Memory categories
-description: "Episodic raw turns plus five extracted experiential categories - identity, knowledge, context, instructions, uncertainty."
+description: "Episodic raw turns plus five extracted experiential categories. Identity, knowledge, context, instructions, and uncertainty."
 ---
 
 # Memory categories

--- a/src/content/agent-memory/index/mental-model/provenance-and-traceability.mdx
+++ b/src/content/agent-memory/index/mental-model/provenance-and-traceability.mdx
@@ -1,7 +1,7 @@
 ---
 position: 5
 title: Provenance and traceability
-description: "The source object on every record - kinds, spans, trust, derivation, and traces."
+description: "The source object carried on every record. Kinds, spans, trust, derivation, and traces."
 ---
 
 # Provenance and traceability

--- a/src/content/agent-memory/index/mental-model/two-layer-architecture.mdx
+++ b/src/content/agent-memory/index/mental-model/two-layer-architecture.mdx
@@ -1,7 +1,7 @@
 ---
 position: 1
 title: Unified substrate and authority
-description: "One SurrealDB graph for authoritative and experiential knowledge - provenance and reconciliation, not two silos."
+description: "One SurrealDB graph for authoritative and experiential knowledge. Provenance and reconciliation in one place, rather than two silos."
 ---
 
 # Unified substrate and authority

--- a/src/content/agent-memory/index/operations/forget.mdx
+++ b/src/content/agent-memory/index/operations/forget.mdx
@@ -1,7 +1,7 @@
 ---
 position: 3
 title: Forgetting memories
-description: "How to retire or permanently erase memories - default forget, purge, and scoped erasure."
+description: "Default forget, purge, and scoped erasure. How to retire or permanently erase memories."
 ---
 
 # Forgetting memories

--- a/src/content/agent-memory/index/quickstarts/hosted.mdx
+++ b/src/content/agent-memory/index/quickstarts/hosted.mdx
@@ -1,7 +1,7 @@
 ---
 position: 2
 title: Hosted quickstart
-description: "Get up and running with SurrealDB Agent Memory on SurrealDB Cloud in five minutes."
+description: "Get SurrealDB Agent Memory running in five minutes. Runs on SurrealDB Cloud, with no server to install."
 ---
 
 # Hosted quickstart

--- a/src/content/agent-memory/index/quickstarts/surrealdb-cloud.mdx
+++ b/src/content/agent-memory/index/quickstarts/surrealdb-cloud.mdx
@@ -1,7 +1,7 @@
 ---
 position: 1
 title: Agent Memory on SurrealDB Cloud
-description: "How SurrealDB Agent Memory contexts, authentication, and APIs work on SurrealDB Cloud."
+description: "How contexts, authentication and the APIs work on SurrealDB Cloud. For SurrealDB Agent Memory."
 ---
 
 # Agent Memory on SurrealDB Cloud

--- a/src/content/agent-memory/index/reasoning/authority-hierarchy.mdx
+++ b/src/content/agent-memory/index/reasoning/authority-hierarchy.mdx
@@ -1,7 +1,7 @@
 ---
 position: 4
 title: Authority when pillars meet
-description: "How the Authoritative and Experiential pillars interact - reconciliation, uncertainty, and resolves_to."
+description: "How the Authoritative and Experiential pillars interact. Reconciliation, uncertainty, and resolves_to."
 ---
 
 # Authority when pillars meet

--- a/src/content/agent-memory/index/reasoning/cross-layer-linking.mdx
+++ b/src/content/agent-memory/index/reasoning/cross-layer-linking.mdx
@@ -1,7 +1,7 @@
 ---
 position: 4
 title: Cross-layer linking
-description: "How authoritative documents and experiential facts relate in the unified graph."
+description: "How authoritative documents and experiential facts relate. Both live in the unified graph."
 ---
 
 # Cross-layer linking

--- a/src/content/agent-memory/index/reasoning/extraction-pipeline.mdx
+++ b/src/content/agent-memory/index/reasoning/extraction-pipeline.mdx
@@ -1,7 +1,7 @@
 ---
 position: 1
 title: Extraction pipeline
-description: "How SurrealDB Agent Memory classifies and extracts structured memory from conversation turns."
+description: "How structured memory is extracted from conversation turns. Classification and extraction in SurrealDB Agent Memory."
 ---
 
 # Extraction pipeline

--- a/src/content/agent-memory/index/reasoning/instructions-and-uncertainties.mdx
+++ b/src/content/agent-memory/index/reasoning/instructions-and-uncertainties.mdx
@@ -1,7 +1,7 @@
 ---
 position: 5
 title: Instructions and uncertainties
-description: "How SurrealDB Agent Memory captures behavioural directives and tracks ambiguous or contradictory information."
+description: "How behavioural directives are captured and tracked. Including ambiguous or contradictory information."
 ---
 
 # Instructions and uncertainties

--- a/src/content/agent-memory/index/reasoning/reconciliation-and-supersession.mdx
+++ b/src/content/agent-memory/index/reasoning/reconciliation-and-supersession.mdx
@@ -1,7 +1,7 @@
 ---
 position: 2
 title: Reconciliation and supersession
-description: "How SurrealDB Agent Memory deduplicates entities, detects conflicts, and tracks corrections with full history."
+description: "How entities are deduplicated and conflicts detected. Corrections are tracked with full history."
 ---
 
 # Reconciliation and supersession

--- a/src/content/agent-memory/index/reasoning/temporal-validity.mdx
+++ b/src/content/agent-memory/index/reasoning/temporal-validity.mdx
@@ -1,7 +1,7 @@
 ---
 position: 3
 title: Temporal validity
-description: "How SurrealDB Agent Memory tracks when facts were true using valid_from and valid_until."
+description: "How SurrealDB Agent Memory tracks when facts were true. Using valid_from and valid_until."
 ---
 
 # Temporal validity

--- a/src/content/agent-memory/index/retrieve/hybrid-search.mdx
+++ b/src/content/agent-memory/index/retrieve/hybrid-search.mdx
@@ -1,7 +1,7 @@
 ---
 position: 1
 title: Hybrid search
-description: "Using vector, BM25, and graph-density retrieval modes in SurrealDB Agent Memory."
+description: "Vector, BM25, and graph-density retrieval modes. How each mode behaves in SurrealDB Agent Memory."
 ---
 
 # Hybrid search

--- a/src/content/agent-memory/index/retrieve/keywords-and-bm25.mdx
+++ b/src/content/agent-memory/index/retrieve/keywords-and-bm25.mdx
@@ -1,7 +1,7 @@
 ---
 position: 3
 title: Keywords and BM25
-description: "Using keyword extraction and full-text search in SurrealDB Agent Memory's knowledge layer."
+description: "Keyword extraction and full-text search. How both work in SurrealDB Agent Memory's knowledge layer."
 ---
 
 # Keywords and BM25

--- a/src/content/agent-memory/index/sessions/adding-turns.mdx
+++ b/src/content/agent-memory/index/sessions/adding-turns.mdx
@@ -1,7 +1,7 @@
 ---
 position: 2
 title: Adding turns
-description: "How to add conversation turns and interpret the structured extraction result."
+description: "How to add conversation turns. Interpreting the structured extraction result."
 ---
 
 # Adding turns

--- a/src/content/agent-memory/index/sessions/creating-sessions.mdx
+++ b/src/content/agent-memory/index/sessions/creating-sessions.mdx
@@ -1,7 +1,7 @@
 ---
 position: 1
 title: Creating sessions
-description: "How to create and manage conversation sessions in SurrealDB Agent Memory."
+description: "How to create and manage conversation sessions. Covers session lifecycle in SurrealDB Agent Memory."
 ---
 
 # Creating sessions

--- a/src/content/agent-memory/index/sessions/state-and-diffs.mdx
+++ b/src/content/agent-memory/index/sessions/state-and-diffs.mdx
@@ -1,7 +1,7 @@
 ---
 position: 4
 title: State and diffs
-description: "Reading structured memory state and tracking what changed between turns."
+description: "Reading structured memory state. Also tracking what changed between turns."
 ---
 
 # State and diffs

--- a/src/content/agent-memory/index/tuning/caching-and-invalidation.mdx
+++ b/src/content/agent-memory/index/tuning/caching-and-invalidation.mdx
@@ -1,7 +1,7 @@
 ---
 position: 3
 title: Caching and invalidation
-description: "How SurrealDB Agent Memory's semantic response cache works and how to manage memory lifecycle."
+description: "How the semantic response cache works. Managing the memory lifecycle in SurrealDB Agent Memory."
 ---
 
 # Caching and invalidation

--- a/src/content/agent-memory/index/tuning/models-per-stage.mdx
+++ b/src/content/agent-memory/index/tuning/models-per-stage.mdx
@@ -1,7 +1,7 @@
 ---
 position: 1
 title: Models per stage
-description: "Configure which LLM is used for each processing stage in SurrealDB Agent Memory."
+description: "Configure which LLM runs at each processing stage. For every stage in SurrealDB Agent Memory."
 ---
 
 # Models per stage

--- a/src/content/agent-memory/index/tuning/ontology-grounding.mdx
+++ b/src/content/agent-memory/index/tuning/ontology-grounding.mdx
@@ -1,7 +1,7 @@
 ---
 position: 2
 title: Extraction vocabulary
-description: "How SurrealDB Agent Memory keeps entity names, attribute keys, and relation labels consistent across extractions."
+description: "How entity names and attribute keys stay consistent. Relation labels are grounded across extractions too."
 ---
 
 # Extraction vocabulary

--- a/src/content/agent-memory/index/welcome/accuracy-promise.mdx
+++ b/src/content/agent-memory/index/welcome/accuracy-promise.mdx
@@ -1,7 +1,7 @@
 ---
 position: 3
 title: The accuracy promise
-description: "Defensible correctness - provenance, reconciliation, tri-temporal history, traces, and inspectable substrate state."
+description: "Defensible correctness in SurrealDB Agent Memory. Provenance, reconciliation, tri-temporal history, traces, and inspectable substrate state."
 ---
 
 # The accuracy promise

--- a/src/content/agent-memory/index/welcome/how-it-works.mdx
+++ b/src/content/agent-memory/index/welcome/how-it-works.mdx
@@ -1,7 +1,7 @@
 ---
 position: 4
 title: How it works in five minutes
-description: "From a message to structured substrate state - extraction, reconciliation, traces, and tiered reads."
+description: "From a message to structured substrate state. Extraction, reconciliation, traces, and tiered reads."
 ---
 
 # How it works in five minutes

--- a/src/content/agent-memory/index/welcome/what-is-surrealdb-agent-memory.mdx
+++ b/src/content/agent-memory/index/welcome/what-is-surrealdb-agent-memory.mdx
@@ -1,7 +1,7 @@
 ---
 position: 1
 title: What is SurrealDB Agent Memory?
-description: "SurrealDB Agent Memory as a memory and knowledge layer - one SurrealDB substrate, provenance-first, trace-aware, tri-temporal."
+description: "A memory and knowledge layer for AI agents. One SurrealDB substrate, provenance-first, trace-aware, and tri-temporal."
 ---
 
 # What is SurrealDB Agent Memory?

--- a/src/content/agent-memory/index/welcome/why-agentic-memory.mdx
+++ b/src/content/agent-memory/index/welcome/why-agentic-memory.mdx
@@ -1,7 +1,7 @@
 ---
 position: 2
 title: Why agentic memory?
-description: "Why conversational agents need structured memory beyond plain retrieval."
+description: "Why conversational agents need structured memory. Plain retrieval is not enough on its own."
 ---
 
 # Why agentic memory?

--- a/src/content/agent-memory/integrations/index.mdx
+++ b/src/content/agent-memory/integrations/index.mdx
@@ -1,7 +1,7 @@
 ---
 position: 0
 title: Agent Memory integrations
-description: "Connecting SurrealDB Agent Memory to your stack - SDKs, MCP server, AI SDKs, agent frameworks, voice tools, and automation."
+description: "SDKs, the MCP server, AI SDKs and agent frameworks. Connecting SurrealDB Agent Memory to your stack, plus voice tools and automation."
 ---
 
 # Integrations

--- a/src/content/agent-memory/reference/agents.mdx
+++ b/src/content/agent-memory/reference/agents.mdx
@@ -1,7 +1,7 @@
 ---
 position: 1
 title: Agent guide (AGENTS.md)
-description: "Instructions for coding agents integrating with SurrealDB Agent Memory - copy into Cursor rules or skills."
+description: "Copy these into your Cursor rules or agent skills. Instructions for coding agents integrating with SurrealDB Agent Memory."
 ---
 
 # Agent guide (AGENTS.md)

--- a/src/content/agent-memory/reference/rest-api.mdx
+++ b/src/content/agent-memory/reference/rest-api.mdx
@@ -1,7 +1,7 @@
 ---
 position: 2
 title: REST API
-description: "End-user HTTP endpoints on the unified SurrealDB Agent Memory substrate."
+description: "End-user HTTP endpoints on the unified substrate. For SurrealDB Agent Memory."
 ---
 
 # REST API

--- a/src/content/agent-memory/reference/sdk-javascript.mdx
+++ b/src/content/agent-memory/reference/sdk-javascript.mdx
@@ -6,6 +6,8 @@ description: "Package layout and configuration for @surrealdb/memory."
 
 # JavaScript SDK reference
 
+The `@surrealdb/memory` package is the JavaScript and TypeScript client for SurrealDB Agent Memory. This page covers installing it and configuring a client.
+
 > [!NOTE]
 | Item | Value |
 | --- | --- |

--- a/src/content/agent-memory/reference/sdk-kotlin.mdx
+++ b/src/content/agent-memory/reference/sdk-kotlin.mdx
@@ -1,7 +1,7 @@
 ---
 position: 6
 title: Kotlin SDK reference
-description: "Package layout, configuration, and error model for the SurrealDB Agent Memory Kotlin client."
+description: "The SurrealDB Agent Memory Kotlin client. Package layout, configuration, and the error model."
 ---
 
 # Kotlin SDK reference

--- a/src/content/agent-memory/reference/sdk-python.mdx
+++ b/src/content/agent-memory/reference/sdk-python.mdx
@@ -1,7 +1,7 @@
 ---
 position: 7
 title: Python SDK reference
-description: "Package layout and configuration for the SurrealDB Agent Memory client in surrealdb."
+description: "The SurrealDB Agent Memory client inside the surrealdb package. Package layout and configuration."
 ---
 
 # Python SDK reference

--- a/src/content/agent-memory/reference/sdk-swift.mdx
+++ b/src/content/agent-memory/reference/sdk-swift.mdx
@@ -1,10 +1,12 @@
 ---
 position: 8
 title: Swift SDK reference
-description: "Package layout and configuration for the SurrealDB Agent Memory Swift client."
+description: "The SurrealDB Agent Memory Swift client. Package layout and configuration."
 ---
 
 # Swift SDK reference
+
+The `AgentMemory` product in `surrealdb.swift` is the Swift client for SurrealDB Agent Memory. This page covers adding the package and configuring a client.
 
 > [!NOTE]
 | Item | Value |

--- a/src/content/build/ai-agents/ai-frameworks.mdx
+++ b/src/content/build/ai-agents/ai-frameworks.mdx
@@ -1,7 +1,7 @@
 ---
 position: 3
 title: AI frameworks
-description: "Framework integrations that let AI and machine learning libraries use SurrealDB for vectors, memory, and pipelines."
+description: "Framework integrations for AI and machine learning libraries. Use SurrealDB for vectors, memory, and pipelines."
 ---
 
 SurrealDB integrates with widely used AI and machine learning frameworks so you can use a single database for features, training or evaluation pipelines, and agent orchestration. Each integration page explains setup, typical patterns, and links to upstream documentation where helpful.

--- a/src/content/build/ai-agents/index.mdx
+++ b/src/content/build/ai-agents/index.mdx
@@ -1,7 +1,7 @@
 ---
 position: 1
 title: AI agents
-description: "The ways SurrealDB fits into AI tooling - MCP servers, Agent Skills, and framework integrations - and what the database gives an agent."
+description: "MCP servers, Agent Skills, and framework integrations for SurrealDB. The ways SurrealDB fits into AI tooling, and what it gives an agent."
 ---
 
 # AI agents

--- a/src/content/build/ai-agents/mcp/index.mdx
+++ b/src/content/build/ai-agents/mcp/index.mdx
@@ -1,7 +1,7 @@
 ---
 position: 1
 title: SurrealDB MCP Server
-description: "Connect Claude, Cursor, and other AI tools to your SurrealDB Cloud account with a single URL."
+description: "Connect Claude, Cursor, and other AI tools to SurrealDB Cloud. One URL is all the configuration needs."
 ---
 
 # SurrealDB MCP Server

--- a/src/content/build/embedding/index.mdx
+++ b/src/content/build/embedding/index.mdx
@@ -1,7 +1,7 @@
 ---
 position: 1
 title: Embedding SurrealDB
-description: In this section, you will find detailed instructions on how to embed SurrealDB into your application depending on your programming language.
+description: "How to embed SurrealDB into your application. Detailed instructions for each supported programming language."
 ---
 
 # Embedding SurrealDB

--- a/src/content/build/embedding/storage-engines.mdx
+++ b/src/content/build/embedding/storage-engines.mdx
@@ -1,7 +1,7 @@
 ---
 position: 2
 title: Storage engines
-description: "What a storage engine does for SurrealDB, and how to think about choosing one."
+description: "What a storage engine does for SurrealDB. How to think about choosing one."
 ---
 
 # Storage engines

--- a/src/content/build/integrations/authentication/better-auth/transactions-and-limitations.mdx
+++ b/src/content/build/integrations/authentication/better-auth/transactions-and-limitations.mdx
@@ -6,6 +6,8 @@ description: How the @surrealdb/better-auth adapter handles transactions, and th
 
 # Transactions & limitations
 
+The `@surrealdb/better-auth` adapter uses transactions internally, and exposes them for operations you want to group yourself. This page covers that behaviour and the limitations that come with it.
+
 ## Transactions
 
 Transaction support is built in. Better Auth uses transactions internally for operations that need atomicity (for example, creating a session alongside a new user record), so most applications never call the transaction API directly.

--- a/src/content/build/integrations/index.mdx
+++ b/src/content/build/integrations/index.mdx
@@ -1,7 +1,7 @@
 ---
 position: 1
 title: Integrations
-description: "Integrations that connect SurrealDB to AI frameworks, embeddings providers, agents, and data tools."
+description: "Integrations connecting SurrealDB to AI frameworks and embeddings. Also agents and data tools."
 ---
 
 # Integrations

--- a/src/content/build/migrating/index.mdx
+++ b/src/content/build/migrating/index.mdx
@@ -1,7 +1,7 @@
 ---
 position: 1
 title: Migrating to SurrealDB
-description: Moving data into SurrealDB from other databases, older SurrealDB releases, or files and streams.
+description: "Moving data into SurrealDB from other databases, or older releases. Also from files and streams."
 ---
 
 # Migrating

--- a/src/content/explore/ml-models/index.mdx
+++ b/src/content/explore/ml-models/index.mdx
@@ -1,7 +1,7 @@
 ---
 position: 1
 title: Introduction
-description: "SurrealML stores and runs trained ML models in SurrealDB - train in Python, then load and infer with sklearn or PyTorch."
+description: "SurrealML runs trained ML models in SurrealDB: train in Python. Then load and infer with sklearn or PyTorch."
 ---
 
 # SurrealML

--- a/src/content/explore/studio/surrealql-editors.mdx
+++ b/src/content/explore/studio/surrealql-editors.mdx
@@ -1,7 +1,7 @@
 ---
 position: 3
 title: SurrealQL editors
-description: "SurrealQL editor shortcuts in SurrealDB Studio for indentation, comments, multi-cursor edits, running queries, record inspection, and JSON formatting."
+description: "SurrealQL editor shortcuts in SurrealDB Studio. Indentation, comments, multi-cursor edits, running queries, record inspection, and JSON formatting."
 ---
 
 # SurrealQL editors

--- a/src/content/explore/tutorials/index.mdx
+++ b/src/content/explore/tutorials/index.mdx
@@ -1,7 +1,7 @@
 ---
 position: 1
 title: Demos and tutorials
-description: "Hands-on demo applications and tutorials to learn SurrealDB by building real projects."
+description: "Hands-on demo applications and tutorials. Learn SurrealDB by building real projects."
 ---
 
 # Demos and tutorials

--- a/src/content/explore/tutorials/tutorials/gen-ai-chatbot.mdx
+++ b/src/content/explore/tutorials/tutorials/gen-ai-chatbot.mdx
@@ -6,6 +6,8 @@ description: "In this guide, you'll learn how to use LangChain Python components
 
 # Make a GenAI chatbot using Graph RAG with SurrealDB and LangChain
 
+This tutorial builds a GenAI chatbot from LangChain Python components, Ollama and SurrealDB, retrieving context through the graph rather than through vector similarity alone. It opens with how traditional RAG works, so that the difference is clear before any code.
+
 ## What is traditional RAG
 
 Retrieval-Augmented Generation (RAG) is an AI technique that enhances the capabilities of large language models (LLMs) by allowing them to retrieve relevant information from a knowledge base *before* generating a response. It uses vector similarity search to find the most relevant document chunks, which are then provided as additional context to the LLM, enabling the LLM to produce more accurate and grounded responses.

--- a/src/content/index/agents/claude-code.mdx
+++ b/src/content/index/agents/claude-code.mdx
@@ -59,5 +59,5 @@ claude mcp remove surrealdb
 
 ## Next steps
 
-- [MCP in Claude](/docs/build/ai-agents/mcp/claude) — Claude Desktop and the Claude app, and troubleshooting
-- [Example usages](/docs/build/ai-agents/mcp/examples) — more prompts to try
+- [MCP in Claude](/docs/build/ai-agents/mcp/claude) - Claude Desktop and the Claude app, and troubleshooting
+- [Example usages](/docs/build/ai-agents/mcp/examples) - more prompts to try

--- a/src/content/index/agents/claude-code.mdx
+++ b/src/content/index/agents/claude-code.mdx
@@ -1,7 +1,7 @@
 ---
 position: 2
 title: Claude Code
-description: "Set up Claude Code for SurrealDB with the hosted MCP server and the official Agent Skills."
+description: "Hosted MCP server and Agent Skills setup for Claude Code. Covers the .mcp.json entry, signing in, and checking it worked."
 ---
 
 # Claude Code

--- a/src/content/index/agents/codex.mdx
+++ b/src/content/index/agents/codex.mdx
@@ -1,7 +1,7 @@
 ---
 position: 3
 title: Codex
-description: "Set up the OpenAI Codex CLI for SurrealDB with the hosted MCP server and the official Agent Skills."
+description: "Hosted MCP server and Agent Skills setup for the Codex CLI. Covers the config.toml entry, signing in, and checking it worked."
 ---
 
 # Codex

--- a/src/content/index/agents/codex.mdx
+++ b/src/content/index/agents/codex.mdx
@@ -51,5 +51,5 @@ codex mcp list
 
 ## Next steps
 
-- [SurrealDB MCP Server](/docs/build/ai-agents/mcp) — every tool the server publishes
-- [Agent Skills](/docs/build/ai-agents/agent-skills) — what each skill covers
+- [SurrealDB MCP Server](/docs/build/ai-agents/mcp) - every tool the server publishes
+- [Agent Skills](/docs/build/ai-agents/agent-skills) - what each skill covers

--- a/src/content/index/agents/cursor.mdx
+++ b/src/content/index/agents/cursor.mdx
@@ -51,5 +51,5 @@ Delete the `surrealdb` entry from `mcp.json`. Cursor stops offering the tools in
 
 ## Next steps
 
-- [MCP in Cursor](/docs/build/ai-agents/mcp/cursor) — the full guide, including troubleshooting
-- [Example usages](/docs/build/ai-agents/mcp/examples) — more prompts to try
+- [MCP in Cursor](/docs/build/ai-agents/mcp/cursor) - the full guide, including troubleshooting
+- [Example usages](/docs/build/ai-agents/mcp/examples) - more prompts to try

--- a/src/content/index/agents/cursor.mdx
+++ b/src/content/index/agents/cursor.mdx
@@ -1,7 +1,7 @@
 ---
 position: 4
 title: Cursor
-description: "Set up Cursor for SurrealDB with the hosted MCP server and the official Agent Skills."
+description: "Hosted MCP server and Agent Skills setup for Cursor. Covers the mcp.json entry, signing in, and checking it worked."
 ---
 
 # Cursor

--- a/src/content/index/agents/github-copilot.mdx
+++ b/src/content/index/agents/github-copilot.mdx
@@ -1,7 +1,7 @@
 ---
 position: 5
 title: GitHub Copilot
-description: "Set up GitHub Copilot agent mode for SurrealDB with the hosted MCP server and the official Agent Skills."
+description: "Hosted MCP server and Agent Skills setup for GitHub Copilot. Copilot reads the same .vscode/mcp.json file that VS Code does."
 ---
 
 # GitHub Copilot

--- a/src/content/index/agents/github-copilot.mdx
+++ b/src/content/index/agents/github-copilot.mdx
@@ -52,5 +52,5 @@ Open Copilot Chat in agent mode and ask which SurrealDB tools it can use. The to
 
 ## Next steps
 
-- [Visual Studio Code](/docs/agents/vscode) — the same file, without Copilot
-- [SurrealDB MCP Server](/docs/build/ai-agents/mcp) — every tool the server publishes
+- [Visual Studio Code](/docs/agents/vscode) - the same file, without Copilot
+- [SurrealDB MCP Server](/docs/build/ai-agents/mcp) - every tool the server publishes

--- a/src/content/index/agents/index.mdx
+++ b/src/content/index/agents/index.mdx
@@ -39,7 +39,7 @@ Setup connects two things: packaged knowledge of how SurrealDB behaves, and tool
 
 ## Next steps
 
-- [SurrealDB MCP Server](/docs/build/ai-agents/mcp) — the hosted server in full, including every tool it publishes
-- [Embedded MCP](/docs/build/ai-agents/mcp/embedded) — the MCP server inside SurrealDB, for databases you run yourself
-- [Agent Skills](/docs/build/ai-agents/agent-skills) — what each skill covers, and how to find community skills
-- [Example usages](/docs/build/ai-agents/mcp/examples) — prompts that show what an assistant can do once it is set up
+- [SurrealDB MCP Server](/docs/build/ai-agents/mcp) - the hosted server in full, including every tool it publishes
+- [Embedded MCP](/docs/build/ai-agents/mcp/embedded) - the MCP server inside SurrealDB, for databases you run yourself
+- [Agent Skills](/docs/build/ai-agents/agent-skills) - what each skill covers, and how to find community skills
+- [Example usages](/docs/build/ai-agents/mcp/examples) - prompts that show what an assistant can do once it is set up

--- a/src/content/index/agents/vscode.mdx
+++ b/src/content/index/agents/vscode.mdx
@@ -42,9 +42,9 @@ npx skills add surrealdb/agent-skills
 
 ## Check it worked
 
-Ask chat which SurrealDB tools it has available. If nothing appears, reload the window — VS Code reads `mcp.json` at startup.
+Ask chat which SurrealDB tools it has available. If nothing appears, reload the window - VS Code reads `mcp.json` at startup.
 
 ## Next steps
 
-- [GitHub Copilot](/docs/agents/github-copilot) — the same file, with Copilot agent mode
-- [SurrealDB MCP Server](/docs/build/ai-agents/mcp) — every tool the server publishes
+- [GitHub Copilot](/docs/agents/github-copilot) - the same file, with Copilot agent mode
+- [SurrealDB MCP Server](/docs/build/ai-agents/mcp) - every tool the server publishes

--- a/src/content/index/agents/vscode.mdx
+++ b/src/content/index/agents/vscode.mdx
@@ -1,7 +1,7 @@
 ---
 position: 6
 title: Visual Studio Code
-description: "Set up Visual Studio Code for SurrealDB with the hosted MCP server and the official Agent Skills."
+description: "Hosted MCP server and Agent Skills setup for VS Code. Covers the servers object in mcp.json, for a workspace or globally."
 ---
 
 # Visual Studio Code

--- a/src/content/index/agents/windsurf.mdx
+++ b/src/content/index/agents/windsurf.mdx
@@ -38,11 +38,11 @@ Open the Cascade panel and ask which SurrealDB tools it has access to.
 
 ## Try it
 
-> Deploy nothing yet — just tell me what a small instance in eu-west-1 would cost per month.
+> Deploy nothing yet - just tell me what a small instance in eu-west-1 would cost per month.
 
 Cascade prices the configuration and waits for your go-ahead. Creating an instance costs money, so the server never does it without one.
 
 ## Next steps
 
-- [SurrealDB MCP Server](/docs/build/ai-agents/mcp) — every tool the server publishes
-- [Agent Skills](/docs/build/ai-agents/agent-skills) — what each skill covers
+- [SurrealDB MCP Server](/docs/build/ai-agents/mcp) - every tool the server publishes
+- [Agent Skills](/docs/build/ai-agents/agent-skills) - what each skill covers

--- a/src/content/index/agents/windsurf.mdx
+++ b/src/content/index/agents/windsurf.mdx
@@ -1,7 +1,7 @@
 ---
 position: 7
 title: Windsurf
-description: "Set up Windsurf for SurrealDB with the hosted MCP server and the official Agent Skills."
+description: "Hosted MCP server and Agent Skills setup for Windsurf. Windsurf uses serverUrl in mcp_config.json rather than url."
 ---
 
 # Windsurf

--- a/src/content/index/agents/zed.mdx
+++ b/src/content/index/agents/zed.mdx
@@ -41,5 +41,5 @@ Ask the assistant panel which SurrealDB tools it can call.
 
 ## Next steps
 
-- [SurrealDB MCP Server](/docs/build/ai-agents/mcp) — every tool the server publishes
-- [Agent Skills](/docs/build/ai-agents/agent-skills) — what each skill covers
+- [SurrealDB MCP Server](/docs/build/ai-agents/mcp) - every tool the server publishes
+- [Agent Skills](/docs/build/ai-agents/agent-skills) - what each skill covers

--- a/src/content/index/agents/zed.mdx
+++ b/src/content/index/agents/zed.mdx
@@ -1,7 +1,7 @@
 ---
 position: 8
 title: Zed
-description: "Set up the Zed editor for SurrealDB with the hosted MCP server and the official Agent Skills."
+description: "Hosted MCP server and Agent Skills setup for Zed. Covers the context_servers entry in the Zed settings file."
 ---
 
 # Zed

--- a/src/content/index/build.mdx
+++ b/src/content/index/build.mdx
@@ -1,7 +1,7 @@
 ---
 position: 11
 title: Build
-description: "Putting SurrealDB into an application: embedding the engine, migrating from another database, connecting frameworks and tools, and wiring it to AI agents."
+description: "Putting SurrealDB into an application: embedding the engine. Migrating from another database, connecting frameworks, and wiring it to AI agents."
 ---
 
 # Build

--- a/src/content/index/explore.mdx
+++ b/src/content/index/explore.mdx
@@ -1,7 +1,7 @@
 ---
 position: 13
 title: Explore
-description: "Tools and worked examples: SurrealDB Studio, video tutorials and demos, machine-learning models, and the SurrealDB Labs archive."
+description: "SurrealDB Studio, video tutorials and demos, and worked examples. Machine-learning models, and the SurrealDB Labs archive."
 ---
 
 # Explore

--- a/src/content/index/index.mdx
+++ b/src/content/index/index.mdx
@@ -1,7 +1,7 @@
 ---
 position: 0
 title: Getting started
-description: "The official documentation for SurrealDB, a multi-model database for modern applications."
+description: "The official documentation for SurrealDB, a multi-model database. Built for modern applications."
 ---
 
 SurrealDB stores relational, document, graph, time-series, vector and full-text data in one engine, queried through SurrealQL and reachable from ten official SDKs. It runs embedded in your application, as a single node, or as a distributed cluster.

--- a/src/content/index/languages/community.mdx
+++ b/src/content/index/languages/community.mdx
@@ -1,7 +1,7 @@
 ---
 position: 11
 title: Community SDKs
-description: Community-maintained and experimental SurrealDB clients for languages beyond the official SDKs.
+description: "Community-maintained and experimental SurrealDB clients. For languages beyond the official SDKs."
 ---
 
 # Community SDKs

--- a/src/content/index/languages/index.mdx
+++ b/src/content/index/languages/index.mdx
@@ -1,7 +1,7 @@
 ---
 position: 0
 title: SDKs
-description: "The official SurrealDB SDKs, one per language, each with a quickstart that gets you connected and a reference covering every method."
+description: "One official SurrealDB SDK per language. Each has a quickstart that gets you connected and a reference covering every method."
 ---
 
 SurrealDB has ten official SDKs. Each speaks the same RPC protocol over WebSocket or HTTP, so the concepts carry between them: connect, select a namespace and database, sign in, then query. What differs is the idiom - types, async model and error handling follow the host language.

--- a/src/content/index/languages/javascript.mdx
+++ b/src/content/index/languages/javascript.mdx
@@ -1,7 +1,7 @@
 ---
 position: 4
 title: JavaScript quickstart
-description: Connect to SurrealDB and run your first queries with the JavaScript SDK.
+description: "Connect and run your first queries with the JavaScript SDK."
 ---
 
 # Getting started

--- a/src/content/index/learn.mdx
+++ b/src/content/index/learn.mdx
@@ -1,7 +1,7 @@
 ---
 position: 10
 title: Learn
-description: "How SurrealDB stores, queries and secures data: SurrealQL, schema definition, the document, graph, vector and time-series models, and the access-control system."
+description: "How SurrealDB stores, queries and secures data: SurrealQL and schema. The document, graph, vector and time-series models, and access control."
 ---
 
 # Learn

--- a/src/content/index/manage.mdx
+++ b/src/content/index/manage.mdx
@@ -1,7 +1,7 @@
 ---
 position: 12
 title: Manage
-description: "Running SurrealDB in production: managed instances, organisations and billing, the surrealctl CLI, observability, schema migration and self-hosting."
+description: "Running SurrealDB in production: managed instances and organisations. Billing, the surrealctl CLI, observability, schema migration and self-hosting."
 ---
 
 # Manage

--- a/src/content/index/reference.mdx
+++ b/src/content/index/reference.mdx
@@ -1,7 +1,7 @@
 ---
 position: 14
 title: Reference
-description: "Complete syntax and API surface: SurrealQL statements and functions, the HTTP, RPC, CBOR and Postgres wire protocols, the command-line tools, and every official SDK."
+description: "SurrealQL statements and functions, and the full API surface. The HTTP, RPC, CBOR and Postgres wire protocols, the command-line tools, and every official SDK."
 ---
 
 # Reference

--- a/src/content/index/running/cloud.mdx
+++ b/src/content/index/running/cloud.mdx
@@ -1,7 +1,7 @@
 ---
 position: 3
 title: SurrealDB Cloud
-description: "Get a free managed SurrealDB instance with an email sign-in - persistent data without installing the server yourself."
+description: "Get a free managed SurrealDB instance with an email sign-in. Persistent data without installing the server yourself."
 ---
 
 # SurrealDB Cloud

--- a/src/content/index/running/docker.mdx
+++ b/src/content/index/running/docker.mdx
@@ -6,6 +6,8 @@ description: "Use this tutorial to get started with SurrealDB from within Docker
 
 # Run with Docker
 
+Docker runs SurrealDB without installing the server on the host machine. This page covers starting it from the official image and choosing a version tag.
+
 ## Running the SurrealDB server using Docker
 
 To get started using Docker, you can use the `latest` tag. To view all the available versions and tags, or to use a specific tag visit the [Docker Hub](https://hub.docker.com/r/surrealdb/surrealdb) page. To start a server use the [`start`](/docs/reference/cli/surrealdb-cli/commands/start) command. In Docker, SurrealDB listens on port `8000` in all interfaces by default so that the host can connect to the container in the default bridge networking mode.

--- a/src/content/index/running/file-backed.mdx
+++ b/src/content/index/running/file-backed.mdx
@@ -1,7 +1,7 @@
 ---
 position: 6
 title: File-backed
-description: "For the purposes of getting started with SurrealDB quickly, we will start a RocksDB database which persists data on the filesystem."
+description: "Start a RocksDB database that persists data on the filesystem. The quickest way to get started with data that survives a restart."
 ---
 
 # Run a single-node, on-disk server

--- a/src/content/index/running/in-memory.mdx
+++ b/src/content/index/running/in-memory.mdx
@@ -1,7 +1,7 @@
 ---
 position: 5
 title: In-memory
-description: "For the purposes of getting started with SurrealDB quickly, we will start an in-memory database which does not persist data on shutdown."
+description: "Start an in-memory SurrealDB database. The quickest way to get started, though data does not persist on shutdown."
 ---
 
 # Run a single-node, in-memory server

--- a/src/content/index/running/installation/index.mdx
+++ b/src/content/index/running/installation/index.mdx
@@ -1,7 +1,7 @@
 ---
 position: 1
 title: Installation
-description: "Install the SurrealDB server on your machine: macOS, Windows, Linux, and nightly builds."
+description: "Install the SurrealDB server on your machine: macOS, Windows, Linux. Nightly builds are covered too."
 ---
 
 # Installation

--- a/src/content/index/running/multi-node.mdx
+++ b/src/content/index/running/multi-node.mdx
@@ -1,7 +1,7 @@
 ---
 position: 7
 title: Multi-node
-description: "Run SurrealDB against distributed storage for horizontally scalable, highly available clusters."
+description: "Run SurrealDB against distributed storage: horizontally scalable. Highly available clusters."
 ---
 
 # Run a multi-node cluster

--- a/src/content/index/running/overview.mdx
+++ b/src/content/index/running/overview.mdx
@@ -1,7 +1,7 @@
 ---
 position: 1
 title: Running SurrealDB
-description: "Ways to run SurrealDB - from a browser sandbox to a managed cloud instance to installing on your own hardware."
+description: "Ways to run SurrealDB, from a browser sandbox to managed cloud. Or install it on your own hardware."
 ---
 
 # Running SurrealDB

--- a/src/content/index/running/sandbox.mdx
+++ b/src/content/index/running/sandbox.mdx
@@ -1,7 +1,7 @@
 ---
 position: 2
 title: SurrealDB Studio Sandbox
-description: "Try SurrealDB in the browser with the SurrealDB Studio Sandbox - no install and no account required."
+description: "Try SurrealDB in the browser with the Studio Sandbox. No install and no account required."
 ---
 
 # SurrealDB Studio Sandbox

--- a/src/content/learn/data-models/architecture.mdx
+++ b/src/content/learn/data-models/architecture.mdx
@@ -1,7 +1,7 @@
 ---
 position: 1
 title: Architecture
-description: "How SurrealDB separates compute from storage, how every data model maps onto one storage engine, and how namespaces, databases and tables are structured."
+description: "How SurrealDB separates compute from storage. Every data model maps onto one storage engine, and namespaces, databases and tables give the structure."
 ---
 
 # Architecture

--- a/src/content/learn/data-models/full-text-search/search-indexes.mdx
+++ b/src/content/learn/data-models/full-text-search/search-indexes.mdx
@@ -6,6 +6,8 @@ description: Apply FULLTEXT ANALYZER indexes to single fields per index, and und
 
 # Search indexes
 
+A search index makes a field searchable through an analyzer that has already been defined. This page covers defining one, why each index takes a single field, and the parse error that follows from listing several.
+
 ## Defining an index that uses an analyzer
 
 Once a search analyzer is defined, it can be applied to the fields of a table to make them searchable by [defining an index](/docs/reference/query-language/statements/define/indexes#full-text-search-fulltext-index) that uses the `FULLTEXT ANALYZER` clause.

--- a/src/content/learn/data-models/index.mdx
+++ b/src/content/learn/data-models/index.mdx
@@ -1,7 +1,7 @@
 ---
 position: 0
 title: Data Models
-description: Store and query document, graph, vector, time-series, and geospatial data with SurrealDB.
+description: "Store and query document, graph, vector, time-series, geospatial. All the data models SurrealDB supports, in one database."
 ---
 
 # Multi-model

--- a/src/content/learn/data-models/time-series/aggregation-queries.mdx
+++ b/src/content/learn/data-models/time-series/aggregation-queries.mdx
@@ -6,6 +6,8 @@ description: Build downsampling with pre-computed table views, live queries, dro
 
 # Aggregation queries
 
+Time-series data is usually written at full resolution and read at a coarser one, which means aggregating as it arrives rather than on every query. This page covers the four SurrealDB features that do that, and how the result compares with a specialised time-series database.
+
 ## Modelling metrics
 
 For doing metrics in SurrealDB you can choose one or combine:

--- a/src/content/learn/data-models/time-series/iot-and-telemetry-patterns.mdx
+++ b/src/content/learn/data-models/time-series/iot-and-telemetry-patterns.mdx
@@ -6,6 +6,8 @@ description: Model sensor readings with nested fields or complex record IDs, use
 
 # IoT and telemetry patterns
 
+Sensor data arrives constantly and is almost always read back by time range, which makes the record ID the main modelling decision. This page works through an IoT example covering nested fields, array-based record IDs, range queries over them, and metadata attached through record links.
+
 ## Modelling time series data in SurrealDB
 
 Let’s explore a practical example using IoT sensor data.

--- a/src/content/learn/data-models/vector-search/hybrid-search.mdx
+++ b/src/content/learn/data-models/vector-search/hybrid-search.mdx
@@ -6,6 +6,8 @@ description: Compare lexical full-text search with vector similarity on the same
 
 # Hybrid search
 
+Full-text search and vector search find different things, and the two together usually rank better than either alone. This page compares them on one dataset, then fuses their rankings with `search::rrf` and related helpers.
+
 ## Vector search vs full-text search
 
 SurrealDB supports [full-text search](/docs/learn/data-models/full-text-search/overview) and Vector Search. Full-text search (FTS) involves indexing documents using an [FTS index](/docs/reference/query-language/statements/define/indexes#full-text-search-fulltext-index) that makes use of an [analyzer](/docs/reference/query-language/statements/define/analyzer) that breaks down text using [tokenizers](/docs/reference/query-language/statements/define/analyzer#tokenizers) and [filters](/docs/reference/query-language/statements/define/analyzer#filters).

--- a/src/content/learn/data-models/vector-search/similarity-search.mdx
+++ b/src/content/learn/data-models/vector-search/similarity-search.mdx
@@ -6,6 +6,8 @@ description: "Run SurrealQL similarity queries with the liquids example, use vec
 
 # Similarity search
 
+Vector search finds records by meaning rather than by the words they contain. This page runs similarity queries over an example dataset, covering the `vector::` distance and similarity helpers and how to filter KNN results with predicates.
+
 ## Vector search in SurrealDB
 
 <img src="~/assets/img/image/light/VC.png" darkSrc="~/assets/img/image/dark/VC.png" alt="What is Vector Search" />

--- a/src/content/learn/extensions/index.mdx
+++ b/src/content/learn/extensions/index.mdx
@@ -1,7 +1,7 @@
 ---
 position: 1
 title: Extensions
-description: "Extend SurrealDB with custom modules and WASM plugins through the Surrealism extension system."
+description: "Extend SurrealDB with custom modules and WASM plugins. Done through the Surrealism extension system."
 ---
 
 # Extensions

--- a/src/content/learn/extensions/plugins/quick-tutorial.mdx
+++ b/src/content/learn/extensions/plugins/quick-tutorial.mdx
@@ -4,6 +4,8 @@ title: Quick tutorial
 description: A quick tutorial showing the steps involved in turning regular Rust code into SurrealDB-accessible WASM functions.
 ---
 
+This tutorial turns ordinary Rust code into a SurrealDB-accessible WASM module, from `surreal module init` through to calling the function from SurrealQL.
+
 ## Getting started: regular Rust code
 
 Starting a Surrealism project is best done using the `surreal module init` command, which is similar to `cargo run` when starting a project in Rust. The `Cargo.toml` file will include the following line to instruct cargo to generate a `.wasm` file instead of the standard `.rlib` file when compiling Rust.

--- a/src/content/learn/querying/concepts-and-guides/sessions-and-scoping.mdx
+++ b/src/content/learn/querying/concepts-and-guides/sessions-and-scoping.mdx
@@ -4,6 +4,8 @@ title: Sessions and scoping
 description: "A session stores information about the current connection."
 ---
 
+A session holds the state a connection carries between queries: the active namespace and database, the authenticated user, and any metadata set on it. This page covers what that context contains and how it is read and changed.
+
 ## What is session context?
 
 A session stores information about the current connection, including:

--- a/src/content/learn/querying/concepts-and-guides/testing.mdx
+++ b/src/content/learn/querying/concepts-and-guides/testing.mdx
@@ -6,6 +6,8 @@ description: "This page details a number of ways that SurrealDB can be tested."
 
 # Testing SurrealDB
 
+This page covers the ways a SurrealDB database can be tested, starting with the SDKs, which is where most testing happens.
+
 ## SDKs
 
 Database testing by users is most frequently done using an SDK, particularly for the languages in which SurrealDB can be used [in embedded mode](/docs/build/embedding). This allows testing to be conducted in just a few lines of code.

--- a/src/content/learn/querying/graphql/via-bruno.mdx
+++ b/src/content/learn/querying/graphql/via-bruno.mdx
@@ -6,6 +6,8 @@ description: "In this section, you will explore querying SurrealDB using Bruno."
 
 # GraphQL via Bruno
 
+Bruno is an API client that can send GraphQL queries to SurrealDB over HTTP. This page covers starting a server and querying it from Bruno.
+
 ## Getting started
 
 Before you can start making queries, you need to start SurrealDB. You can do this by starting a new instance of SurrealDB with the [`surreal start`](/docs/reference/cli/surrealdb-cli/commands/start) command, Docker, or SurrealDB Studio.

--- a/src/content/learn/querying/index.mdx
+++ b/src/content/learn/querying/index.mdx
@@ -1,7 +1,7 @@
 ---
 position: 1
 title: Querying
-description: "Query SurrealDB with SurrealQL, SDKs or GraphQL - SQL-like syntax with graphs, links and practical querying tips."
+description: "SurrealQL, the SDKs and GraphQL: SQL-like syntax for SurrealDB. Graphs, links, and practical querying tips."
 ---
 
 In this section we will learn about the multitude of ways to write and send queries to your SurrealDB database. The main focus is on the SurrealQL query language, which strongly resembles traditional SQL but differs in a number of ways to accommodate patterns such as graph traversal, record links, and other features unique to SurrealDB.

--- a/src/content/learn/schema-management/index.mdx
+++ b/src/content/learn/schema-management/index.mdx
@@ -1,7 +1,7 @@
 ---
 position: 1
 title: Schema management
-description: "How to shape data in SurrealDB: tables, fields, indexes, events, tenancy, and related patterns."
+description: "Tables, fields, indexes and events: how to shape data in SurrealDB. Tenancy and related patterns too."
 ---
 
 # Schema management

--- a/src/content/learn/schema-management/schema-design/index.mdx
+++ b/src/content/learn/schema-management/schema-design/index.mdx
@@ -1,7 +1,7 @@
 ---
 position: 1
 title: Schema design
-description: "What DEFINE does in SurrealDB and how to inspect what you have defined."
+description: "What DEFINE does in SurrealDB. How to inspect what you have defined."
 ---
 
 # Designing with `DEFINE`, `ALTER`, and `REMOVE`

--- a/src/content/learn/schema-management/schema-design/sample-industry-schemas.mdx
+++ b/src/content/learn/schema-management/schema-design/sample-industry-schemas.mdx
@@ -381,7 +381,7 @@ RELATE purchase_order:450001 -> ordered_from -> vendor:welding;
 CREATE po_line:line10 SET
     purchase_order = purchase_order:450001,
     line_number = 10,
-    description = "Structural welding — pipe rack",
+    description = "Structural welding - pipe rack",
     amount_cents = 18500000,
     wbs = wbs_element:pad3_civil;
 RELATE po_line:line10 -> charges -> wbs_element:pad3_civil;
@@ -1173,7 +1173,7 @@ CREATE note:[encounter:one, time::now()] SET author = "Dr. Leung", content = "Pa
 
 ## Related SurrealQL statements
 
-- [SurrealKit schema migration](/docs/manage/schema-migration) — official CLI for versioning and applying schema from `.surql` files
+- [SurrealKit schema migration](/docs/manage/schema-migration) - official CLI for versioning and applying schema from `.surql` files
 - [DEFINE TABLE](/docs/reference/query-language/statements/define/table)
 - [DEFINE FIELD](/docs/reference/query-language/statements/define/field)
 - [RELATE](/docs/reference/query-language/statements/relate)

--- a/src/content/learn/schema-management/tables-and-fields/record-id-best-practices.mdx
+++ b/src/content/learn/schema-management/tables-and-fields/record-id-best-practices.mdx
@@ -4,6 +4,8 @@ title: Record ID best practices
 description: "How best to make a decision on what kind of record ID format to use in your database."
 ---
 
+A record ID is chosen once and queried forever, so its format decides how easily records can be looked up, ranged over and kept unique. This page collects the tips and trade-offs for choosing one.
+
 ## Tips and best practices for record IDs
 
 This page contains a number of tips and best practices when working with record IDs in SurrealDB.

--- a/src/content/learn/security/authentication/summary.mdx
+++ b/src/content/learn/security/authentication/summary.mdx
@@ -6,6 +6,8 @@ description: This page summarizes some of the security features offered by Surre
 
 # Security summary
 
+This page is a starting point for the security of SurrealDB: the features the product offers, and the security practices behind how it is built. Each section links to the fuller treatment elsewhere in the documentation.
+
 > [!NOTE]
 > This page is intended to direct the reader to other more specific and comprehensive resources. Some information shown in this page may be simplified or omit information that could be relevant in a particular scenario. When available, we recommend that you consult the provided references.
 

--- a/src/content/learn/security/authentication/users.mdx
+++ b/src/content/learn/security/authentication/users.mdx
@@ -7,6 +7,8 @@ description: There are multiple forms of authentication built into SurrealDB, su
 
 # Authentication
 
+SurrealDB has two kinds of user, and they exist for different purposes: one administers the database, the other belongs to the application built on it.
+
 - [System users](#system-users): Created by the SurrealDB administrator and used for managing and consuming the database.
 - [Record users](#record-users): Used for consuming the database within permissions logic, they allow custom signup and signin.
 

--- a/src/content/learn/security/best-practices/troubleshooting.mdx
+++ b/src/content/learn/security/best-practices/troubleshooting.mdx
@@ -6,6 +6,8 @@ description: This page provides some troubleshooting advice to support users in 
 
 # Troubleshooting
 
+This page collects the errors that come up most often when using SurrealDB's security features, with the cause of each and how to resolve it.
+
 ## Authentication
 
 ### Invalid authentication error

--- a/src/content/learn/security/index.mdx
+++ b/src/content/learn/security/index.mdx
@@ -1,7 +1,7 @@
 ---
 position: 1
 title: Security
-description: "Learn how to secure your SurrealDB deployment with authentication, authorization, and security best practices."
+description: "Secure a SurrealDB deployment with authentication and authorisation. Plus security best practices."
 ---
 
 # Security

--- a/src/content/manage/enterprise/index.mdx
+++ b/src/content/manage/enterprise/index.mdx
@@ -1,7 +1,7 @@
 ---
 position: 1
 title: Enterprise Edition
-description: "What SurrealDB Enterprise Edition adds over Community: distributed live queries, S3-backed file storage, audit logging, FIPS-validated cryptography, trusted execution, and contractual support."
+description: "What Enterprise Edition adds over Community: distributed live queries. S3-backed file storage, audit logging, FIPS-validated cryptography, trusted execution, and contractual support."
 ---
 
 # Enterprise Edition <Edition value="enterprise" />

--- a/src/content/manage/instances/architecture.mdx
+++ b/src/content/manage/instances/architecture.mdx
@@ -1,7 +1,7 @@
 ---
 position: 5
 title: Architecture
-description: "The single-node and multi-node topologies behind the Start and Scale plans, and what each one means for growth and recovery."
+description: "The topologies behind the Start and Scale plans. Single-node and multi-node, and what each means for growth and recovery."
 ---
 
 # Architecture

--- a/src/content/manage/instances/backups.mdx
+++ b/src/content/manage/instances/backups.mdx
@@ -1,7 +1,7 @@
 ---
 position: 8
 title: Backups and recovery
-description: "Automated snapshots, retention tiers, and restoring a snapshot into a new instance."
+description: "Automated snapshots and retention tiers. Restoring a snapshot into a new instance."
 ---
 
 # Backups and recovery

--- a/src/content/manage/instances/configure.mdx
+++ b/src/content/manage/instances/configure.mdx
@@ -1,7 +1,7 @@
 ---
 position: 3
 title: Configure an instance
-description: "Instance settings in SurrealDB Studio: capabilities, compute and storage, pausing, and deletion."
+description: "Instance settings in SurrealDB Studio. Capabilities, compute and storage, pausing, and deletion."
 ---
 
 # Configure an instance

--- a/src/content/manage/instances/connect/index.mdx
+++ b/src/content/manage/instances/connect/index.mdx
@@ -1,7 +1,7 @@
 ---
 position: 1
 title: Connect to an instance
-description: "The four routes to an instance: SurrealDB Studio, the CLI, a client SDK, and the HTTP API. Includes where to find the connection details."
+description: "The four routes to a SurrealDB Cloud instance. SurrealDB Studio, the CLI, a client SDK, and the HTTP API, plus where to find the connection details."
 ---
 
 # Connect to an instance

--- a/src/content/manage/instances/create.mdx
+++ b/src/content/manage/instances/create.mdx
@@ -1,7 +1,7 @@
 ---
 position: 2
 title: Create an instance
-description: "Deploy an instance from SurrealDB Studio: choose a plan, instance type, region, version, name, starting data, and storage."
+description: "Deploy an instance from SurrealDB Studio. Choose a plan, instance type, region, version, name, starting data, and storage."
 ---
 
 # Create an instance

--- a/src/content/manage/instances/high-availability.mdx
+++ b/src/content/manage/instances/high-availability.mdx
@@ -1,7 +1,7 @@
 ---
 position: 7
 title: High availability
-description: "What a Start instance and a Scale cluster each survive, and how to plan for the failures they do not."
+description: "What a Start instance and a Scale cluster each survive. How to plan for the failures they do not."
 ---
 
 # High availability

--- a/src/content/manage/instances/import-and-export.mdx
+++ b/src/content/manage/instances/import-and-export.mdx
@@ -1,7 +1,7 @@
 ---
 position: 9
 title: Import and export
-description: "Move data in and out of an instance with surreal export and surreal import, including size limits and partial-import behaviour."
+description: "Move data in and out with surreal export and surreal import. Covers size limits and partial-import behaviour."
 ---
 
 # Import and export

--- a/src/content/manage/instances/index.mdx
+++ b/src/content/manage/instances/index.mdx
@@ -1,7 +1,7 @@
 ---
 position: 1
 title: Instances
-description: "What an instance is, how the Start and Scale plans differ, and where each operational task is documented."
+description: "What a SurrealDB Cloud instance is. How the Start and Scale plans differ, and where each operational task is documented."
 ---
 
 # Instances

--- a/src/content/manage/instances/monitoring.mdx
+++ b/src/content/manage/instances/monitoring.mdx
@@ -1,7 +1,7 @@
 ---
 position: 11
 title: Monitoring
-description: "The instance dashboard, the metrics groups and log filters in SurrealDB Studio, and how they relate to the full observability surface."
+description: "The instance dashboard, metrics groups, and log filters. How each relates to the full observability surface in SurrealDB Studio."
 ---
 
 # Monitoring

--- a/src/content/manage/instances/network-access.mdx
+++ b/src/content/manage/instances/network-access.mdx
@@ -1,7 +1,7 @@
 ---
 position: 12
 title: Network access
-description: "Control which outbound destinations queries may reach, using the network access capability and its allow and deny patterns."
+description: "Control which outbound destinations queries may reach. Uses the network access capability and its allow and deny patterns."
 ---
 
 # Network access

--- a/src/content/manage/instances/private-connectivity.mdx
+++ b/src/content/manage/instances/private-connectivity.mdx
@@ -1,7 +1,7 @@
 ---
 position: 13
 title: Private connectivity
-description: "Reach an instance from your AWS VPC over AWS PrivateLink, and set the public, private, or dual access mode."
+description: "Reach an instance from your AWS VPC over AWS PrivateLink. Set the public, private, or dual access mode."
 ---
 
 # Private connectivity

--- a/src/content/manage/instances/scaling.mdx
+++ b/src/content/manage/instances/scaling.mdx
@@ -1,7 +1,7 @@
 ---
 position: 6
 title: Scaling
-description: "When to resize an instance, what scales on each plan, and how to confirm a resize solved the bottleneck."
+description: "When to resize an instance, and what scales on each plan. How to confirm a resize solved the bottleneck."
 ---
 
 # Scaling

--- a/src/content/manage/instances/versions-and-upgrades.mdx
+++ b/src/content/manage/instances/versions-and-upgrades.mdx
@@ -1,7 +1,7 @@
 ---
 position: 10
 title: Versions and upgrades
-description: "Change the SurrealDB release an instance runs, and what happens to the instance during the upgrade."
+description: "Change the SurrealDB release an instance runs. What happens to the instance during the upgrade."
 ---
 
 # Versions and upgrades

--- a/src/content/manage/observability/audit-logging.mdx
+++ b/src/content/manage/observability/audit-logging.mdx
@@ -1,7 +1,7 @@
 ---
 position: 7
 title: Audit logging
-description: "The Enterprise audit log pipeline: events captured, record shape, rotation, hash chaining, redaction and pipeline self-metrics."
+description: "The Enterprise audit log pipeline. Events captured, record shape, rotation, hash chaining, redaction, and pipeline self-metrics."
 ---
 
 # Audit logging

--- a/src/content/manage/observability/configuration.mdx
+++ b/src/content/manage/observability/configuration.mdx
@@ -1,7 +1,7 @@
 ---
 position: 6
 title: Configuration reference
-description: "Every observability, audit log and slow-query log environment variable, plus recommended configurations for local, production and multi-tenant deployments."
+description: "Every observability, audit log and slow-query log variable. Recommended configurations for local, production and multi-tenant deployments."
 ---
 
 # Configuration reference

--- a/src/content/manage/observability/enterprise-observability.mdx
+++ b/src/content/manage/observability/enterprise-observability.mdx
@@ -1,7 +1,7 @@
 ---
 position: 4
 title: Enterprise observability
-description: Metrics, logs, and traces in SurrealDB Enterprise versus Community - OTLP opt-ins, audit and slow-query pipelines, and cluster instruments.
+description: "Metrics, logs, and traces in Enterprise versus Community. OTLP opt-ins, audit and slow-query pipelines, and cluster instruments."
 ---
 
 # Enterprise observability

--- a/src/content/manage/observability/index.mdx
+++ b/src/content/manage/observability/index.mdx
@@ -1,7 +1,7 @@
 ---
 position: 0
 title: Observability
-description: "Logging, Prometheus pull, OTLP push, Enterprise pipelines, metric catalogues, and Tokio console - production visibility for SurrealDB Community and Enterprise."
+description: "Production visibility for SurrealDB Community and Enterprise. Logging, Prometheus pull, OTLP push, Enterprise pipelines, metric catalogues, and Tokio console."
 ---
 
 # Observability

--- a/src/content/manage/observability/observability.mdx
+++ b/src/content/manage/observability/observability.mdx
@@ -1,7 +1,7 @@
 ---
 position: 2
 title: Observability (metrics and Prometheus)
-description: Unified OpenTelemetry metrics, `GET /metrics`, scraper authentication, naming, migration, and behaviour common to Community and Enterprise.
+description: "Unified OpenTelemetry metrics common to Community and Enterprise. The `GET /metrics` endpoint, scraper authentication, naming, and migration."
 ---
 
 # Observability (metrics and Prometheus)

--- a/src/content/manage/observability/telemetry.mdx
+++ b/src/content/manage/observability/telemetry.mdx
@@ -1,7 +1,7 @@
 ---
 position: 3
 title: Telemetry (OTLP)
-description: OTLP push export - metrics, logs, traces, intervals, backward-compatible instruments, and differences before and after SurrealDB 3.1.
+description: "OTLP push export of metrics, logs, and traces. Intervals, backward-compatible instruments, and differences before and after SurrealDB 3.1."
 ---
 
 # Telemetry (OTLP)

--- a/src/content/manage/organisations/index.mdx
+++ b/src/content/manage/organisations/index.mdx
@@ -1,7 +1,7 @@
 ---
 position: 1
 title: Organisations
-description: "The container for instances, members, usage, and billing, and what each section of the organisation view holds."
+description: "The container for instances, members, usage, and billing. What each section of the organisation view holds."
 ---
 
 # Organisations

--- a/src/content/manage/schema-migration/index.mdx
+++ b/src/content/manage/schema-migration/index.mdx
@@ -1,7 +1,7 @@
 ---
 position: 1
 title: SurrealKit schema migration
-description: "SurrealKit is the official schema management and migration CLI for SurrealDB. Define your schema in .surql files and keep databases in sync across every environment."
+description: "SurrealKit is the official schema migration CLI for SurrealDB. Define your schema in .surql files and keep databases in sync across every environment."
 ---
 
 # SurrealKit

--- a/src/content/manage/self-hosted/index.mdx
+++ b/src/content/manage/self-hosted/index.mdx
@@ -1,7 +1,7 @@
 ---
 position: 1
 title: Self-hosted
-description: "Deploy and operate SurrealDB on your own infrastructure: deployment models, containers, configuration, backups, monitoring, and upgrades."
+description: "SurrealDB deployment models on your own infrastructure. Containers, configuration, backups, monitoring, and upgrades."
 ---
 
 # Self-hosted

--- a/src/content/manage/self-hosted/managed-kubernetes.mdx
+++ b/src/content/manage/self-hosted/managed-kubernetes.mdx
@@ -6,6 +6,8 @@ description: "Options for running SurrealDB on Amazon EKS, Google GKE, and Azure
 
 # Managed Kubernetes
 
+SurrealDB runs on Amazon EKS, Google GKE and Azure AKS. This page covers the three deployment models available on them - managed Scale, a self-hosted Enterprise cluster, and single-node RocksDB - and which one fits.
+
 > [!IMPORTANT]
 > Production **multi-node** SurrealDB uses shared distributed storage with replication and consensus. For managed HA, use the [Scale plan](https://surrealdb.com/pricing/scale). Self-hosted multi-node clusters on Kubernetes are available with [SurrealDB Enterprise](https://surrealdb.com/enterprise).
 

--- a/src/content/manage/surrealctl/index.mdx
+++ b/src/content/manage/surrealctl/index.mdx
@@ -1,7 +1,7 @@
 ---
 position: 1
 title: surrealctl
-description: "The control-plane CLI: what surrealctl does, when to reach for it instead of SurrealDB Studio or the surreal binary, and a sixty-second quickstart."
+description: "What the surrealctl control-plane CLI does. When to reach for it instead of SurrealDB Studio or the surreal binary, plus a sixty-second quickstart."
 ---
 
 # surrealctl

--- a/src/content/reference/cli/index.mdx
+++ b/src/content/reference/cli/index.mdx
@@ -1,7 +1,7 @@
 ---
 position: 1
 title: CLI Tools
-description: "Reference for the three SurrealDB command-line tools: surrealctl for the control plane, surreal for the data plane, and surqlfmt for formatting SurrealQL."
+description: "Reference for surrealctl, surreal and surqlfmt. The control plane, the data plane, and formatting SurrealQL."
 ---
 
 SurrealDB ships three command-line tools. They are installed separately and cover different jobs, so most workflows use more than one of them.

--- a/src/content/reference/dotnet/index.mdx
+++ b/src/content/reference/dotnet/index.mdx
@@ -1,7 +1,7 @@
 ---
 position: 1
 title: .NET SDK
-description: The SurrealDB SDK for .NET provides a number of methods for interacting with your SurrealDB database.
+description: "The official SurrealDB SDK for .NET. Provides methods for interacting with your SurrealDB database."
 ---
 
 # .NET SDK

--- a/src/content/reference/dotnet/methods/delete.mdx
+++ b/src/content/reference/dotnet/methods/delete.mdx
@@ -7,6 +7,8 @@ description: The .NET SDK for SurrealDB enables simple and advanced querying of 
 
 # `.Delete()` {#delete}
 
+`Delete` removes a single record, or every record in a table, through the .NET SDK.
+
 
 ```csharp title="Method Syntax"
 await db.Delete(resource)

--- a/src/content/reference/golang/embedding.mdx
+++ b/src/content/reference/golang/embedding.mdx
@@ -6,6 +6,8 @@ description: The surrealdb.c C FFI library contains Go bindings that can be used
 
 # Using an embedded instance
 
+The Go bindings in `surrealdb.c` let a Go program run SurrealDB in-process instead of connecting to a server. This page covers building the C library, setting up CGO, and connecting to an embedded instance.
+
 ## Setup
 
 1. Build surrealdb.c and set up CGO

--- a/src/content/reference/golang/index.mdx
+++ b/src/content/reference/golang/index.mdx
@@ -1,7 +1,7 @@
 ---
 position: 1
 title: Go SDK
-description: The SurrealDB SDK for Go enables simple and advanced querying of a remote database from server-side applications.
+description: "The official SurrealDB SDK for Go. Simple and advanced querying of a remote database from server-side applications."
 ---
 
 # Go SDK

--- a/src/content/reference/java/index.mdx
+++ b/src/content/reference/java/index.mdx
@@ -1,7 +1,7 @@
 ---
 position: 1
 title: Java SDK
-description: The SurrealDB SDK for Java enables simple and advanced querying of a remote or embedded database.
+description: "The official SurrealDB SDK for Java. Simple and advanced querying of a remote or embedded database."
 ---
 
 # Java SDK

--- a/src/content/reference/javascript/concepts/connecting-to-surrealdb.mdx
+++ b/src/content/reference/javascript/concepts/connecting-to-surrealdb.mdx
@@ -1,7 +1,7 @@
 ---
 position: 1
 title: Connecting to SurrealDB
-description: The SurrealDB SDK for JavaScript enables simple and advanced querying of a remote or embedded database.
+description: "Connecting to SurrealDB from JavaScript. Remote and embedded connections with the official SDK."
 ---
 
 # Connecting to SurrealDB

--- a/src/content/reference/javascript/index.mdx
+++ b/src/content/reference/javascript/index.mdx
@@ -1,7 +1,7 @@
 ---
 position: 1
 title: JavaScript SDK
-description: The SurrealDB SDK for JavaScript enables simple and advanced querying of a remote or embedded database.
+description: "The official SurrealDB SDK for JavaScript. Simple and advanced querying of a remote or embedded database."
 ---
 
 # JavaScript SDK

--- a/src/content/reference/kotlin/index.mdx
+++ b/src/content/reference/kotlin/index.mdx
@@ -1,7 +1,7 @@
 ---
 position: 1
 title: Kotlin SDK
-description: The SurrealDB SDK for Kotlin is a coroutine-based, Kotlin Multiplatform client for querying a remote SurrealDB instance.
+description: "The official SurrealDB SDK for Kotlin. A coroutine-based, Kotlin Multiplatform client for querying a remote instance."
 ---
 
 # Kotlin SDK

--- a/src/content/reference/mojo/index.mdx
+++ b/src/content/reference/mojo/index.mdx
@@ -1,7 +1,7 @@
 ---
 position: 1
 title: Mojo SDK
-description: The SurrealDB SDK for Mojo enables simple and advanced querying of a remote database over HTTP, HTTPS, and WebSocket.
+description: "The official SurrealDB SDK for Mojo. Simple and advanced querying of a remote database over HTTP, HTTPS, and WebSocket."
 ---
 
 # Mojo SDK

--- a/src/content/reference/php/index.mdx
+++ b/src/content/reference/php/index.mdx
@@ -1,7 +1,7 @@
 ---
 position: 1
 title: PHP SDK
-description: The SurrealDB SDK for PHP lets you query a remote SurrealDB instance from any PHP application, with a stable v1 release and a v2 rewrite in alpha.
+description: "The official SurrealDB SDK for PHP. Query a remote instance from any PHP application, with a stable v1 release and a v2 rewrite in alpha."
 ---
 
 # PHP SDK

--- a/src/content/reference/python/index.mdx
+++ b/src/content/reference/python/index.mdx
@@ -1,7 +1,7 @@
 ---
 position: 1
 title: Python SDK
-description: The SurrealDB SDK for Python enables simple and advanced querying of a remote or embedded database.
+description: "The official SurrealDB SDK for Python. Simple and advanced querying of a remote or embedded database."
 ---
 
 # Python SDK

--- a/src/content/reference/query-language/functions/database-functions/api.mdx
+++ b/src/content/reference/query-language/functions/database-functions/api.mdx
@@ -6,6 +6,8 @@ description: These functions can be used with the DEFINE API or DEFINE CONFIG st
 
 # API functions
 
+API functions run as middleware on a custom endpoint, altering a request before it is handled or a response before it is returned. They are passed in inside a `DEFINE API` or `DEFINE CONFIG API` statement.
+
 <table>
   <thead>
     <tr>

--- a/src/content/reference/query-language/index.mdx
+++ b/src/content/reference/query-language/index.mdx
@@ -1,7 +1,7 @@
 ---
 position: 1
 title: SurrealQL
-description: "Reference for SurrealQL, SurrealDB's query language: statements, clauses, functions, and language primitives."
+description: "SurrealQL statements, clauses, functions and language primitives. The full reference for the SurrealDB query language."
 ---
 
 # SurrealQL

--- a/src/content/reference/query-language/language-primitives/record-references.mdx
+++ b/src/content/reference/query-language/language-primitives/record-references.mdx
@@ -8,6 +8,8 @@ description: "Record references allow you to link records together, enabling you
 
 <Since v="v2.2.0" />
 
+A record reference is a link SurrealDB tracks in both directions, so the record being pointed at knows what points to it. This page covers adding a `REFERENCE` clause to a field, traversing references, and choosing what happens when a referenced record is deleted.
+
 ## Basic concepts
 
 Reference tracking begins by adding a `REFERENCE` clause to any `DEFINE FIELD` statement, as long as the field is a top-level field of type `record` or array of records.

--- a/src/content/reference/rest-api/index.mdx
+++ b/src/content/reference/rest-api/index.mdx
@@ -1,7 +1,7 @@
 ---
 position: 1
 title: REST API
-description: "SurrealDB exposes an HTTP-based REST API for executing queries, managing authentication, and performing CRUD operations."
+description: "The SurrealDB REST API: executing queries over HTTP. Manage authentication and perform CRUD operations."
 ---
 
 # REST API

--- a/src/content/reference/rust/index.mdx
+++ b/src/content/reference/rust/index.mdx
@@ -1,7 +1,7 @@
 ---
 position: 1
 title: Rust SDK
-description: "The SurrealDB SDK for Rust enables you to interact with SurrealDB from client-side, server-side applications, systems, APIs, embedded systems, and IoT devices."
+description: "The official SurrealDB SDK for Rust. Use SurrealDB from client-side and server-side applications, systems, APIs, embedded systems, and IoT devices."
 ---
 
 # Rust SDK

--- a/src/content/reference/rust/methods/insert.mdx
+++ b/src/content/reference/rust/methods/insert.mdx
@@ -7,6 +7,8 @@ description: The .insert() method for the SurrealDB Rust SDK inserts a record or
 
 # `insert()`
 
+`insert` adds one record or many to a table, and inserts graph edges through `.relation()`.
+
 <Tabs>
 
 <TabItem label="3.x">

--- a/src/content/reference/swift/index.mdx
+++ b/src/content/reference/swift/index.mdx
@@ -1,7 +1,7 @@
 ---
 position: 1
 title: Swift SDK
-description: The SurrealDB SDK for Swift enables simple and advanced querying of a remote database from Apple-platform and server-side Swift applications.
+description: "The official SurrealDB SDK for Swift. Simple and advanced querying of a remote database from Apple-platform and server-side Swift applications."
 ---
 
 # Swift SDK

--- a/src/lib/agent-instructions.md
+++ b/src/lib/agent-instructions.md
@@ -4,8 +4,8 @@ You are an AI coding agent, and the person you are working with has asked you to
 
 Setup connects two things:
 
-1. **Agent Skills** — packaged knowledge of SurrealQL, vector search, and the SurrealDB Python SDK, so the code you write matches how SurrealDB behaves.
-2. **The SurrealDB MCP Server** — tools you can call against the user's SurrealDB Cloud account: deploy and manage instances, run SurrealQL against them, read metrics and logs, and check usage.
+1. **Agent Skills** - packaged knowledge of SurrealQL, vector search, and the SurrealDB Python SDK, so the code you write matches how SurrealDB behaves.
+2. **The SurrealDB MCP Server** - tools you can call against the user's SurrealDB Cloud account: deploy and manage instances, run SurrealQL against them, read metrics and logs, and check usage.
 
 Install both unless the user asks for one of them.
 
@@ -168,11 +168,11 @@ The server acts as the user: it sees only the organisations they belong to, resp
 
 Most clients open a browser window for sign-in. Tell the user what to do in theirs:
 
-- **Claude Code** — run `/mcp`, choose **surrealdb**, and approve the connection.
-- **Cursor** — open **Settings → MCP**, find **surrealdb**, and click **Connect**. The indicator turns green.
-- **VS Code** — reload the window, start the server from the MCP view, and approve the connection.
-- **Windsurf** — restart, then connect from **Settings → MCP**.
-- **Anything else** — the client prompts on first use, or offers a connect action in its MCP settings.
+- **Claude Code** - run `/mcp`, choose **surrealdb**, and approve the connection.
+- **Cursor** - open **Settings → MCP**, find **surrealdb**, and click **Connect**. The indicator turns green.
+- **VS Code** - reload the window, start the server from the MCP view, and approve the connection.
+- **Windsurf** - restart, then connect from **Settings → MCP**.
+- **Anything else** - the client prompts on first use, or offers a connect action in its MCP settings.
 
 If the client cannot open a browser, or the setup has to run unattended, the user creates a personal access token at [account.surrealdb.com/tokens](https://account.surrealdb.com/tokens) and passes it as a header:
 
@@ -229,7 +229,7 @@ Tell the user, briefly:
 
 ## Reference: what the MCP server can do
 
-You never call these by hand — the client offers them, and most clients show the call before it runs. Read-only tools are marked safe, so a client can approve them without asking every time.
+You never call these by hand - the client offers them, and most clients show the call before it runs. Read-only tools are marked safe, so a client can approve them without asking every time.
 
 | Group | Tools cover |
 | --- | --- |
@@ -271,10 +271,10 @@ Every stdio call runs with owner-level access, because there is no network hands
 
 ## Where to read more
 
-- [Agent setup](/docs/agents) — this document as a page, with per-agent steps
-- [SurrealDB MCP Server](/docs/build/ai-agents/mcp) — the hosted server in full
-- [Embedded MCP](/docs/build/ai-agents/mcp/embedded) — the server inside SurrealDB
-- [Agent Skills](/docs/build/ai-agents/agent-skills) — what each skill covers
-- [AI agents](/docs/build/ai-agents) — frameworks, memory, and what the database gives an agent
-- [SurrealDB Agent Memory](/docs/agent-memory) — memory that persists across sessions
-- [SurrealDB documentation](https://surrealdb.com/docs/llms.txt) — the full documentation index, as markdown
+- [Agent setup](/docs/agents) - this document as a page, with per-agent steps
+- [SurrealDB MCP Server](/docs/build/ai-agents/mcp) - the hosted server in full
+- [Embedded MCP](/docs/build/ai-agents/mcp/embedded) - the server inside SurrealDB
+- [Agent Skills](/docs/build/ai-agents/agent-skills) - what each skill covers
+- [AI agents](/docs/build/ai-agents) - frameworks, memory, and what the database gives an agent
+- [SurrealDB Agent Memory](/docs/agent-memory) - memory that persists across sessions
+- [SurrealDB documentation](https://surrealdb.com/docs/llms.txt) - the full documentation index, as markdown


### PR DESCRIPTION
https://github.com/surrealdb/docs.surrealdb.com/pull/1994 makes some improvements that include 100% llms.txt coverage. Some of these descriptions trail off because of the 70 character limit, which can be changed into two sentences instead, making the part inside llms.txt into complete sentences.

This also reminds one that the `description` which originally wasn't displayed to the user is now, which results in pages like this that essentially have four bits of frontmatter before getting into the actual content:

* A title: Traces and memory evolution
* A description: Graph-resident traces, reflection, elaboration, consolidation, and semantic response reuse.
* Another title: Tracing as graph-resident memory
* Another description: SurrealDB Agent Memory stores three trace kinds as first-class nodes in the substrate, linked by real edges to entities, attributes, passages, and model calls. Traces are inputs to future ranking and consolidation - not only external telemetry.

<img width="2000" height="1071" alt="image" src="https://github.com/user-attachments/assets/ae599303-0bc4-4af8-8af4-e368cbfd902d" />

So this PR mostly stops displaying `description`. That allows the description to be more optimised for LLMs and visiting web page indexers, while letting the reader to quickly get to the actual content. There are a few pages that don't have much of a description (`description` alone did the job) so this PR also adds a sentence or two at the top where this is the case.

The page above ends up looking like this instead.

<img width="1826" height="1470" alt="image" src="https://github.com/user-attachments/assets/47e3656c-455e-4b2b-9cde-dac0b8c285bd" />
