### PR TITLE
docs: rebrand the CLI and MCP surface as Agent Memory

### DIFF
--- a/src/content/agent-memory/cookbooks/build/coding-agent-with-project-memory.mdx
+++ b/src/content/agent-memory/cookbooks/build/coding-agent-with-project-memory.mdx
@@ -43,7 +43,7 @@ If you prefer to configure the MCP server manually, add it to your editor's MCP 
 ```json
 {
   "mcpServers": {
-    "spectron": {
+    "agent-memory": {
       "url": "https://<your-context-host>/mcp",
       "headers": {
         "Authorization": "Bearer <your-api-key>",
@@ -130,11 +130,11 @@ To ingest project documentation into authoritative knowledge:
 
 ```bash
 # One document at a time
-spectron documents upload ./docs/architecture.md --label "topic=architecture"
-spectron documents upload ./docs/api-spec.yaml --label "topic=api"
+agent-memory documents upload ./docs/architecture.md --label "topic=architecture"
+agent-memory documents upload ./docs/api-spec.yaml --label "topic=api"
 
 # Or ingest a whole folder recursively
-spectron ingest ./docs --label "topic=project-docs"
+agent-memory ingest ./docs --label "topic=project-docs"
 ```
 
 ---

--- a/src/content/agent-memory/cookbooks/patterns/spoiler-safe-narrative-memory.mdx
+++ b/src/content/agent-memory/cookbooks/patterns/spoiler-safe-narrative-memory.mdx
@@ -77,7 +77,7 @@ Adjust the synthetic timeline to your ordering scheme; the important part is tha
 For PDFs or markdown split into pages:
 
 ```bash
-spectron documents upload ./chapters/ch08.txt \
+agent-memory documents upload ./chapters/ch08.txt \
   --scope org/my-app/reader/alice \
   --label chapter=8 --label page=5 \
   --as-of 1886-03-01T00:00:00Z

--- a/src/content/agent-memory/index/architecture/glossary.mdx
+++ b/src/content/agent-memory/index/architecture/glossary.mdx
@@ -92,7 +92,7 @@ SurrealDB Agent Memory’s vocabulary is precise, but the intent is everyday: me
 
 ## S
 
-**Scope** - Hierarchical slash paths (`org/acme/user/alice/`) that partition data within a Context. Register with `spectron scopes create` before use. Distinct from **permissions** and from **labels** (`key=value` descriptors).
+**Scope** - Hierarchical slash paths (`org/acme/user/alice/`) that partition data within a Context. Register with `agent-memory scopes create` before use. Distinct from **permissions** and from **labels** (`key=value` descriptors).
 
 **Session** - A conversation container: ordered **turns**, scope, and metadata.
 

--- a/src/content/agent-memory/index/architecture/traces-and-evolution.mdx
+++ b/src/content/agent-memory/index/architecture/traces-and-evolution.mdx
@@ -18,7 +18,7 @@ SurrealDB Agent Memory stores three trace kinds as **first-class nodes** in the 
 | **`decision_trace`** | Every reconciliation | Input extraction, confidence, trust, per-record outcome (created, updated, superseded, flagged), plus the acting principal, any **on-behalf-of** delegation target, and the session scope under which the write ran | `considered`, `created`, `superseded`, `flagged`, `parent_trace` |
 | **`response_trace`** | `/chat` and `/reflect` | User message, assembled prompt, model response, tokens, cost, latency | `used_retrieval`, `produced_decision`, `wrote`, `parent_session` (session id for `/chat`; also populated on the unified query path) |
 
-Traces are queryable (for example `GET /api/v1/{ctx}/traces` and `GET /api/v1/{ctx}/traces/{id}`) and inspectable from the CLI (`spectron inspect trace:…`). Trace listing respects the same access model as memory: principals with **`grant:manage`** or appropriate **`memory:read`** grants see traces in their region; others see only traces whose session scope falls within their read grant. See [Surface, models, and security](/docs/agent-memory/architecture/surface-security-and-models) for HTTP and CLI detail.
+Traces are queryable (for example `GET /api/v1/{ctx}/traces` and `GET /api/v1/{ctx}/traces/{id}`) and inspectable from the CLI (`agent-memory inspect trace:…`). Trace listing respects the same access model as memory: principals with **`grant:manage`** or appropriate **`memory:read`** grants see traces in their region; others see only traces whose session scope falls within their read grant. See [Surface, models, and security](/docs/agent-memory/architecture/surface-security-and-models) for HTTP and CLI detail.
 
 **Feedback loops** (examples):
 

--- a/src/content/agent-memory/index/index.mdx
+++ b/src/content/agent-memory/index/index.mdx
@@ -11,7 +11,9 @@ SurrealDB Agent Memory is a memory and knowledge layer for AI agents. It is an a
 Use this hub to go from principles to running code, then dive into the product sections (memory & knowledge, integrations, cookbooks, reference).
 
 > [!NOTE]
-> SurrealDB Agent Memory was developed under the project name **Spectron**, and that name is retained throughout the shipped interface: the `spectron` binary, the `SPECTRON_*` environment variables, the `spectron_*` MCP tool names, and the `X-Spectron-*` request headers. The client SDKs have already been renamed - the JavaScript package is `@surrealdb/memory`, the Python one `surrealdb-memory`, and so on. The rule of thumb is that prose and SDKs use the product name, while anything you type at a shell or set as configuration still uses `spectron`. Those remaining names will be renamed in a future release.
+> SurrealDB Agent Memory was developed under the project name **Spectron**, and the rename is arriving in stages. Already renamed: the client SDKs (`@surrealdb/memory`, `surrealdb-memory`, and so on), the framework integrations, and — as of the CLI rebrand — the **`agent-memory`** binary and the MCP server, which now registers as `agent-memory`.
+>
+> Still carrying the old name: the **`spectrond`** server binary, the **`SPECTRON_*`** environment variables, and the **`X-Spectron-*`** request headers. Those are configuration and wire contract rather than things the product is called, so they are unchanged for now.
 
 ## Architecture
 

--- a/src/content/agent-memory/index/ingest/authoritative/knowledge-nodes.mdx
+++ b/src/content/agent-memory/index/ingest/authoritative/knowledge-nodes.mdx
@@ -18,7 +18,7 @@ Use these paths when your data is already structured:
 
 - **Unstructured text** (PDF, Markdown, HTML): `POST /api/v1/{ctx}/documents` - async chunking and extraction.
 - **Structured triples you already trust**: `POST /api/v1/{ctx}/facts` with `infer: "triples"`.
-- **Conversational extraction**: `POST /api/v1/{ctx}/facts/batch` or `spectron remember`.
+- **Conversational extraction**: `POST /api/v1/{ctx}/facts/batch` or `agent-memory remember`.
 
 ## Cross-layer linking
 

--- a/src/content/agent-memory/index/ingest/authoritative/uploading-documents.mdx
+++ b/src/content/agent-memory/index/ingest/authoritative/uploading-documents.mdx
@@ -69,7 +69,7 @@ Response:
 ### CLI
 
 ```bash
-spectron documents upload ./returns-policy.pdf \
+agent-memory documents upload ./returns-policy.pdf \
   --scope org/acme/team/eng \
   --label team=eng \
   --url "$SPECTRON_URL" \
@@ -122,7 +122,7 @@ These edges feed **`hybrid_graph`** reranking (document-link density) and citati
 
 Documents and their chunks inherit the caller's **resolved write scope** from the API key when you omit explicit scope on upload - required for scoped keys to recall their own uploads.
 
-You can **narrow** tagging with **`scopes`** on **`POST /documents`**, **`spectron documents upload --scope …`**, or MCP **`upload`** - the path must lie within the caller's `memory:write` region (out-of-region scope returns **`403`**). A document's scope is **fixed at upload** - reprocess rejects a non-empty `scopes` field with **`400`**.
+You can **narrow** tagging with **`scopes`** on **`POST /documents`**, **`agent-memory documents upload --scope …`**, or MCP **`upload`** - the path must lie within the caller's `memory:write` region (out-of-region scope returns **`403`**). A document's scope is **fixed at upload** - reprocess rejects a non-empty `scopes` field with **`400`**.
 
 Optional **`labels`** (`key=value` strings) are stamped on the document, chunks, and sections. They follow the same validation rules as fact ingest and are **not** copied onto reconciled graph rows.
 

--- a/src/content/agent-memory/index/ingest/experiential/remember.mdx
+++ b/src/content/agent-memory/index/ingest/experiential/remember.mdx
@@ -13,8 +13,8 @@ Conversation turns (`/facts`, `/facts/batch`, `/chat`) and document uploads shar
 Register scope paths before first write:
 
 ```bash
-spectron scopes create org/acme
-spectron scopes create org/acme/user/alice
+agent-memory scopes create org/acme
+agent-memory scopes create org/acme/user/alice
 ```
 
 ## Primary write paths
@@ -36,11 +36,11 @@ export SPECTRON_URL=http://localhost:9090
 export SPECTRON_API_KEY=...
 export SPECTRON_CONTEXT_ID=dev
 
-spectron remember "Alice was promoted to CTO." --scope org/acme/user/alice
+agent-memory remember "Alice was promoted to CTO." --scope org/acme/user/alice
 
-spectron remember "The reveal happened on page 42." --scope org/acme --as-of 1886-01-01T00:00:00Z
+agent-memory remember "The reveal happened on page 42." --scope org/acme --as-of 1886-01-01T00:00:00Z
 
-spectron remember --from-file ./transcript.jsonl --scope org/acme/user/alice --extract per_message
+agent-memory remember --from-file ./transcript.jsonl --scope org/acme/user/alice --extract per_message
 ```
 </TabItem>
 
