### PR TITLE
docs: document where a sequence stands, and what OVERWRITE resets

### DIFF
--- a/src/content/reference/query-language/statements/alter/sequence.mdx
+++ b/src/content/reference/query-language/statements/alter/sequence.mdx
@@ -8,7 +8,7 @@ description: "The ALTER SEQUENCE statement is used to modify a defined sequence.
 
 <Since v="v3.0.0" />
 
-The `ALTER SEQUENCE` statement is used to modify a defined sequence.
+The `ALTER SEQUENCE` statement is used to modify a defined sequence. `TIMEOUT` is the only clause it accepts; to change a sequence's `BATCH` or `START`, redefine it with [`DEFINE SEQUENCE ... OVERWRITE`](/docs/reference/query-language/statements/define/sequence#resetting-a-sequence-with-overwrite), which also restarts its counting.
 
 <Tabs syncKey="alter-statement">
   <TabItem label="SurrealQL Syntax">

--- a/src/content/reference/query-language/statements/define/sequence.mdx
+++ b/src/content/reference/query-language/statements/define/sequence.mdx
@@ -15,7 +15,7 @@ The key features of a sequence are as follows:
 * Batch allocation: Nodes request ranges of sequence values at once, reducing network chatter and coordination overhead.
 * Node ownership tagging: Every batch is tagged with the requesting node's UUID to prevent overlap between nodes.
 * Durable Persistence: Sequence metadata is stored in the underlying key-value store to survive restarts and network partitions.
-* Concurrent, thread-safe access: A DashMap caches active sequences, allowing lock-free reads on the hot path.
+* Concurrent, thread-safe access: each node caches the sequences it is serving, so consecutive values are handed out without returning to the store.
 * Exponential back-off with full jitter: When a batch-allocation attempt fails, the node retries with an exponential delay that includes full jitter to avoid thundering-herd effects across the cluster.
 * Automatic cleanup: Listens for namespace and database-removal events and purges the corresponding sequence state.
 
@@ -85,6 +85,97 @@ sequence::nextval("seq");        -- 2
 UPDATE my:counter SET val += 1;  -- 1
 ```
 
+## Resetting a sequence with `OVERWRITE`
+
+`DEFINE SEQUENCE ... OVERWRITE` does not only replace the configuration: it discards the position the sequence has reached and starts counting again from `START`.
+
+```surql
+DEFINE SEQUENCE mySeq4 BATCH 10 START 1;
+sequence::nextval('mySeq4');
+sequence::nextval('mySeq4');
+
+DEFINE SEQUENCE OVERWRITE mySeq4 BATCH 10 START 1;
+sequence::nextval('mySeq4');
+```
+
+```surql title="Output"
+1
+2
+1
+```
+
+That makes `OVERWRITE` the way to move a sequence to a new position - give it a `START` above every value already in use:
+
+```surql
+DEFINE SEQUENCE OVERWRITE mySeq4 BATCH 10 START 500;
+sequence::nextval('mySeq4');
+```
+
+```surql title="Output"
+500
+```
+
+Because it restarts counting, an `OVERWRITE` with a `START` at or below values the sequence has already issued will hand those values out a second time.
+
+<Since v="v3.3.0" />
+
+An `OVERWRITE` applies to a sequence that is already serving. On earlier versions it takes effect only after the node restarts.
+
+## Reading where a sequence stands
+
+<Since v="v3.3.0" />
+
+`INFO FOR DB STRUCTURE` reports each sequence's `resume` value: the lowest value no node has issued. That is the bound to reposition a sequence to, and the value an export records as `START`. `start` continues to report the value in the definition.
+
+On a cluster `resume` is not necessarily the value the next `sequence::nextval` returns, because a node still holding a batch it reserved earlier serves from that batch, below the bound.
+
+```surql
+DEFINE SEQUENCE mySeq5 BATCH 10 START 100;
+sequence::nextval('mySeq5');
+sequence::nextval('mySeq5');
+INFO FOR DB STRUCTURE.sequences;
+```
+
+```surql title="Output"
+[
+    {
+        batch: '10',
+        name: 'mySeq5',
+        resume: '102',
+        start: '100',
+        timeout: NONE
+    }
+]
+```
+
+## Sequences and exports
+
+<Since v="v3.3.0" />
+
+An export records each sequence at the position it has reached, so importing it leaves the sequence counting on from the data that came with it.
+
+On earlier versions an export records the `START` the sequence was declared with, so an import rewinds it while the imported records keep the values already allocated from it. Where the sequence feeds a record id, the first write after the import fails with `Database record ... already exists`; where it feeds an ordinary field, the sequence silently repeats values already in that column. After importing a dump taken on an earlier version, reposition each sequence before writing to the restored database.
+
+Take the new `START` from the data the sequence feeds. Where it feeds an ordinary field, read that field:
+
+```surql
+LET $next = math::max(SELECT VALUE no FROM inv) + 1;
+DEFINE SEQUENCE OVERWRITE invoice_no BATCH 1000 START $next;
+```
+
+Where it feeds a record id, take the id out of the record first:
+
+```surql
+LET $next = math::max(SELECT VALUE record::id(id) FROM thing) + 1;
+DEFINE SEQUENCE OVERWRITE order_id BATCH 1000 START $next;
+```
+
+Repeat this for every sequence in the imported database.
+
+> [!IMPORTANT]
+> Before v3.3.0, `DEFINE SEQUENCE ... OVERWRITE` does not take effect on a running node: the node keeps serving from the position it held, and the new `START` applies only after a restart. On those versions, restart the instance after repositioning and confirm with `sequence::nextval` before resuming writes.
+
 ## See also
 
 * [Sequence functions](/docs/reference/query-language/functions/database-functions/sequence)
+* [`ALTER SEQUENCE`](/docs/reference/query-language/statements/alter/sequence)

--- a/src/content/reference/query-language/statements/define/sequence.mdx
+++ b/src/content/reference/query-language/statements/define/sequence.mdx
@@ -129,6 +129,9 @@ An `OVERWRITE` applies to a sequence that is already serving. On earlier version
 
 On a cluster `resume` is not necessarily the value the next `sequence::nextval` returns, because a node still holding a batch it reserved earlier serves from that batch, below the bound.
 
+> [!IMPORTANT]
+> Read `resume` and reposition the sequence while nothing is drawing from it. The value is a bound on what has been issued *at the moment it is read*: if the sequence is still in use, it is stale by the time the `DEFINE SEQUENCE ... OVERWRITE` lands, and repositioning to a value the sequence has since passed hands those values out again. Stop the writers, reposition, then let them back.
+
 ```surql
 DEFINE SEQUENCE mySeq5 BATCH 10 START 100;
 sequence::nextval('mySeq5');
