### PR TITLE
Remove spectrond references from Agent Memory docs

### DIFF
--- a/src/content/agent-memory/index/index.mdx
+++ b/src/content/agent-memory/index/index.mdx
@@ -11,7 +11,7 @@ SurrealDB Agent Memory is a memory and knowledge layer for AI agents. It is an a
 Use this hub to go from principles to running code, then dive into the product sections (memory & knowledge, integrations, cookbooks, reference).
 
 > [!NOTE]
-> SurrealDB Agent Memory was developed under the project name **Spectron**, and that name is retained throughout the shipped interface: the `spectron` and `spectrond` binaries, the `SPECTRON_*` environment variables, the `spectron_*` MCP tool names, and the `X-Spectron-*` request headers. The client SDKs have already been renamed - the JavaScript package is `@surrealdb/memory`, the Python one `surrealdb-memory`, and so on. The rule of thumb is that prose and SDKs use the product name, while anything you type at a shell or set as configuration still uses `spectron`. Those remaining names will be renamed in a future release.
+> SurrealDB Agent Memory was developed under the project name **Spectron**, and that name is retained throughout the shipped interface: the `spectron` binary, the `SPECTRON_*` environment variables, the `spectron_*` MCP tool names, and the `X-Spectron-*` request headers. The client SDKs have already been renamed - the JavaScript package is `@surrealdb/memory`, the Python one `surrealdb-memory`, and so on. The rule of thumb is that prose and SDKs use the product name, while anything you type at a shell or set as configuration still uses `spectron`. Those remaining names will be renamed in a future release.
 
 ## Architecture
 

--- a/src/content/agent-memory/integrations/surfaces/embedded-library.mdx
+++ b/src/content/agent-memory/integrations/surfaces/embedded-library.mdx
@@ -19,7 +19,7 @@ There is no supported in-process library that runs extraction and recall inside 
 
 ## Rust agents
 
-Deploy **`spectrond`** and call the HTTP API or generated client.
+Deploy the SurrealDB Agent Memory server and call the HTTP API or generated client.
 
 ## Related
 

--- a/src/content/agent-memory/reference/cli.mdx
+++ b/src/content/agent-memory/reference/cli.mdx
@@ -6,17 +6,10 @@ description: "Command-line interface reference."
 
 # CLI reference
 
-SurrealDB Agent Memory ships two binaries:
-
-| Binary | Role |
-| --- | --- |
-| **`spectrond`** | Server (runs in your container or cluster): `api`, `worker`, `scheduler`, `management`, `bootstrap` |
-| **`spectron`** | Client: `remember`, `recall`, `chat`, `documents`, provisioning helpers |
-
-The **`spectron`** CLI is what integrators install locally. **`spectrond`** is operated via Docker, Kubernetes, or your platform team.
+SurrealDB Agent Memory ships **`spectron`**, the client CLI integrators install locally: `remember`, `recall`, `chat`, `documents`, and provisioning helpers.
 
 > [!NOTE]
-> Both binaries carry **Spectron**, the project name SurrealDB Agent Memory was developed under. The product name changed ahead of the executables, which will be renamed in a future release.
+> `spectron` carries **Spectron**, the project name SurrealDB Agent Memory was developed under. The product name changed ahead of the executable, which will be renamed in a future release.
 
 ## Installing the CLI
 
@@ -65,7 +58,7 @@ shasum -a 256 -c spectron-*.tgz.sha256   # macOS / Linux
 
 The binaries are unsigned. Downloading with `curl` avoids the macOS Gatekeeper quarantine flag that a browser download adds; if you did download through a browser, clear it first with `xattr -d com.apple.quarantine ./spectron`.
 
-## Connection flags (client)
+## Connection flags
 
 Most `spectron` subcommands accept:
 
