### PR TITLE
docs: install the Claude plugin by its current name

### DIFF
--- a/src/content/agent-memory/integrations/mcp-server/coding-assistants/claude-desktop-and-code.mdx
+++ b/src/content/agent-memory/integrations/mcp-server/coding-assistants/claude-desktop-and-code.mdx
@@ -6,17 +6,17 @@ description: "Connecting SurrealDB Agent Memory to Claude Code, Cowork, and Clau
 
 # Claude
 
-The official [SurrealDB plugin marketplace for Claude](https://github.com/surrealdb/ai-claude-plugin) ships a **`spectron`** plugin that connects Claude to your SurrealDB Agent Memory instance's `/mcp` endpoint and installs a usage skill. It supports **Claude Code**, **Cowork**, and **Claude Desktop**. There is no default URL - point it at your own instance (SurrealDB Cloud: your context host from SurrealDB Studio **API keys**; self-hosted: your server's base URL).
+The official [SurrealDB plugin marketplace for Claude](https://github.com/surrealdb/ai-claude-plugin) ships an **`agent-memory`** plugin that connects Claude to your SurrealDB Agent Memory instance's `/mcp` endpoint and installs a usage skill. It supports **Claude Code**, **Cowork**, and **Claude Desktop**. There is no default URL - point it at your own instance (SurrealDB Cloud: your context host from SurrealDB Studio **API keys**; self-hosted: your server's base URL).
 
 ## Claude Code and Cowork
 
 ### Install the plugin
 
-Add the marketplace, then install the `spectron` plugin:
+Add the marketplace, then install the `agent-memory` plugin:
 
 ```bash
 /plugin marketplace add surrealdb/ai-claude-plugin
-/plugin install spectron@surrealdb
+/plugin install agent-memory@surrealdb
 ```
 
 Claude Code reads the plugin directly - the MCP server and the usage skill load automatically.
@@ -29,14 +29,14 @@ The SurrealDB Agent Memory MCP has no default URL. Set your instance endpoint an
 
 <TabItem label="Bash">
 ```bash
-export AGENT_MEMORY_MCP_URL="https://<your-spectron-instance>/mcp"
+export AGENT_MEMORY_MCP_URL="https://<your-agent-memory-instance>/mcp"
 export AGENT_MEMORY_MCP_TOKEN="<your-api-key>"
 ```
 </TabItem>
 
 <TabItem label="PowerShell">
 ```powershell
-$env:AGENT_MEMORY_MCP_URL = "https://<your-spectron-instance>/mcp"
+$env:AGENT_MEMORY_MCP_URL = "https://<your-agent-memory-instance>/mcp"
 $env:AGENT_MEMORY_MCP_TOKEN = "<your-api-key>"
 ```
 </TabItem>
@@ -66,7 +66,7 @@ The bearer token is your SurrealDB Agent Memory context API key. Each key is bou
 claude mcp list
 ```
 
-You should see **spectron** connected. In a session, ask "What MCP tools do you have access to?" and Claude should list the SurrealDB Agent Memory tools: `remember`, `recall`, `context`, `reflect`, `forget`, `upload`, `inspect`.
+You should see **agent-memory** connected. In a session, ask "What MCP tools do you have access to?" and Claude should list the SurrealDB Agent Memory tools: `remember`, `recall`, `context`, `reflect`, `forget`, `upload`, `inspect`.
 
 ### Usage examples
 
@@ -94,7 +94,7 @@ Open **Settings → Connectors → Add custom connector** and add:
 
 | Name | URL | Header |
 |---|---|---|
-| `spectron` | your SurrealDB Agent Memory `/mcp` endpoint (for example `https://<your-spectron-instance>/mcp`) | `Authorization: Bearer <your-api-key>` |
+| `agent-memory` | your SurrealDB Agent Memory `/mcp` endpoint (for example `https://<your-agent-memory-instance>/mcp`) | `Authorization: Bearer <your-api-key>` |
 
 ### Option B - Manual config
 
@@ -110,7 +110,7 @@ Merge the following into `claude_desktop_config.json`, then restart Claude Deskt
   "mcpServers": {
     "agent-memory": {
       "type": "http",
-      "url": "https://<your-spectron-instance>/mcp",
+      "url": "https://<your-agent-memory-instance>/mcp",
       "headers": {
         "Authorization": "Bearer <your-api-key>"
       }
@@ -123,7 +123,7 @@ You can validate the file with `cat ~/Library/Application\ Support/Claude/claude
 
 ### Skill (optional)
 
-Claude Desktop cannot load plugins, but you can add the SurrealDB Agent Memory usage skill by hand: open **Settings → Skills → Upload skill** and upload the `plugins/spectron/skills/mcp/` folder from the [plugin repo](https://github.com/surrealdb/ai-claude-plugin).
+Claude Desktop cannot load plugins, but you can add the SurrealDB Agent Memory usage skill by hand: open **Settings → Skills → Upload skill** and upload the `plugins/agent-memory/skills/agent-memory/` folder from the [plugin repo](https://github.com/surrealdb/ai-claude-plugin).
 
 ### Verify the installation
 
@@ -138,6 +138,6 @@ Narrow reads and writes with the per-tool **`scope`** argument (slash paths, for
 
 ## Removing SurrealDB Agent Memory
 
-**Claude Code / Cowork:** remove the `spectron` plugin from the `/plugin` menu, or run `claude mcp remove spectron`.
+**Claude Code / Cowork:** remove the `agent-memory` plugin from the `/plugin` menu, or run `claude mcp remove agent-memory`.
 
-**Claude Desktop:** remove the `spectron` connector, or delete the `"spectron"` key from `claude_desktop_config.json`, then restart Claude Desktop.
+**Claude Desktop:** remove the `agent-memory` connector, or delete the `"agent-memory"` key from `claude_desktop_config.json`, then restart Claude Desktop.

--- a/src/content/agent-memory/integrations/mcp-server/coding-assistants/codex.mdx
+++ b/src/content/agent-memory/integrations/mcp-server/coding-assistants/codex.mdx
@@ -11,7 +11,7 @@ Installing SurrealDB Agent Memory in the [OpenAI Codex CLI](https://developers.o
 For integration rules your agent should follow (auth, scope, endpoints, common mistakes), see **[Agent guide (AGENTS.md)](/docs/agent-memory/reference/agents)**. You can add it to your project's `AGENTS.md`, which Codex reads automatically.
 
 > [!NOTE]
-> SurrealDB also publishes a [Codex plugin](https://github.com/surrealdb/ai-codex-plugin) that adds a SurrealDB Agent Memory usage skill. It is a local marketplace for now - clone the repo, then run `codex plugin marketplace add "$PWD"` and `codex plugin add agent-memory@surrealdb`. The manual MCP configuration below works with or without it.
+> SurrealDB also publishes a [Codex plugin](https://github.com/surrealdb/ai-codex-plugin) that bundles the same managed MCP server with a SurrealDB Agent Memory usage skill and optional turn capture, which records completed conversation turns to a Context you configure. It is a local marketplace for now - clone the repo, then run `codex plugin marketplace add "$PWD"` and `codex plugin add agent-memory@surrealdb`. The manual MCP configuration below works with or without it.
 
 ## Configure
 

--- a/src/content/agent-memory/integrations/mcp-server/coding-assistants/codex.mdx
+++ b/src/content/agent-memory/integrations/mcp-server/coding-assistants/codex.mdx
@@ -11,7 +11,7 @@ Installing SurrealDB Agent Memory in the [OpenAI Codex CLI](https://developers.o
 For integration rules your agent should follow (auth, scope, endpoints, common mistakes), see **[Agent guide (AGENTS.md)](/docs/agent-memory/reference/agents)**. You can add it to your project's `AGENTS.md`, which Codex reads automatically.
 
 > [!NOTE]
-> SurrealDB also publishes a [Codex plugin](https://github.com/surrealdb/ai-codex-plugin) that adds a SurrealDB Agent Memory usage skill. It is a local marketplace for now - clone the repo, then run `codex plugin marketplace add "$PWD"` and `codex plugin add spectron@surrealdb`. The manual MCP configuration below works with or without it.
+> SurrealDB also publishes a [Codex plugin](https://github.com/surrealdb/ai-codex-plugin) that adds a SurrealDB Agent Memory usage skill. It is a local marketplace for now - clone the repo, then run `codex plugin marketplace add "$PWD"` and `codex plugin add agent-memory@surrealdb`. The manual MCP configuration below works with or without it.
 
 ## Configure
 


### PR DESCRIPTION
[ai-claude-plugin#2](https://github.com/surrealdb/ai-claude-plugin/pull/2) renamed the plugin `spectron` → `agent-memory`. The marketplace is a plain git repo with no publish step, so the rename was live on merge and this no longer resolves:

```diff
-/plugin install spectron@surrealdb
+/plugin install agent-memory@surrealdb
```

While in the file, three more things on the same page were wrong:

- **The Desktop connector table contradicted the JSON below it.** The table row said `spectron`; the manual-config block directly beneath already said `"agent-memory"`.
- **The skill upload path never existed.** It said `plugins/spectron/skills/mcp/`. The skill lives at `plugins/agent-memory/skills/agent-memory/` — verified against the plugin repo's current tree. This was wrong before the rename too.
- The `<your-spectron-instance>` placeholder, for consistency with the rest of the page.

The uninstall instructions (`claude mcp remove spectron`, the `"spectron"` config key) are updated to match too.

### Deliberately unchanged

The **Codex** page keeps `codex plugin add spectron@surrealdb`. That points at [ai-codex-plugin](https://github.com/surrealdb/ai-codex-plugin), a **different** repo whose plugin is still named `spectron` (v0.3.0) — so that instruction is correct as written. That repo hasn't had a rename pass and is worth one.