@@ -170,7 +173,7 @@ LET $next = math::max(SELECT VALUE record::id(id) FROM thing) + 1;
 DEFINE SEQUENCE OVERWRITE order_id BATCH 1000 START $next;
 ```
 
-Repeat this for every sequence in the imported database.
+Repeat this for every sequence in the imported database, before any client starts writing to it.
 
 > [!IMPORTANT]
 > Before v3.3.0, `DEFINE SEQUENCE ... OVERWRITE` does not take effect on a running node: the node keeps serving from the position it held, and the new `START` applies only after a restart. On those versions, restart the instance after repositioning and confirm with `sequence::nextval` before resuming writes.

--- a/src/content/reference/query-language/statements/info.mdx
+++ b/src/content/reference/query-language/statements/info.mdx
@@ -119,7 +119,7 @@ INFO FOR NS;
 
 ### Database information
 
-The `DB` or `DATABASE` command returns information regarding the users, tables, params, models, functions, analyzers and access methods under the database in use.
+The `DB` or `DATABASE` command returns information regarding the users, tables, params, models, modules, functions, analyzers, apis, buckets, configs, sequences and access methods under the database in use.
 
 > [!NOTE]
 > You must be authenticated as a top-level root user, a namespace user, or a database user to execute this command.
@@ -142,7 +142,11 @@ INFO FOR DB;
     configs: {},
     functions: {},
     models: {},
+    modules: {},
     params: {},
+    sequences: {
+        order_id: 'DEFINE SEQUENCE order_id BATCH 1000 START 1'
+    },
     tables: {
         person: 'DEFINE TABLE person TYPE ANY SCHEMALESS PERMISSIONS NONE'
     },


### PR DESCRIPTION
Documents sequence behaviour that was missing, and the two changes landing in v3.3.0.

## What was missing

`DEFINE SEQUENCE ... OVERWRITE` appears in the syntax line and is explained nowhere. It does not merely replace the configuration: it **discards the position the sequence has reached and starts counting from `START` again**. That is both a way to silently reissue ids and the only way to reposition a sequence, so it now has a section of its own.

## What v3.3.0 changes

- **`INFO FOR DB STRUCTURE` reports a `resume` value** per sequence — the lowest value no node has issued. Documented as the bound to reposition to and the value an export records as `START`, and explicitly *not* what the next `sequence::nextval` returns: on a cluster, a node still holding a batch it reserved earlier serves from below that bound.
- **An export records each sequence at the position it reached**, rather than the `START` it was declared with.

The second needs the older behaviour spelled out, because anyone importing a dump taken before v3.3.0 has to reposition every sequence by hand. Where the sequence feeds a record id the first write fails loudly with ``Database record ... already exists``; where it feeds an ordinary field **nothing is raised at all** and the column simply repeats values. That page now carries the repair, including the caveat that on those versions `OVERWRITE` does not take effect until the node restarts.

Reported publicly as surrealdb/surrealdb#7502.

## Also

- `ALTER SEQUENCE` now says `TIMEOUT` is the only clause it accepts, and points at `DEFINE ... OVERWRITE` for `BATCH`/`START`.
- Corrects the feature list on `DEFINE SEQUENCE`: sequences are not cached in a DashMap, and reads are not lock-free.

## Checks

Both repair snippets were run against v3.2.4 — the version readers needing them are on — after a first draft of them turned out to be wrong: `SELECT VALUE id` yields a record id, not an integer, so the record-id form needs `record::id(id)`. `INFO FOR DB STRUCTURE.sequences` was confirmed to parse, and the key order in the sample output matches what the server emits. The `OVERWRITE` and `resume` outputs come from the engine change's own regression tests.

`bun run build` fails on this branch, but it fails identically on a pristine `main` — a `vite-plugin-vercel`/rolldown `output.file` vs `output.dir` conflict in the Vercel bundling step, after all 1007 pages render. Unrelated to this change, and worth someone looking at separately.
