### PR TITLE
Latest features

### DIFF
--- a/src/content/agent-memory/index/quickstarts/surrealdb-cloud.mdx
+++ b/src/content/agent-memory/index/quickstarts/surrealdb-cloud.mdx
@@ -23,7 +23,7 @@ Customers integrate against the **context host** and **`sk-ctx-…` API keys** f
 | --- | --- |
 | **Owner** | Subscribe to SurrealDB Agent Memory plans, billing, delete contexts |
 | **Admin** | Create contexts, mint API keys, call admin proxy routes (principals, scopes, grants, usage) |
-| **Member** | Use Workbench, Lookup, Documents, and Scopes in SurrealDB Studio; broker a short-lived access token for SDK use |
+| **Member** | Use Workbench, Lookup, Knowledge graph, Documents, and Scopes in SurrealDB Studio; broker a short-lived access token for SDK use |
 
 Admin proxy routes return **403** for members. See [Key policy](/docs/agent-memory/reference/configuration#key-policy) for how self-service and Cloud-brokered keys are governed.
 
@@ -33,8 +33,10 @@ Admin proxy routes return **403** for members. See [Key policy](/docs/agent-memo
 | --- | --- |
 | Context list, deploy, billing, delete | Yes |
 | API keys + per-context endpoint | Yes |
-| Workbench (live chat + memory updates) | Yes |
-| Lookup (ask a context what it knows about a topic) | Yes |
+| Overview (principal, access, and what lives in the context) | Yes |
+| Workbench (chat, tune retrieval, inspect what a reply recalled and learned) | Yes |
+| Lookup (ask what the context knows about one thing) | Yes |
+| Knowledge graph (everything the context knows as one navigable graph) | Yes |
 | Documents (upload, browse, search) | Yes |
 | Scopes (register and browse paths) | Yes |
 | Integration snippets (SDK, REST, MCP, frameworks) | Yes |
@@ -50,7 +52,7 @@ You need the **Owner** or **Admin** role to deploy a context. Members can use th
 
 ### 1. Deploy a context
 
-1. In [SurrealDB Studio](https://studio.surrealdb.com), open **Contexts** from the left sidebar.
+1. In [SurrealDB Studio](https://studio.surrealdb.com), open **Agent Memory** from the left sidebar.
 2. Click **Deploy new context** at the top of the screen.
 3. Give the context a name. Any name works.
 4. Select a region.
@@ -75,6 +77,7 @@ The Workbench is a chat surface that writes to memory as you use it.
 
 1. Open **Documents** from the left sidebar. Upload files for SurrealDB Agent Memory to ingest.
 2. Open **Lookup** from the left sidebar and ask what the context knows about a topic. It answers from the facts it holds on that topic, drawn from your Workbench turns and the documents you uploaded.
+3. Open **Knowledge graph** to see everything the context knows as one navigable graph, rather than one topic at a time.
 
 Your context is now live and learning. To move from Studio to code, create an API key in the context's **API keys** view, then follow the [Hosted quickstart](/docs/agent-memory/quickstarts/hosted).
 

--- a/src/content/reference/cli/surrealdb-cli/environment-variables.mdx
+++ b/src/content/reference/cli/surrealdb-cli/environment-variables.mdx
@@ -408,6 +408,13 @@ Resource limits for [ISO GQL](/docs/learn/querying/gql/overview) `MATCH` executi
   <tbody>
 
     <tr>
+      <td scope="row" data-label="Env var"><code>SURREAL_GRAPH_INLINE_PROPS_CAP</code> <Since v="v3.3.0" /></td>
+      <td scope="row" data-label="Default">64</td>
+      <td scope="row" data-label="Allowed values">A byte size</td>
+      <td scope="row" data-label="Notes">Largest encoded payload an <a href="/docs/reference/query-language/statements/define/field#using-inline-to-filter-a-traversal-during-the-scan"><code>INLINE</code></a> field set may occupy inside a graph adjacency entry. A larger payload spills, leaving the values on the edge record only.</td>
+    </tr>
+
+    <tr>
       <td scope="row" data-label="Env var"><code>SURREAL_EXTERNAL_SORTING_BUFFER_LIMIT</code></td>
       <td scope="row" data-label="Default">50000</td>
       <td scope="row" data-label="Allowed values">A usize</td>

--- a/src/content/reference/query-language/statements/alter/access.mdx
+++ b/src/content/reference/query-language/statements/alter/access.mdx
@@ -19,6 +19,7 @@ The `ALTER ACCESS` statement can be used to modify an existing defined [access](
 ALTER ACCESS [ IF EXISTS ] @name
   ON [ ROOT | NAMESPACE | DATABASE ]
   [ AUTHENTICATE @expression | DROP AUTHENTICATE ]
+  [ CONTEXT @expression | DROP CONTEXT ]
   [ DURATION
     [ FOR GRANT [ @duration | NONE ] ]
     [ FOR TOKEN [ @duration | NONE ] ]
@@ -78,6 +79,29 @@ ALTER ACCESS [ IF EXISTS ] @name
                   "children": [
                     { "type": "Terminal", "text": "DROP" },
                     { "type": "Terminal", "text": "AUTHENTICATE" }
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "type": "Optional",
+            "child": {
+              "type": "Choice",
+              "index": 0,
+              "children": [
+                {
+                  "type": "Sequence",
+                  "children": [
+                    { "type": "Terminal", "text": "CONTEXT" },
+                    { "type": "NonTerminal", "text": "@expression" }
+                  ]
+                },
+                {
+                  "type": "Sequence",
+                  "children": [
+                    { "type": "Terminal", "text": "DROP" },
+                    { "type": "Terminal", "text": "CONTEXT" }
                   ]
                 }
               ]
@@ -178,7 +202,7 @@ ALTER ACCESS [ IF EXISTS ] @name
   </TabItem>
 </Tabs>
 
-Note that this statement does not allow modification of the access type itself (`RECORD` / `JWT` / `BEARER`), only its duration, the `AUTHENTICATE` clause, and a `COMMENT`.
+Note that this statement does not allow modification of the access type itself (`RECORD` / `JWT` / `BEARER`), only its duration, the `AUTHENTICATE` and `CONTEXT` clauses, and a `COMMENT`.
 
 ## Example usage
 

--- a/src/content/reference/query-language/statements/define/access/index.mdx
+++ b/src/content/reference/query-language/statements/define/access/index.mdx
@@ -29,6 +29,7 @@ DEFINE ACCESS [ OVERWRITE | IF NOT EXISTS ] @name
       [ WITH REFRESH ]
     | BEARER FOR [ USER | RECORD ]
   [ AUTHENTICATE @expression ]
+  [ CONTEXT @expression ]
   [ DURATION
     [ FOR GRANT @duration ]
     [ FOR TOKEN @duration ]
@@ -94,6 +95,37 @@ In both cases, the clause expects nothing to be returned and will otherwise fail
 The clause therefore reaches only the namespace or database that owns the access method. A statement inside it that targets another namespace fails, whatever role the user who defined the access method holds.
 
 The Editor role is a system role, so table and field `PERMISSIONS` clauses do not apply to lookups made inside these clauses. A `SELECT` against a record table behaves the same whether or not that table restricts record users.
+
+## With `CONTEXT` clause
+
+<Since v="v3.3.0" />
+
+The `CONTEXT` clause attaches a value to the session at authentication time, and permission expressions read it back as `$session.data`. It is evaluated once, after `AUTHENTICATE`, with `$auth` already bound.
+
+```surql
+DEFINE ACCESS account ON DATABASE TYPE RECORD
+    SIGNIN { RETURN SELECT * FROM user WHERE email = $email }
+    CONTEXT { RETURN { tier: $auth.tier, teams: $auth.teams } }
+    DURATION FOR SESSION 12h;
+```
+
+`CONTEXT` keeps whatever it returns by storing it in `$session.data`, which holds the value in the shape the clause produced it, objects and arrays included.
+
+That is the difference from `AUTHENTICATE`, which yields an identity that is reduced to a record link before being bound to `$auth`. So a projection assembled there arrives as the record id alone, and any extra fields built alongside it are dropped. `CONTEXT` is thus used when you prefer to keep these fields.
+
+The main use for `CONTEXT` is in permissions. A predicate that needs per-account authorisation otherwise queries a table for every record it filters, and that cost scales with the size of the table it queries. Reading the same facts from `$session.data` filters against a value already on the session instead:
+
+```surql
+DEFINE TABLE invoice SCHEMAFULL
+    PERMISSIONS FOR select WHERE team IN $session.data.teams;
+```
+
+`session` is a protected parameter name, so a client cannot shadow `$session.data` with `LET` or with an SDK `set` call. That is what makes the value safe to authorise against.
+
+`CONTEXT` is also available on [`ALTER ACCESS`](/docs/reference/query-language/statements/alter/access), and an access method without the clause behaves exactly as it did before.
+
+> [!NOTE]
+> The value is computed when the session authenticates, so it is a snapshot rather than a live view. A change written after authentication is not reflected until the session authenticates again. Put facts that change within a session's lifetime in the permission predicate itself, and keep `CONTEXT` for the ones that hold for as long as the session does.
 
 ## Using `IF NOT EXISTS` clause
 

--- a/src/content/reference/query-language/statements/define/field.mdx
+++ b/src/content/reference/query-language/statements/define/field.mdx
@@ -23,6 +23,7 @@ The `DEFINE FIELD` statement allows you to instantiate a named field on a table,
 ```syntax title="SurrealQL Syntax"
 DEFINE FIELD [ OVERWRITE | IF NOT EXISTS ] @name ON [ TABLE ] @table
 	[ TYPE @type [ FLEXIBLE ] ]
+	[ INLINE ]
 	[ REFERENCE 
 		[ ON DELETE REJECT | 
 			ON DELETE CASCADE | 
@@ -1246,6 +1247,37 @@ CREATE user SET name = 'Ada';
 	}
 ]
 ```
+
+## Using INLINE to filter a traversal during the scan
+
+<Since v="v3.3.0" />
+
+An `INLINE` field on a relation table is stored twice: once on the edge record as usual, and again inside the adjacency entries that the graph traversal walks. A traversal filtered on that field can then test the predicate while it scans, and fetch only the edge records that match.
+
+```surql
+DEFINE TABLE likes TYPE RELATION IN person OUT post;
+DEFINE FIELD score ON likes TYPE number INLINE;
+```
+
+Inlining a field has no effect on the way it is queried. It is read and written exactly as before, and a traversal such as `person:one->likes[WHERE score > 8]->post` returns the same records. What changes is how many edge records the traversal has to read to produce them, which is why the clause is worth having on a filter that may run over many edges.
+
+An inlined field can be thought of as an index in that it is a write-side cost paid for a read-side gain. Conversely, a field that is filtered rarely and written constantly is not one that you would want to inline.
+
+Values for an inlined field should also be kept small. A payload larger than `SURREAL_GRAPH_INLINE_PROPS_CAP` (64 bytes by default) is spilled, meaning the value stays on the record only and the traversal falls back to fetching it. See [environment variables](/docs/reference/cli/surrealdb-cli/environment-variables).
+
+`ALTER FIELD` adds the clause to an existing field and removes it again, so the decision is reversible without redefining the field.
+
+### What INLINE rejects
+
+| Rejected | Error |
+| --- | --- |
+| A field on a table that is not `TYPE RELATION` | `INLINE requires an existing TYPE RELATION table` |
+| The `id`, `in` or `out` fields | `the 'id', 'in' and 'out' fields already live in the adjacency keys and cannot be INLINE` |
+| A nested field path, such as `meta.score` | `only a top-level field can be INLINE` |
+| A `COMPUTED` field | There is no stored value to embed |
+| A field on a [`LIGHTWEIGHT`](/docs/reference/query-language/statements/define/table#using-lightweight-for-relations-without-properties) relation | A lightweight relation has no edge records, so it has no fields at all |
+
+Demoting a relation table to a normal table while it still carries `INLINE` fields is also rejected.
 
 ## Defining a reference
 

--- a/src/content/reference/query-language/statements/define/table.mdx
+++ b/src/content/reference/query-language/statements/define/table.mdx
@@ -25,7 +25,7 @@ The `DEFINE TABLE` statement allows you to declare your table by name, enabling 
 DEFINE TABLE [ OVERWRITE | IF NOT EXISTS ] @name
 	[ DROP ]
 	[ SCHEMAFULL | SCHEMALESS ]
-	[ TYPE [ ANY | NORMAL | RELATION [ IN | FROM ] @table [ OUT | TO ] @table [ ENFORCED ]]]
+	[ TYPE [ ANY | NORMAL | RELATION [ IN | FROM ] @table [ OUT | TO ] @table [ ENFORCED ] [ LIGHTWEIGHT ]]]
 	[ AS SELECT @projections
 		FROM @tables
 		[ WHERE @condition ]
@@ -770,6 +770,71 @@ The endpoint check is an admission gate on the write path, so it is deferred dur
 
 > [!WARNING]
 > Before SurrealDB 3.3.0, restoring an export of a database containing an `ENFORCED` relation table silently dropped its edges whenever the relation table sorted before its endpoint tables - `knows` before `person`, for example. The vertices and their counts restored correctly, so the loss only showed up on a traversal. If you restored such an export on an earlier version, check the edge counts before relying on the result.
+
+## Using LIGHTWEIGHT for relations without properties
+
+<Since v="v3.3.0" />
+
+A relation can be specified as `LIGHTWEIGHT`, in which it becomes an edge that stores nothing but the connection between its two endpoints. There is no edge record, so the edge cannot carry properties, and the table cannot take a `DEFINE FIELD`, a `DEFINE INDEX` or a `DEFINE EVENT`.
+
+```surql
+DEFINE TABLE follows TYPE RELATION IN person OUT person LIGHTWEIGHT;
+```
+
+The saving in storage is the reward for opting into these constraints. The reason is that **the edge's id becomes the pair of endpoints**, written `follows:[in, out]`, so identity and connection are the same value. That makes `RELATE` idempotent:
+
+```surql
+CREATE person:one, person:two RETURN NONE;
+RELATE person:one->follows->person:two;
+```
+
+```surql title="Output"
+[{ id: follows:[person:one, person:two], in: person:one, out: person:two }]
+```
+
+Running that `RELATE` again returns the same record, because the id it would write is the one already there. On a classic relation the same two statements produce two separate edges with two generated ids. Supplying your own non-canonical id on a lightweight table is rejected, so the guarantee holds however the edge is written.
+
+This is the behaviour that the [unique-key pattern](/docs/reference/query-language/statements/relate#handling-duplicate-edge-record-ids) builds by hand on a classic relation, using a composite id or a field plus a unique index. `LIGHTWEIGHT` makes it a property of the table, with no index to define and keep in step.
+
+`LIGHTWEIGHT` implies [`ENFORCED`](#using-enforced-to-ensure-that-related-records-exist), because a vertex deletion is the only cleanup a record-less edge has. `IN` and `OUT` are therefore required, and can be widened but not narrowed while the table holds edges. The pair renders canonically as `ENFORCED LIGHTWEIGHT` and parses in either order.
+
+### What a lightweight relation rejects
+
+The clause is a promise that the edge will never need a record, and everything that assumes one raises an error rather than failing quietly:
+
+| Rejected | Why |
+| --- | --- |
+| A data clause on `RELATE`, and `CREATE` / `INSERT RELATION` / `UPDATE` / `UPSERT` | There is no record to write fields to |
+| `DEFINE FIELD`, `DEFINE INDEX`, `DEFINE EVENT` on the table | Same, and an index has no record to point at |
+| `SCHEMAFULL`, `CHANGEFEED`, `DROP`, and `AS` clauses | Each presumes stored records |
+| A `LIVE SELECT` subscription on the table | Not supported on a record-less relation |
+| Clearing the flag on a table that holds edges | The edges have no records to fall back to |
+| Setting it on a table that already holds edges | The existing edges have non-canonical ids |
+| Narrowing `IN` or `OUT` while edges exist | The endpoint tables are what make a full scan possible |
+| `REMOVE TABLE` while edges exist | The edges live under the endpoint tables' keys, which a table wipe cannot reach |
+| Using a lightweight edge as the endpoint of another relation | An edge on an edge would break the record-less scan |
+
+Reads are unaffected, because the engine synthesizes the record a query expects. A point read by canonical id returns the endpoints as well as the id:
+
+```surql
+SELECT * FROM ONLY follows:[person:one, person:two];
+```
+
+```surql title="Output"
+{ id: follows:[person:one, person:two], in: person:one, out: person:two }
+```
+
+Idiom access resolves against that same synthesized record, so `follows:[person:one, person:two].out.id` returns `person:two`, and `record::exists` answers as it would for a stored edge. Counts, [record ranges](/docs/reference/query-language/language-primitives/data-types/record-ids#record-ranges) and ordering all work, reading the relation from its endpoint tables, and table-level `PERMISSIONS` are enforced as they are on a classic relation.
+
+`DELETE` works in every form: by id, by traversal, by whole table, and through a vertex cascade. Only writes are not permitted:
+
+```surql
+UPDATE follows:[person:one, person:two] SET weight = 1;
+```
+
+```surql title="Error output"
+"a LIGHTWEIGHT relation's edges cannot be updated: they carry no data beyond `id`, `in` and `out`"
+```
 
 ## Inserting data from undefined fields on a `SCHEMAFULL` table
 


### PR DESCRIPTION
Latest features in the newest release as well as some wording changes in Studio.

Cool stuff:

- LIGHTWEIGHT relation tables (just an ID and no metadata)
- INLINE fields on relation tables (a bit like an index for when filtering)
- CONTEXT clause to keep info in $session so you don't have to query the whole table in PERMISSIONS clauses