### PR TITLE
Make the search modal readable and say what it searches

### DIFF
--- a/src/components/SearchDocs/index.tsx
+++ b/src/components/SearchDocs/index.tsx
@@ -11,17 +11,12 @@ import {
     VisuallyHidden,
 } from "@mantine/core";
 import { useDebouncedValue, useHotkeys, useInputState, useOs } from "@mantine/hooks";
-import {
-    Spotlight,
-    type SpotlightActionData,
-    type SpotlightFilterFunction,
-    spotlight,
-} from "@mantine/spotlight";
+import { Spotlight, type SpotlightActionData, spotlight } from "@mantine/spotlight";
 import { Icon, iconArrowLeft, iconSearch } from "@surrealdb/ui";
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { type ReactNode, useCallback, useEffect, useMemo, useState } from "react";
 import { usePageContext } from "vike-react/usePageContext";
-import { getProductFromPath } from "~/utils/product";
+import { getProductFromPath, PRODUCT_META } from "~/utils/product";
 import { RateLimitError, SearchError, type SearchResult, searchDocs } from "~/utils/search";
 import { SearchResultCard } from "./SearchResult";
 import classes from "./style.module.scss";
@@ -50,8 +45,6 @@ function mapResultsToActions(results: SearchResult[], query: string): SpotlightA
         ),
     })) as SpotlightActionData[];
 }
-
-const noFilter: SpotlightFilterFunction = (_query, actions) => actions;
 
 export function SearchDocs(props: UnstyledButtonProps) {
     const [search, setSearch] = useInputState("");
@@ -181,34 +174,68 @@ export function SearchDocs(props: UnstyledButtonProps) {
                     ? `${actions.length} result${actions.length === 1 ? "" : "s"} for ${debouncedSearch}`
                     : ""}
             </VisuallyHidden>
-            <Spotlight
-                actions={hasQuery ? actions : []}
-                nothingFound={nothingFound}
-                filter={noFilter}
+            {/* Composed rather than the `<Spotlight>` shorthand, which renders
+                the search, the list and the empty state and nothing else -
+                the scope line needs a footer beneath them. */}
+            <Spotlight.Root
                 scrollable
                 maxHeight={500}
                 transitionProps={{ transition: "fade-down" }}
-                overlayProps={{ blur: 0 }}
+                overlayProps={{ blur: 0, backgroundOpacity: 0.5 }}
                 classNames={{
                     inner: classes.searchScreen,
+                    body: classes.searchBody,
                     actionsList: classes.searchList,
+                    action: classes.searchAction,
                     content: classes.searchContent,
                     search: classes.searchInput,
                     empty: classes.searchEmpty,
+                    footer: classes.searchFooter,
                 }}
-                searchProps={{
-                    placeholder: "Search the docs",
-                    leftSection: loading ? <Loader size="xs" /> : <Icon path={iconSearch} />,
-                    autoFocus: true,
-                    onChange: setSearch,
-                    value: search,
-                    className: classes.searchInput,
-                    rightSection: <Kbd>Esc</Kbd>,
-                    mod: {
-                        expanded: actions.length > 0 && hasQuery,
-                    },
-                }}
-            />
+            >
+                <Spotlight.Search
+                    placeholder="Search the docs"
+                    leftSection={loading ? <Loader size="xs" /> : <Icon path={iconSearch} />}
+                    autoFocus
+                    onChange={setSearch}
+                    value={search}
+                    className={classes.searchInput}
+                    rightSection={<Kbd>Esc</Kbd>}
+                    mod={{ expanded: actions.length > 0 && hasQuery }}
+                />
+                {actions.length > 0 ? (
+                    <Spotlight.ActionsList>
+                        {actions.map(({ id, ...action }) => (
+                            <Spotlight.Action
+                                key={id}
+                                {...action}
+                            />
+                        ))}
+                    </Spotlight.ActionsList>
+                ) : (
+                    <Spotlight.Empty>{nothingFound}</Spotlight.Empty>
+                )}
+                {/* The index is shared but the query is scoped to whichever
+                    product the reader is currently in, so the panel says which
+                    one rather than leaving a missing page look like a gap. */}
+                <Spotlight.Footer>
+                    <Text
+                        fz="xs"
+                        c="dimmed"
+                    >
+                        Searching{" "}
+                        <Text
+                            span
+                            inherit
+                            c="bright"
+                            fw={500}
+                        >
+                            {PRODUCT_META[product].label}
+                        </Text>{" "}
+                        documentation
+                    </Text>
+                </Spotlight.Footer>
+            </Spotlight.Root>
         </>
     );
 }

--- a/src/components/SearchDocs/index.tsx
+++ b/src/components/SearchDocs/index.tsx
@@ -190,9 +190,29 @@ export function SearchDocs(props: UnstyledButtonProps) {
                     content: classes.searchContent,
                     search: classes.searchInput,
                     empty: classes.searchEmpty,
-                    footer: classes.searchFooter,
                 }}
             >