@@ -50,11 +50,11 @@ $env:SPECTRON_URL = "http://localhost:9090"
 $env:SPECTRON_API_KEY = "..."
 $env:SPECTRON_CONTEXT_ID = "dev"
 
-spectron remember "Alice was promoted to CTO." --scope org/acme/user/alice
+agent-memory remember "Alice was promoted to CTO." --scope org/acme/user/alice
 
-spectron remember "The reveal happened on page 42." --scope org/acme --as-of 1886-01-01T00:00:00Z
+agent-memory remember "The reveal happened on page 42." --scope org/acme --as-of 1886-01-01T00:00:00Z
 
-spectron remember --from-file ./transcript.jsonl --scope org/acme/user/alice --extract per_message
+agent-memory remember --from-file ./transcript.jsonl --scope org/acme/user/alice --extract per_message
 ```
 </TabItem>
 </Tabs>
@@ -134,7 +134,7 @@ See [Sessions and turns](/docs/agent-memory/mental-model/sessions-and-turns).
 Manuals, policies, and files use the **document** path, not `/facts`:
 
 ```bash
-spectron documents upload ./policy.pdf
+agent-memory documents upload ./policy.pdf
 ```
 
 See [Knowledge hub](/docs/agent-memory/memory-and-knowledge).

--- a/src/content/agent-memory/index/mental-model/contexts-and-scope.mdx
+++ b/src/content/agent-memory/index/mental-model/contexts-and-scope.mdx
@@ -112,7 +112,7 @@ Matches org-wide facts at `org/acme` and user-specific facts at `org/acme/user/a
 
 Matches org-wide memory only - not Alice’s private rows unless your grant includes her path.
 
-Register paths before first use: `spectron scopes create org/acme/user/alice`.
+Register paths before first use: `agent-memory scopes create org/acme/user/alice`.
 
 ### Default write region
 
@@ -188,7 +188,7 @@ A `*` anywhere other than the end is rejected.
 > Use `org/acme/*` when you mean the region.
 
 > [!NOTE]
-> Register a scope path with `spectron scopes create` before a write targets it.
+> Register a scope path with `agent-memory scopes create` before a write targets it.
 > Creating paths is its own verb (`scope:create`), so the identity that registers
 > the vocabulary is often not the one that writes into it.
 

--- a/src/content/agent-memory/index/mental-model/provenance-and-traceability.mdx
+++ b/src/content/agent-memory/index/mental-model/provenance-and-traceability.mdx
@@ -41,7 +41,7 @@ Extraction and reconciliation emit **`decision_trace`** nodes. Ranked reads emit
 ## Practical surfaces
 
 - HTTP: `GET /api/v1/{ctx}/traces`, `GET /api/v1/{ctx}/traces/{id}` ([REST API](/docs/agent-memory/reference/rest-api)).
-- CLI: `spectron inspect trace:…`, `spectron entities history …` ([Surface, models, and security](/docs/agent-memory/architecture/surface-security-and-models)).
+- CLI: `agent-memory inspect trace:…`, `agent-memory entities history …` ([Surface, models, and security](/docs/agent-memory/architecture/surface-security-and-models)).
 
 ## Related topics
 

--- a/src/content/agent-memory/index/mental-model/sessions-and-turns.mdx
+++ b/src/content/agent-memory/index/mental-model/sessions-and-turns.mdx
@@ -24,8 +24,8 @@ Content-Type: application/json
 ```
 
 ```bash
-spectron sessions list
-spectron sessions show <session_id>
+agent-memory sessions list
+agent-memory sessions show <session_id>
 ```
 
 ## What is a turn?
@@ -86,8 +86,8 @@ Session-scoped **state** and **diff** endpoints support debugging what changed a
 ## CLI transcript tooling
 
 ```bash
-spectron sessions list
-spectron sessions show sess_01hw…
+agent-memory sessions list
+agent-memory sessions show sess_01hw…
 ```
 
 See [Creating sessions](/docs/agent-memory/sessions/creating-sessions) and [Adding turns](/docs/agent-memory/sessions/adding-turns) for operational detail aligned with the current API.

--- a/src/content/agent-memory/index/operations/forget.mdx
+++ b/src/content/agent-memory/index/operations/forget.mdx
@@ -54,11 +54,11 @@ Authorization: Bearer sk-...
 The response counts how many records were expired. Scope is enforced by the API key’s grants - you cannot forget outside the scopes your key is allowed to write (and forget) within.
 
 ```bash
-spectron forget "anything about my old job" \
+agent-memory forget "anything about my old job" \
   --url "$SPECTRON_URL" --api-key "$SPECTRON_API_KEY" --context-id "$SPECTRON_CONTEXT_ID"
 
 # Preview matches without expiring anything
-spectron forget "anything about my old job" --dry-run \
+agent-memory forget "anything about my old job" --dry-run \
   --url "$SPECTRON_URL" --api-key "$SPECTRON_API_KEY" --context-id "$SPECTRON_CONTEXT_ID"
 ```
 
@@ -115,7 +115,7 @@ Use scoped forget for GDPR-style deletion when a principal’s entire branch mus
 
 | Goal | Operation | Erases from storage? |
 | --- | --- | --- |
-| Preview what would be retired | **`POST /forget`** with **`dryRun: true`** or **`spectron forget --dry-run`** | No - read-only count |
+| Preview what would be retired | **`POST /forget`** with **`dryRun: true`** or **`agent-memory forget --dry-run`** | No - read-only count |
 | Agent should stop mentioning something | **`POST /forget`** (default) or **`DELETE /entities/...`** | No - expired, still auditable |
 | User’s erasure request for specific topics | **`POST /forget`** with **`purge: true`** | Yes - matched content removed |
 | Delete everything for a user/team scope | **`POST /scopes/forget`** | Yes - entire subtree removed |

--- a/src/content/agent-memory/index/quickstarts/hosted.mdx
+++ b/src/content/agent-memory/index/quickstarts/hosted.mdx
@@ -55,10 +55,10 @@ Use the exact **host** from SurrealDB Studio settings or API keys - not a generi
 Scoped writes require registered paths. With the CLI pointed at your context:
 
 ```bash
-spectron scopes create org/acme \
+agent-memory scopes create org/acme \
   --url "$SPECTRON_URL" --api-key "$SPECTRON_API_KEY" --context-id "$SPECTRON_CONTEXT_ID"
 
-spectron scopes create org/acme/user/alice \
+agent-memory scopes create org/acme/user/alice \
   --url "$SPECTRON_URL" --api-key "$SPECTRON_API_KEY" --context-id "$SPECTRON_CONTEXT_ID"
 ```
 

--- a/src/content/agent-memory/index/retrieve/recall.mdx
+++ b/src/content/agent-memory/index/retrieve/recall.mdx
@@ -8,12 +8,12 @@ description: "Unified retrieval over facts and document passages."
 
 SurrealDB Agent Memory exposes one fused read path over the **unified substrate**: structured facts from turns and passages from documents. Use **`POST /api/v1/{context_id}/query`** for ranked hits and **`POST /api/v1/{context_id}/context`** for a pre-formatted LLM block.
 
-Register scope paths before use (`spectron scopes create org/acme/user/alice`). See [Contexts and scope](/docs/agent-memory/mental-model/contexts-and-scope).
+Register scope paths before use (`agent-memory scopes create org/acme/user/alice`). See [Contexts and scope](/docs/agent-memory/mental-model/contexts-and-scope).
 
 ## Ranked hits - `/query`
 
 ```bash
-spectron recall "What role does Alice have?" --json \
+agent-memory recall "What role does Alice have?" --json \
   --url "$SPECTRON_URL" \
   --api-key "$SPECTRON_API_KEY" \
   --context-id "$SPECTRON_CONTEXT_ID" \
@@ -73,7 +73,7 @@ Content-Type: application/json
 ```
 
 ```bash
-spectron context "What role does Alice have?"
+agent-memory context "What role does Alice have?"
 ```
 
 ## Session-scoped context
@@ -93,7 +93,7 @@ POST /api/v1/{context_id}/documents/query
 ```
 
 ```bash
-spectron recall "return policy" --include passages
+agent-memory recall "return policy" --include passages
 ```
 
 ## Chat (composed recall + synthesis)
@@ -103,7 +103,7 @@ POST /api/v1/{context_id}/chat
 ```
 
 ```bash