@@ -92,64 +85,6 @@ spectron config get api_key --reveal
 ```
 
 Without **`--reveal`**, `api_key` is shown as `<hidden>`.
-
----
-
-## `spectrond` - server (operators)
-
-Run inside the SurrealDB Agent Memory container or host image.
-
-### `bootstrap`
-
-One-time control-plane initialisation. Prints management and context API keys. Fails if the Context already exists.
-
-```bash
-docker compose exec spectron spectrond bootstrap \
-  --connection-string "ws://surrealdb:8000;root;root"
-```
-
-Pin a stable Context API key (instead of a random mint) with **`--context-api-key`** or **`SPECTRON_API_KEY`**, mirroring how **`--management-api-key`** / **`SPECTRON_MANAGEMENT_API_KEY`** pins the management key. Validate the value with `spectrond generate-key` first.
-
-### Development runtime
-
-Local bring-up runs **api + worker + scheduler** in one process (not for production). Pass **`--bootstrap`** to seed the Context on an empty database, print the keys, then serve - on later restarts against the same database the seed is a no-op (logs and skips) instead of erroring:
-
-```bash
-spectrond dev start --bootstrap \
-  --connection-string "$SURREALDB_CONNECTION" \
-  --bind-address 0.0.0.0:9090 \
-  --context-api-key "$SPECTRON_API_KEY"
-```
-
-Without `--bootstrap`, run standalone `spectrond bootstrap` once, then `dev start` as before.
-
-```bash
-spectrond dev start \
-  --connection-string "$SURREALDB_CONNECTION" \
-  --bind-address 0.0.0.0:9090
-```
-
-Export LLM provider keys before `dev start` if you need extraction or chat (`infer: full` is not embeddings-only). A bare `spectrond start` alias exists for older single-process layouts but is hidden from `--help` - prefer `dev start` or the split production roles below.
-
-For a full provisioning walkthrough (bootstrap, scopes, principals, keys, upload, query), follow the [Hosted quickstart](/docs/agent-memory/quickstarts/hosted) and [CLI](#connection-flags-client) reference below.
-
-### Production roles
-
-```bash
-spectrond api start …          # REST + MCP
-spectrond worker start …       # job queue consumer
-spectrond scheduler start …    # periodic background work
-spectrond management start …   # management REST only
-```
-
-Common flags:
-
-| Flag | Env | Default |
-| --- | --- | --- |
-| `--connection-string` | `SURREALDB_CONNECTION` | - |
-| `--embeddings-api-key` | `SPECTRON_EMBEDDINGS_API_KEY` | - |
-| `--bind-address` | `SPECTRON_BIND_ADDRESS` | `0.0.0.0:9090` |
-| `--object-store-url` | `SPECTRON_OBJECT_STORE_URL` | - |
 
 ---
 
@@ -199,75 +134,36 @@ The MCP server is served at `/mcp` on the same host and port as the REST API - n
 
 ### Operator provisioning
 
-```bash
-spectrond contexts create …
-spectrond keys generate-key …
-spectrond keys rotate <context_id> <key_name> [--expires-in <seconds>]
-```
+Contexts and management keys are created, listed, and rotated through the management REST API - see the [Management API reference](/docs/agent-memory/reference/management-api).
 
-**Create principals** (management API - not the data-plane Context key). The two
-binaries reach the control plane over different transports, so each takes its own
-URL:
-
-| Binary | Transport | Flag reads | Default port |
-| --- | --- | --- | --- |
-| `spectrond` (`contexts`, `principals`, `keys`) | gRPC | `SPECTRON_MANAGEMENT_GRPC_URL` | `9091` |
-| `spectron` (thin client) | REST | `SPECTRON_MANAGEMENT_URL` | `9090` |
+**Create principals** with the `spectron` thin client, which reads `SPECTRON_MANAGEMENT_URL`, `SPECTRON_MANAGEMENT_API_KEY`, and `SPECTRON_CONTEXT_ID` from the environment:
 
 <Tabs syncKey="shell">
 
 <TabItem label="Bash">
 ```bash
-export SPECTRON_MANAGEMENT_GRPC_URL=http://127.0.0.1:9091   # spectrond speaks gRPC
-export SPECTRON_MANAGEMENT_URL=http://127.0.0.1:9090        # spectron speaks REST
+export SPECTRON_MANAGEMENT_URL=http://127.0.0.1:9090
 export SPECTRON_MANAGEMENT_API_KEY=sp-…
+export SPECTRON_CONTEXT_ID=demo
 