+                {/* The index is shared but the query is scoped to whichever
+                    product the reader is currently in, so the panel names the
+                    one it is searching rather than leaving another product's
+                    page looking like a gap in the results. */}
+                <Box className={classes.searchScope}>
+                    <Text
+                        fz="xs"
+                        c="dimmed"
+                    >
+                        Searching{" "}
+                        <Text
+                            span
+                            inherit
+                            c="bright"
+                            fw={500}
+                        >
+                            {PRODUCT_META[product].label}
+                        </Text>{" "}
+                        documentation
+                    </Text>
+                </Box>
                 <Spotlight.Search
                     placeholder="Search the docs"
                     leftSection={loading ? <Loader size="xs" /> : <Icon path={iconSearch} />}
@@ -215,26 +235,6 @@ export function SearchDocs(props: UnstyledButtonProps) {
                 ) : (
                     <Spotlight.Empty>{nothingFound}</Spotlight.Empty>
                 )}
-                {/* The index is shared but the query is scoped to whichever
-                    product the reader is currently in, so the panel says which
-                    one rather than leaving a missing page look like a gap. */}
-                <Spotlight.Footer>
-                    <Text
-                        fz="xs"
-                        c="dimmed"
-                    >
-                        Searching{" "}
-                        <Text
-                            span
-                            inherit
-                            c="bright"
-                            fw={500}
-                        >
-                            {PRODUCT_META[product].label}
-                        </Text>{" "}
-                        documentation
-                    </Text>
-                </Spotlight.Footer>
             </Spotlight.Root>
         </>
     );

--- a/src/components/SearchDocs/style.module.scss
+++ b/src/components/SearchDocs/style.module.scss
@@ -32,8 +32,17 @@
 .search-content {
 	border-radius: var(--mantine-radius-md);
 	border: 1px solid var(--surreal-glass-subtle);
-	background-color: rgba(from var(--mantine-color-obsidian-7) r g b / 0.5);
-	backdrop-filter: blur(8px);
+	// Near-solid. At half opacity the page behind read straight through the
+	// panel and competed with the results for the reader's attention. The
+	// blur and the last few percent of transparency keep it a raised surface
+	// rather than a flat sheet, and the base drops to obsidian-8 so a hovered
+	// row at obsidian-7 has somewhere to step up to.
+	background-color: rgba(from var(--mantine-color-obsidian-8) r g b / 0.96);
+	backdrop-filter: blur(16px);
+	box-shadow: 0 16px 48px rgba(0, 0, 0, 0.45);
+	display: flex;
+	flex-direction: column;
+	overflow: hidden;
 
 	// The translucent dark glass reads as murk on the light theme, so the
 	// panel goes solid white with the site's standard line colour and the
@@ -44,6 +53,17 @@
 		backdrop-filter: none;
 		box-shadow: 0 1px 3px rgba(14, 12, 20, 0.04), 0 16px 48px rgba(14, 12, 20, 0.10);
 	}
+}
+
+// The kit lays the panel out as a flex column so the results take the space
+// the input and the footer leave over. That rule is keyed on a class the
+// modal never receives here, so it is restated - without it the footer is
+// pushed past the panel's height cap and renders below its bottom edge.
+.search-body {
+	display: flex;
+	flex-direction: column;
+	flex: 1;
+	min-height: 0;
 }
 
 .search-input {
@@ -63,6 +83,16 @@
 	color: var(--mantine-color-slate-text);
 }
 
