### PR TITLE
Correct info on multiple sessions in Python

### DIFF
--- a/src/content/reference/python/concepts/multiple-sessions.mdx
+++ b/src/content/reference/python/concepts/multiple-sessions.mdx
@@ -67,7 +67,7 @@ Call `.new_session()` on an existing connection to create a new session. The asy
 	</TabItem>
 </Tabs>
 
-A newly created session does not inherit the namespace, database, or authentication state of the parent connection. You must configure these explicitly on the session.
+A new session starts with the parent connection's identity, but nothing else from it. If the connection holds a token, `.new_session()` authenticates the session with that token, so the session begins as the same user. As the connection's namespace and database are not carried over, `.use()` can be called on the session, as the examples below do. The exception is a token whose own claims name a namespace and database, since those travel with the identity rather than with the connection.
 
 ## Isolating namespace and database
 
@@ -105,6 +105,8 @@ In the example above, `session_a` reads from the `docs` database while `session_
 ## Independent authentication
 
 Each session can authenticate as a different user. This is useful when you need to perform operations on behalf of multiple users without managing separate connections.
+
+Signing in on a session replaces the identity it started with, so a session only acts as the connection's user until you sign it in as someone else.
 
 <Tabs syncKey="python-sync-async">
 	<TabItem value="sync" label="Synchronous" default>


### PR DESCRIPTION
PR to correct the info on multiple sessions in Python as noticed in this issue: https://github.com/surrealdb/docs.surrealdb.com/issues/1958