-spectron chat "Summarise what you know about Alice"
+agent-memory chat "Summarise what you know about Alice"
 ```
 
 SurrealDB Agent Memory runs recall internally, then calls the configured response model. Use `--stream` for SSE.

--- a/src/content/agent-memory/index/sessions/creating-sessions.mdx
+++ b/src/content/agent-memory/index/sessions/creating-sessions.mdx
@@ -19,7 +19,7 @@ Sessions answer both. The session is the provenance anchor: every extracted fact
 
 ## Session scope
 
-Scope on create is a **DNF selector** (`scopes`): an OR of conjunctive slash-path clauses (for example `[["org/acme/user/alice"]]`). Register paths with `spectron scopes create` before first use. SurrealDB Agent Memory propagates the session scope to all records created during the session.
+Scope on create is a **DNF selector** (`scopes`): an OR of conjunctive slash-path clauses (for example `[["org/acme/user/alice"]]`). Register paths with `agent-memory scopes create` before first use. SurrealDB Agent Memory propagates the session scope to all records created during the session.
 
 ```json
 [["org/acme/user/alice"]]

--- a/src/content/agent-memory/index/welcome/accuracy-promise.mdx
+++ b/src/content/agent-memory/index/welcome/accuracy-promise.mdx
@@ -60,6 +60,6 @@ Curated knowledge and conversational knowledge are distinguished by **`source.ki
 
 ## Observable today
 
-Operators can use HTTP and CLI surfaces (`spectron entities …`, `spectron sessions …`, `spectron recall …`, `spectron inspect trace:…`) plus direct SurrealDB access on self-hosted stacks to read live state and historical belief - the same substrate the ranker uses. A fuller inspectability list is in [Surface, models, and security](/docs/agent-memory/architecture/surface-security-and-models).
+Operators can use HTTP and CLI surfaces (`agent-memory entities …`, `agent-memory sessions …`, `agent-memory recall …`, `agent-memory inspect trace:…`) plus direct SurrealDB access on self-hosted stacks to read live state and historical belief - the same substrate the ranker uses. A fuller inspectability list is in [Surface, models, and security](/docs/agent-memory/architecture/surface-security-and-models).
 
 Together, these properties mean “is the agent correct?” has a defensible answer: you can point to records, spans, traces, and time axes - not only to a model transcript.

--- a/src/content/agent-memory/integrations/ai-sdks/cloudflare-workers-ai.mdx
+++ b/src/content/agent-memory/integrations/ai-sdks/cloudflare-workers-ai.mdx
@@ -95,7 +95,7 @@ ctx.waitUntil(spectron.rememberMany(turns, { scope }));
 
 ## Scope per user or session
 
-Pass a `scope` on every call to isolate memory. A scope is a slash path or an array of paths, for example `["org/acme/user/alice"]`. Register paths with `spectron scopes create` before first use.
+Pass a `scope` on every call to isolate memory. A scope is a slash path or an array of paths, for example `["org/acme/user/alice"]`. Register paths with `agent-memory scopes create` before first use.
 
 ## Next steps
 

--- a/src/content/agent-memory/integrations/ai-sdks/tanstack-ai.mdx
+++ b/src/content/agent-memory/integrations/ai-sdks/tanstack-ai.mdx
@@ -111,7 +111,7 @@ The agent loop invokes the tool automatically when the model asks for it.
 
 ## Scope per user or session
 
-Pass a `scope` on every call to isolate memory. A scope is a slash path or an array of paths, for example `["org/acme/user/alice"]` for one user, or a session-specific path such as `["org/acme/session/abc123"]`. Register paths with `spectron scopes create` before first use.
+Pass a `scope` on every call to isolate memory. A scope is a slash path or an array of paths, for example `["org/acme/user/alice"]` for one user, or a session-specific path such as `["org/acme/session/abc123"]`. Register paths with `agent-memory scopes create` before first use.
 
 ## Next steps
 

--- a/src/content/agent-memory/integrations/automation/n8n.mdx
+++ b/src/content/agent-memory/integrations/automation/n8n.mdx
@@ -60,7 +60,7 @@ Wrap either request in an **HTTP Request Tool** node and attach it to the AI Age
 
 ## Scope per user or workflow
 
-Set the `scope` on each call to isolate memory. A scope is a slash path or an array of paths, for example `["org/acme/user/alice"]`. Derive it from workflow data such as a chat user id. Register paths with `spectron scopes create` before first use.
+Set the `scope` on each call to isolate memory. A scope is a slash path or an array of paths, for example `["org/acme/user/alice"]`. Derive it from workflow data such as a chat user id. Register paths with `agent-memory scopes create` before first use.
 
 ## Next steps
 

--- a/src/content/agent-memory/integrations/automation/zo-computer.mdx
+++ b/src/content/agent-memory/integrations/automation/zo-computer.mdx
@@ -70,7 +70,7 @@ A skill recalls context with `get_context()` before it answers, then records the
 
 ## Scope per user
 
-Each helper scopes to the Zo user with a slash path such as `user/alice`. Register paths with `spectron scopes create` before first use. On **SurrealDB Cloud**, use your context host from SurrealDB Studio **API keys** as the `AGENT_MEMORY_ENDPOINT`.
+Each helper scopes to the Zo user with a slash path such as `user/alice`. Register paths with `agent-memory scopes create` before first use. On **SurrealDB Cloud**, use your context host from SurrealDB Studio **API keys** as the `AGENT_MEMORY_ENDPOINT`.
 
 ## Next steps
 

--- a/src/content/agent-memory/integrations/frameworks/agno.mdx
+++ b/src/content/agent-memory/integrations/frameworks/agno.mdx
@@ -97,7 +97,7 @@ memory.remember_many(
 
 ## Scope per user
 
-Pass a `scope` on every call to isolate memory. A scope is a slash path or an array of paths, for example `["org/acme/user/alice"]`. Register paths with `spectron scopes create` before first use.
+Pass a `scope` on every call to isolate memory. A scope is a slash path or an array of paths, for example `["org/acme/user/alice"]`. Register paths with `agent-memory scopes create` before first use.
 
 ## Next steps
 

--- a/src/content/agent-memory/integrations/frameworks/autogen.mdx
+++ b/src/content/agent-memory/integrations/frameworks/autogen.mdx
@@ -91,7 +91,7 @@ memory.remember_many(
 
 ## Scope per user
 
-Pass a `scope` on every call to isolate memory. A scope is a slash path or an array of paths, for example `["org/acme/user/alice"]`. Register paths with `spectron scopes create` before first use.
+Pass a `scope` on every call to isolate memory. A scope is a slash path or an array of paths, for example `["org/acme/user/alice"]`. Register paths with `agent-memory scopes create` before first use.
 
 ## Next steps
 

--- a/src/content/agent-memory/integrations/frameworks/camel-ai.mdx
+++ b/src/content/agent-memory/integrations/frameworks/camel-ai.mdx
@@ -96,7 +96,7 @@ memory.remember_many(
 
 ## Scope per user
 
-Pass a `scope` on every call to isolate memory. A scope is a slash path or an array of paths, for example `["org/acme/user/alice"]`. Register paths with `spectron scopes create` before first use.
+Pass a `scope` on every call to isolate memory. A scope is a slash path or an array of paths, for example `["org/acme/user/alice"]`. Register paths with `agent-memory scopes create` before first use.
 
 ## Next steps
 

--- a/src/content/agent-memory/integrations/frameworks/llamaindex.mdx
+++ b/src/content/agent-memory/integrations/frameworks/llamaindex.mdx
@@ -85,7 +85,7 @@ block = memory.query_context("what is the return policy?", k=8, lens=["org/acme"
 
 ## Scope per user
 
-Pass a `scope` on every call to isolate memory. A scope is a slash path or an array of paths, for example `["org/acme/user/alice"]`. Register paths with `spectron scopes create` before first use.
+Pass a `scope` on every call to isolate memory. A scope is a slash path or an array of paths, for example `["org/acme/user/alice"]`. Register paths with `agent-memory scopes create` before first use.
 
 ## Next steps
 

--- a/src/content/agent-memory/integrations/frameworks/openclaw.mdx
+++ b/src/content/agent-memory/integrations/frameworks/openclaw.mdx
@@ -19,21 +19,21 @@ By default the plugin **augments** OpenClaw's built-in memory. It can optionally
 
 ```bash
 openclaw plugins install @surrealdb/agent-memory-openclaw