-spectrond principals create demo "Planner bot" \
-  --kind agent \
-  --grant memory:read=team/eng \
-  --grant memory:write=team/eng \
-  --url "$SPECTRON_MANAGEMENT_GRPC_URL" \
-  --api-key "$SPECTRON_MANAGEMENT_API_KEY"
-
-# thin client (reads SPECTRON_MANAGEMENT_* + SPECTRON_CONTEXT_ID from env)
-spectron principals create "Planner bot" --kind agent -c demo \
+spectron principals create "Planner bot" --kind agent \
   --grant memory:read=team/eng --grant memory:write=team/eng
 ```
 </TabItem>
 
 <TabItem label="PowerShell">
 ```powershell
-$env:SPECTRON_MANAGEMENT_GRPC_URL = "http://127.0.0.1:9091"   # spectrond speaks gRPC
-$env:SPECTRON_MANAGEMENT_URL = "http://127.0.0.1:9090"   # spectron speaks REST
+$env:SPECTRON_MANAGEMENT_URL = "http://127.0.0.1:9090"
 $env:SPECTRON_MANAGEMENT_API_KEY = "sp-…"
+$env:SPECTRON_CONTEXT_ID = "demo"
 
-spectrond principals create demo "Planner bot" `
-  --kind agent `
-  --grant memory:read=team/eng `
-  --grant memory:write=team/eng `
-  --url "$SPECTRON_MANAGEMENT_GRPC_URL" `
-  --api-key "$SPECTRON_MANAGEMENT_API_KEY"
-
-# thin client (reads SPECTRON_MANAGEMENT_* + SPECTRON_CONTEXT_ID from env)
-spectron principals create "Planner bot" --kind agent -c demo `
+spectron principals create "Planner bot" --kind agent `
   --grant memory:read=team/eng --grant memory:write=team/eng
 ```
 </TabItem>
 </Tabs>
 
-Prints the server-minted principal `id`. Mint an agent key for that principal via the management API or `spectrond keys generate-key`.
-
-> [!NOTE]
-> Point `spectrond` at the REST port and the call fails with `grpc-status header
-> missing, mapped from HTTP status code 404`. The endpoint is reachable; it
-> speaks the other protocol. Both servers run at full parity, so the choice is
-> transport only.
-
-The management REST default (`9090`) is the same port the end-user API server
-uses. When you run both on one host, override one of them - for example
-`--bind-address 0.0.0.0:9095 --grpc-bind-address 0.0.0.0:9096` on
-`spectrond management start` - and use the ports you chose in the variables
-above.
+Prints the server-minted principal `id`. Mint an agent key for that principal via the [management API](/docs/agent-memory/reference/management-api).
 
 ### Terminal workbench
 

--- a/src/content/agent-memory/reference/management-api.mdx
+++ b/src/content/agent-memory/reference/management-api.mdx
@@ -16,7 +16,7 @@ Management endpoints require a **management** API key as a Bearer token:
 Authorization: Bearer <management-key>
 ```
 
-Keys are printed once by bootstrap or minted via `spectrond keys generate-key` / management REST. They are distinct from per-Context end-user keys.
+Keys are printed once by bootstrap or minted via the management REST API. They are distinct from per-Context end-user keys.
 
 ## Contexts
 


### PR DESCRIPTION
## Summary
- `spectrond` is an internal server binary and should not be documented publicly - only `spectron` (the client CLI) is user-facing.
- Rewrote the [CLI reference](src/content/agent-memory/reference/cli.mdx) to drop the `spectrond` server/operator section entirely (bootstrap, dev runtime, production roles) and the two-binary framing; operator provisioning (contexts, management keys) now points to the management REST API, with principal creation kept on the `spectron` thin REST client.
- Updated the Agent Memory hub note, the Rust "embedded library" integration page, and the management API auth section to drop `spectrond` mentions without losing the underlying information.

## Test plan
- [x] `bun run qa` / `bun run qc` pass
- [x] Verified all four changed pages render correctly in the dev server (no leftover `spectrond` references, internal links resolve, `Tabs`/`TabItem` block still renders)
- [x] Confirmed no other file in the repo (content, redirects, `llms.txt`, search) references `spectrond`, and no page links into the removed anchors