+// The scope line. Mantine's own rule colour is a neutral grey, so it takes
+// the site's tokens like every other divider in the panel.
+.search-footer {
+	border-top-color: var(--surreal-glass-subtle);
+
+	@include light {
+		border-top-color: var(--surreal-border-default);
+	}
+}
+
 // The keyboard hints on the empty screen: a content-width table of
 // [key | action] rows, centred as one block beneath the heading.
 .tutorial-grid {
@@ -79,22 +109,26 @@
 
 .search-list {
 	border-top: none;
+	min-height: 0;
+}
 
-	button {
-		transition: background-color 250ms ease, color 250ms ease;
-		padding: var(--mantine-spacing-sm) var(--mantine-spacing-md);
-	}
+// A result is an anchor rather than a button, so these are hung on the
+// Spotlight `action` class instead of an element name - the earlier `button`
+// selectors matched nothing, which left Mantine's own grey hover in place.
+.search-action {
+	transition: background-color 250ms ease, color 250ms ease;
+	padding: var(--mantine-spacing-sm) var(--mantine-spacing-md);
 
-	button+button {
-		border-top: 1px solid var(--mantine-color-obsidian-8);
+	&+& {
+		border-top: 1px solid var(--mantine-color-obsidian-7);
 
 		@include light {
 			border-top: 1px solid var(--mantine-color-gray-1);
 		}
 	}
 
-	button:hover,
-	button[data-selected] {
+	&:hover,
+	&[data-selected] {
 		background-color: var(--mantine-color-obsidian-7);
 
 		// The apex site's light surface, matching every other light hover.

--- a/src/components/SearchDocs/style.module.scss
+++ b/src/components/SearchDocs/style.module.scss
@@ -32,13 +32,13 @@
 .search-content {
 	border-radius: var(--mantine-radius-md);
 	border: 1px solid var(--surreal-glass-subtle);
-	// Near-solid. At half opacity the page behind read straight through the
-	// panel and competed with the results for the reader's attention. The
-	// blur and the last few percent of transparency keep it a raised surface
-	// rather than a flat sheet, and the base drops to obsidian-8 so a hovered
-	// row at obsidian-7 has somewhere to step up to.
-	background-color: rgba(from var(--mantine-color-obsidian-8) r g b / 0.96);
-	backdrop-filter: blur(16px);
+	// Glass, but readable. At half opacity over an 8px blur the page behind
+	// read straight through the panel and competed with the results, so the
+	// tint carries more of the weight and the blur takes what is left down to
+	// a smear. The base drops to obsidian-8 so a hovered row at obsidian-7
+	// has somewhere to step up to.
+	background-color: rgba(from var(--mantine-color-obsidian-8) r g b / 0.8);
+	backdrop-filter: blur(24px);
 	box-shadow: 0 16px 48px rgba(0, 0, 0, 0.45);
 	display: flex;
 	flex-direction: column;
@@ -83,14 +83,11 @@
 	color: var(--mantine-color-slate-text);
 }
 
-// The scope line. Mantine's own rule colour is a neutral grey, so it takes
-// the site's tokens like every other divider in the panel.
-.search-footer {
-	border-top-color: var(--surreal-glass-subtle);
-
-	@include light {
-		border-top-color: var(--surreal-border-default);
-	}
+// The scope line, sitting above the input as the panel's own title. The inset
+// is the results list's, not the input's, because the results are what the
+// reader's eye runs down.
+.search-scope {
+	padding: var(--mantine-spacing-sm) var(--mantine-spacing-lg) 0;
 }
 
 // The keyboard hints on the empty screen: a content-width table of


### PR DESCRIPTION
Three fixes to the docs search panel.

### Background opacity

The panel sat at `obsidian-7 / 0.5` over an 8px blur, so the page behind read straight through it and competed with the results. It now sits at `obsidian-8 / 0.8` over a 24px blur, with a drop shadow - the tint and the blur share the work rather than the tint doing all of it, so the panel stays glass but what shows through is a smear rather than legible page text. The base drops from obsidian-7 to obsidian-8 so a hovered row at obsidian-7 has somewhere to step up to, matching the surface/hover pairing the rest of the site uses. The scrim behind the panel goes to 0.5 to separate it from the page.

### Scope line

The search index is shared but the query is scoped to whichever product the reader is in, and nothing said so - a page missing from the results looked like a gap rather than another product's page. A line at the top left, above the input, now reads "Searching **Database** documentation" or "Searching **Agent Memory** documentation". Its inset is the results list's rather than the input's, so it lines up with the column of result icons.

That needs a slot the `<Spotlight>` shorthand does not render - it emits the search, the list and the empty state and nothing else - so the panel is composed from `Spotlight.Root`, `.Search`, `.ActionsList`, `.Action` and `.Empty`. Behaviour is unchanged: same store, same keyboard handling, same controlled query. The `noFilter` shim goes away with it, since the actions are now mapped by hand.

### Hovered result background

Hovering a result gave Mantine's neutral grey (`--mantine-color-dark-6`, `#2e2e2e`) rather than obsidian. The rules for the result rows were written against `button`, but a result is an anchor - that is what keeps middle-click, ctrl-click and copy-link working - so they had been matching nothing since, taking the row padding and the separators down with the hover colour. They are now hung on the Spotlight `action` class, which restores all three: obsidian-7 on hover and on the keyboard-selected row, `sm md` padding, and hairline separators between rows.

While fixing that: the kit lays the panel out as a flex column so the results take the space the input and the scope line leave over, but that rule is keyed on a class the modal never receives here. Without it the panel overflowed its own height cap, so it is restated on our own `body` class.

### Verification

Checked in both products on the dev server, dark theme:

- Panel reads as glass, with the page behind blurred past legibility and the results sharp against it.
- Scope line reads "Searching Database documentation" on `/docs` and "Searching Agent Memory documentation" on `/docs/agent-memory`, and results are scoped to match.
- Hovered row renders obsidian; row separators and padding are back.
- Layout holds with a full result set (7 results).

Light theme is untouched apart from the layout rules, which are theme-independent: the panel stays solid white with `--surreal-surface-light` on hover.