-openclaw agent_memory setup
+openclaw agentMemory setup
 openclaw gateway restart
 ```
 
-`openclaw agent_memory setup` prints the config block and the two hook flags to add.
+`openclaw agentMemory setup` prints the config block and the two hook flags to add.
 
 ## Configure
 
-Configuration lives in `~/.openclaw/openclaw.json` under `plugins.entries.agent_memory`. Connection fields accept `${ENV_VAR}` references so secrets stay out of the file:
+Configuration lives in `~/.openclaw/openclaw.json` under `plugins.entries.agentMemory`. Connection fields accept `${ENV_VAR}` references so secrets stay out of the file:
 
 ```json
 {
   "plugins": {
     "entries": {
-      "agent_memory": {
+      "agentMemory": {
         "enabled": true,
         "hooks": {
           "allowConversationAccess": true,
@@ -78,7 +78,7 @@ The plugin maps SurrealDB Agent Memory's operations onto OpenClaw's agent lifecy
 | `before_prompt_build` | Relevant memory is injected as `<agent_memory>` before the model runs |
 | `agent_end` | The turn is persisted, with platform metadata stripped |
 | `session_end` | Recent facts are consolidated into durable observations |
-| `gateway_start` / `agent_memory index` | Workspace memory files (`MEMORY.md`, `memory/**`) are seeded |
+| `gateway_start` / `agentMemory index` | Workspace memory files (`MEMORY.md`, `memory/**`) are seeded |
 
 ## Agent tools
 
@@ -87,16 +87,16 @@ The agent can call these directly: `agent_memory_recall`, `agent_memory_context`
 ## CLI
 
 ```bash
-openclaw agent_memory setup [--takeover]   # print config + required hook flags
-openclaw agent_memory status               # config, slot mode, and identity
-openclaw agent_memory health               # check the connection
-openclaw agent_memory index                # seed workspace memory files
-openclaw agent_memory recall <query>       # search memory
-openclaw agent_memory reflect <query>      # synthesise an answer from memory
-openclaw agent_memory forget <query>       # forget matching memories
+openclaw agentMemory setup [--takeover]   # print config + required hook flags
+openclaw agentMemory status               # config, slot mode, and identity
+openclaw agentMemory health               # check the connection
+openclaw agentMemory index                # seed workspace memory files
+openclaw agentMemory recall <query>       # search memory
+openclaw agentMemory reflect <query>      # synthesise an answer from memory
+openclaw agentMemory forget <query>       # forget matching memories
 ```
 
 ## Memory modes
 
 - **Augment (default):** runs alongside the built-in memory core. Nothing about the memory slot changes.
-- **Takeover (experimental):** `openclaw agent_memory setup --takeover` prints a patch that sets `plugins.slots.memory` to `agent_memory`, making SurrealDB Agent Memory the sole memory provider.
+- **Takeover (experimental):** `openclaw agentMemory setup --takeover` prints a patch that sets `plugins.slots.memory` to `agentMemory`, making SurrealDB Agent Memory the sole memory provider.

--- a/src/content/agent-memory/integrations/mcp-server/coding-assistants/antigravity.mdx
+++ b/src/content/agent-memory/integrations/mcp-server/coding-assistants/antigravity.mdx
@@ -20,7 +20,7 @@ The `install-mcp` helper does not cover Antigravity, so configure the server by 
 ```json
 {
   "mcpServers": {
-    "spectron": {
+    "agent-memory": {
       "serverUrl": "https://<your-context-host>/mcp",
       "headers": {
         "Authorization": "Bearer <your-api-key>",
@@ -60,7 +60,7 @@ Antigravity calls `memory_recall` before composing its response.
 
 ## Scope per tool call
 
-Narrow reads and writes with the per-tool **`scope`** argument (slash paths, for example `["org/acme/project/platform"]`). Register paths with `spectron scopes create` before first use. For project isolation, use separate contexts or distinct scope paths.
+Narrow reads and writes with the per-tool **`scope`** argument (slash paths, for example `["org/acme/project/platform"]`). Register paths with `agent-memory scopes create` before first use. For project isolation, use separate contexts or distinct scope paths.
 
 ## Removing SurrealDB Agent Memory
 

--- a/src/content/agent-memory/integrations/mcp-server/coding-assistants/claude-desktop-and-code.mdx
+++ b/src/content/agent-memory/integrations/mcp-server/coding-assistants/claude-desktop-and-code.mdx
@@ -47,7 +47,7 @@ If `AGENT_MEMORY_MCP_URL` is unset, the server will not connect. The plugin's MC
 ```json
 {
   "mcpServers": {
-    "spectron": {
+    "agent-memory": {
       "type": "http",
       "url": "${AGENT_MEMORY_MCP_URL}",
       "headers": {
@@ -108,7 +108,7 @@ Merge the following into `claude_desktop_config.json`, then restart Claude Deskt
 ```json
 {
   "mcpServers": {
-    "spectron": {
+    "agent-memory": {
       "type": "http",
       "url": "https://<your-spectron-instance>/mcp",
       "headers": {
@@ -134,7 +134,7 @@ Claude Desktop cannot load plugins, but you can add the SurrealDB Agent Memory u
 
 ## Scope on tool calls
 
-Narrow reads and writes with the per-tool **`scope`** argument (slash paths, for example `["org/acme/user/alice"]` or `["org/acme/project/orders-service"]`). Register paths with `spectron scopes create` before first use. Use separate contexts or distinct scope paths to keep memory isolated per repository.
+Narrow reads and writes with the per-tool **`scope`** argument (slash paths, for example `["org/acme/user/alice"]` or `["org/acme/project/orders-service"]`). Register paths with `agent-memory scopes create` before first use. Use separate contexts or distinct scope paths to keep memory isolated per repository.
 
 ## Removing SurrealDB Agent Memory
 

--- a/src/content/agent-memory/integrations/mcp-server/coding-assistants/codex.mdx
+++ b/src/content/agent-memory/integrations/mcp-server/coding-assistants/codex.mdx
@@ -18,7 +18,7 @@ For integration rules your agent should follow (auth, scope, endpoints, common m
 Codex reads MCP servers from `~/.codex/config.toml` (or `.codex/config.toml` in a trusted project). Add a Streamable HTTP entry with a `url` and a bearer token sourced from an environment variable:
 
 ```toml
-[mcp_servers.spectron]
+[mcp_servers.agent-memory]
 url = "https://<your-context-host>/mcp"
 bearer_token_env_var = "AGENT_MEMORY_API_KEY"
 http_headers = { "X-Spectron-Context" = "acme-prod" }
@@ -76,8 +76,8 @@ Codex calls `memory_recall` before answering.
 
 ## Scope per tool call
 
-Narrow reads and writes by passing a **`scope`** argument on each tool (slash paths, for example `["org/acme/project/api"]`). Register paths with `spectron scopes create` before first use. For project isolation, use separate contexts or distinct scope paths.
+Narrow reads and writes by passing a **`scope`** argument on each tool (slash paths, for example `["org/acme/project/api"]`). Register paths with `agent-memory scopes create` before first use. For project isolation, use separate contexts or distinct scope paths.
 
 ## Removing SurrealDB Agent Memory
 
-Delete the `[mcp_servers.spectron]` block from `~/.codex/config.toml`, or run `codex mcp remove spectron`.
+Delete the `[mcp_servers.agent-memory]` block from `~/.codex/config.toml`, or run `codex mcp remove spectron`.

--- a/src/content/agent-memory/integrations/mcp-server/coding-assistants/cursor.mdx
+++ b/src/content/agent-memory/integrations/mcp-server/coding-assistants/cursor.mdx
@@ -30,7 +30,7 @@ The URL is the first argument; auth is passed with `--header`, and `--oauth no` 
 ```json
 {
   "mcpServers": {
-    "spectron": {
+    "agent-memory": {
       "url": "https://<your-context-host>/mcp",
       "headers": {
         "Authorization": "Bearer <your-api-key>",
@@ -48,7 +48,7 @@ The URL is the first argument; auth is passed with `--header`, and `--oauth no` 
 
 ### Scope per tool call
 
-The shipped `install-mcp` helper does **not** set a default scope. Narrow reads and writes by passing a **`scope`** argument on each tool (slash paths, for example `["org/acme/user/alice"]` or `["org/acme/project/platform-v3"]`). Register paths with `spectron scopes create` before first use.
+The shipped `install-mcp` helper does **not** set a default scope. Narrow reads and writes by passing a **`scope`** argument on each tool (slash paths, for example `["org/acme/user/alice"]` or `["org/acme/project/platform-v3"]`). Register paths with `agent-memory scopes create` before first use.
 
 For project isolation, use separate contexts or distinct scope paths in tool arguments, not install-time flags.
 

--- a/src/content/agent-memory/integrations/mcp-server/coding-assistants/jetbrains-air.mdx
+++ b/src/content/agent-memory/integrations/mcp-server/coding-assistants/jetbrains-air.mdx
@@ -25,7 +25,7 @@ The `install-mcp` helper does not cover JetBrains Air, so configure the server b
 ```json
 {
   "mcpServers": {
-    "spectron": {
+    "agent-memory": {
       "url": "https://<your-context-host>/mcp",
       "headers": {
         "Authorization": "Bearer <your-api-key>",
@@ -83,7 +83,7 @@ Air's permission mode, cycled with `Shift+Tab`, applies to the task as a whole r
 
 ## Scope per tool call
 
-Narrow reads and writes with the per-tool **`scope`** argument (slash paths, for example `["org/acme/project/platform"]`). Register paths with `spectron scopes create` before first use. For project isolation, use separate contexts or distinct scope paths.
+Narrow reads and writes with the per-tool **`scope`** argument (slash paths, for example `["org/acme/project/platform"]`). Register paths with `agent-memory scopes create` before first use. For project isolation, use separate contexts or distinct scope paths.
 
 ## Removing SurrealDB Agent Memory
 

--- a/src/content/agent-memory/integrations/mcp-server/coding-assistants/jetbrains.mdx
+++ b/src/content/agent-memory/integrations/mcp-server/coding-assistants/jetbrains.mdx
@@ -17,7 +17,7 @@ The `install-mcp` helper does not cover JetBrains IDEs, so configure the server 
 ```json
 {
   "mcpServers": {
-    "spectron": {
+    "agent-memory": {
       "url": "https://<your-context-host>/mcp",
       "headers": {
         "Authorization": "Bearer <your-api-key>",
@@ -56,7 +56,7 @@ AI Assistant calls `memory_recall` before answering.
 
 ## Scope per project
 
-Narrow reads and writes with the per-tool **`scope`** argument (slash paths, for example `["org/acme/project/platform"]`). Register paths with `spectron scopes create` before first use. For project isolation, use separate contexts or distinct scope paths.
+Narrow reads and writes with the per-tool **`scope`** argument (slash paths, for example `["org/acme/project/platform"]`). Register paths with `agent-memory scopes create` before first use. For project isolation, use separate contexts or distinct scope paths.
 
 ## Removing SurrealDB Agent Memory
 

--- a/src/content/agent-memory/integrations/mcp-server/coding-assistants/opencode.mdx
+++ b/src/content/agent-memory/integrations/mcp-server/coding-assistants/opencode.mdx
@@ -31,7 +31,7 @@ OpenCode reads configuration from `opencode.json` in your workspace root (or `~/
 {
   "$schema": "https://opencode.ai/config.json",
   "mcp": {
-    "spectron": {
+    "agent-memory": {
       "type": "remote",
       "url": "https://<your-context-host>/mcp",
       "enabled": true,
@@ -86,7 +86,7 @@ OpenCode calls `memory_recall` before answering.
 
 ## Scope per tool call
 
-Narrow reads and writes with the per-tool **`scope`** argument (slash paths, for example `["org/acme/project/cli"]`). Register paths with `spectron scopes create` before first use. For project isolation, use separate contexts or distinct scope paths.
+Narrow reads and writes with the per-tool **`scope`** argument (slash paths, for example `["org/acme/project/cli"]`). Register paths with `agent-memory scopes create` before first use. For project isolation, use separate contexts or distinct scope paths.
 
 ## Removing SurrealDB Agent Memory
 

--- a/src/content/agent-memory/integrations/mcp-server/coding-assistants/vscode.mdx
+++ b/src/content/agent-memory/integrations/mcp-server/coding-assistants/vscode.mdx
@@ -46,7 +46,7 @@ To make the server available in every workspace instead, add the same entry to y
 ```json
 {
   "servers": {
-    "spectron": {
+    "agent-memory": {
       "type": "http",
       "url": "https://<your-context-host>/mcp",
       "headers": {
@@ -75,7 +75,7 @@ The `.vscode/mcp.json` file can be committed to your repository so the team shar
     }
   ],
   "servers": {
-    "spectron": {
+    "agent-memory": {
       "type": "http",
       "url": "https://<your-context-host>/mcp",
       "headers": {

--- a/src/content/agent-memory/integrations/mcp-server/coding-assistants/windsurf.mdx
+++ b/src/content/agent-memory/integrations/mcp-server/coding-assistants/windsurf.mdx
@@ -34,7 +34,7 @@ The URL is the first argument; auth is passed with `--header`, and `--oauth no` 
 ```json
 {
   "mcpServers": {
-    "spectron": {
+    "agent-memory": {
       "serverUrl": "https://<your-context-host>/mcp",
       "headers": {
         "Authorization": "Bearer <your-api-key>",
@@ -49,7 +49,7 @@ Windsurf uses `serverUrl` rather than `url`. The `install-mcp` command writes th
 
 ## Scope on tool calls
 
-Pass a **`scope`** argument on each tool (slash paths, for example `["org/acme/user/alice"]`). The install helper does not set default scope; register paths with `spectron scopes create` before first use.
+Pass a **`scope`** argument on each tool (slash paths, for example `["org/acme/user/alice"]`). The install helper does not set default scope; register paths with `agent-memory scopes create` before first use.
 
 ## Verify the installation
 

--- a/src/content/agent-memory/integrations/mcp-server/coding-assistants/zed.mdx
+++ b/src/content/agent-memory/integrations/mcp-server/coding-assistants/zed.mdx
@@ -30,7 +30,7 @@ Open Zed settings (`cmd`/`ctrl` `,`), which edits `~/.config/zed/settings.json`,
 ```json
 {
   "context_servers": {
-    "spectron": {
+    "agent-memory": {
       "url": "https://<your-context-host>/mcp",
       "headers": {
         "Authorization": "Bearer <your-api-key>",
@@ -48,7 +48,7 @@ On **SurrealDB Cloud**, use your context host from SurrealDB Studio **API keys**
 > ```json
 > {
 >   "context_servers": {
->     "spectron": {
+>     "agent-memory": {
 >       "command": {
 >         "path": "npx",
 >         "args": ["-y", "mcp-remote", "https://<your-context-host>/mcp", "--header", "Authorization: Bearer <your-api-key>"]
@@ -82,7 +82,7 @@ Zed calls `memory_recall` before answering.
 
 ## Scope per project
 
-Narrow reads and writes with the per-tool **`scope`** argument (slash paths, for example `["org/acme/project/editor"]`). Register paths with `spectron scopes create` before first use. For project isolation, use separate contexts or distinct scope paths.
+Narrow reads and writes with the per-tool **`scope`** argument (slash paths, for example `["org/acme/project/editor"]`). Register paths with `agent-memory scopes create` before first use. For project isolation, use separate contexts or distinct scope paths.
 
 ## Removing SurrealDB Agent Memory
 

--- a/src/content/agent-memory/integrations/mcp-server/install.mdx
+++ b/src/content/agent-memory/integrations/mcp-server/install.mdx
@@ -33,7 +33,7 @@ Any MCP client can be configured by hand:
 ```json
 {
   "mcpServers": {
-    "spectron": {
+    "agent-memory": {
       "url": "https://<your-context-host>/mcp",
       "headers": {
         "Authorization": "Bearer <your-api-key>"

--- a/src/content/agent-memory/integrations/mcp-server/tools-reference.mdx
+++ b/src/content/agent-memory/integrations/mcp-server/tools-reference.mdx
@@ -12,7 +12,7 @@ SurrealDB Agent Memory exposes seven tools over the Model Context Protocol at `/
 > Older docs used names such as `memory_store`, `memory_recall`, and `knowledge_search`. Those prefixes are retired - use the short names above.
 
 > [!NOTE]
-> REST-aligned responses use **camelCase** (`queryMs`, `traceId`, `trace.traceId`). **Scope** arguments are slash paths (for example `org/acme/user/alice`). Register paths with `spectron scopes create` before use.
+> REST-aligned responses use **camelCase** (`queryMs`, `traceId`, `trace.traceId`). **Scope** arguments are slash paths (for example `org/acme/user/alice`). Register paths with `agent-memory scopes create` before use.
 
 ## Common fields
 

--- a/src/content/agent-memory/integrations/observability/agentops.mdx
+++ b/src/content/agent-memory/integrations/observability/agentops.mdx
@@ -82,7 +82,7 @@ The model call is captured in the AgentOps session automatically. To attribute t
 
 ## Scope per user
 
-Pass a `scope` on every SurrealDB Agent Memory call to isolate memory. A scope is a slash path or an array of paths, for example `["org/acme/user/alice"]`. Register paths with `spectron scopes create` before first use.
+Pass a `scope` on every SurrealDB Agent Memory call to isolate memory. A scope is a slash path or an array of paths, for example `["org/acme/user/alice"]`. Register paths with `agent-memory scopes create` before first use.
 
 ## Next steps
 

--- a/src/content/agent-memory/integrations/observability/respan.mdx
+++ b/src/content/agent-memory/integrations/observability/respan.mdx
@@ -75,7 +75,7 @@ The recall and storage calls appear in Respan's trace tree alongside the model c
 
 ## Scope per user
 
-Pass a `scope` on every SurrealDB Agent Memory call to isolate memory. A scope is a slash path or an array of paths, for example `["org/acme/user/alice"]`. Register paths with `spectron scopes create` before first use.
+Pass a `scope` on every SurrealDB Agent Memory call to isolate memory. A scope is a slash path or an array of paths, for example `["org/acme/user/alice"]`. Register paths with `agent-memory scopes create` before first use.
 
 ## Next steps
 

--- a/src/content/agent-memory/integrations/sdks/dart.mdx
+++ b/src/content/agent-memory/integrations/sdks/dart.mdx
@@ -53,6 +53,6 @@ await for (final chunk in client.chatStream('Tell me a story')) {
 client.close();
 ```
 
-`scopes` accepts a slash-path string or a list of paths. Register paths with `spectron scopes create` before first use.
+`scopes` accepts a slash-path string or a list of paths. Register paths with `agent-memory scopes create` before first use.
 
 The client covers the rest of the SurrealDB Agent Memory end-user surface (documents, sessions, entities, and governance) over the same REST API. See the [REST API](/docs/agent-memory/integrations/surfaces/rest) for the full contract.

--- a/src/content/agent-memory/integrations/sdks/python.mdx
+++ b/src/content/agent-memory/integrations/sdks/python.mdx
@@ -52,7 +52,7 @@ Both clients are pinned to one context and call `/api/v1/{context}/…`. Pass `c
 
 ## Scope
 
-On the wire, scope is a **ScopeSet**: an ordered array of slash-path strings (for example `["org/acme/user/alice"]`). Register paths with `spectron scopes create` before first use; see [Contexts and scope](/docs/agent-memory/mental-model/contexts-and-scope).
+On the wire, scope is a **ScopeSet**: an ordered array of slash-path strings (for example `["org/acme/user/alice"]`). Register paths with `agent-memory scopes create` before first use; see [Contexts and scope](/docs/agent-memory/mental-model/contexts-and-scope).
 
 The Python client accepts:
 
@@ -204,8 +204,8 @@ pip install agent-memory-google-adk           # Google ADK
 The **`spectron`** binary exposes the same operations without the SDK:
 
 ```bash
-spectron remember "Alice was promoted to CTO."
-spectron recall "What is Alice's role?" --json
+agent-memory remember "Alice was promoted to CTO."
+agent-memory recall "What is Alice's role?" --json
 ```
 
 → [CLI reference](/docs/agent-memory/reference/cli) · [REST API](/docs/agent-memory/reference/rest-api)

--- a/src/content/agent-memory/integrations/surfaces/rest.mdx
+++ b/src/content/agent-memory/integrations/surfaces/rest.mdx
@@ -64,7 +64,7 @@ curl -sS "$SPECTRON_URL/api/v1/$SPECTRON_CONTEXT_ID/query" \
   -d '{"query":"What is Alice'\''s role?","limit":10,"scope":["org/acme/user/alice"]}'
 ```
 
-The [`spectron`](/docs/agent-memory/reference/cli) CLI wraps the same paths (`spectron remember`, `spectron recall`, `spectron chat`).
+The [`spectron`](/docs/agent-memory/reference/cli) CLI wraps the same paths (`agent-memory remember`, `agent-memory recall`, `agent-memory chat`).
 
 ## Full reference
 

--- a/src/content/agent-memory/reference/agents.mdx
+++ b/src/content/agent-memory/reference/agents.mdx
@@ -215,7 +215,7 @@ POST /api/v1/{context_id}/keys/{name}/rotate?ttl_seconds=2592000
 7. **Idempotent retries without idempotency keys** - duplicate writes may return **`409`**; use idempotency headers where documented.
 8. **`use_reranker: true` without server reranker** - requires `SPECTRON_RERANKER_URL` + `SPECTRON_RERANKER_MODEL` or it falls back to bi-encoder order.
 9. **MCP JSON-RPC errors for business failures** - not-found and auth failures return **`isError: true`** with `error.status`, not JSON-RPC `-32603`.
-10. **`POST /forget` without checking dry run** - pass **`dryRun: true`** (or `spectron forget --dry-run`) to preview; omitting it expires records immediately.
+10. **`POST /forget` without checking dry run** - pass **`dryRun: true`** (or `agent-memory forget --dry-run`) to preview; omitting it expires records immediately.
 11. **Per-Context OCR/STT config** - multimodal HTTP providers are **deployment env vars** (`SPECTRON_OCR_*`, `SPECTRON_CLIP_*`, `SPECTRON_STT_*`), not Context patch fields.
 
 ---

--- a/src/content/agent-memory/reference/cli.mdx
+++ b/src/content/agent-memory/reference/cli.mdx
@@ -6,23 +6,30 @@ description: "Command-line interface reference."
 
 # CLI reference
 
-SurrealDB Agent Memory ships **`spectron`**, the client CLI integrators install locally: `remember`, `recall`, `chat`, `documents`, and provisioning helpers.
+SurrealDB Agent Memory ships two binaries:
+
+| Binary | Role |
+| --- | --- |
+| **`spectrond`** | Server (runs in your container or cluster): `api`, `worker`, `scheduler`, `management`, `bootstrap` |
+| **`agent-memory`** | Client: `remember`, `recall`, `chat`, `documents`, provisioning helpers |
+
+The **`agent-memory`** CLI is what integrators install locally. **`spectrond`** is operated via Docker, Kubernetes, or your platform team.
 
 > [!NOTE]
-> `spectron` carries **Spectron**, the project name SurrealDB Agent Memory was developed under. The product name changed ahead of the executable, which will be renamed in a future release.
+> The client binary is **`agent-memory`**. It was called `spectron` before the CLI rebrand; if you installed it earlier, `agent-memory upgrade` replaces it. The server binary is still **`spectrond`**, and every `SPECTRON_*` environment variable keeps its name — see [Configuration](/docs/agent-memory/reference/configuration).
 
 ## Installing the CLI
 
 Prebuilt `spectron` binaries for macOS, Linux, and Windows are published to `download.surrealdb.com` under a version path. On macOS and Linux the install script resolves the latest version, verifies the checksum, and installs to `/usr/local/bin` (or `~/.local/bin` when that is not writable):
 
 ```bash
-curl -fsSL https://download.surrealdb.com/spectron/install.sh | sh
+curl -fsSL https://download.surrealdb.com/agent-memory/install.sh | sh
 ```
 
 Set **`SPECTRON_INSTALL_DIR`** to install somewhere else. Once installed, the CLI updates itself in place, so you do not need to re-run the script:
 
 ```bash
-spectron upgrade
+agent-memory upgrade
 ```
 
 ### Manual download
@@ -30,8 +37,8 @@ spectron upgrade
 To install by hand, resolve the current version from the pointer file, then download the archive for your platform:
 
 ```bash
-VERSION=$(curl -fsSL https://download.surrealdb.com/spectron/latest.txt)
-BASE="https://download.surrealdb.com/spectron/${VERSION}/spectron-${VERSION}"
+VERSION=$(curl -fsSL https://download.surrealdb.com/agent-memory/latest.txt)
+BASE="https://download.surrealdb.com/agent-memory/${VERSION}/agent-memory-${VERSION}"
 
 # macOS (Apple Silicon)
 curl -fsSL "${BASE}.darwin-arm64.tgz" | tar -xz && sudo mv spectron /usr/local/bin/
@@ -46,7 +53,7 @@ curl -fsSL "${BASE}.linux-amd64.tgz" | tar -xz && sudo mv spectron /usr/local/bi
 curl -fsSL "${BASE}.linux-arm64.tgz" | tar -xz && sudo mv spectron /usr/local/bin/
 ```
 
-On **Windows**, download `spectron-<version>.windows-amd64.zip` from `https://download.surrealdb.com/spectron/<version>/` (use `latest.txt` for `<version>`), extract it, and put the folder containing `spectron.exe` on `PATH`. `spectron upgrade` works on Windows once a first install is on `PATH`.
+On **Windows**, download `spectron-<version>.windows-amd64.zip` from `https://download.surrealdb.com/agent-memory/<version>/` (use `latest.txt` for `<version>`), extract it, and put the folder containing `spectron.exe` on `PATH`. `agent-memory upgrade` works on Windows once a first install is on `PATH`.
 
 ### Verifying the download
 
@@ -58,7 +65,7 @@ shasum -a 256 -c spectron-*.tgz.sha256   # macOS / Linux
 
 The binaries are unsigned. Downloading with `curl` avoids the macOS Gatekeeper quarantine flag that a browser download adds; if you did download through a browser, clear it first with `xattr -d com.apple.quarantine ./spectron`.
 
-## Connection flags
+## Connection flags (client)
 
 Most `spectron` subcommands accept:
 
@@ -69,7 +76,7 @@ Most `spectron` subcommands accept:
 | `--context-id` / `-c` | `SPECTRON_CONTEXT_ID` | Context id in `/api/v1/{context_id}/...` |
 
 ```bash
-spectron login --url http://localhost:9090 \
+agent-memory login --url http://localhost:9090 \
   --api-key "$SPECTRON_API_KEY" \
   --context-id dev
 ```
@@ -78,13 +85,71 @@ Stores a named profile for later commands.
 
 ### Local config and secrets
 
-`spectron login` and `spectron config set` write profiles to `~/.config/spectron/config.toml` with owner-only permissions (`0600` on Unix). **`config set`** prints the key name, never the value. To display a stored secret:
+`agent-memory login` and `agent-memory config set` write profiles to `~/.config/spectron/config.toml` with owner-only permissions (`0600` on Unix). **`config set`** prints the key name, never the value. To display a stored secret:
 
 ```bash
-spectron config get api_key --reveal
+agent-memory config get api_key --reveal
 ```
 
 Without **`--reveal`**, `api_key` is shown as `<hidden>`.
+
+---
+
+## `spectrond` - server (operators)
+
+Run inside the SurrealDB Agent Memory container or host image.
+
+### `bootstrap`
+
+One-time control-plane initialisation. Prints management and context API keys. Fails if the Context already exists.
+
+```bash
+docker compose exec spectron spectrond bootstrap \
+  --connection-string "ws://surrealdb:8000;root;root"
+```
+
+Pin a stable Context API key (instead of a random mint) with **`--context-api-key`** or **`SPECTRON_API_KEY`**, mirroring how **`--management-api-key`** / **`SPECTRON_MANAGEMENT_API_KEY`** pins the management key. Validate the value with `spectrond generate-key` first.
+
+### Development runtime
+
+Local bring-up runs **api + worker + scheduler** in one process (not for production). Pass **`--bootstrap`** to seed the Context on an empty database, print the keys, then serve - on later restarts against the same database the seed is a no-op (logs and skips) instead of erroring:
+
+```bash
+spectrond dev start --bootstrap \
+  --connection-string "$SURREALDB_CONNECTION" \
+  --bind-address 0.0.0.0:9090 \
+  --context-api-key "$SPECTRON_API_KEY"
+```
+
+Without `--bootstrap`, run standalone `spectrond bootstrap` once, then `dev start` as before.
+
+```bash
+spectrond dev start \
+  --connection-string "$SURREALDB_CONNECTION" \
+  --bind-address 0.0.0.0:9090
+```
+
+Export LLM provider keys before `dev start` if you need extraction or chat (`infer: full` is not embeddings-only). A bare `spectrond start` alias exists for older single-process layouts but is hidden from `--help` - prefer `dev start` or the split production roles below.
+
+For a full provisioning walkthrough (bootstrap, scopes, principals, keys, upload, query), follow the [Hosted quickstart](/docs/agent-memory/quickstarts/hosted) and [CLI](#connection-flags-client) reference below.
+
+### Production roles
+
+```bash
+spectrond api start …          # REST + MCP
+spectrond worker start …       # job queue consumer
+spectrond scheduler start …    # periodic background work
+spectrond management start …   # management REST only
+```
+
+Common flags:
+
+| Flag | Env | Default |
+| --- | --- | --- |
+| `--connection-string` | `SURREALDB_CONNECTION` | - |
+| `--embeddings-api-key` | `SPECTRON_EMBEDDINGS_API_KEY` | - |
+| `--bind-address` | `SPECTRON_BIND_ADDRESS` | `0.0.0.0:9090` |
+| `--object-store-url` | `SPECTRON_OBJECT_STORE_URL` | - |
 
 ---
 
@@ -94,12 +159,12 @@ Without **`--reveal`**, `api_key` is shown as `<hidden>`.
 
 | Command | REST equivalent |
 | --- | --- |
-| `spectron remember "…"` | `POST /api/v1/{ctx}/facts` |
-| `spectron recall "…"` | `POST /api/v1/{ctx}/query` |
-| `spectron context "…"` | `POST /api/v1/{ctx}/context` |
-| `spectron chat [message]` | `POST /api/v1/{ctx}/chat` |
-| `spectron reflect "…"` | `POST /api/v1/{ctx}/reflect` |
-| `spectron forget "…"` | `POST /api/v1/{ctx}/forget` |
+| `agent-memory remember "…"` | `POST /api/v1/{ctx}/facts` |
+| `agent-memory recall "…"` | `POST /api/v1/{ctx}/query` |
+| `agent-memory context "…"` | `POST /api/v1/{ctx}/context` |
+| `agent-memory chat [message]` | `POST /api/v1/{ctx}/chat` |
+| `agent-memory reflect "…"` | `POST /api/v1/{ctx}/reflect` |
+| `agent-memory forget "…"` | `POST /api/v1/{ctx}/forget` |
 
 `forget` supports **`--dry-run`** to preview matches without expiring records.
 
@@ -107,15 +172,15 @@ Without **`--reveal`**, `api_key` is shown as `<hidden>`.
 
 `recall` flags: `--limit`, `--mode hybrid|vector|bm25|graph`, `--include facts,passages`. Pass **`scope`** on the REST `/query` body - the CLI does not expose `--scope` on `recall` today.
 
-**Unsupported CLI flags (rejected with a clear error):** `remember --confidence`, `--trust`, `--location`; `recall --min-trust`; `spectron lifecycle expire --older-than` (expiry thresholds are configured per Context, not per CLI invocation). Use REST or management API where those controls exist.
+**Unsupported CLI flags (rejected with a clear error):** `remember --confidence`, `--trust`, `--location`; `recall --min-trust`; `agent-memory lifecycle expire --older-than` (expiry thresholds are configured per Context, not per CLI invocation). Use REST or management API where those controls exist.
 
 ### Documents
 
 ```bash
-spectron documents upload ./manual.pdf --scope org/acme/team/eng --label team=eng
-spectron ingest ./folder --scope org/acme/team/eng --label team=eng
-spectron documents list
-spectron recall "return policy" --include passages
+agent-memory documents upload ./manual.pdf --scope org/acme/team/eng --label team=eng
+agent-memory ingest ./folder --scope org/acme/team/eng --label team=eng
+agent-memory documents list
+agent-memory recall "return policy" --include passages
 ```
 
 `--scope` on upload narrows tagging to a path within the caller's `memory:write` region (same semantics as `remember --scope`). `--label` may be repeated for `key=value` tags stamped on the document and chunks. Omit `--scope` to use the full write region.
@@ -123,9 +188,9 @@ spectron recall "return policy" --include passages
 ### Sessions, entities, traces
 
 ```bash
-spectron sessions list
-spectron entities show Person/alice
-spectron traces show <trace_id>
+agent-memory sessions list
+agent-memory entities show Person/alice
+agent-memory traces show <trace_id>
 ```
 
 ### MCP server
@@ -134,43 +199,82 @@ The MCP server is served at `/mcp` on the same host and port as the REST API - n
 
 ### Operator provisioning
 
-Contexts and management keys are created, listed, and rotated through the management REST API - see the [Management API reference](/docs/agent-memory/reference/management-api).
+```bash
+spectrond contexts create …
+spectrond keys generate-key …
+spectrond keys rotate <context_id> <key_name> [--expires-in <seconds>]
+```
 
-**Create principals** with the `spectron` thin client, which reads `SPECTRON_MANAGEMENT_URL`, `SPECTRON_MANAGEMENT_API_KEY`, and `SPECTRON_CONTEXT_ID` from the environment:
+**Create principals** (management API - not the data-plane Context key). The two
+binaries reach the control plane over different transports, so each takes its own
+URL:
+
+| Binary | Transport | Flag reads | Default port |
+| --- | --- | --- | --- |
+| `spectrond` (`contexts`, `principals`, `keys`) | gRPC | `SPECTRON_MANAGEMENT_GRPC_URL` | `9091` |
+| `spectron` (thin client) | REST | `SPECTRON_MANAGEMENT_URL` | `9090` |
 
 <Tabs syncKey="shell">
 
 <TabItem label="Bash">
 ```bash
-export SPECTRON_MANAGEMENT_URL=http://127.0.0.1:9090
+export SPECTRON_MANAGEMENT_GRPC_URL=http://127.0.0.1:9091   # spectrond speaks gRPC
+export SPECTRON_MANAGEMENT_URL=http://127.0.0.1:9090        # agent-memory speaks REST
 export SPECTRON_MANAGEMENT_API_KEY=sp-…
-export SPECTRON_CONTEXT_ID=demo
 
-spectron principals create "Planner bot" --kind agent \
+spectrond principals create demo "Planner bot" \
+  --kind agent \
+  --grant memory:read=team/eng \
+  --grant memory:write=team/eng \
+  --url "$SPECTRON_MANAGEMENT_GRPC_URL" \
+  --api-key "$SPECTRON_MANAGEMENT_API_KEY"
+
+# thin client (reads SPECTRON_MANAGEMENT_* + SPECTRON_CONTEXT_ID from env)
+agent-memory principals create "Planner bot" --kind agent -c demo \
   --grant memory:read=team/eng --grant memory:write=team/eng
 ```
 </TabItem>
 
 <TabItem label="PowerShell">
 ```powershell
-$env:SPECTRON_MANAGEMENT_URL = "http://127.0.0.1:9090"
+$env:SPECTRON_MANAGEMENT_GRPC_URL = "http://127.0.0.1:9091"   # spectrond speaks gRPC
+$env:SPECTRON_MANAGEMENT_URL = "http://127.0.0.1:9090"   # agent-memory speaks REST
 $env:SPECTRON_MANAGEMENT_API_KEY = "sp-…"
-$env:SPECTRON_CONTEXT_ID = "demo"
 
-spectron principals create "Planner bot" --kind agent `
+spectrond principals create demo "Planner bot" `
+  --kind agent `
+  --grant memory:read=team/eng `
+  --grant memory:write=team/eng `
+  --url "$SPECTRON_MANAGEMENT_GRPC_URL" `
+  --api-key "$SPECTRON_MANAGEMENT_API_KEY"
+
+# thin client (reads SPECTRON_MANAGEMENT_* + SPECTRON_CONTEXT_ID from env)
+agent-memory principals create "Planner bot" --kind agent -c demo `
   --grant memory:read=team/eng --grant memory:write=team/eng
 ```
 </TabItem>
 </Tabs>
 
-Prints the server-minted principal `id`. Mint an agent key for that principal via the [management API](/docs/agent-memory/reference/management-api).
+Prints the server-minted principal `id`. Mint an agent key for that principal via the management API or `spectrond keys generate-key`.
+
+> [!NOTE]
+> Point `spectrond` at the REST port and the call fails with `grpc-status header
+> missing, mapped from HTTP status code 404`. The endpoint is reachable; it
+> speaks the other protocol. Both servers run at full parity, so the choice is
+> transport only.
+
+The management REST default (`9090`) is the same port the end-user API server
+uses. When you run both on one host, override one of them - for example
+`--bind-address 0.0.0.0:9095 --grpc-bind-address 0.0.0.0:9096` on
+`spectrond management start` - and use the ports you chose in the variables
+above.
 
 ### Terminal workbench
 
 | Command | Description |
 | --- | --- |
-| `spectron tui` | Four-pane workbench: input, entity tree, trace timeline, inspector (`Tab` cycles panes). `--session <id>` pins a session; `--replay <path>` plays a recorded jsonl without HTTP. |
-| `spectron repl` | Interactive REPL: bare lines and **`/remember`** write facts (`infer: full`); `/recall`, `/chat`, `/inspect`, `/scope`, `/as-of`, `/upload`, `/forget`, `/record`; tab completion from prior responses. Colour is on when stdout is a terminal; pass **`--ascii`** for plain output (same flag as `spectron tui`). |
+| `agent-memory tui` | Four-pane workbench: input, entity tree, trace timeline, inspector (`Tab` cycles panes). `--session <id>` pins a session; `--replay <path>` plays a recorded jsonl without HTTP. |
+| `agent-memory repl` | Interactive REPL: bare lines and **`/remember`** write facts (`infer: full`); `/recall`, `/chat`, `/inspect`, `/scope`, `/as-of`, `/upload`, `/forget`, `/record`; tab completion from prior responses. Colour is on when stdout is a terminal; pass **`--ascii`** for plain output (same flag as `agent-memory tui`). |
 
 Scope in the REPL and TUI uses **slash paths** (`org/acme/user/alice`), matching the wire `ScopeSet`.
 
@@ -182,6 +286,6 @@ Interactive mode supports structured triple writes:
 /fact entity=Person/Alice attr=role val=CTO
 ```
 
-Uses the same triple syntax as `spectron remember --triple` (`infer=triples`).
+Uses the same triple syntax as `agent-memory remember --triple` (`infer=triples`).
 
 Run `spectron --help` for the full command tree.

--- a/src/content/agent-memory/reference/configuration.mdx
+++ b/src/content/agent-memory/reference/configuration.mdx
@@ -13,7 +13,7 @@ SurrealDB Agent Memory has two configuration surfaces: server-wide settings (in 
 Server configuration is provided via environment variables or a TOML configuration file passed at startup. These settings apply to all Contexts unless overridden at the Context level.
 
 > [!NOTE]
-> Every variable keeps the `SPECTRON_` prefix from **Spectron**, the project name SurrealDB Agent Memory was developed under. These names are part of the shipped interface, so the product renaming leaves them unchanged for now; they will be renamed in a future release.
+> Every variable keeps the `SPECTRON_` prefix from **Spectron**, the project name SurrealDB Agent Memory was developed under. The CLI binary is now `agent-memory` and the SDKs have been renamed, but these variables are configuration the server already reads, so they are deliberately unchanged.
 
 ### Core settings
 

--- a/src/content/agent-memory/reference/glossary.mdx
+++ b/src/content/agent-memory/reference/glossary.mdx
@@ -102,7 +102,7 @@ The **`source`** field on each `/query` hit: `entity`, `attribute`, `memory_chun
 
 ## Scope floor
 
-The minimum scope paths that an API key must include in its requests. A key scoped to `org/acme` cannot make requests at `org/beta`. The server enforces this at the query level. Register paths with `spectron scopes create` before use.
+The minimum scope paths that an API key must include in its requests. A key scoped to `org/acme` cannot make requests at `org/beta`. The server enforces this at the query level. Register paths with `agent-memory scopes create` before use.
 
 ## Semantic response cache
 

--- a/src/content/agent-memory/reference/mcp-tools.mdx
+++ b/src/content/agent-memory/reference/mcp-tools.mdx
@@ -12,7 +12,7 @@ SurrealDB Agent Memory's MCP server exposes **seven** tools at `/mcp`: `remember
 > Older docs and some third-party snippets used names like `memory_store` or `knowledge_search`. Those prefixes are gone - use the short names above. Authoritative schemas live in the SurrealDB Agent Memory server (`spectron-user-api` MCP tools module).
 
 > [!NOTE]
-> REST responses use **camelCase** (`queryMs`, `traceId`, `trace.traceId`). **Scope selectors** on the wire use DNF (`ScopeSets`): writes take **`scope`** / **`scopes`**, reads take **`lens`** - an OR of conjunctive slash-path clauses. Register paths with `spectron scopes create` before use. See [Contexts and scope](/docs/agent-memory/mental-model/contexts-and-scope#wire-format-scopesets).
+> REST responses use **camelCase** (`queryMs`, `traceId`, `trace.traceId`). **Scope selectors** on the wire use DNF (`ScopeSets`): writes take **`scope`** / **`scopes`**, reads take **`lens`** - an OR of conjunctive slash-path clauses. Register paths with `agent-memory scopes create` before use. See [Contexts and scope](/docs/agent-memory/mental-model/contexts-and-scope#wire-format-scopesets).
 
 ## Authentication
 
@@ -21,7 +21,7 @@ All tools use **`Authorization: Bearer`** authentication (same as REST). Pass th
 ```json
 {
   "mcpServers": {
-    "spectron": {
+    "agent-memory": {
       "url": "https://spectron.example.com/mcp",
       "headers": {
         "Authorization": "Bearer sk-...",
@@ -41,7 +41,7 @@ Scope is layered on each tool call:
 1. **Grant region** (from the API key's principal) - enforced server-side; cannot be widened past what the key allows.
 2. **Per-call `scope` / `lens` argument** - DNF selector narrowing the operation within the grant (`scope`/`scopes` on writes, `lens` on `recall` / `context`).
 
-Register paths with `spectron scopes create` before first use.
+Register paths with `agent-memory scopes create` before first use.
 
 ---
 

--- a/src/content/agent-memory/reference/rest-api.mdx
+++ b/src/content/agent-memory/reference/rest-api.mdx
@@ -63,8 +63,8 @@ A flat `["a", "b"]` means **a OR b**. For **a AND b** in one clause, nest: `[["a
 Register paths before first use:
 
 ```bash
-spectron scopes create org/acme
-spectron scopes create org/acme/user/alice
+agent-memory scopes create org/acme
+agent-memory scopes create org/acme/user/alice
 ```
 
 See [Contexts and scope](/docs/agent-memory/mental-model/contexts-and-scope).


### PR DESCRIPTION
Documents [surrealdb/spectron@2c8630d](https://github.com/surrealdb/spectron/commit/2c8630d94329c6fe0d61b7c407963d8797258674), which rebranded the public CLI and the REST/MCP surface as Agent Memory. Until now the docs told people to install and type `spectron`, which no longer exists.

## What the commit changed, and what these docs now say

**The client binary is `agent-memory`.** The crate is still `spectron-cli`; only the produced binary was renamed, so every documented invocation moves:

```diff
-curl -fsSL https://download.surrealdb.com/spectron/install.sh | sh
+curl -fsSL https://download.surrealdb.com/agent-memory/install.sh | sh

-spectron login
-spectron remember "…"
+agent-memory login
+agent-memory remember "…"
```

Release artefacts moved with it — `download.surrealdb.com/agent-memory/${VERSION}/agent-memory-${VERSION}` and `latest.txt`.

**The MCP server registers as `agent-memory`.** The commit changed the server's advertised name in the `initialize` handshake, and the setup instruction is now `claude mcp add agent-memory`. Every client config block follows — the JSON `"agent-memory": { … }` entry across Claude, Cursor, VS Code, Zed, Windsurf, JetBrains, opencode and Antigravity, plus the Codex TOML `[mcp_servers.agent-memory]`. Tool references become `mcp__agent-memory__*`.

## What the commit deliberately left alone — and so did I

| Kept | Why |
| --- | --- |
| **`spectrond`** | the server binary was not renamed |
| **`SPECTRON_*`** | configuration the server already reads; unchanged |
| **`X-Spectron-Context`**, **`X-Spectron-On-Behalf-Of`** | wire contract |
| short MCP tool names (`recall`, `remember`, …) | never had a prefix; the tools page already documented them correctly |
| `https://spectron.dev/errors/…` | the `type` URIs in RFC 7807 responses |
| `docker compose exec spectron spectrond bootstrap` | the first `spectron` there is a compose **service** name, not the binary |

## The three naming notes are rewritten

They said the opposite of what is now true — that the binaries keep the Spectron name and would be renamed later. `index/index.mdx`, `reference/cli.mdx` and `reference/configuration.mdx` now split it honestly: SDKs, integrations, the CLI and the MCP server are renamed; `spectrond`, `SPECTRON_*` and the `X-Spectron-*` headers are not, because they are configuration and wire contract rather than product naming.

`reference/cli.mdx` also gains an upgrade note, since anyone who installed the old binary needs `agent-memory upgrade` rather than a rename on disk.

## Relationship to #1998

No overlap in intent — [#1998](https://github.com/surrealdb/docs.surrealdb.com/pull/1998) renames the integration **packages and their APIs**; this renames the **CLI and MCP surface**. They touch some of the same files but different lines. Either order merges; the second may need a trivial rebase.

## Verification

- `bun run qau` (biome) — clean
- `bun run build` — exit 0
- `grep` confirms `spectrond`, `SPECTRON_*`, `X-Spectron-*` and `spectron.dev` are all still present and untouched, and that the compose service line is intact
